### PR TITLE
Support dynamic NSX version check

### DIFF
--- a/pkg/nsx/client_test.go
+++ b/pkg/nsx/client_test.go
@@ -57,14 +57,13 @@ func TestNSXHealthChecker_CheckNSXHealth(t *testing.T) {
 		})
 		patches.Reset()
 	}
-
 }
 
 func TestGetClient(t *testing.T) {
 	cf := config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{NsxApiUser: "1", NsxApiPassword: "1"}}
 	cf.VCConfig = &config.VCConfig{}
 	client := GetClient(&cf)
-	assert.True(t, client == nil)
+	assert.True(t, client != nil)
 
 	cluster := &Cluster{}
 	patches := gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
@@ -74,7 +73,9 @@ func TestGetClient(t *testing.T) {
 
 	client = GetClient(&cf)
 	patches.Reset()
-	assert.True(t, client == nil)
+	assert.True(t, client != nil)
+	nsxVerionSupported := client.NSXCheckVersion()
+	assert.True(t, nsxVerionSupported == false)
 
 	patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
 		nsxVersion := &NsxVersion{NodeVersion: "3.2.1"}
@@ -83,6 +84,8 @@ func TestGetClient(t *testing.T) {
 	client = GetClient(&cf)
 	patches.Reset()
 	assert.True(t, client != nil)
+	nsxVerionSupported = client.NSXCheckVersion()
+	assert.True(t, nsxVerionSupported == true)
 }
 
 func IsInstanceOf(objectPtr, typePtr interface{}) bool {

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -253,7 +253,7 @@ func (cluster *Cluster) GetVersion() (*NsxVersion, error) {
 	return nsxVersion, err
 }
 
-func (nsxVersion *NsxVersion) Validate(minVersion [3]int64) error {
+func (nsxVersion *NsxVersion) Validate() error {
 	re, _ := regexp.Compile(`^([\d]+).([\d]+).([\d]+)`)
 	result := re.Find([]byte(nsxVersion.NodeVersion))
 	if len(result) < 1 {
@@ -261,12 +261,7 @@ func (nsxVersion *NsxVersion) Validate(minVersion [3]int64) error {
 		log.Error(err, "check version", "version", nsxVersion.NodeVersion)
 		return err
 	}
-	if !nsxVersion.featureSupported(minVersion) {
-		version := fmt.Sprintf("%d:%d:%d", minVersion[0], minVersion[1], minVersion[2])
-		err := errors.New("nsxt version " + nsxVersion.NodeVersion + " is old this feature needs version " + version)
-		log.Error(err, "validate NsxVersion failed")
-		return err
-	}
+
 	return nil
 }
 

--- a/pkg/nsx/cluster_test.go
+++ b/pkg/nsx/cluster_test.go
@@ -59,7 +59,7 @@ func TestCluster_getThumbprint(t *testing.T) {
 	tb = cluster.getThumbprint(host)
 	assert.Equal(t, tb, "123")
 
-	//two api server, two thumbprint
+	// two api server, two thumbprint
 	thumbprint = []string{"123", "234"}
 	cluster.config.Thumbprint = thumbprint
 	tb = cluster.getThumbprint("127.0.0.1:443")
@@ -67,7 +67,7 @@ func TestCluster_getThumbprint(t *testing.T) {
 	tb = cluster.getThumbprint("127.0.0.2:443")
 	assert.Equal(t, tb, "234")
 
-	//two api server no port, two thumbprint
+	// two api server no port, two thumbprint
 	cluster.endpoints[0].provider = &address{host: "127.0.0.1"}
 	cluster.endpoints[1].provider = &address{host: "127.0.0.2"}
 	tb = cluster.getThumbprint("127.0.0.1:443")
@@ -138,7 +138,7 @@ func TestCluster_Health(t *testing.T) {
 	addr := &address{host: "10.0.0.1", scheme: "https"}
 	addr1 := &address{host: "10.0.0.2", scheme: "https"}
 	addr2 := &address{host: "10.0.0.3", scheme: "https"}
-	eps := []*Endpoint{&Endpoint{status: DOWN}, &Endpoint{status: DOWN}, &Endpoint{status: DOWN}}
+	eps := []*Endpoint{{status: DOWN}, {status: DOWN}, {status: DOWN}}
 	eps[0].provider = addr
 	eps[1].provider = addr1
 	eps[2].provider = addr2
@@ -176,23 +176,22 @@ func TestCluster_enableFeature(t *testing.T) {
 }
 
 func TestCluster_validate(t *testing.T) {
-	miniVersion := [3]int64{3, 2, 0}
 	nsxVersion := &NsxVersion{}
 	nsxVersion.NodeVersion = "12"
 	expect := errors.New("error version format")
-	err := nsxVersion.Validate(miniVersion)
+	err := nsxVersion.Validate()
 	assert.Equal(t, err, expect)
 
 	nsxVersion.NodeVersion = "12.3"
-	err = nsxVersion.Validate(miniVersion)
+	err = nsxVersion.Validate()
 	assert.Equal(t, err, expect)
 
 	nsxVersion.NodeVersion = "3.2.3.3.0.18844962"
-	err = nsxVersion.Validate(miniVersion)
+	err = nsxVersion.Validate()
 	assert.Equal(t, err, nil)
 
 	nsxVersion.NodeVersion = "3.2.3"
-	err = nsxVersion.Validate(miniVersion)
+	err = nsxVersion.Validate()
 	assert.Equal(t, err, nil)
 }
 


### PR DESCRIPTION
SecurityPolicy service can only be activated from NSX 3.2.0 onwards.
This patch is to add nsx version check and activate SecurityPolicy service dynamically.
As a result, this dynamic NSX version check can support that NSX is upgraded
from 3.1.x to 3.2.x when nsx operator is running.