### PR TITLE
Add thumbprint verify

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -182,7 +182,7 @@ func (vcConfig *VCConfig) validate() error {
 	}
 
 	if vcConfig.HttpsPort == 0 {
-		err := errors.New("Invalid field " + "HttpsPort")
+		err := errors.New("invalid field " + "HttpsPort")
 		log.Error(err, "validate VcConfig failed", "HttpsPort", vcConfig.HttpsPort)
 		return err
 	}
@@ -190,9 +190,24 @@ func (vcConfig *VCConfig) validate() error {
 }
 
 func (nsxConfig *NsxConfig) validate() error {
-	if len(nsxConfig.NsxApiManagers) == 0 {
-		err := errors.New("Invalid field " + "NsxApiManagers")
+	mCount := len(nsxConfig.NsxApiManagers)
+	if mCount == 0 {
+		err := errors.New("invalid field " + "NsxApiManagers")
 		log.Error(err, "validate NsxConfig failed", "NsxApiManagers", nsxConfig.NsxApiManagers)
+		return err
+	}
+	tpCount := len(nsxConfig.Thumbprint)
+	if tpCount == 0 {
+		log.V(1).Info("no thumbprint provided")
+		return nil
+	}
+	if tpCount == 1 {
+		log.V(1).Info("all endpoints share one thumbprint")
+		return nil
+	}
+	if tpCount > 1 && tpCount != mCount {
+		err := errors.New("thumbprint count not match manager count")
+		log.Error(err, "validate NsxConfig failed", "thumbprint count", tpCount, "manager count", mCount)
 		return err
 	}
 	return nil
@@ -200,7 +215,7 @@ func (nsxConfig *NsxConfig) validate() error {
 
 func (coeConfig *CoeConfig) validate() error {
 	if len(coeConfig.Cluster) == 0 {
-		err := errors.New("Invalid field " + "Cluster")
+		err := errors.New("invalid field " + "Cluster")
 		log.Error(err, "validate coeConfig failed")
 		return err
 	}
@@ -245,7 +260,6 @@ func (nsxVersion *NsxVersion) featureSupported() bool {
 
 func (nsxVersion *NsxVersion) getVersion(host string, userName string, password string, tokenProvider auth.TokenProvider) error {
 	tlsConfig := tls.Config{InsecureSkipVerify: true}
-	tlsConfig.BuildNameToCertificate()
 	tr := &http.Transport{
 		TLSClientConfig: &tlsConfig,
 		IdleConnTimeout: 60 * time.Second,

--- a/pkg/controllers/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy_controller.go
@@ -37,7 +37,7 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	log.Info("reconciling securitypolicy CR", "securitypolicy", req.NamespacedName)
 
 	if err := r.Client.Get(ctx, req.NamespacedName, obj); err != nil {
-		log.Error(err, "unable to fetch security policy CR")
+		log.Error(err, "unable to fetch security policy CR", "req", req.NamespacedName)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -35,7 +35,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 	// Set log level for vsphere-automation-sdk-go
 	logger := logrus.New()
 	vspherelog.SetLogger(logger)
-	c := NewConfig(strings.Join(cf.NsxApiManagers, ","), cf.NsxApiUser, cf.NsxApiPassword, "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
+	c := NewConfig(strings.Join(cf.NsxApiManagers, ","), cf.NsxApiUser, cf.NsxApiPassword, "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, cf.Thumbprint)
 	cluster, _ := NewCluster(c)
 	queryClient := search.NewQueryClient(restConnector(cluster))
 	groupClient := domains.NewGroupsClient(restConnector(cluster))

--- a/pkg/nsx/cluster_test.go
+++ b/pkg/nsx/cluster_test.go
@@ -26,7 +26,8 @@ func TestNewCluster(t *testing.T) {
 	defer ts.Close()
 	index := strings.Index(ts.URL, "//")
 	a := ts.URL[index+2:]
-	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
+	thumbprint := []string{"123"}
+	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
 	_, err := NewCluster(config)
 	assert.True(t, err == nil, fmt.Sprintf("Created cluster failed %v", err))
 }

--- a/pkg/nsx/config.go
+++ b/pkg/nsx/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	CAFile string
 	// Specify a Thumbprint string to use in verifying the NSX Manager server certificate. This option is ignored
 	// if "Insecure" is set to True or "CAFile" is defined.
-	Thumbprint string
+	Thumbprint []string
 	// Maximum concurrent connections to each NSX manager.
 	ConcurrentConnections int
 	// If True, the client will retry requests failed on "Too many requests" error.
@@ -58,7 +58,7 @@ type Config struct {
 }
 
 // NewConfig creates a nsx configuration. It provides default values for those items not in function parameters.
-func NewConfig(apiManagers, username, password, caFile string, concurrentConnections, retries, httpTimeout, connIdleTimeout int, insecure, allowOverwriteHeader, allowPassThrough bool, apiRateMode ratelimiter.Type, tokenProvider auth.TokenProvider, clientCertProvider auth.ClientCertProvider) *Config {
+func NewConfig(apiManagers, username, password, caFile string, concurrentConnections, retries, httpTimeout, connIdleTimeout int, insecure, allowOverwriteHeader, allowPassThrough bool, apiRateMode ratelimiter.Type, tokenProvider auth.TokenProvider, clientCertProvider auth.ClientCertProvider, thumbprint []string) *Config {
 	apis := strings.Split(apiManagers, ",")
 	for i, v := range apis {
 		apis[i] = strings.TrimSpace(v)
@@ -78,5 +78,6 @@ func NewConfig(apiManagers, username, password, caFile string, concurrentConnect
 		TokenProvider:         tokenProvider,
 		ClientCertProvider:    clientCertProvider,
 		CAFile:                caFile,
+		Thumbprint:            thumbprint,
 	}
 }

--- a/pkg/nsx/endpoint_test.go
+++ b/pkg/nsx/endpoint_test.go
@@ -92,9 +92,9 @@ func (m *mockObject) Scheme() string {
 
 var (
 	result = []string{`{"module_name":"common-services","error_message":"The credentials were incorrect or the account specified has been locked.","error_code":403}`,
-		`{"module_name":"common-services","error_message":"The credentials were incorrect or the account specified has been locked.","error_code":200}`,
-		`{"module_name":"common-services","error_message":"The credentials were incorrect or the account specified has been locked.","error_code":200}`,
-		`{"module_name":"common-services","error_message":"The credentials were incorrect or the account specified has been locked.","error_code":200}`,
+		`{"module_name":"common-services","error_message":"The credentials were incorrect or the account specified has been locked.","error_code":403}`,
+		`{"module_name":"common-services","error_message":"The credentials were incorrect or the account specified has been locked.","error_code":403}`,
+		`{"module_name":"common-services","error_message":"The credentials were incorrect or the account specified has been locked.","error_code":403}`,
 	}
 	status = []int{
 		http.StatusForbidden,

--- a/pkg/nsx/services/nsxapi_test.go
+++ b/pkg/nsx/services/nsxapi_test.go
@@ -20,7 +20,7 @@ var host string = "10.180.127.117,10.180.119.135,10.180.114.111"
 
 func TestGroup(t *testing.T) {
 	domainIDParam := "default"
-	config := nsx.NewConfig(host, "admin", "Admin!23Admin", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
+	config := nsx.NewConfig(host, "admin", "Admin!23Admin", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster, _ := nsx.NewCluster(config)
 	connector, _ := cluster.NewRestConnector()
 	groupClient := domains.NewGroupsClient(connector)
@@ -31,7 +31,7 @@ func TestGroup(t *testing.T) {
 
 func TestSecurityPolicy(t *testing.T) {
 	domainIDParam := "default"
-	config := nsx.NewConfig(host, "admin", "Admin!23Admin", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
+	config := nsx.NewConfig(host, "admin", "Admin!23Admin", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster, _ := nsx.NewCluster(config)
 	connector, _ := cluster.NewRestConnector()
 	securityClient := domains.NewSecurityPoliciesClient(connector)
@@ -42,7 +42,7 @@ func TestSecurityPolicy(t *testing.T) {
 
 func TestRule(t *testing.T) {
 	domainIDParam := "default"
-	config := nsx.NewConfig(host, "admin", "Admin!23Admin", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
+	config := nsx.NewConfig(host, "admin", "Admin!23Admin", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster, _ := nsx.NewCluster(config)
 	connector, _ := cluster.NewRestConnector()
 	securityClient := domains.NewSecurityPoliciesClient(connector)
@@ -56,7 +56,7 @@ func TestRule(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	config := nsx.NewConfig(host, "admin", "Admin!23Admin", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
+	config := nsx.NewConfig(host, "admin", "Admin!23Admin", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster, _ := nsx.NewCluster(config)
 	connector, _ := cluster.NewRestConnector()
 	queryClient := search.NewQueryClient(connector)

--- a/pkg/nsx/transport.go
+++ b/pkg/nsx/transport.go
@@ -54,7 +54,7 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 			}
 			transTime := time.Since(start) - waitTime
 			ep.adjustRate(waitTime, resp.StatusCode)
-			log.V(1).Info("RoundTrip got response", "transTime", transTime)
+			log.V(1).Info("RoundTrip got response", "request", r.URL, "method", r.Method, "transTime", transTime)
 			if err = util.InitErrorFromResponse(ep.Host(), resp); err == nil {
 				ep.setAliveTime(start.Add(transTime))
 				return nil

--- a/pkg/nsx/transport_test.go
+++ b/pkg/nsx/transport_test.go
@@ -27,7 +27,7 @@ func TestRoundTripConnectionRefused(t *testing.T) {
 	}))
 	defer ts.Close()
 	a := "127.0.0.1"
-	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
+	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster := &Cluster{}
 	tr := cluster.createTransport(config.TokenProvider, idleConnTimeout)
 	client := cluster.createHTTPClient(tr, idleConnTimeout)
@@ -51,7 +51,7 @@ func TestRoundTripDecodeBodyFailed(t *testing.T) {
 	defer ts.Close()
 	index := strings.Index(ts.URL, "//")
 	a := ts.URL[index+2:]
-	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
+	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster := &Cluster{}
 	tr := cluster.createTransport(config.TokenProvider, timeout)
 	client := cluster.createHTTPClient(tr, 30)
@@ -85,7 +85,7 @@ func TestRoundTripAuthFailed(t *testing.T) {
 	defer ts.Close()
 	index := strings.Index(ts.URL, "//")
 	a := ts.URL[index+2:]
-	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
+	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster, err := NewCluster(config)
 	assert.Nil(err, fmt.Sprintf("Create cluster error %v", err))
 	cluster.endpoints[0], _ = NewEndpoint(ts.URL, &cluster.client, &cluster.noBalancerClient, cluster.endpoints[0].ratelimiter, nil)
@@ -118,13 +118,13 @@ func TestRoundTripRetry(t *testing.T) {
 	defer ts.Close()
 	index := strings.Index(ts.URL, "//")
 	a := ts.URL[index+2:]
-	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
+	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster, err := NewCluster(config)
 	assert.Nil(err, fmt.Sprintf("Create cluster error %v", err))
 	cluster.endpoints[0], _ = NewEndpoint(ts.URL, &cluster.client, &cluster.noBalancerClient, cluster.endpoints[0].ratelimiter, nil)
 	cluster.endpoints[0].keepAlive()
 	tr := cluster.transport
-	req, err := http.NewRequest("GET", ts.URL, nil)
+	req, _ := http.NewRequest("GET", ts.URL, nil)
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	_, err = tr.RoundTrip(req)
@@ -136,7 +136,7 @@ func TestRoundTripRetry(t *testing.T) {
 func TestSelectEndpoint(t *testing.T) {
 	assert := assert.New(t)
 	a := "127.0.0.1, 127.0.0.2, 127.0.0.3"
-	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil)
+	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster := &Cluster{}
 	tr := cluster.createTransport(config.TokenProvider, idleConnTimeout)
 	client := cluster.createHTTPClient(tr, timeout)


### PR DESCRIPTION
Add thumbprint validation, thumbprint number should be 1 or equal to endpoint number if want to verify it.
When tls dial, it will calculate the thumbprint and compare it with local thumbprint.