### PR TITLE
Fix the condition issues for pod/vm selector

### DIFF
--- a/pkg/nsx/services/firewall.go
+++ b/pkg/nsx/services/firewall.go
@@ -976,15 +976,19 @@ func (service *SecurityPolicyService) updatePeerExpressions(obj *v1alpha1.Securi
 		memberType = "SegmentPort"
 		service.addOperatorIfNeeded(expressions, "AND")
 		podExpression := service.buildExpression(
-			"Condition", memberType, util.TagScopeNCPPod, "Tag", "EQUALS", "EQUALS")
-		expressions.Add(podExpression)
+			"Condition", memberType, fmt.Sprintf("%s|", util.TagScopeNCPPod), "Tag", "EQUALS", "EQUALS")
 
 		if peer.NamespaceSelector == nil {
+			podExpression = service.buildExpression(
+				"Condition", memberType,
+				fmt.Sprintf("%s|%s", util.TagScopeNCPProject, obj.ObjectMeta.Namespace),
+				"Tag", "EQUALS", "EQUALS")
 			mixedCriteria = false
 		} else {
 			mixedCriteria = true
 		}
 
+		expressions.Add(podExpression)
 		tagValueExpression = podExpression
 		matchLabels = peer.PodSelector.MatchLabels
 		matchExpressions = &peer.PodSelector.MatchExpressions
@@ -996,15 +1000,19 @@ func (service *SecurityPolicyService) updatePeerExpressions(obj *v1alpha1.Securi
 		memberType = "SegmentPort"
 		service.addOperatorIfNeeded(expressions, "AND")
 		vmExpression := service.buildExpression(
-			"Condition", memberType, util.TagScopeNCPVNETInterface, "Tag", "EQUALS", "EQUALS")
-		expressions.Add(vmExpression)
+			"Condition", memberType, fmt.Sprintf("%s|", util.TagScopeNCPVNETInterface), "Tag", "EQUALS", "EQUALS")
 
 		if peer.NamespaceSelector == nil {
+			vmExpression = service.buildExpression(
+				"Condition", memberType,
+				fmt.Sprintf("%s|%s", util.TagScopeNCPVIFProject, obj.ObjectMeta.Namespace),
+				"Tag", "EQUALS", "EQUALS")
 			mixedCriteria = false
 		} else {
 			mixedCriteria = true
 		}
 
+		expressions.Add(vmExpression)
 		tagValueExpression = vmExpression
 		matchLabels = peer.VMSelector.MatchLabels
 		matchExpressions = &peer.VMSelector.MatchExpressions


### PR DESCRIPTION
1. When building the expression, if there's only "ncp/pod" in the
   "value" property, the "ncp/pod" will appear in place of the
   "tag equals", not of the "scope equals" which we are expecting.
   This patch will change "ncp/pod" to "ncp/pod|" to fix this issue.
2. If namespaceSelector not set in the peer, the rule should select
   the pod/vm in the same namespace instead of all namespaces.