### PR TITLE
Fix 2 issues

### DIFF
--- a/pkg/nsx/endpoint.go
+++ b/pkg/nsx/endpoint.go
@@ -123,6 +123,7 @@ func (ep *Endpoint) keepAlive() error {
 			return err
 		}
 	}
+	req.Header.Add("x-xsrf-token", ep.XSRFToken())
 	resp, err := ep.noBalancerClient.Do(req)
 	if err != nil {
 		log.Error(err, "failed to validate API cluster", "endpoint", ep.Host())

--- a/pkg/nsx/services/store.go
+++ b/pkg/nsx/services/store.go
@@ -71,7 +71,7 @@ func keyFunc(obj interface{}) (string, error) {
 
 func queryTagCondition(service *SecurityPolicyService) string {
 	return fmt.Sprintf("tags.scope:%s AND tags.tag:%s",
-		strings.Replace(util.TagScopeCluster, "/", "\\/", -1), service.NSXClient.NsxConfig.Cluster)
+		strings.Replace(util.TagScopeCluster, "/", "\\/", -1), strings.Replace(service.NSXClient.NsxConfig.Cluster, ":", "\\:", -1))
 }
 
 func queryGroup(service *SecurityPolicyService, wg *sync.WaitGroup, fatalErrors chan error) {


### PR DESCRIPTION
1. Add xsrf header while making API call
2. Escape ':' character if it's present in cluster name, which is usually
   true for WCP