### PR TITLE
Fix ip 1.1.1.1 in wrap_test.go

### DIFF
--- a/pkg/nsx/services/securitypolicy/store_test.go
+++ b/pkg/nsx/services/securitypolicy/store_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func Test_queryTagCondition(t *testing.T) {
-	config2 := nsx.NewConfig("1.1.1.1", "1", "1", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
+	config2 := nsx.NewConfig("localhost", "1", "1", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster, _ := nsx.NewCluster(config2)
 	rc, _ := cluster.NewRestConnector()
 	service = &SecurityPolicyService{
@@ -72,7 +72,7 @@ func keyFunc2(obj interface{}) (string, error) {
 }
 
 func Test_queryGroup(t *testing.T) {
-	config := nsx.NewConfig("1.1.1.1", "1", "1", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
+	config := nsx.NewConfig("localhost", "1", "1", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster, _ := nsx.NewCluster(config)
 	rc, _ := cluster.NewRestConnector()
 	service = &SecurityPolicyService{
@@ -114,7 +114,7 @@ func Test_queryGroup(t *testing.T) {
 }
 
 func Test_querySecurityPolicy(t *testing.T) {
-	config := nsx.NewConfig("1.1.1.1", "1", "1", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
+	config := nsx.NewConfig("localhost", "1", "1", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster, _ := nsx.NewCluster(config)
 	rc, _ := cluster.NewRestConnector()
 	service = &SecurityPolicyService{
@@ -156,7 +156,7 @@ func Test_querySecurityPolicy(t *testing.T) {
 }
 
 func Test_queryRule(t *testing.T) {
-	config := nsx.NewConfig("1.1.1.1", "1", "1", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
+	config := nsx.NewConfig("localhost", "1", "1", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster, _ := nsx.NewCluster(config)
 	rc, _ := cluster.NewRestConnector()
 	service = &SecurityPolicyService{

--- a/pkg/nsx/services/securitypolicy/wrap_test.go
+++ b/pkg/nsx/services/securitypolicy/wrap_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func fakeService() *SecurityPolicyService {
-	c := nsx.NewConfig("1.1.1.1", "1", "1", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
+	c := nsx.NewConfig("localhost", "1", "1", "", 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster, _ := nsx.NewCluster(c)
 	rc, _ := cluster.NewRestConnector()
 	service = &SecurityPolicyService{


### PR DESCRIPTION
Client.Timeout exceeded while awaiting headers when failed to ping 1.1.1.1.