### PR TITLE
Add MatchExpression support for SecurityPolicy

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/client-go/util/workqueue"
 
+	mapset "github.com/deckarep/golang-set"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util/locerrors"
 )
 
@@ -86,4 +87,18 @@ func Sha1(data string) string {
 	h.Write([]byte(data))
 	sum := h.Sum(nil)
 	return fmt.Sprintf("%x", sum)
+}
+
+func RemoveDuplicateStr(strSlice []string) []string {
+	stringSet := mapset.NewSet()
+
+	for _, d := range strSlice {
+		stringSet.Add(d)
+	}
+	resultStr := make([]string, len(stringSet.ToSlice()))
+	for i, v := range stringSet.ToSlice() {
+		resultStr[i] = v.(string)
+	}
+
+	return resultStr
 }


### PR DESCRIPTION
1.Support MatchExpression Operator: 'NotIn', 'Exists',
'DoesNotExist' for VM/Pod/Namespace label selectors
in SecurityPolicy

2.Given NSX doesn't support MatchExpression Operator 'In',
and only five criteria are allowed currently,
which results into a gigantic group expression body to be passed to NSX.
So, only allow just one Operator 'In' MatchExpressions with at most
of five values in it.

3.Add NSX-T limitation and NSGroup Criteria check