### PR TITLE
Enhance nsx version check per feature

### DIFF
--- a/pkg/controllers/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy_controller.go
@@ -61,9 +61,8 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Since securitypolicy service can only be activated from nsx 3.2.0 onwards,
 	// So need to check nsx version before starting securitypolicy Reconcile
-	if !r.Service.NSXClient.NSXCheckVersion() {
-		err := errors.New("NSX version check failed")
-		log.Error(err, "SecurityPolicy feature is not supported")
+	if !r.Service.NSXClient.NSXCheckVersionForSecurityPolicy() {
+		err := errors.New("NSX version check failed, SecurityPolicy feature is not supported")
 		updateFail(r, &ctx, obj, &err)
 		return resultRequeueAfter5mins, nil
 	}

--- a/pkg/controllers/securitypolicy_controller_test.go
+++ b/pkg/controllers/securitypolicy_controller_test.go
@@ -179,7 +179,7 @@ func TestSecurityPolicyReconciler_Reconcile(t *testing.T) {
 	_, err := r.Reconcile(ctx, req)
 	assert.Equal(t, err, errNotFound)
 
-	checkNsxVersionPatch := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient), "NSXCheckVersion", func(_ *nsx.Client) bool {
+	checkNsxVersionPatch := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient), "NSXCheckVersionForSecurityPolicy", func(_ *nsx.Client) bool {
 		return true
 	})
 	defer checkNsxVersionPatch.Reset()

--- a/pkg/nsx/client_test.go
+++ b/pkg/nsx/client_test.go
@@ -74,8 +74,8 @@ func TestGetClient(t *testing.T) {
 	client = GetClient(&cf)
 	patches.Reset()
 	assert.True(t, client != nil)
-	nsxVerionSupported := client.NSXCheckVersion()
-	assert.True(t, nsxVerionSupported == false)
+	securityPolicySupported := client.NSXCheckVersionForSecurityPolicy()
+	assert.True(t, securityPolicySupported == false)
 
 	patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
 		nsxVersion := &NsxVersion{NodeVersion: "3.2.1"}
@@ -84,8 +84,8 @@ func TestGetClient(t *testing.T) {
 	client = GetClient(&cf)
 	patches.Reset()
 	assert.True(t, client != nil)
-	nsxVerionSupported = client.NSXCheckVersion()
-	assert.True(t, nsxVerionSupported == true)
+	securityPolicySupported = client.NSXCheckVersionForSecurityPolicy()
+	assert.True(t, securityPolicySupported == true)
 }
 
 func IsInstanceOf(objectPtr, typePtr interface{}) bool {

--- a/pkg/nsx/cluster_test.go
+++ b/pkg/nsx/cluster_test.go
@@ -161,18 +161,25 @@ func TestCluster_Health(t *testing.T) {
 }
 
 func TestCluster_enableFeature(t *testing.T) {
-	miniVersion := [3]int64{3, 2, 0}
+	// Test case for enabling feature SecurityPolicy
 	nsxVersion := &NsxVersion{}
 	nsxVersion.NodeVersion = "3.1.3.3.0.18844962"
-	assert.False(t, nsxVersion.featureSupported(miniVersion))
+	assert.False(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
 	nsxVersion.NodeVersion = "3.2.0.3.0.18844962"
-	assert.True(t, nsxVersion.featureSupported(miniVersion))
+	assert.True(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
 	nsxVersion.NodeVersion = "3.11.0.3.0.18844962"
-	assert.True(t, nsxVersion.featureSupported(miniVersion))
+	assert.True(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
 	nsxVersion.NodeVersion = "4.1.0"
-	assert.True(t, nsxVersion.featureSupported(miniVersion))
+	assert.True(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
 	nsxVersion.NodeVersion = "3.2.0"
-	assert.True(t, nsxVersion.featureSupported(miniVersion))
+	assert.True(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
+
+	// Test case for invalid feature
+	feature := "notSecurityPolicy"
+	nsxVersion.NodeVersion = "3.1.3.3.0.18844962"
+	assert.False(t, nsxVersion.featureSupported(feature))
+	nsxVersion.NodeVersion = "3.2.0"
+	assert.False(t, nsxVersion.featureSupported(feature))
 }
 
 func TestCluster_validate(t *testing.T) {


### PR DESCRIPTION
This patch is to:
1. enhance nsx version check per feature.
2. read nsx version only from API request not from cached version,
   this is to avoid cached version not updated or mismatched with nsx manager.