### PR TITLE
Add Sec Policy CR Ready status condition

### DIFF
--- a/pkg/apis/v1alpha1/securitypolicy_types.go
+++ b/pkg/apis/v1alpha1/securitypolicy_types.go
@@ -114,7 +114,7 @@ type SecurityPolicyStatus struct {
 // SecurityPolicyCondition defines the condition of policy.
 type SecurityPolicyCondition struct {
 	// Type defines the type of condition.
-	Type string `json:"type"`
+	Type SecurityPolicyStatusCondition `json:"type"`
 	// Status shows the status of condition, one of True or False.
 	Status corev1.ConditionStatus `json:"status"`
 	// Reason shows a brief reason of condition.
@@ -122,6 +122,16 @@ type SecurityPolicyCondition struct {
 	// Message shows a human readable message about the condition.
 	Message string `json:"message,omitempty"`
 }
+
+// SecurityPolicyStatusCondition is an aspect of operator state.
+type SecurityPolicyStatusCondition string
+
+const (
+	// Ready indicates whether NSX Operator was able to successfully make
+	// a PATCH call to create/update Security Policy on NSX associated
+	// with the user created Security Policy CR
+	SecurityPolicyReady SecurityPolicyStatusCondition = "Ready"
+)
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status

--- a/pkg/controllers/securitypolicy_controller_test.go
+++ b/pkg/controllers/securitypolicy_controller_test.go
@@ -1,0 +1,101 @@
+/* Copyright © 2021 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package controllers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func NewFakeSecurityPolicyReconciler() *SecurityPolicyReconciler {
+	return &SecurityPolicyReconciler{
+		Client:  fake.NewClientBuilder().Build(),
+		Scheme:  fake.NewClientBuilder().Build().Scheme(),
+		Service: nil,
+	}
+}
+
+func TestSecurityPolicyController_updateSecurityPolicyStatusConditions(t *testing.T) {
+	r := NewFakeSecurityPolicyReconciler()
+	ctx := context.TODO()
+	dummySP := &v1alpha1.SecurityPolicy{}
+
+	// Case: Security Policy CRD creation fails
+	newConditions := []v1alpha1.SecurityPolicyCondition{
+		{
+			Type:    v1alpha1.SecurityPolicyReady,
+			Status:  v1.ConditionFalse,
+			Message: "NSX Security Policy could not be created/updated",
+			Reason:  "Error occurred while processing the Security Policy CRD. Please check the config and try again",
+		},
+	}
+	r.updateSecurityPolicyStatusConditions(&ctx, dummySP, newConditions)
+
+	if !reflect.DeepEqual(dummySP.Status.Conditions, newConditions) {
+		t.Fatalf("Failed to correctly update Status Conditions when conditions haven't changed")
+	}
+
+	// Case: No change in Conditions
+	dummyConditions := []v1alpha1.SecurityPolicyCondition{
+		{
+			Type:    v1alpha1.SecurityPolicyReady,
+			Status:  v1.ConditionFalse,
+			Message: "NSX Security Policy could not be created/updated",
+			Reason:  "Error occurred while processing the Security Policy CRD. Please check the config and try again",
+		},
+	}
+	dummySP.Status.Conditions = dummyConditions
+
+	newConditions = []v1alpha1.SecurityPolicyCondition{
+		{
+			Type:    v1alpha1.SecurityPolicyReady,
+			Status:  v1.ConditionFalse,
+			Message: "NSX Security Policy could not be created/updated",
+			Reason:  "Error occurred while processing the Security Policy CRD. Please check the config and try again",
+		},
+	}
+
+	r.updateSecurityPolicyStatusConditions(&ctx, dummySP, newConditions)
+
+	if !reflect.DeepEqual(dummySP.Status.Conditions, newConditions) {
+		t.Fatalf("Failed to correctly update Status Conditions when conditions haven't changed")
+	}
+
+	// Case: SP CRD Creation succeeds after failure
+	newConditions = []v1alpha1.SecurityPolicyCondition{
+		{
+			Type:    v1alpha1.SecurityPolicyReady,
+			Status:  v1.ConditionTrue,
+			Message: "NSX Security Policy has been successfully created/updated",
+			Reason:  "NSX API returned 200 response code for PATCH",
+		},
+	}
+
+	r.updateSecurityPolicyStatusConditions(&ctx, dummySP, newConditions)
+
+	if !reflect.DeepEqual(dummySP.Status.Conditions, newConditions) {
+		t.Fatalf("Failed to correctly update Status Conditions when conditions haven't changed")
+	}
+
+	// Case: SP CRD Update failed
+	newConditions = []v1alpha1.SecurityPolicyCondition{
+		{
+			Type:    v1alpha1.SecurityPolicyReady,
+			Status:  v1.ConditionFalse,
+			Message: "NSX Security Policy could not be created/updated",
+			Reason:  "Error occurred while processing the Security Policy CRD. Please check the config and try again",
+		},
+	}
+
+	r.updateSecurityPolicyStatusConditions(&ctx, dummySP, newConditions)
+
+	if !reflect.DeepEqual(dummySP.Status.Conditions, newConditions) {
+		t.Fatalf("Failed to correctly update Status Conditions when conditions haven't changed")
+	}
+}


### PR DESCRIPTION
We add status condition - Ready to the Security Policy Custom Resource. It's updated as follow:
- It is set to True if Operator can successfully process the custom
  resource and create an NSX Security Policy
- It is set to False if Operator faces an error while processing the
  Security Policy Custom Resource