### PR TITLE
Fix not finding local thumbprint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 )
 
 require (
+	github.com/agiledragon/gomonkey v2.0.2+incompatible // indirect
 	github.com/beevik/etree v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
+github.com/agiledragon/gomonkey v2.0.2+incompatible h1:eXKi9/piiC3cjJD1658mEE2o3NjkJ5vDLgYjCQu0Xlw=
+github.com/agiledragon/gomonkey v2.0.2+incompatible/go.mod h1:2NGfXu1a80LLr2cmWXGBDaHEjb1idR6+FVlX5T3D9hw=
 github.com/agiledragon/gomonkey/v2 v2.4.0 h1:YDQJYiSQ8o78dCMXehU1E4F/Kh4jPX+MV+/iK/yfL7s=
 github.com/agiledragon/gomonkey/v2 v2.4.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -92,22 +92,32 @@ func (cluster *Cluster) NewRestConnector() (*policyclient.RestConnector, *Header
 	return connector, header
 }
 
-func (cluster *Cluster) createTransport(tokenProvider auth.TokenProvider, idle time.Duration) *Transport {
-	dial := func(network, addr string) (net.Conn, error) {
-		host := strings.Split(addr, ":")[0]
-		var thumbprint string
-		tpCount := len(cluster.config.Thumbprint)
-		if tpCount == 1 {
-			thumbprint = cluster.config.Thumbprint[0]
-		}
-		if tpCount > 1 {
-			for index, ep := range cluster.endpoints {
-				if ep.Host() == host {
-					thumbprint = cluster.config.Thumbprint[index]
-					break
-				}
+func (cluster *Cluster) getThumbprint(addr string) string {
+	host := addr[:strings.Index(addr, ":")]
+	var thumbprint string
+	tpCount := len(cluster.config.Thumbprint)
+	if tpCount == 1 {
+		thumbprint = cluster.config.Thumbprint[0]
+	}
+	if tpCount > 1 {
+		for index, ep := range cluster.endpoints {
+			epHost := ep.Host()
+			if pos := strings.Index(ep.Host(), ":"); pos > 0 {
+				epHost = epHost[:pos]
+			}
+			if epHost == host {
+				thumbprint = cluster.config.Thumbprint[index]
+				break
 			}
 		}
+	}
+	return thumbprint
+}
+
+func (cluster *Cluster) createTransport(tokenProvider auth.TokenProvider, idle time.Duration) *Transport {
+	dial := func(network, addr string) (net.Conn, error) {
+		thumbprint := cluster.getThumbprint(addr)
+		tpCount := len(cluster.config.Thumbprint)
 		config := &tls.Config{
 			InsecureSkipVerify: true,
 			VerifyConnection: func(cs tls.ConnectionState) error {

--- a/pkg/nsx/cluster_test.go
+++ b/pkg/nsx/cluster_test.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/agiledragon/gomonkey"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
 )
@@ -30,4 +32,44 @@ func TestNewCluster(t *testing.T) {
 	config := NewConfig(a, "admin", "passw0rd", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
 	_, err := NewCluster(config)
 	assert.True(t, err == nil, fmt.Sprintf("Created cluster failed %v", err))
+}
+
+func TestCluster_getThumbprint(t *testing.T) {
+	// one api server, one thumbprint
+	thumbprint := []string{"123"}
+	host := "127.0.0.1:443"
+
+	cluster := &Cluster{}
+	cluster.config = &Config{}
+	cluster.config.Thumbprint = thumbprint
+	tb := cluster.getThumbprint(host)
+	assert.Equal(t, tb, "123")
+
+	// two api server share one thumbprint
+	ep1 := &Endpoint{}
+	ep2 := &Endpoint{}
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(ep1), "KeepAlive", func(_ *Endpoint) {
+	})
+	defer patch.Reset()
+	cluster.endpoints = []*Endpoint{ep1, ep2}
+	cluster.endpoints[0].provider = &address{host: "127.0.0.1:443"}
+	cluster.endpoints[1].provider = &address{host: "127.0.0.2:443"}
+	tb = cluster.getThumbprint(host)
+	assert.Equal(t, tb, "123")
+
+	//two api server, two thumbprint
+	thumbprint = []string{"123", "234"}
+	cluster.config.Thumbprint = thumbprint
+	tb = cluster.getThumbprint("127.0.0.1:443")
+	assert.Equal(t, tb, "123")
+	tb = cluster.getThumbprint("127.0.0.2:443")
+	assert.Equal(t, tb, "234")
+
+	//two api server no port, two thumbprint
+	cluster.endpoints[0].provider = &address{host: "127.0.0.1"}
+	cluster.endpoints[1].provider = &address{host: "127.0.0.2"}
+	tb = cluster.getThumbprint("127.0.0.1:443")
+	assert.Equal(t, tb, "123")
+	tb = cluster.getThumbprint("127.0.0.2:443")
+	assert.Equal(t, tb, "234")
 }

--- a/pkg/nsx/endpoint.go
+++ b/pkg/nsx/endpoint.go
@@ -203,7 +203,7 @@ func (ep *Endpoint) setup() {
 func (ep *Endpoint) setStatus(s EndpointStatus) {
 	ep.Lock()
 	if ep.status != s {
-		log.Info("endpoint status is changing", "endpoing", ep.Host(), "oldStatus", ep.status, "newStatus", s)
+		log.Info("endpoint status is changing", "endpoint", ep.Host(), "oldStatus", ep.status, "newStatus", s)
 		ep.status = s
 	}
 	ep.Unlock()


### PR DESCRIPTION
Api manager in config may include port and scheme
when searching local thumbprint, it should move the port part
and only compare host