### PR TITLE
Add nsx status checker for liveness probe

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,7 @@ func init() {
 
 func main() {
 	var probeAddr string
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8088", "The address the probe endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8383", "The address the probe endpoint binds to.")
 	config.AddFlags()
 	opts := zap.Options{
 		Development: true,
@@ -76,7 +76,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	if err := mgr.AddHealthzCheck("healthz", nsxClient.NSXChecker.CheckNSXHealth); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -20,15 +20,15 @@ import (
 )
 
 // ClusterHealth indicates cluster status.
-type ClusterHealth int32
+type ClusterHealth string
 
 const (
 	// RED means all endpoints status are DOWN.
-	RED ClusterHealth = iota
+	RED ClusterHealth = "RED"
 	// ORANGE means not all endpoints status are UP.
-	ORANGE
+	ORANGE ClusterHealth = "ORANGE"
 	// GREEN means endpoints status are UP.
-	GREEN
+	GREEN ClusterHealth = "GREEN"
 )
 
 // Cluster consists of endpoint and provides http.Client used to send http requests.


### PR DESCRIPTION
Use localhost:8383/healthz to invoke api get request.