### PR TITLE
Add JWT token support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.5 // indirect
@@ -57,6 +58,7 @@ require (
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/vmware/govmomi v0.27.2
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.4.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -113,6 +114,7 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-xdr v0.0.0-20161123171359-e6a2ba005892/go.mod h1:CTDl0pzVzE5DEzZhPfvhY/9sPFMQIxaJ9VAMs9AagrE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -171,6 +173,10 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
+github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -237,6 +243,7 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v0.0.0-20170306145142-6a5e28554805/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
@@ -438,6 +445,11 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
+github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.27.2 h1:Ecooqg069gUbl5EuWYwcrvzRqMkah9J8BXaf9HCEGVM=
+github.com/vmware/govmomi v0.27.2/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
+github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/vmware/vsphere-automation-sdk-go/lib v0.4.0 h1:H341o+0k6BfcehXvCK9w+G/Yx8GgjrWam91ANlsVrE4=
 github.com/vmware/vsphere-automation-sdk-go/lib v0.4.0/go.mod h1:o0p10EpvLFXbws63s9vV66+OQwalnXJPNgl+BvPz5PY=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.4.0 h1:SJI34JDj28bZyTI93kCTdklXHaxJUnR+ebkMQ8eWfgA=

--- a/pkg/nsx/auth/jwt/JWTtokenprovider.go
+++ b/pkg/nsx/auth/jwt/JWTtokenprovider.go
@@ -1,0 +1,60 @@
+/* Copyright © 2021 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package jwt
+
+import (
+	"io/ioutil"
+	"strings"
+	"time"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/auth"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	VC_SVCACCOUNT_USER_PATH = "/etc/nsx-ujo/vc/username"
+	VC_SVCACCOUNT_PWD_PATH  = "/etc/nsx-ujo/vc/password"
+)
+
+var (
+	log = logf.Log.WithName("nsx").WithName("jwt")
+)
+
+type JWTTokenProvider struct {
+	cache *JWTCache
+}
+
+func (provider *JWTTokenProvider) GetToken(refreshToken bool) (string, error) {
+	return provider.cache.GetJWT(refreshToken)
+}
+
+func (provider *JWTTokenProvider) HeaderValue(token string) string {
+	return "Bearer " + token
+}
+
+func NewTokenProvider(vcConfig *config.VcConfig, caCert []byte) (auth.TokenProvider, error) {
+	f, err := ioutil.ReadFile(VC_SVCACCOUNT_USER_PATH)
+	if err != nil {
+		log.Error(err, "failed to read user name")
+		return nil, err
+	}
+	username := strings.TrimRight(string(f), "\n\r")
+
+	f, err = ioutil.ReadFile(VC_SVCACCOUNT_PWD_PATH)
+	if err != nil {
+		log.Error(err, "failed to read password")
+		return nil, err
+	}
+	password := strings.TrimRight(string(f), "\n\r")
+
+	tesClient, err := NewTESClient(vcConfig.VcEndPoint, vcConfig.HttpsPort, vcConfig.SsoDomain, username, password, nil, true)
+	if err != nil {
+		log.Error(err, "failed to create tes client")
+		return nil, err
+	}
+
+	cache := NewJWTCache(tesClient, 60*time.Second)
+	return &JWTTokenProvider{cache: cache}, nil
+}

--- a/pkg/nsx/auth/jwt/jwtcache.go
+++ b/pkg/nsx/auth/jwt/jwtcache.go
@@ -1,0 +1,84 @@
+/* Copyright © 2021 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package jwt
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	gojwt "github.com/golang-jwt/jwt"
+)
+
+const (
+	minFreshInterval = 30 * time.Second
+)
+
+// JWTCache ...
+type JWTCache struct {
+	tesClient     *TESClient
+	mutex         sync.Mutex
+	jwt           string
+	expire        time.Time
+	freshInterval time.Duration
+}
+
+// NewJWTCache ...
+func NewJWTCache(tesClient *TESClient, freshInterval time.Duration) *JWTCache {
+	if freshInterval < minFreshInterval {
+		freshInterval = minFreshInterval
+	}
+	return &JWTCache{
+		tesClient:     tesClient,
+		freshInterval: freshInterval,
+	}
+}
+
+func (cache *JWTCache) GetJWT(refreshToken bool) (string, error) {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+	if !refreshToken {
+		if cache.jwt != "" && time.Now().Add(cache.freshInterval).Before(cache.expire) {
+			return cache.jwt, nil
+		}
+	}
+	jwt, err := cache.refreshJWT()
+	if err != nil || jwt == "" {
+		log.V(1).Info("Refresh JWT error", err)
+		return "", err
+	}
+	exp, err := cache.getJWTExpire(jwt)
+	if err != nil {
+		return "", err
+	}
+	if cache.jwt == "" || cache.expire.Before(exp) {
+		cache.jwt = jwt
+		cache.expire = exp
+	}
+	return cache.jwt, nil
+}
+
+func (cache *JWTCache) refreshJWT() (string, error) {
+	if jwt, err := cache.tesClient.ExchangeJWT(cache.tesClient.signer.Token, false); err != nil {
+		log.Error(err, "JWT cache failed to refresh JWT ")
+		return "", err
+	} else {
+		return jwt, nil
+	}
+}
+
+func (cache *JWTCache) getJWTExpire(jwt string) (time.Time, error) {
+	token, _, err := new(gojwt.Parser).ParseUnverified(jwt, gojwt.MapClaims{})
+	if err != nil {
+		return time.Now(), err
+	}
+	claims := token.Claims.(gojwt.MapClaims)
+	expirationTime, ok := claims["exp"].(float64)
+	if !ok {
+		errMsg := fmt.Sprintf("JWT doesn't have claim 'exp' of type 'float64'; claims: %v", claims)
+		return time.Now(), errors.New(errMsg)
+	}
+	return time.Unix(int64(expirationTime), 0), nil
+}

--- a/pkg/nsx/auth/jwt/tesclient.go
+++ b/pkg/nsx/auth/jwt/tesclient.go
@@ -1,0 +1,80 @@
+/* Copyright © 2021 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package jwt
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type tokenExchange struct {
+	Spec tokenExchangeSpec `json:"spec"`
+}
+
+type tokenExchangeSpec struct {
+	Audience           string `json:"audience"`
+	GrantType          string `json:"grant_type"`
+	RequestedTokenType string `json:"requested_token_type"`
+	SubjectToken       string `json:"subject_token"`
+	SubjectTokenType   string `json:"subject_token_type"`
+}
+
+// TESClient requests Token Exchange Service (TES) to issue JWT in exchange
+// for SAML token.
+type TESClient struct {
+	*VCClient
+}
+
+// NewTESClient creates a TESClient object.
+func NewTESClient(hostname string, port int, ssoDomain string, username, password string, caCertPem []byte, insecureSkipVerify bool) (*TESClient, error) {
+	client, err := NewVCClient(hostname, port, ssoDomain, username, password, caCertPem, insecureSkipVerify)
+	if err != nil {
+		log.Error(err, "new TESClient failed")
+		return nil, err
+	}
+	return &TESClient{client}, nil
+}
+
+func newTokenExchange(samlToken string, useOldAudience bool) *tokenExchange {
+	audience := "vmware-tes:vc:nsxd-v2:nsx"
+	if useOldAudience {
+		audience = "vmware-tes:vc:nsxd:nsx"
+	}
+	return &tokenExchange{
+		Spec: tokenExchangeSpec{
+			Audience:           audience,
+			GrantType:          "urn:ietf:params:oauth:grant-type:token-exchange",
+			RequestedTokenType: "urn:ietf:params:oauth:token-type:id_token",
+			SubjectToken:       base64.StdEncoding.EncodeToString([]byte(samlToken)),
+			SubjectTokenType:   "urn:ietf:params:oauth:token-type:saml2",
+		},
+	}
+}
+
+// ExchangeJWT requests TES to issue JWT in exchange for the specified SAML token.
+func (client *TESClient) ExchangeJWT(samlToken string, useOldAudience bool) (string, error) {
+	// assume that response should have "access_token" field
+	// no retry while hit "Unknown audience value" error
+	log.V(1).Info("sending saml token to TES for JWT")
+
+	exchange := newTokenExchange(samlToken, useOldAudience)
+	body, err := json.Marshal(*exchange)
+	if err != nil {
+		return "", err
+	}
+
+	var res struct {
+		Value map[string]interface{} `json:"value"`
+	}
+	tesErr := client.HandleRequest("/vcenter/tokenservice/token-exchange", body, &res)
+	if tesErr != nil {
+		msg := fmt.Sprintf("Failed to exchange JWT due to error :%v", tesErr)
+		log.Error(tesErr, "failed to exchange JWT")
+		return "", errors.New(msg)
+	}
+
+	return res.Value["access_token"].(string), nil
+}

--- a/pkg/nsx/auth/jwt/vcclient.go
+++ b/pkg/nsx/auth/jwt/vcclient.go
@@ -1,0 +1,298 @@
+/* Copyright © 2021 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package jwt
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/vmware/govmomi/sts"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// VCClient tracks a client session token.
+type VCClient struct {
+	url          *url.URL
+	httpClient   *http.Client
+	sessionMutex sync.Mutex
+	session      string
+	signer       *sts.Signer
+	ssoDomain    string
+}
+
+var (
+	stsClientMutex sync.Mutex
+	stsClient      *sts.Client
+)
+
+func createHttpClient(insecureSkipVerify bool, caCertPem []byte) *http.Client {
+	tlsConfig := &tls.Config{InsecureSkipVerify: insecureSkipVerify}
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+	if len(caCertPem) > 0 {
+		clientCertPool := x509.NewCertPool()
+		clientCertPool.AppendCertsFromPEM(caCertPem)
+		tlsConfig.RootCAs = clientCertPool
+	}
+	return &http.Client{Transport: transport, Timeout: time.Minute}
+}
+
+// NewVCClient creates a new logged in VC client with vapi session.
+func NewVCClient(hostname string, port int, ssoDomain string, userName, password string, caCertPem []byte, insecureSkipVerify bool) (*VCClient, error) {
+	httpClient := createHttpClient(insecureSkipVerify, caCertPem)
+	baseurl := fmt.Sprintf("https://%s:%d/rest", hostname, port)
+	vcurl, _ := url.Parse(baseurl)
+	vcurl.User = url.UserPassword(userName, password)
+	vcClient := &VCClient{
+		url:        vcurl,
+		httpClient: httpClient,
+		ssoDomain:  ssoDomain,
+	}
+
+	err := vcClient.getorRenewVAPISession()
+	if err != nil {
+		return nil, err
+	}
+	return vcClient, nil
+}
+
+// createVAPISession creates a VAPI session using the specified STS signer and sets it on the vcClient.
+func (vcClient *VCClient) createVAPISession() (string, error) {
+	log.Info("creating new vapi session for vcClient")
+	request, err := vcClient.prepareRequest(http.MethodPost, "/com/vmware/cis/session", nil)
+	if err != nil {
+		return "", err
+	}
+	response, err := vcClient.httpClient.Do(request)
+	var sessionData map[string]string
+	err = handleHTTPResponse(response, &sessionData)
+	if err != nil {
+		return "", err
+	}
+
+	session, ok := sessionData["value"]
+	if !ok {
+		msg := fmt.Sprintf("unexpected session data %v from vapi-endpoint", sessionData)
+		err := errors.New(msg)
+		log.Error(err, "failed to create VAPI session")
+		return "", errors.New(msg)
+	}
+	return session, nil
+}
+
+// getorRenewVAPISession gets a new VAPI session for the vcClient.
+func (vcClient *VCClient) getorRenewVAPISession() error {
+	signer, err := vcClient.createHOKSigner()
+	if err != nil {
+		return err
+	}
+	vcClient.signer = signer
+	session, err := vcClient.createVAPISession()
+	if err != nil {
+		return err
+	}
+
+	vcClient.sessionMutex.Lock()
+	vcClient.session = session
+	vcClient.sessionMutex.Unlock()
+	return nil
+}
+
+// createHOKSigner creates a Hok token for the service account user.
+func (vcClient *VCClient) createHOKSigner() (*sts.Signer, error) {
+	log.V(1).Info("creating Holder of Key signer")
+	userName := vcClient.url.User.Username()
+	password, _ := vcClient.url.User.Password()
+	client, err := vcClient.getorCreateSTSClient()
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := createCertificate(userName)
+	if err != nil {
+		log.Error(err, "failed to process service account keypair")
+		return nil, err
+	}
+
+	req := sts.TokenRequest{
+		Certificate: cert,
+		Userinfo:    url.UserPassword(userName, password),
+		Delegatable: true,
+		Renewable:   true,
+	}
+
+	signed, err := client.Issue(context.Background(), req)
+	if err != nil {
+		log.Error(err, "failed to get token from cert,key pair")
+		return nil, err
+	}
+	return signed, nil
+}
+
+// getorCreateSTSClient return a STS client of the vCenter. Creates a new client only if doesn't exist.
+func (vcClient *VCClient) getorCreateSTSClient() (*sts.Client, error) {
+	stsClientMutex.Lock()
+	defer stsClientMutex.Unlock()
+
+	if stsClient != nil {
+		return stsClient, nil
+	}
+
+	vimSdkURL := fmt.Sprintf("https://%s/sdk", vcClient.url.Host)
+	vimClient, err := vcClient.createVimClient(context.Background(), vimSdkURL)
+	if err != nil {
+		return nil, err
+	}
+
+	sc := vcClient.createSCClient(vimClient)
+	return &sts.Client{Client: sc, RoundTripper: sc}, nil
+}
+
+func (vcClient *VCClient) createSCClient(vimClient *vim25.Client) *soap.Client {
+	url := fmt.Sprintf("https://%s/sts/STSService/%s", vcClient.url.Host, vcClient.ssoDomain)
+	return vimClient.Client.NewServiceClient(url, "oasis:names:tc:SAML:2.0:assertion")
+}
+
+func (vcClient *VCClient) createVimClient(ctx context.Context, vimSdkURL string) (*vim25.Client, error) {
+	log.V(1).Info("creating vmomi client")
+	vcURL, err := url.Parse(vimSdkURL)
+	if err != nil {
+		return nil, err
+	}
+	vimClient, err := vim25.NewClient(ctx, soap.NewClient(vcURL, true))
+	if err != nil {
+		log.Error(err, "failed to create VIM client", "vimSdkURL", vimSdkURL)
+		return nil, err
+	}
+	return vimClient, nil
+}
+
+// HandleRequest sends a POST request
+func (client *VCClient) HandleRequest(urlPath string, data []byte, responseData interface{}) error {
+	// reew vAPISession if status code is '401'
+	for i := 0; i < 3; i++ {
+		request, err := client.prepareRequest(http.MethodPost, urlPath, data)
+		if err != nil {
+			return err
+		}
+
+		response, err := client.httpClient.Do(request)
+		if err != nil {
+			return err
+		}
+		log.V(1).Info("HTTP request: %v, response %v", request, response)
+		if response.StatusCode == http.StatusUnauthorized {
+			if err = client.getorRenewVAPISession(); err != nil {
+				log.Error(err, "failed to renew VAPI session")
+				return err
+			}
+			continue
+		}
+		err = handleHTTPResponse(response, responseData)
+		return err
+	}
+	return nil
+}
+
+func (client *VCClient) prepareRequest(method string, urlPath string, data []byte) (*http.Request, error) {
+	url := fmt.Sprintf("%s://%s/rest/%s", client.url.Scheme, client.url.Host, urlPath)
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if client.signer != nil {
+		client.signer.SignRequest(req)
+
+	} else if client.session != "" {
+		req.Header.Set("vmware-api-session-id", client.session)
+	} else {
+		return nil, errors.New("invalid client - either session id or token should be set")
+	}
+	return req, nil
+}
+
+func createCertificate(userName string) (*tls.Certificate, error) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		log.Error(err, "failed to generate RSA private key")
+		return nil, err
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		log.Error(err, "failed to generate random serial number")
+		return nil, err
+	}
+	currentTime := time.Now()
+	notBeforeTime := currentTime.Add(-6 * time.Minute).UTC()
+	notAfterTime := currentTime.Add(60 * time.Minute).UTC()
+	log.V(1).Info("generating certificate", "user", userName, "notBefore", notBeforeTime, "notAfter", notAfterTime)
+	certTemplate := x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: userName},
+		Issuer:                pkix.Name{CommonName: userName},
+		NotBefore:             notBeforeTime,
+		NotAfter:              notAfterTime,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &privKey.PublicKey, privKey)
+	if err != nil {
+		log.Error(err, "failed to generate certificate")
+		return nil, err
+	}
+
+	cert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+	privateKey := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privKey)})
+	certificate, err := tls.X509KeyPair([]byte(cert), []byte(privateKey))
+	if err != nil {
+		log.Error(err, "failed to process service account keypair")
+		return nil, err
+	}
+
+	return &certificate, nil
+}
+
+func handleHTTPResponse(response *http.Response, result interface{}) error {
+	if response.StatusCode >= 300 {
+		err := errors.New("Received HTTP Error")
+		log.Error(err, "handle http response", "status", response.StatusCode, "requestUrl", response.Request.URL, "response", response)
+		return err
+	}
+	if result == nil {
+		return nil
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(body, result); err != nil {
+		log.Error(err, "Error converting HTTP response to result", "result type", result)
+		return err
+	}
+	log.V(1).Info("response body", result)
+
+	return nil
+}

--- a/pkg/nsx/client_test.go
+++ b/pkg/nsx/client_test.go
@@ -5,11 +5,12 @@ package nsx
 
 import (
 	"fmt"
-	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/auth/jwt"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra"
@@ -45,27 +46,37 @@ func TestClient(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	host := "10.191.254.13, 10.191.248.221, 10.191.249.48 "
-	config := NewConfig(host, "admin", "Admin!23Admin", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
+	host := "10.161.65.224"
+	vcConfig := config.VcConfig{}
+	vcConfig.VcEndPoint = "10.161.72.156"
+	vcConfig.SsoDomain = "vsphere.local"
+	vcConfig.HttpsPort = 443
+	provider, err := jwt.NewTokenProvider(&vcConfig, nil)
+	if err != nil {
+		log.Error(err, "Create token provider err %v")
+	}
+	config := NewConfig(host, "admin", "Admin!23Admin", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, provider, nil)
 	cluster, _ := NewCluster(config)
 
 	connector, _ := cluster.NewRestConnector()
+	//search.NewDslClient()
 	queryClient := search.NewQueryClient(connector)
-	queryParam := "Segment"
-	for i := 0; i < 4; i++ {
-		response, err := queryClient.List(url.QueryEscape(queryParam), nil, nil, nil, nil, nil)
+	queryParam := "resource_type:Group AND tags.scope:ncp\\/project"
+	for i := 0; i < 1; i++ {
+		response, err := queryClient.List(queryParam, nil, nil, nil, nil, nil)
 		assert.True(t, err == nil, fmt.Sprintf("Query segment failed due to %v ", err))
 		log.V(1).Info("query segment", "resultCount", *response.ResultCount)
 	}
 	for i := 0; i < 20; i++ {
 		go func() {
-			response, err := queryClient.List(url.QueryEscape(queryParam), nil, nil, nil, nil, nil)
+			response, err := queryClient.List(queryParam, nil, nil, nil, nil, nil)
 			assert.True(t, err == nil, fmt.Sprintf("Query segment failed due to %v ", err))
 			log.V(1).Info("query segment", "resultCount", *response.ResultCount)
 		}()
 		time.Sleep(time.Microsecond)
 	}
 	time.Sleep(time.Second * 3)
+
 }
 
 func createRule(domainIDParam string, groupName string, serviceName string, cluster *Cluster) error {
@@ -91,7 +102,6 @@ func createGroup(domainID string, groupName string, cluster *Cluster) error {
 	connector, _ := cluster.NewRestConnector()
 	groupClient := domains.NewGroupsClient(connector)
 	groupParam := model.Group{}
-
 	fields := make(map[string]data.DataValue)
 	fields["member_type"] = data.NewStringValue("VirtualMachine")
 	fields["value"] = data.NewStringValue("webvm")

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -56,7 +56,7 @@ func NewCluster(config *Config) (*Cluster, error) {
 	cluster.noBalancerClient = cluster.createNoBalancerClient(time.Duration(config.HTTPTimeout), time.Duration(config.ConnIdleTimeout))
 
 	r := ratelimiter.NewRateLimiter(config.APIRateMode)
-	eps, err := cluster.createEndpoints(config.APIManagers, &cluster.client, &cluster.noBalancerClient, r)
+	eps, err := cluster.createEndpoints(config.APIManagers, &cluster.client, &cluster.noBalancerClient, r, config.TokenProvider)
 	if err != nil {
 		log.Error(err, "creating cluster failed")
 		return nil, err
@@ -119,10 +119,10 @@ func (cluster *Cluster) createNoBalancerClient(timeout, idle time.Duration) http
 	return noBClient
 }
 
-func (cluster *Cluster) createEndpoints(apiManagers []string, client *http.Client, noBClient *http.Client, r ratelimiter.RateLimiter) ([]*Endpoint, error) {
+func (cluster *Cluster) createEndpoints(apiManagers []string, client *http.Client, noBClient *http.Client, r ratelimiter.RateLimiter, tokenProvider auth.TokenProvider) ([]*Endpoint, error) {
 	eps := make([]*Endpoint, len(apiManagers))
 	for i := range eps {
-		ep, err := NewEndpoint(apiManagers[i], client, noBClient, r)
+		ep, err := NewEndpoint(apiManagers[i], client, noBClient, r, tokenProvider)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/nsx/endpoint_test.go
+++ b/pkg/nsx/endpoint_test.go
@@ -112,7 +112,7 @@ func TestCreateAuthSession(t *testing.T) {
 	client := cluster.createHTTPClient(tr, 30)
 	noBClient := cluster.createNoBalancerClient(90, 90)
 	rl := ratelimiter.NewFixRateLimiter(10)
-	ep, err := NewEndpoint("10.0.0.1", &client, &noBClient, rl)
+	ep, err := NewEndpoint("10.0.0.1", &client, &noBClient, rl, nil)
 	assert.Nil(err, fmt.Sprintf("Endpoint create failed due to %v", err))
 
 	certProvider := createNcpPovider()
@@ -169,7 +169,7 @@ func TestKeepAlive(t *testing.T) {
 	client := cluster.createHTTPClient(tr, 30)
 	noBClient := cluster.createNoBalancerClient(90, 90)
 	rl := ratelimiter.NewFixRateLimiter(10)
-	ep, err := NewEndpoint(ts.URL[len("http://"):], &client, &noBClient, rl)
+	ep, err := NewEndpoint(ts.URL[len("http://"):], &client, &noBClient, rl, nil)
 
 	assert.Nil(err, fmt.Sprintf("Endpoint create failed due to %v", err))
 	ep.setStatus(UP)

--- a/pkg/nsx/transport_test.go
+++ b/pkg/nsx/transport_test.go
@@ -33,7 +33,7 @@ func TestRoundTripConnectionRefused(t *testing.T) {
 	client := cluster.createHTTPClient(tr, idleConnTimeout)
 	noBClient := cluster.createNoBalancerClient(timeout, idleConnTimeout)
 	r := ratelimiter.NewRateLimiter(config.APIRateMode)
-	eps, _ := cluster.createEndpoints(config.APIManagers, &client, &noBClient, r)
+	eps, _ := cluster.createEndpoints(config.APIManagers, &client, &noBClient, r, nil)
 	eps[0].status = UP
 	tr.endpoints = eps
 	req, err := http.NewRequest("GET", ts.URL, nil)
@@ -57,7 +57,7 @@ func TestRoundTripDecodeBodyFailed(t *testing.T) {
 	client := cluster.createHTTPClient(tr, 30)
 	noBClient := cluster.createNoBalancerClient(30, 20)
 	r := ratelimiter.NewRateLimiter(config.APIRateMode)
-	eps, _ := cluster.createEndpoints(config.APIManagers, &client, &noBClient, r)
+	eps, _ := cluster.createEndpoints(config.APIManagers, &client, &noBClient, r, nil)
 	eps[0].status = UP
 	tr.endpoints = eps
 	req, err := http.NewRequest("GET", ts.URL, nil)
@@ -88,7 +88,7 @@ func TestRoundTripAuthFailed(t *testing.T) {
 	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
 	cluster, err := NewCluster(config)
 	assert.Nil(err, fmt.Sprintf("Create cluster error %v", err))
-	cluster.endpoints[0], _ = NewEndpoint(ts.URL, &cluster.client, &cluster.noBalancerClient, cluster.endpoints[0].ratelimiter)
+	cluster.endpoints[0], _ = NewEndpoint(ts.URL, &cluster.client, &cluster.noBalancerClient, cluster.endpoints[0].ratelimiter, nil)
 	cluster.endpoints[0].keepAlive()
 	tr := cluster.transport
 	req, err := http.NewRequest("GET", ts.URL, nil)
@@ -121,7 +121,7 @@ func TestRoundTripRetry(t *testing.T) {
 	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
 	cluster, err := NewCluster(config)
 	assert.Nil(err, fmt.Sprintf("Create cluster error %v", err))
-	cluster.endpoints[0], _ = NewEndpoint(ts.URL, &cluster.client, &cluster.noBalancerClient, cluster.endpoints[0].ratelimiter)
+	cluster.endpoints[0], _ = NewEndpoint(ts.URL, &cluster.client, &cluster.noBalancerClient, cluster.endpoints[0].ratelimiter, nil)
 	cluster.endpoints[0].keepAlive()
 	tr := cluster.transport
 	req, err := http.NewRequest("GET", ts.URL, nil)
@@ -142,7 +142,7 @@ func TestSelectEndpoint(t *testing.T) {
 	client := cluster.createHTTPClient(tr, timeout)
 	noBClient := cluster.createNoBalancerClient(timeout, idleConnTimeout)
 	r := ratelimiter.NewRateLimiter(config.APIRateMode)
-	eps, _ := cluster.createEndpoints(config.APIManagers, &client, &noBClient, r)
+	eps, _ := cluster.createEndpoints(config.APIManagers, &client, &noBClient, r, nil)
 	// all eps DOWN
 	ep, err := tr.selectEndpoint()
 	assert.NotNil(t, err, fmt.Sprintf("Select endpoint error %s", err))


### PR DESCRIPTION
 1. ServiceAccount: nsx-operator will be configured with a ServiceAccount for
 NSX-T
 2. STS: Using the ServiceAccount, nsx-operator must first connect to Secure
 Token Service (STS) to retrieve SAML Holder of Key Tokens.
 3. Using this SAML HoK, create a session with VC and retrieve the session ID.
 This session ID is needed in order to authenticate with TES in the next step.
 4. TES: Once a SAML HoK token is retrieved, nsx-operator must connect to Token
 Exchange Service (TES), to validate its SAML token and in return retrieve a JWT.
 5. NSX-T: Once a SAML token is validated and nsx-operator acquires a JWT,
 nsx-operator will use this JWT in its request headers to perform CRUD operations
  on NSX-T.
 6. Once a JWT expires, nsx-operator must renew the token and retry the request.