### PR TITLE
Auto decrement page size when 60576 errcode appears

### DIFF
--- a/pkg/nsx/util/errors.go
+++ b/pkg/nsx/util/errors.go
@@ -550,3 +550,12 @@ func CreateConnectionError(host string) *ConnectionError {
 	nsxErr.msg = m
 	return nsxErr
 }
+
+// PageMaxError For client usage
+type PageMaxError struct {
+	Desc string
+}
+
+func (err PageMaxError) Error() string {
+	return err.Desc
+}


### PR DESCRIPTION
When it reports 60576 error code, meaning the content of one page is too large to transport, of queryGroup, querySecurityPolicy and queryGroup, auto decrement by 100 records and retry, and it goes on.