### PR TITLE
Fix mixing staleGroups with staleRules when deleting legacy resources

### DIFF
--- a/pkg/nsx/services/firewall.go
+++ b/pkg/nsx/services/firewall.go
@@ -98,7 +98,7 @@ func (service *SecurityPolicyService) CreateOrUpdateSecurityPolicy(obj *v1alpha1
 	finalSecurityPolicy.Rules = finalRules
 
 	finalGroups := make([]model.Group, 0)
-	for i := len(staleRules) - 1; i >= 0; i-- { // Don't use range, it would copy the element
+	for i := len(staleGroups) - 1; i >= 0; i-- { // Don't use range, it would copy the element
 		staleGroups[i].MarkedForDelete = &MarkedForDelete // InfraClient need this field to delete the group
 	}
 	finalGroups = append(finalGroups, staleGroups...)


### PR DESCRIPTION
The process exits reporting panic: runtime error: index out of range [0] with length 0. It's an obvious error.
When there are stale rules and no stale groups, it would definitely hit this crashing down.