### PR TITLE
Add NSXServiceAccount Controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,12 @@ replace (
 	github.com/vmware/vsphere-automation-sdk-go/lib => github.com/TaoZou1/vsphere-automation-sdk-go/lib v0.5.2
 	github.com/vmware/vsphere-automation-sdk-go/runtime => github.com/TaoZou1/vsphere-automation-sdk-go/runtime v0.5.2
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt => github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt v0.9.3
+	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp => github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt-mp v0.3.1-0.20221020082725-84e89979deb6
 )
 
 require (
 	github.com/agiledragon/gomonkey v2.0.2+incompatible
-	github.com/agiledragon/gomonkey/v2 v2.4.0
+	github.com/agiledragon/gomonkey/v2 v2.9.0
 	github.com/coreos/go-semver v0.3.0
 	github.com/deckarep/golang-set v1.8.0
 	github.com/go-logr/logr v1.2.3
@@ -26,6 +27,7 @@ require (
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.5.0
 	github.com/vmware/vsphere-automation-sdk-go/runtime v0.5.0
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.6.0
+	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.3.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.5.0
 	golang.org/x/time v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -39,11 +39,13 @@ github.com/TaoZou1/vsphere-automation-sdk-go/runtime v0.5.2 h1:RgDmwSyqCOfMAGTfI
 github.com/TaoZou1/vsphere-automation-sdk-go/runtime v0.5.2/go.mod h1:GqC85noyNzapJN4vIAO9jJ1EKVo3+jCW4/2VTaMvuSg=
 github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt v0.9.3 h1:u7Qr1LRqz98ouREoRE5rZA5O4l8TtMG3NYkrZFYigBc=
 github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt v0.9.3/go.mod h1:9iS9n04yKlWA4AoVU6GpvMcFB7inP1D7kMyZb5RQVdM=
+github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt-mp v0.3.1-0.20221020082725-84e89979deb6 h1:sFObhyzxRrFCQvvZgVbWwAGyxUvhlom14Axv0Cjix90=
+github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt-mp v0.3.1-0.20221020082725-84e89979deb6/go.mod h1:75a9Rt4zCs3FA+pFi5HIMdNvl+5AHUDMCNblLZiErg4=
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
 github.com/agiledragon/gomonkey v2.0.2+incompatible h1:eXKi9/piiC3cjJD1658mEE2o3NjkJ5vDLgYjCQu0Xlw=
 github.com/agiledragon/gomonkey v2.0.2+incompatible/go.mod h1:2NGfXu1a80LLr2cmWXGBDaHEjb1idR6+FVlX5T3D9hw=
-github.com/agiledragon/gomonkey/v2 v2.4.0 h1:YDQJYiSQ8o78dCMXehU1E4F/Kh4jPX+MV+/iK/yfL7s=
-github.com/agiledragon/gomonkey/v2 v2.4.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
+github.com/agiledragon/gomonkey/v2 v2.9.0 h1:PDiKKybR596O6FHW+RVSG0Z7uGCBNbmbUXh3uCNQ7Hc=
+github.com/agiledragon/gomonkey/v2 v2.9.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,8 @@ type K8sConfig struct {
 	EnableRestore      bool   `ini:"enable_restore"`
 	EnablePromMetrics  bool   `ini:"enable_prometheus_metrics"`
 	KubeConfigFile     string `ini:"kubeconfig"`
+	// Controlled by FSS
+	EnableAntreaNSXInterworking bool `ini:"enable_antrea_nsx_interworking"`
 }
 
 type VCConfig struct {

--- a/pkg/controllers/common/types.go
+++ b/pkg/controllers/common/types.go
@@ -2,20 +2,21 @@ package common
 
 import (
 	"time"
-	
+
 	ctrl "sigs.k8s.io/controller-runtime"
-	
+
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/mediator"
 )
 
 const (
-	MetricResTypeSecurityPolicy = "securitypolicy"
+	MetricResTypeSecurityPolicy    = "securitypolicy"
+	MetricResTypeNSXServiceAccount = "nsxserviceaccount"
 )
 
 var (
 	ResultNormal            = ctrl.Result{}
 	ResultRequeue           = ctrl.Result{Requeue: true}
 	ResultRequeueAfter5mins = ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Minute}
-	
+
 	ServiceMediator = mediator.ServiceMediator{}
 )

--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
@@ -1,0 +1,236 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package nsxserviceaccount
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"time"
+
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	nsxvmwarecomv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/nsxserviceaccount"
+)
+
+var (
+	log                     = logger.Log
+	ResultNormal            = common.ResultNormal
+	ResultRequeue           = common.ResultRequeue
+	ResultRequeueAfter5mins = common.ResultRequeueAfter5mins
+	MetricResType           = common.MetricResTypeNSXServiceAccount
+)
+
+// NSXServiceAccountReconciler reconciles a NSXServiceAccount object
+type NSXServiceAccountReconciler struct {
+	client.Client
+	Scheme  *apimachineryruntime.Scheme
+	Service *nsxserviceaccount.NSXServiceAccountService
+}
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
+func (r *NSXServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	obj := &nsxvmwarecomv1alpha1.NSXServiceAccount{}
+	log.Info("reconciling CR", "nsxserviceaccount", req.NamespacedName)
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerSyncTotal, MetricResType)
+
+	if err := r.Client.Get(ctx, req.NamespacedName, obj); err != nil {
+		log.Error(err, "unable to fetch NSXServiceAccount CR", "req", req.NamespacedName)
+		return ResultNormal, client.IgnoreNotFound(err)
+	}
+
+	// Since NSXServiceAccount service can only be activated from NSX 4.1.0 onwards,
+	// So need to check NSX version before starting NSXServiceAccount reconcile
+	if !r.Service.NSXClient.NSXCheckVersionForNSXServiceAccount() {
+		err := errors.New("NSX version check failed, NSXServiceAccount feature is not supported")
+		updateFail(r, &ctx, obj, &err)
+		// if NSX version check fails, it will be put back to reconcile queue and be reconciled after 5 minutes
+		return ResultRequeueAfter5mins, nil
+	}
+
+	if obj.ObjectMeta.DeletionTimestamp.IsZero() {
+		metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateTotal, MetricResType)
+		if !controllerutil.ContainsFinalizer(obj, servicecommon.NSXServiceAccountFinalizerName) {
+			controllerutil.AddFinalizer(obj, servicecommon.NSXServiceAccountFinalizerName)
+			if err := r.Client.Update(ctx, obj); err != nil {
+				log.Error(err, "add finalizer", "nsxserviceaccount", req.NamespacedName)
+				updateFail(r, &ctx, obj, &err)
+				return ResultRequeue, err
+			}
+			log.V(1).Info("added finalizer on CR", "nsxserviceaccount", req.NamespacedName)
+		}
+
+		if obj.Status.Phase == nsxvmwarecomv1alpha1.NSXServiceAccountPhaseRealized {
+			return ResultNormal, nil
+		}
+		if err := r.Service.CreateOrUpdateNSXServiceAccount(ctx, obj); err != nil {
+			log.Error(err, "operate failed, would retry exponentially", "nsxserviceaccount", req.NamespacedName)
+			updateFail(r, &ctx, obj, &err)
+			return ResultRequeue, err
+		}
+		updateSuccess(r, &ctx, obj)
+	} else {
+		if controllerutil.ContainsFinalizer(obj, servicecommon.NSXServiceAccountFinalizerName) {
+			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, MetricResType)
+			if err := r.Service.DeleteNSXServiceAccount(ctx, types.NamespacedName{
+				Namespace: obj.Namespace,
+				Name:      obj.Name,
+			}); err != nil {
+				log.Error(err, "deleting failed, would retry exponentially", "nsxserviceaccount", req.NamespacedName)
+				deleteFail(r, &ctx, obj, &err)
+				return ResultRequeue, err
+			}
+			controllerutil.RemoveFinalizer(obj, servicecommon.NSXServiceAccountFinalizerName)
+			if err := r.Client.Update(ctx, obj); err != nil {
+				log.Error(err, "removing finalizer failed, would retry exponentially", "nsxserviceaccount", req.NamespacedName)
+				deleteFail(r, &ctx, obj, &err)
+				return ResultRequeue, err
+			}
+			log.V(1).Info("removed finalizer", "nsxserviceaccount", req.NamespacedName)
+			deleteSuccess(r, &ctx, obj)
+		} else {
+			// only print a message because it's not a normal case
+			log.Info("finalizers cannot be recognized", "nsxserviceaccount", req.NamespacedName)
+		}
+	}
+
+	return ResultNormal, nil
+}
+
+// setupWithManager sets up the controller with the Manager.
+func (r *NSXServiceAccountReconciler) setupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&nsxvmwarecomv1alpha1.NSXServiceAccount{}).
+		WithEventFilter(predicate.Funcs{
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				// Suppress Delete events to avoid filtering them out in the Reconcile function
+				return false
+			},
+		}).
+		WithOptions(
+			controller.Options{
+				MaxConcurrentReconciles: runtime.NumCPU(),
+			}).
+		Complete(r)
+}
+
+// Start setup manager and launch GC
+func (r *NSXServiceAccountReconciler) Start(mgr ctrl.Manager) error {
+	err := r.setupWithManager(mgr)
+	if err != nil {
+		return err
+	}
+
+	go r.GarbageCollector(make(chan bool), servicecommon.GCInterval)
+	return nil
+}
+
+// GarbageCollector collect NSXServiceAccount which has been removed from crd.
+// cancel is used to break the loop during UT
+func (r *NSXServiceAccountReconciler) GarbageCollector(cancel chan bool, timeout time.Duration) {
+	ctx := context.Background()
+	log.Info("garbage collector started")
+	for {
+		select {
+		case <-cancel:
+			return
+		case <-time.After(timeout):
+		}
+		nsxServiceAccountUIDSet := r.Service.ListNSXServiceAccountRealization()
+		if len(nsxServiceAccountUIDSet) == 0 {
+			continue
+		}
+		nsxServiceAccountList := &nsxvmwarecomv1alpha1.NSXServiceAccountList{}
+		err := r.Client.List(ctx, nsxServiceAccountList)
+		if err != nil {
+			log.Error(err, "failed to list NSXServiceAccount CR")
+			continue
+		}
+		gcSuccessCount, gcErrorCount := r.garbageCollector(nsxServiceAccountUIDSet, nsxServiceAccountList)
+		log.V(1).Info("gc collects NSXServiceAccount CR", "success", gcSuccessCount, "error", gcErrorCount)
+	}
+}
+
+func (r *NSXServiceAccountReconciler) garbageCollector(nsxServiceAccountUIDSet sets.String, nsxServiceAccountList *nsxvmwarecomv1alpha1.NSXServiceAccountList) (gcSuccessCount, gcErrorCount uint32) {
+	nsxServiceAccountCRUIDMap := map[string]types.NamespacedName{}
+	for _, nsxServiceAccount := range nsxServiceAccountList.Items {
+		nsxServiceAccountCRUIDMap[string(nsxServiceAccount.UID)] = types.NamespacedName{
+			Namespace: nsxServiceAccount.Namespace,
+			Name:      nsxServiceAccount.Name,
+		}
+	}
+
+	for nsxServiceAccountUID := range nsxServiceAccountUIDSet {
+		if _, ok := nsxServiceAccountCRUIDMap[nsxServiceAccountUID]; ok {
+			continue
+		}
+		log.V(1).Info("gc collects NSXServiceAccount CR", "UID", nsxServiceAccountUID)
+		namespacedName := r.Service.GetNSXServiceAccountNameByUID(nsxServiceAccountUID)
+		if namespacedName.Namespace == "" || namespacedName.Name == "" {
+			continue
+		}
+		metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, MetricResType)
+		err := r.Service.DeleteNSXServiceAccount(context.TODO(), namespacedName)
+		if err != nil {
+			gcErrorCount++
+			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteFailTotal, MetricResType)
+		} else {
+			gcSuccessCount++
+			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteSuccessTotal, MetricResType)
+		}
+	}
+	return
+}
+
+func (r *NSXServiceAccountReconciler) updateNSXServiceAccountStatus(ctx *context.Context, o *nsxvmwarecomv1alpha1.NSXServiceAccount, e *error) {
+	obj := o
+	if e != nil && *e != nil {
+		obj = o.DeepCopy()
+		obj.Status.Phase = nsxvmwarecomv1alpha1.NSXServiceAccountPhaseFailed
+		obj.Status.Reason = fmt.Sprintf("Error: %v", *e)
+	}
+	err := r.Client.Status().Update(*ctx, obj)
+	if err != nil {
+		log.Error(err, "update NSXServiceAccount failed", "Namespace", obj.Namespace, "Name", obj.Name, "Status", obj.Status)
+	} else {
+		log.V(1).Info("updated NSXServiceAccount", "Namespace", obj.Namespace, "Name", obj.Name, "Status", obj.Status)
+	}
+}
+
+func updateFail(r *NSXServiceAccountReconciler, c *context.Context, o *nsxvmwarecomv1alpha1.NSXServiceAccount, e *error) {
+	r.updateNSXServiceAccountStatus(c, o, e)
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateFailTotal, MetricResType)
+}
+
+func deleteFail(r *NSXServiceAccountReconciler, c *context.Context, o *nsxvmwarecomv1alpha1.NSXServiceAccount, e *error) {
+	r.updateNSXServiceAccountStatus(c, o, e)
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteFailTotal, MetricResType)
+}
+
+func updateSuccess(r *NSXServiceAccountReconciler, c *context.Context, o *nsxvmwarecomv1alpha1.NSXServiceAccount) {
+	r.updateNSXServiceAccountStatus(c, o, nil)
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateSuccessTotal, MetricResType)
+}
+
+func deleteSuccess(r *NSXServiceAccountReconciler, _ *context.Context, _ *nsxvmwarecomv1alpha1.NSXServiceAccount) {
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteSuccessTotal, MetricResType)
+}

--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
@@ -1,0 +1,777 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package nsxserviceaccount
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	gomonkey "github.com/agiledragon/gomonkey/v2"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	nsxvmwarecomv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/nsxserviceaccount"
+)
+
+func newFakeNSXServiceAccountReconciler() *NSXServiceAccountReconciler {
+	return &NSXServiceAccountReconciler{
+		Client:  fake.NewClientBuilder().Build(),
+		Scheme:  fake.NewClientBuilder().Build().Scheme(),
+		Service: nil,
+	}
+}
+
+func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
+	deletionTimestamp := &metav1.Time{
+		Time: time.Date(1, time.January, 15, 0, 0, 0, 0, time.Local),
+	}
+	type args struct {
+		req controllerruntime.Request
+	}
+	requestArgs := args{
+		req: controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "name"}},
+	}
+	tests := []struct {
+		name        string
+		prepareFunc func(*testing.T, *NSXServiceAccountReconciler, context.Context) *gomonkey.Patches
+		args        args
+		want        controllerruntime.Result
+		wantErr     bool
+		expectedCR  *nsxvmwarecomv1alpha1.NSXServiceAccount
+	}{
+		{
+			name:        "NotFound",
+			prepareFunc: nil,
+			args:        requestArgs,
+			want:        ResultNormal,
+			wantErr:     false,
+			expectedCR:  nil,
+		},
+		{
+			name: "NSXVersionCheckFailed",
+			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: requestArgs.req.Namespace,
+						Name:      requestArgs.req.Name,
+					},
+				}))
+				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersionForNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{false},
+					Times:  1,
+				}})
+				return
+			},
+			args:    requestArgs,
+			want:    ResultRequeueAfter5mins,
+			wantErr: false,
+			expectedCR: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       requestArgs.req.Namespace,
+					Name:            requestArgs.req.Name,
+					ResourceVersion: "2",
+				},
+				Spec: nsxvmwarecomv1alpha1.NSXServiceAccountSpec{},
+				Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{
+					Phase:  nsxvmwarecomv1alpha1.NSXServiceAccountPhaseFailed,
+					Reason: "Error: NSX version check failed, NSXServiceAccount feature is not supported",
+				},
+			},
+		},
+		{
+			name: "AddFinalizerFailed",
+			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: requestArgs.req.Namespace,
+						Name:      requestArgs.req.Name,
+					},
+				}))
+				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersionForNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{true},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(r.Client, "Update", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{fmt.Errorf("mock error")},
+					Times:  1,
+				}, {
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				return
+			},
+			args:    requestArgs,
+			want:    ResultRequeue,
+			wantErr: true,
+			expectedCR: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       requestArgs.req.Namespace,
+					Name:            requestArgs.req.Name,
+					ResourceVersion: "1",
+				},
+				Spec:   nsxvmwarecomv1alpha1.NSXServiceAccountSpec{},
+				Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{},
+			},
+		},
+		{
+			name: "CreateError",
+			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: requestArgs.req.Namespace,
+						Name:      requestArgs.req.Name,
+					},
+				}))
+				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersionForNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{true},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(r.Service, "CreateOrUpdateNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{fmt.Errorf("mock error")},
+					Times:  1,
+				}})
+				return
+			},
+			args:    requestArgs,
+			want:    ResultRequeue,
+			wantErr: true,
+			expectedCR: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       requestArgs.req.Namespace,
+					Name:            requestArgs.req.Name,
+					Finalizers:      []string{servicecommon.NSXServiceAccountFinalizerName},
+					ResourceVersion: "3",
+				},
+				Spec: nsxvmwarecomv1alpha1.NSXServiceAccountSpec{},
+				Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{
+					Phase:  nsxvmwarecomv1alpha1.NSXServiceAccountPhaseFailed,
+					Reason: "Error: mock error",
+				},
+			},
+		},
+		{
+			name: "CreateSkip",
+			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: requestArgs.req.Namespace,
+						Name:      requestArgs.req.Name,
+					},
+					Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{
+						Phase: nsxvmwarecomv1alpha1.NSXServiceAccountPhaseRealized,
+					},
+				}))
+				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersionForNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{true},
+					Times:  1,
+				}})
+				return
+			},
+			args:    requestArgs,
+			want:    ResultNormal,
+			wantErr: false,
+			expectedCR: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       requestArgs.req.Namespace,
+					Name:            requestArgs.req.Name,
+					Finalizers:      []string{servicecommon.NSXServiceAccountFinalizerName},
+					ResourceVersion: "2",
+				},
+				Spec: nsxvmwarecomv1alpha1.NSXServiceAccountSpec{},
+				Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{
+					Phase: nsxvmwarecomv1alpha1.NSXServiceAccountPhaseRealized,
+				},
+			},
+		},
+		{
+			name: "CreateSuccess",
+			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: requestArgs.req.Namespace,
+						Name:      requestArgs.req.Name,
+					},
+				}))
+				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersionForNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{true},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(r.Service, "CreateOrUpdateNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				return
+			},
+			args:    requestArgs,
+			want:    ResultNormal,
+			wantErr: false,
+			expectedCR: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       requestArgs.req.Namespace,
+					Name:            requestArgs.req.Name,
+					Finalizers:      []string{servicecommon.NSXServiceAccountFinalizerName},
+					ResourceVersion: "3",
+				},
+				Spec:   nsxvmwarecomv1alpha1.NSXServiceAccountSpec{},
+				Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{},
+			},
+		},
+		{
+			name: "DeleteWithoutFinalizer",
+			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         requestArgs.req.Namespace,
+						Name:              requestArgs.req.Name,
+						DeletionTimestamp: deletionTimestamp,
+					},
+				}))
+				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersionForNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{true},
+					Times:  1,
+				}})
+				return
+			},
+			args:    requestArgs,
+			want:    ResultNormal,
+			wantErr: false,
+			expectedCR: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         requestArgs.req.Namespace,
+					Name:              requestArgs.req.Name,
+					DeletionTimestamp: deletionTimestamp,
+					ResourceVersion:   "1",
+				},
+				Spec:   nsxvmwarecomv1alpha1.NSXServiceAccountSpec{},
+				Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{},
+			},
+		},
+		{
+			name: "DeleteError",
+			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         requestArgs.req.Namespace,
+						Name:              requestArgs.req.Name,
+						DeletionTimestamp: deletionTimestamp,
+						Finalizers:        []string{servicecommon.NSXServiceAccountFinalizerName},
+					},
+				}))
+				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersionForNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{true},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(r.Service, "DeleteNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{fmt.Errorf("mock error")},
+					Times:  1,
+				}})
+				return
+			},
+			args:    requestArgs,
+			want:    ResultRequeue,
+			wantErr: true,
+			expectedCR: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         requestArgs.req.Namespace,
+					Name:              requestArgs.req.Name,
+					DeletionTimestamp: deletionTimestamp,
+					Finalizers:        []string{servicecommon.NSXServiceAccountFinalizerName},
+					ResourceVersion:   "2",
+				},
+				Spec: nsxvmwarecomv1alpha1.NSXServiceAccountSpec{},
+				Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{
+					Phase:  nsxvmwarecomv1alpha1.NSXServiceAccountPhaseFailed,
+					Reason: "Error: mock error",
+				},
+			},
+		},
+		{
+			name: "RemoveFinalizerFailed",
+			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         requestArgs.req.Namespace,
+						Name:              requestArgs.req.Name,
+						DeletionTimestamp: deletionTimestamp,
+						Finalizers:        []string{servicecommon.NSXServiceAccountFinalizerName},
+					},
+				}))
+				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersionForNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{true},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(r.Service, "DeleteNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(r.Client, "Update", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{fmt.Errorf("mock error")},
+					Times:  1,
+				}, {
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				return
+			},
+			args:    requestArgs,
+			want:    ResultRequeue,
+			wantErr: true,
+			expectedCR: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         requestArgs.req.Namespace,
+					Name:              requestArgs.req.Name,
+					DeletionTimestamp: deletionTimestamp,
+					Finalizers:        []string{servicecommon.NSXServiceAccountFinalizerName},
+					ResourceVersion:   "1",
+				},
+				Spec:   nsxvmwarecomv1alpha1.NSXServiceAccountSpec{},
+				Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{},
+			},
+		},
+		{
+			name: "DeleteSuccess",
+			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         requestArgs.req.Namespace,
+						Name:              requestArgs.req.Name,
+						DeletionTimestamp: deletionTimestamp,
+						Finalizers:        []string{servicecommon.NSXServiceAccountFinalizerName},
+					},
+				}))
+				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersionForNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{true},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(r.Service, "DeleteNSXServiceAccount", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				return
+			},
+			args:       requestArgs,
+			want:       ResultNormal,
+			wantErr:    false,
+			expectedCR: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newFakeNSXServiceAccountReconciler()
+			nsxvmwarecomv1alpha1.AddToScheme(r.Scheme)
+			r.Service = &nsxserviceaccount.NSXServiceAccountService{
+				Service: servicecommon.Service{
+					NSXClient: &nsx.Client{},
+					NSXConfig: &config.NSXOperatorConfig{
+						NsxConfig: &config.NsxConfig{
+							EnforcementPoint: "vmc-enforcementpoint",
+						},
+					},
+				},
+			}
+			ctx := context.TODO()
+			if tt.prepareFunc != nil {
+				patches := tt.prepareFunc(t, r, ctx)
+				defer patches.Reset()
+			}
+
+			got, err := r.Reconcile(ctx, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			fmt.Printf("err: %+v", err)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Reconcile() got = %v, want %v", got, tt.want)
+			}
+			actualCR := &nsxvmwarecomv1alpha1.NSXServiceAccount{}
+			err = r.Client.Get(ctx, tt.args.req.NamespacedName, actualCR)
+			if tt.expectedCR == nil {
+				assert.True(t, errors.IsNotFound(err))
+			} else {
+				assert.Equal(t, tt.expectedCR.ObjectMeta, actualCR.ObjectMeta)
+				assert.Equal(t, tt.expectedCR.Spec, actualCR.Spec)
+				assert.Equal(t, tt.expectedCR.Status, actualCR.Status)
+			}
+		})
+	}
+}
+
+func TestNSXServiceAccountReconciler_GarbageCollector(t *testing.T) {
+	tagScopeNamespace := servicecommon.TagScopeNamespace
+	tagScopeNSXServiceAccountCRName := servicecommon.TagScopeNSXServiceAccountCRName
+	tagScopeNSXServiceAccountCRUID := servicecommon.TagScopeNSXServiceAccountCRUID
+	tests := []struct {
+		name        string
+		prepareFunc func(*testing.T, *NSXServiceAccountReconciler, context.Context) *gomonkey.Patches
+	}{
+		{name: "empty"},
+		{
+			name: "ListCRError",
+			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) *gomonkey.Patches {
+				namespace2 := "ns2"
+				name2 := "name2"
+				clusterName2 := "cl1-ns2-name2"
+				uid2 := "00000000-0000-0000-0000-000000000002"
+				assert.NoError(t, r.Service.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{
+					Name: &clusterName2,
+					Tags: []mpmodel.Tag{{
+						Scope: &tagScopeNamespace,
+						Tag:   &namespace2,
+					}, {
+						Scope: &tagScopeNSXServiceAccountCRName,
+						Tag:   &name2,
+					}, {
+						Scope: &tagScopeNSXServiceAccountCRUID,
+						Tag:   &uid2,
+					}},
+				}))
+				return gomonkey.ApplyMethodSeq(r.Client, "List", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{fmt.Errorf("mock error")},
+					Times:  1,
+				}})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newFakeNSXServiceAccountReconciler()
+			r.Service = &nsxserviceaccount.NSXServiceAccountService{
+				Service: servicecommon.Service{
+					NSXClient: &nsx.Client{},
+					NSXConfig: &config.NSXOperatorConfig{
+						NsxConfig: &config.NsxConfig{
+							EnforcementPoint: "vmc-enforcementpoint",
+						},
+					},
+				},
+			}
+			r.Service.SetUpStore()
+			ctx := context.TODO()
+			cancel := make(chan bool)
+			if tt.prepareFunc != nil {
+				patches := tt.prepareFunc(t, r, ctx)
+				defer patches.Reset()
+			}
+
+			go func() {
+				time.Sleep(150 * time.Millisecond)
+				cancel <- true
+			}()
+			r.GarbageCollector(cancel, 100*time.Millisecond)
+		})
+	}
+}
+
+func TestNSXServiceAccountReconciler_Start(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	service := &nsxserviceaccount.NSXServiceAccountService{}
+	r := &NSXServiceAccountReconciler{
+		Client:  k8sClient,
+		Scheme:  nil,
+		Service: service,
+	}
+	assert.Error(t, r.Start(nil))
+}
+
+func TestNSXServiceAccountReconciler_updateNSXServiceAccountStatus(t *testing.T) {
+	ctx := context.TODO()
+	err := fmt.Errorf("test error")
+	type args struct {
+		ctx *context.Context
+		o   *nsxvmwarecomv1alpha1.NSXServiceAccount
+		e   *error
+	}
+	tests := []struct {
+		name     string
+		initial  args
+		args     args
+		expected args
+	}{
+		{
+			name: "success",
+			initial: args{
+				o: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name1",
+						Namespace: "ns1",
+					},
+				},
+			},
+			args: args{
+				ctx: &ctx,
+				o: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "name1",
+						Namespace:       "ns1",
+						ResourceVersion: "1",
+					},
+					Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{
+						Phase:          nsxvmwarecomv1alpha1.NSXServiceAccountPhaseRealized,
+						Reason:         "testReason",
+						VPCPath:        "testVPCPath",
+						NSXManagers:    []string{"dummyHost:443"},
+						ProxyEndpoints: nsxvmwarecomv1alpha1.NSXProxyEndpoint{},
+						ClusterID:      "testClusterID",
+						ClusterName:    "testClusterName",
+						Secrets: []nsxvmwarecomv1alpha1.NSXSecret{{
+							Name:      "testSecret",
+							Namespace: "ns1",
+						}},
+					},
+				},
+				e: nil,
+			},
+			expected: args{
+				o: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "name1",
+						Namespace:       "ns1",
+						ResourceVersion: "2",
+					},
+					Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{
+						Phase:          nsxvmwarecomv1alpha1.NSXServiceAccountPhaseRealized,
+						Reason:         "testReason",
+						VPCPath:        "testVPCPath",
+						NSXManagers:    []string{"dummyHost:443"},
+						ProxyEndpoints: nsxvmwarecomv1alpha1.NSXProxyEndpoint{},
+						ClusterID:      "testClusterID",
+						ClusterName:    "testClusterName",
+						Secrets: []nsxvmwarecomv1alpha1.NSXSecret{{
+							Name:      "testSecret",
+							Namespace: "ns1",
+						}},
+					},
+				},
+				e: nil,
+			},
+		},
+		{
+			name: "error",
+			initial: args{
+				o: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name1",
+						Namespace: "ns1",
+					},
+				},
+			},
+			args: args{
+				ctx: &ctx,
+				o: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "name1",
+						Namespace:       "ns1",
+						ResourceVersion: "1",
+					},
+					Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{
+						Phase:          nsxvmwarecomv1alpha1.NSXServiceAccountPhaseInProgress,
+						Reason:         "testReason",
+						VPCPath:        "testVPCPath",
+						NSXManagers:    []string{"dummyHost:443"},
+						ProxyEndpoints: nsxvmwarecomv1alpha1.NSXProxyEndpoint{},
+						ClusterID:      "testClusterID",
+						ClusterName:    "testClusterName",
+						Secrets: []nsxvmwarecomv1alpha1.NSXSecret{{
+							Name:      "testSecret",
+							Namespace: "ns1",
+						}},
+					},
+				},
+				e: &err,
+			},
+			expected: args{
+				o: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "name1",
+						Namespace:       "ns1",
+						ResourceVersion: "2",
+					},
+					Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{
+						Phase:          nsxvmwarecomv1alpha1.NSXServiceAccountPhaseFailed,
+						Reason:         "Error: test error",
+						VPCPath:        "testVPCPath",
+						NSXManagers:    []string{"dummyHost:443"},
+						ProxyEndpoints: nsxvmwarecomv1alpha1.NSXProxyEndpoint{},
+						ClusterID:      "testClusterID",
+						ClusterName:    "testClusterName",
+						Secrets: []nsxvmwarecomv1alpha1.NSXSecret{{
+							Name:      "testSecret",
+							Namespace: "ns1",
+						}},
+					},
+				},
+				e: nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newFakeNSXServiceAccountReconciler()
+			nsxvmwarecomv1alpha1.AddToScheme(r.Scheme)
+			assert.NoError(t, r.Client.Create(ctx, tt.initial.o))
+
+			r.updateNSXServiceAccountStatus(tt.args.ctx, tt.args.o, tt.args.e)
+			actualNSXServiceAccount := &nsxvmwarecomv1alpha1.NSXServiceAccount{}
+			assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{
+				Namespace: tt.args.o.Namespace,
+				Name:      tt.args.o.Name,
+			}, actualNSXServiceAccount))
+			assert.Equal(t, tt.expected.o.ObjectMeta, actualNSXServiceAccount.ObjectMeta)
+			assert.Equal(t, tt.expected.o.Spec, actualNSXServiceAccount.Spec)
+			assert.Equal(t, tt.expected.o.Status, actualNSXServiceAccount.Status)
+		})
+	}
+}
+
+func TestNSXServiceAccountReconciler_garbageCollector(t *testing.T) {
+	tagScopeNamespace := servicecommon.TagScopeNamespace
+	tagScopeNSXServiceAccountCRName := servicecommon.TagScopeNSXServiceAccountCRName
+	tagScopeNSXServiceAccountCRUID := servicecommon.TagScopeNSXServiceAccountCRUID
+	type args struct {
+		nsxServiceAccountUIDSet sets.String
+		nsxServiceAccountList   *nsxvmwarecomv1alpha1.NSXServiceAccountList
+	}
+	tests := []struct {
+		name               string
+		prepareFunc        func(*testing.T, *NSXServiceAccountReconciler, context.Context) *gomonkey.Patches
+		args               args
+		wantGcSuccessCount uint32
+		wantGcErrorCount   uint32
+	}{
+		{
+			name: "Delete",
+			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) *gomonkey.Patches {
+				namespace2 := "ns2"
+				name2 := "name2"
+				clusterName2 := "cl1-ns2-name2"
+				uid2 := "00000000-0000-0000-0000-000000000002"
+				assert.NoError(t, r.Service.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{
+					Name: &clusterName2,
+					Tags: []mpmodel.Tag{{
+						Scope: &tagScopeNamespace,
+						Tag:   &namespace2,
+					}, {
+						Scope: &tagScopeNSXServiceAccountCRName,
+						Tag:   &name2,
+					}, {
+						Scope: &tagScopeNSXServiceAccountCRUID,
+						Tag:   &uid2,
+					}},
+				}))
+				namespace3 := "ns3"
+				name3 := "name3"
+				clusterName3 := "cl1-ns3-name3"
+				uid3 := "00000000-0000-0000-0000-000000000003"
+				assert.NoError(t, r.Service.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{
+					Name: &clusterName3,
+					Tags: []mpmodel.Tag{{
+						Scope: &tagScopeNamespace,
+						Tag:   &namespace3,
+					}, {
+						Scope: &tagScopeNSXServiceAccountCRName,
+						Tag:   &name3,
+					}, {
+						Scope: &tagScopeNSXServiceAccountCRUID,
+						Tag:   &uid3,
+					}},
+				}))
+				namespace4 := "ns4"
+				name4 := "name4"
+				clusterName4 := "cl1-ns4-name4"
+				uid4 := "00000000-0000-0000-0000-000000000004"
+				assert.NoError(t, r.Service.ClusterControlPlaneStore.Add(model.ClusterControlPlane{
+					Id: &clusterName4,
+					Tags: []model.Tag{{
+						Scope: &tagScopeNamespace,
+						Tag:   &namespace4,
+					}, {
+						Scope: &tagScopeNSXServiceAccountCRName,
+						Tag:   &name4,
+					}, {
+						Scope: &tagScopeNSXServiceAccountCRUID,
+						Tag:   &uid4,
+					}},
+				}))
+				count := 0
+				return gomonkey.ApplyMethodFunc(r.Service, "DeleteNSXServiceAccount", func(ctx context.Context, namespacedName types.NamespacedName) error {
+					count++
+					if count == 1 && namespacedName.Namespace == "ns3" {
+						return nil
+					} else if count == 2 && namespacedName.Namespace == "ns4" {
+						return fmt.Errorf("mock error")
+					}
+					t.Errorf("wrong DeleteNSXServiceAccount call, seq: %d, namespacedName: %v", count, namespacedName)
+					return nil
+				})
+			},
+			args: args{
+				nsxServiceAccountUIDSet: sets.NewString("00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000003", "00000000-0000-0000-0000-000000000004"),
+				nsxServiceAccountList: &nsxvmwarecomv1alpha1.NSXServiceAccountList{Items: []nsxvmwarecomv1alpha1.NSXServiceAccount{{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "ns1",
+						Name:       "name1",
+						UID:        "00000000-0000-0000-0000-000000000001",
+						Finalizers: []string{servicecommon.NSXServiceAccountFinalizerName},
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "ns2",
+						Name:       "name2",
+						UID:        "00000000-0000-0000-0000-000000000002",
+						Finalizers: []string{servicecommon.NSXServiceAccountFinalizerName},
+					},
+				}}},
+			},
+			wantGcSuccessCount: 1,
+			wantGcErrorCount:   1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newFakeNSXServiceAccountReconciler()
+			r.Service = &nsxserviceaccount.NSXServiceAccountService{
+				Service: servicecommon.Service{
+					NSXClient: &nsx.Client{},
+					NSXConfig: &config.NSXOperatorConfig{
+						NsxConfig: &config.NsxConfig{
+							EnforcementPoint: "vmc-enforcementpoint",
+						},
+					},
+				},
+			}
+			r.Service.SetUpStore()
+			ctx := context.TODO()
+			if tt.prepareFunc != nil {
+				patches := tt.prepareFunc(t, r, ctx)
+				defer patches.Reset()
+			}
+
+			gotGcSuccessCount, gotGcErrorCount := r.garbageCollector(tt.args.nsxServiceAccountUIDSet, tt.args.nsxServiceAccountList)
+			if gotGcSuccessCount != tt.wantGcSuccessCount {
+				t.Errorf("garbageCollector() gotGcSuccessCount = %v, want %v", gotGcSuccessCount, tt.wantGcSuccessCount)
+			}
+			if gotGcErrorCount != tt.wantGcErrorCount {
+				t.Errorf("garbageCollector() gotGcErrorCount = %v, want %v", gotGcErrorCount, tt.wantGcErrorCount)
+			}
+		})
+	}
+}

--- a/pkg/nsx/client_test.go
+++ b/pkg/nsx/client_test.go
@@ -76,6 +76,7 @@ func TestGetClient(t *testing.T) {
 	assert.True(t, client != nil)
 	securityPolicySupported := client.NSXCheckVersionForSecurityPolicy()
 	assert.True(t, securityPolicySupported == false)
+	assert.False(t, client.NSXCheckVersionForNSXServiceAccount())
 
 	patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
 		nsxVersion := &NsxVersion{NodeVersion: "3.2.1"}
@@ -86,6 +87,18 @@ func TestGetClient(t *testing.T) {
 	assert.True(t, client != nil)
 	securityPolicySupported = client.NSXCheckVersionForSecurityPolicy()
 	assert.True(t, securityPolicySupported == true)
+	assert.False(t, client.NSXCheckVersionForNSXServiceAccount())
+
+	patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
+		nsxVersion := &NsxVersion{NodeVersion: "4.1.0"}
+		return nsxVersion, nil
+	})
+	client = GetClient(&cf)
+	patches.Reset()
+	assert.True(t, client != nil)
+	securityPolicySupported = client.NSXCheckVersionForSecurityPolicy()
+	assert.True(t, securityPolicySupported == true)
+	assert.True(t, client.NSXCheckVersionForNSXServiceAccount())
 }
 
 func IsInstanceOf(objectPtr, typePtr interface{}) bool {

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -265,8 +265,12 @@ func (nsxVersion *NsxVersion) Validate() error {
 func (nsxVersion *NsxVersion) featureSupported(feature string) bool {
 	var minVersion [3]int64
 	validFeature := false
-	if feature == FeatureSecurityPolicy {
+	switch feature {
+	case FeatureSecurityPolicy:
 		minVersion = nsx320Version
+		validFeature = true
+	case FeatureNSXServiceAccount:
+		minVersion = nsx401Version
 		validFeature = true
 	}
 	if validFeature {

--- a/pkg/nsx/cluster_test.go
+++ b/pkg/nsx/cluster_test.go
@@ -165,14 +165,28 @@ func TestCluster_enableFeature(t *testing.T) {
 	nsxVersion := &NsxVersion{}
 	nsxVersion.NodeVersion = "3.1.3.3.0.18844962"
 	assert.False(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
+	assert.False(t, nsxVersion.featureSupported(FeatureNSXServiceAccount))
 	nsxVersion.NodeVersion = "3.2.0.3.0.18844962"
 	assert.True(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
+	assert.False(t, nsxVersion.featureSupported(FeatureNSXServiceAccount))
 	nsxVersion.NodeVersion = "3.11.0.3.0.18844962"
 	assert.True(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
+	assert.False(t, nsxVersion.featureSupported(FeatureNSXServiceAccount))
+	nsxVersion.NodeVersion = "4.0.0"
+	assert.True(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
+	assert.False(t, nsxVersion.featureSupported(FeatureNSXServiceAccount))
+	nsxVersion.NodeVersion = "4.0.1"
+	assert.True(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
+	assert.True(t, nsxVersion.featureSupported(FeatureNSXServiceAccount))
 	nsxVersion.NodeVersion = "4.1.0"
 	assert.True(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
+	assert.True(t, nsxVersion.featureSupported(FeatureNSXServiceAccount))
 	nsxVersion.NodeVersion = "3.2.0"
 	assert.True(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
+	assert.False(t, nsxVersion.featureSupported(FeatureNSXServiceAccount))
+	nsxVersion.NodeVersion = "4.2.0"
+	assert.True(t, nsxVersion.featureSupported(FeatureSecurityPolicy))
+	assert.True(t, nsxVersion.featureSupported(FeatureNSXServiceAccount))
 
 	// Test case for invalid feature
 	feature := "notSecurityPolicy"

--- a/pkg/nsx/services/common/builder.go
+++ b/pkg/nsx/services/common/builder.go
@@ -1,0 +1,37 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+func QueryTagCondition(resourceType, cluster string) string {
+	return fmt.Sprintf("%s:%s AND tags.scope:%s AND tags.tag:%s",
+		ResourceType, resourceType,
+		strings.Replace(TagScopeCluster, "/", "\\/", -1),
+		strings.Replace(cluster, ":", "\\:", -1))
+}
+
+func ConvertTagsToMPTags(tags []model.Tag) []mpmodel.Tag {
+	mpTags := make([]mpmodel.Tag, len(tags))
+	for i := 0; i < len(tags); i++ {
+		mpTags[i].Scope = tags[i].Scope
+		mpTags[i].Tag = tags[i].Tag
+	}
+	return mpTags
+}
+
+func ConvertMPTagsToTags(mpTags []mpmodel.Tag) []model.Tag {
+	tags := make([]model.Tag, len(mpTags))
+	for i := 0; i < len(mpTags); i++ {
+		tags[i].Scope = mpTags[i].Scope
+		tags[i].Tag = mpTags[i].Tag
+	}
+	return tags
+}

--- a/pkg/nsx/services/common/builder_test.go
+++ b/pkg/nsx/services/common/builder_test.go
@@ -1,0 +1,120 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package common
+
+import (
+	"reflect"
+	"testing"
+
+	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+func TestConvertMPTagsToTags(t *testing.T) {
+	scope, tag := "scope1", "tag1"
+	type args struct {
+		mpTags []mpmodel.Tag
+	}
+	tests := []struct {
+		name string
+		args args
+		want []model.Tag
+	}{
+		{
+			name: "nil",
+			args: args{
+				mpTags: nil,
+			},
+			want: []model.Tag{},
+		},
+		{
+			name: "standard",
+			args: args{
+				mpTags: []mpmodel.Tag{{
+					Scope: &scope,
+					Tag:   &tag,
+				}},
+			},
+			want: []model.Tag{{
+				Scope: &scope,
+				Tag:   &tag,
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConvertMPTagsToTags(tt.args.mpTags); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ConvertMPTagsToTags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertTagsToMPTags(t *testing.T) {
+	scope, tag := "scope1", "tag1"
+	type args struct {
+		tags []model.Tag
+	}
+	tests := []struct {
+		name string
+		args args
+		want []mpmodel.Tag
+	}{
+		{
+			name: "nil",
+			args: args{
+				tags: nil,
+			},
+			want: []mpmodel.Tag{},
+		},
+		{
+			name: "standard",
+			args: args{
+				tags: []model.Tag{{
+					Scope: &scope,
+					Tag:   &tag,
+				}},
+			},
+			want: []mpmodel.Tag{{
+				Scope: &scope,
+				Tag:   &tag,
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConvertTagsToMPTags(tt.args.tags); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ConvertTagsToMPTags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryTagCondition(t *testing.T) {
+	type args struct {
+		resourceType string
+		cluster      string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "CCP-dummyCluster",
+			args: args{
+				resourceType: ResourceTypeClusterControlPlane,
+				cluster:      "dummyCluster:a:b",
+			},
+			want: "resource_type:clustercontrolplane AND tags.scope:nsx-op\\/cluster AND tags.tag:dummyCluster\\:a\\:b",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := QueryTagCondition(tt.args.resourceType, tt.args.cluster); got != tt.want {
+				t.Errorf("QueryTagCondition() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -15,25 +15,30 @@ import (
 )
 
 const (
-	HashLength                   int    = 8
-	MaxTagLength                 int    = 256
-	TagScopeCluster              string = "nsx-op/cluster"
-	TagScopeNamespace            string = "nsx-op/namespace"
-	TagScopeSecurityPolicyCRName string = "nsx-op/security_policy_cr_name"
-	TagScopeSecurityPolicyCRUID  string = "nsx-op/security_policy_cr_uid"
-	TagScopeRuleID               string = "nsx-op/rule_id"
-	TagScopeGroupType            string = "nsx-op/group_type"
-	TagScopeSelectorHash         string = "nsx-op/selector_hash"
-	TagScopeNCPCluster           string = "ncp/cluster"
-	TagScopeNCPProject           string = "ncp/project"
-	TagScopeNCPVIFProject        string = "ncp/vif_project"
-	TagScopeNCPPod               string = "ncp/pod"
-	TagScopeNCPVNETInterface     string = "ncp/vnet_interface"
-	TagScopeVPCCRName            string = "nsx-op/vpc_cr_name"
-	TagScopeVPCCRUID             string = "nsx-op/vpc_cr_uid"
+	HashLength                      int    = 8
+	MaxTagLength                    int    = 256
+	MaxIdLength                     int    = 255
+	TagScopeCluster                 string = "nsx-op/cluster"
+	TagScopeNamespace               string = "nsx-op/namespace"
+	TagScopeSecurityPolicyCRName    string = "nsx-op/security_policy_cr_name"
+	TagScopeSecurityPolicyCRUID     string = "nsx-op/security_policy_cr_uid"
+	TagScopeRuleID                  string = "nsx-op/rule_id"
+	TagScopeGroupType               string = "nsx-op/group_type"
+	TagScopeSelectorHash            string = "nsx-op/selector_hash"
+	TagScopeNSXServiceAccountCRName string = "nsx-op/nsx_service_account_name"
+	TagScopeNSXServiceAccountCRUID  string = "nsx-op/nsx_service_account_uid"
+	TagScopeNCPCluster              string = "ncp/cluster"
+	TagScopeNCPProject              string = "ncp/project"
+	TagScopeNCPVIFProject           string = "ncp/vif_project"
+	TagScopeNCPPod                  string = "ncp/pod"
+	TagScopeNCPVNETInterface        string = "ncp/vnet_interface"
+	TagScopeVPCCRName               string = "nsx-op/vpc_cr_name"
+	TagScopeVPCCRUID                string = "nsx-op/vpc_cr_uid"
 
 	GCInterval    = 60 * time.Second
 	FinalizerName = "securitypolicy.nsx.vmware.com/finalizer"
+
+	NSXServiceAccountFinalizerName = "nsxserviceaccount.nsx.vmware.com/finalizer"
 )
 
 var (
@@ -42,6 +47,10 @@ var (
 	ResourceTypeGroup          = "Group"
 	ResourceTypeRule           = "Rule"
 	ResourceTypeVPC            = "VPC"
+	// ResourceTypeClusterControlPlane is used by NSXServiceAccountController
+	ResourceTypeClusterControlPlane = "clustercontrolplane"
+	// ResourceTypePrincipalIdentity is used by NSXServiceAccountController, and it is MP resource type.
+	ResourceTypePrincipalIdentity = "principalidentity"
 )
 
 type Service struct {

--- a/pkg/nsx/services/nsxserviceaccount/builder.go
+++ b/pkg/nsx/services/nsxserviceaccount/builder.go
@@ -1,0 +1,35 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package nsxserviceaccount
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+var (
+	tagScopeCluster                 = common.TagScopeCluster
+	tagScopeNamespace               = common.TagScopeNamespace
+	tagScopeNSXServiceAccountCRName = common.TagScopeNSXServiceAccountCRName
+	tagScopeNSXServiceAccountCRUID  = common.TagScopeNSXServiceAccountCRUID
+)
+
+func (s *NSXServiceAccountService) buildBasicTags(obj *v1alpha1.NSXServiceAccount) []model.Tag {
+	uid := string(obj.UID)
+	return []model.Tag{{
+		Scope: &tagScopeCluster,
+		Tag:   &s.NSXConfig.CoeConfig.Cluster,
+	}, {
+		Scope: &tagScopeNamespace,
+		Tag:   &obj.Namespace,
+	}, {
+		Scope: &tagScopeNSXServiceAccountCRName,
+		Tag:   &obj.Name,
+	}, {
+		Scope: &tagScopeNSXServiceAccountCRUID,
+		Tag:   &uid,
+	}}
+}

--- a/pkg/nsx/services/nsxserviceaccount/cluster.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster.go
@@ -1,0 +1,289 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package nsxserviceaccount
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
+)
+
+const (
+	siteId             = "default"
+	enforcementpointId = "default"
+	PortRestAPI        = "rest-api"
+	PortNSXRPCFwdProxy = "nsx-rpc-fwd-proxy"
+	SecretSuffix       = "-nsx-cert"
+	SecretCAName       = "ca.crt"
+	SecretCertName     = "tls.crt"
+	SecretKeyName      = "tls.key"
+)
+
+var (
+	log = logger.Log
+
+	isProtectedTrue = true
+	vpcRole         = "ccp_internal_operator"
+	readerPath      = "/"
+	readerRole      = "cluster_info_reader"
+
+	antreaClusterResourceType = "AntreaClusterControlPlane"
+	revision1                 = int64(1)
+)
+
+type NSXServiceAccountService struct {
+	common.Service
+	PrincipalIdentityStore   *PrincipalIdentityStore
+	ClusterControlPlaneStore *ClusterControlPlaneStore
+}
+
+// InitializeNSXServiceAccount sync NSX resources
+func InitializeNSXServiceAccount(service common.Service) (*NSXServiceAccountService, error) {
+	wg := sync.WaitGroup{}
+	wgDone := make(chan bool)
+	fatalErrors := make(chan error)
+
+	wg.Add(2)
+	nsxServiceAccountService := &NSXServiceAccountService{Service: service}
+
+	nsxServiceAccountService.SetUpStore()
+	go nsxServiceAccountService.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypePrincipalIdentity, nsxServiceAccountService.PrincipalIdentityStore)
+	go nsxServiceAccountService.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypeClusterControlPlane, nsxServiceAccountService.ClusterControlPlaneStore)
+	go func() {
+		wg.Wait()
+		close(wgDone)
+	}()
+
+	select {
+	case <-wgDone:
+		break
+	case err := <-fatalErrors:
+		return nsxServiceAccountService, err
+	}
+
+	return nsxServiceAccountService, nil
+}
+
+func (s *NSXServiceAccountService) SetUpStore() {
+	s.PrincipalIdentityStore = &PrincipalIdentityStore{ResourceStore: common.ResourceStore{
+		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeNSXServiceAccountCRUID: indexFunc}),
+		BindingType: mpmodel.PrincipalIdentityBindingType(),
+	}}
+	s.ClusterControlPlaneStore = &ClusterControlPlaneStore{ResourceStore: common.ResourceStore{
+		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeNSXServiceAccountCRUID: indexFunc}),
+		BindingType: model.ClusterControlPlaneBindingType(),
+	}}
+}
+
+func (s *NSXServiceAccountService) CreateOrUpdateNSXServiceAccount(ctx context.Context, obj *v1alpha1.NSXServiceAccount) error {
+	clusterName := s.getClusterName(obj.Namespace, obj.Name)
+	normalizedClusterName := util.NormalizeId(clusterName)
+	// TODO: Use WCPConfig.NSXTProject as project when WCPConfig.EnableWCPVPCNetwork is true
+	project := s.NSXConfig.CoeConfig.Cluster
+	vpcName := obj.Namespace + "-default-vpc"
+	vpcPath := fmt.Sprintf("/orgs/default/projects/%s/vpcs/%s", util.NormalizeId(project), vpcName)
+
+	// generate certificate
+	subject := util.DefaultSubject
+	subject.CommonName = clusterName
+	cert, key, err := util.GenerateCertificate(&subject, util.DefaultValidDays)
+	if err != nil {
+		return err
+	}
+
+	// create PI
+	if piObj := s.PrincipalIdentityStore.GetByKey(normalizedClusterName); piObj == nil {
+		pi, err := s.NSXClient.WithCertificateClient.Create(mpmodel.PrincipalIdentityWithCertificate{
+			IsProtected: &isProtectedTrue,
+			Name:        &normalizedClusterName,
+			NodeId:      &normalizedClusterName,
+			Role:        nil,
+			RolesForPaths: []mpmodel.RolesForPath{{
+				Path: &readerPath,
+				Roles: []mpmodel.Role{{
+					Role: &readerRole,
+				}},
+			}, {
+				Path: &vpcPath,
+				Roles: []mpmodel.Role{{
+					Role: &vpcRole,
+				}},
+			}},
+			CertificatePem: &cert,
+			Tags:           common.ConvertTagsToMPTags(s.buildBasicTags(obj)),
+		})
+		if err != nil {
+			return err
+		}
+		s.PrincipalIdentityStore.Add(pi)
+	}
+
+	// create ClusterControlPlane
+	clusterId := ""
+	if ccpObj := s.ClusterControlPlaneStore.GetByKey(normalizedClusterName); ccpObj == nil {
+		ccp, err := s.NSXClient.ClusterControlPlanesClient.Update(siteId, enforcementpointId, normalizedClusterName, model.ClusterControlPlane{
+			Revision:     &revision1,
+			ResourceType: &antreaClusterResourceType,
+			Certificate:  &cert,
+			VhcPath:      &vpcPath,
+			Tags:         s.buildBasicTags(obj),
+		})
+		if err != nil {
+			return err
+		}
+		s.ClusterControlPlaneStore.Add(ccp)
+		clusterId = *ccp.NodeId
+	}
+
+	// create Secret
+	secretName := obj.Name + SecretSuffix
+	secretNamespace := obj.Namespace
+	if err := s.Client.Create(ctx, &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: secretNamespace,
+			// TODO: Add labels/annotations
+			Labels:      nil,
+			Annotations: nil,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         obj.APIVersion,
+				Kind:               obj.Kind,
+				Name:               obj.Name,
+				UID:                obj.UID,
+				Controller:         nil,
+				BlockOwnerDeletion: nil,
+			}},
+			Finalizers: nil,
+		},
+		Immutable: nil,
+		// TODO: Add NSX CA
+		Data: map[string][]byte{SecretCertName: []byte(cert), SecretKeyName: []byte(key)},
+		Type: "",
+	}); err != nil {
+		return err
+	}
+
+	// update NSXServiceAccountStatus
+	obj.Status.Phase = v1alpha1.NSXServiceAccountPhaseRealized
+	obj.Status.Reason = "Success."
+	obj.Status.NSXManagers = s.NSXConfig.NsxApiManagers
+	obj.Status.ClusterID = clusterId
+	obj.Status.ClusterName = clusterName
+	obj.Status.Secrets = []v1alpha1.NSXSecret{{
+		Name:      secretName,
+		Namespace: secretNamespace,
+	}}
+	obj.Status.VPCPath = vpcPath
+	// TODO: Add proxy
+	return s.Client.Status().Update(ctx, obj)
+}
+
+func (s *NSXServiceAccountService) DeleteNSXServiceAccount(ctx context.Context, namespacedName types.NamespacedName) error {
+	clusterName := s.getClusterName(namespacedName.Namespace, namespacedName.Name)
+	normalizedClusterName := util.NormalizeId(clusterName)
+	// delete Secret
+	secretName := namespacedName.Name + SecretSuffix
+	secretNamespace := namespacedName.Namespace
+	if err := s.Client.Delete(ctx, &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: secretNamespace}}); err != nil && !errors.IsNotFound(err) {
+		log.Error(err, "failed to delete", "secret", secretName, "namespace", secretNamespace)
+		return err
+	}
+
+	// delete ClusterControlPlane
+	cascade := true
+	if err := s.NSXClient.ClusterControlPlanesClient.Delete(siteId, enforcementpointId, normalizedClusterName, &cascade); err != nil {
+		log.Error(err, "failed to delete", "ClusterControlPlane", normalizedClusterName)
+		return err
+	}
+	s.ClusterControlPlaneStore.Delete(model.ClusterControlPlane{Id: &normalizedClusterName})
+
+	// delete PI
+	if piobj := s.PrincipalIdentityStore.GetByKey(normalizedClusterName); piobj != nil {
+		pi := piobj.(mpmodel.PrincipalIdentity)
+		if err := s.NSXClient.PrincipalIdentitiesClient.Delete(*pi.Id); err != nil {
+			log.Error(err, "failed to delete", "PrincipalIdentity", *pi.Name)
+			return err
+		}
+		if pi.CertificateId != nil && *pi.CertificateId != "" {
+			if err := s.NSXClient.CertificatesClient.Delete(*pi.CertificateId); err != nil {
+				log.Error(err, "failed to delete", "PrincipalIdentity", *pi.Name, "Certificate", *pi.CertificateId)
+				return err
+			}
+		}
+		s.PrincipalIdentityStore.Delete(pi)
+	}
+	return nil
+}
+
+// ListNSXServiceAccountRealization returns all existing realized or failed NSXServiceAccount on NSXT
+func (s *NSXServiceAccountService) ListNSXServiceAccountRealization() sets.String {
+	// List PI
+	uidSet := s.PrincipalIdentityStore.ListIndexFuncValues(common.TagScopeNSXServiceAccountCRUID)
+
+	// List ClusterControlPlane
+	uidSet = uidSet.Union(s.ClusterControlPlaneStore.ListIndexFuncValues(common.TagScopeNSXServiceAccountCRUID))
+	return uidSet
+}
+
+func (s *NSXServiceAccountService) GetNSXServiceAccountNameByUID(uid string) (namespacedName types.NamespacedName) {
+	objs, err := s.PrincipalIdentityStore.ByIndex(common.TagScopeNSXServiceAccountCRUID, uid)
+	if err != nil {
+		log.Error(err, "failed to search PrincipalIdentityStore by UID")
+		return
+	}
+	for _, obj := range objs {
+		pi := obj.(mpmodel.PrincipalIdentity)
+		for _, tag := range pi.Tags {
+			switch *tag.Scope {
+			case common.TagScopeNamespace:
+				namespacedName.Namespace = *tag.Tag
+			case common.TagScopeNSXServiceAccountCRName:
+				namespacedName.Name = *tag.Tag
+			}
+			if namespacedName.Name != "" && namespacedName.Namespace != "" {
+				return
+			}
+		}
+	}
+	objs, err = s.ClusterControlPlaneStore.ByIndex(common.TagScopeNSXServiceAccountCRUID, uid)
+	if err != nil {
+		log.Error(err, "failed to search ClusterControlPlaneStore by UID")
+		return
+	}
+	for _, obj := range objs {
+		ccp := obj.(model.ClusterControlPlane)
+		for _, tag := range ccp.Tags {
+			if tag.Scope != nil {
+				switch *tag.Scope {
+				case common.TagScopeNamespace:
+					namespacedName.Namespace = *tag.Tag
+				case common.TagScopeNSXServiceAccountCRName:
+					namespacedName.Name = *tag.Tag
+				}
+				if namespacedName.Name != "" && namespacedName.Namespace != "" {
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+func (s *NSXServiceAccountService) getClusterName(namespace, name string) string {
+	return fmt.Sprintf("%s-%s-%s", s.NSXConfig.CoeConfig.Cluster, namespace, name)
+}

--- a/pkg/nsx/services/nsxserviceaccount/cluster_test.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster_test.go
@@ -1,0 +1,718 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package nsxserviceaccount
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	nsxvmwarecomv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
+)
+
+type fakeQueryClient struct{}
+
+func (c *fakeQueryClient) List(queryParam string, cursorParam *string, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.SearchResponse, error) {
+	return model.SearchResponse{}, nil
+}
+
+type fakeClusterControlPlanesClient struct{}
+
+func (c *fakeClusterControlPlanesClient) Delete(siteIdParam string, enforcementpointIdParam string, clusterControlPlaneIdParam string, cascadeParam *bool) error {
+	return nil
+}
+
+func (c *fakeClusterControlPlanesClient) Get(siteIdParam string, enforcementpointIdParam string, clusterControlPlaneIdParam string) (model.ClusterControlPlane, error) {
+	return model.ClusterControlPlane{}, nil
+}
+
+func (c *fakeClusterControlPlanesClient) List(siteIdParam string, enforcementpointIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.ClusterControlPlaneListResult, error) {
+	return model.ClusterControlPlaneListResult{}, nil
+}
+
+func (c *fakeClusterControlPlanesClient) Update(siteIdParam string, enforcementpointIdParam string, clusterControlPlaneIdParam string, clusterControlPlaneParam model.ClusterControlPlane) (model.ClusterControlPlane, error) {
+	return model.ClusterControlPlane{}, nil
+}
+
+type fakeMPQueryClient struct{}
+
+func (c *fakeMPQueryClient) List(queryParam string, cursorParam *string, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (mpmodel.SearchResponse, error) {
+	return mpmodel.SearchResponse{}, nil
+}
+
+type fakeWithCertificateClient struct{}
+
+func (c *fakeWithCertificateClient) Create(principalIdentityWithCertificateParam mpmodel.PrincipalIdentityWithCertificate) (mpmodel.PrincipalIdentity, error) {
+	return mpmodel.PrincipalIdentity{}, nil
+}
+
+type fakePrincipalIdentitiesClient struct{}
+
+func (c *fakePrincipalIdentitiesClient) Create(principalIdentityParam mpmodel.PrincipalIdentity) (mpmodel.PrincipalIdentity, error) {
+	return mpmodel.PrincipalIdentity{}, nil
+}
+
+func (c *fakePrincipalIdentitiesClient) Delete(principalIdentityIdParam string) error {
+	return nil
+}
+
+func (c *fakePrincipalIdentitiesClient) Get(principalIdentityIdParam string) (mpmodel.PrincipalIdentity, error) {
+	return mpmodel.PrincipalIdentity{}, nil
+}
+
+func (c *fakePrincipalIdentitiesClient) List() (mpmodel.PrincipalIdentityList, error) {
+	return mpmodel.PrincipalIdentityList{}, nil
+}
+
+func (c *fakePrincipalIdentitiesClient) Updatecertificate(updatePrincipalIdentityCertificateRequestParam mpmodel.UpdatePrincipalIdentityCertificateRequest) (mpmodel.PrincipalIdentity, error) {
+	return mpmodel.PrincipalIdentity{}, nil
+}
+
+type fakeCertificatesClient struct{}
+
+func (c *fakeCertificatesClient) Applycertificate(certIdParam string, serviceTypeParam string, nodeIdParam *string) error {
+	return nil
+}
+
+func (c *fakeCertificatesClient) Delete(certIdParam string) error {
+	return nil
+}
+
+func (c *fakeCertificatesClient) Fetchpeercertificatechain(tlsServiceEndpointParam mpmodel.TlsServiceEndpoint) (mpmodel.PeerCertificateChain, error) {
+	return mpmodel.PeerCertificateChain{}, nil
+}
+
+func (c *fakeCertificatesClient) Get(certIdParam string, detailsParam *bool) (mpmodel.Certificate, error) {
+	return mpmodel.Certificate{}, nil
+}
+
+func (c *fakeCertificatesClient) Importcertificate(trustObjectDataParam mpmodel.TrustObjectData) (mpmodel.CertificateList, error) {
+	return mpmodel.CertificateList{}, nil
+}
+
+func (c *fakeCertificatesClient) Importtrustedca(aliasParam string, trustObjectDataParam mpmodel.TrustObjectData) error {
+	return nil
+}
+
+func (c *fakeCertificatesClient) List(cursorParam *string, detailsParam *bool, includedFieldsParam *string, nodeIdParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string, type_Param *string) (mpmodel.CertificateList, error) {
+	return mpmodel.CertificateList{}, nil
+}
+
+func (c *fakeCertificatesClient) Setapplianceproxycertificateforintersitecommunication(setInterSiteAphCertificateRequestParam mpmodel.SetInterSiteAphCertificateRequest) error {
+	return nil
+}
+
+func (c *fakeCertificatesClient) Setpicertificateforfederation(setPrincipalIdentityCertificateForFederationRequestParam mpmodel.SetPrincipalIdentityCertificateForFederationRequest) error {
+	return nil
+}
+
+func (c *fakeCertificatesClient) Validate(certIdParam string, usageParam *string) (mpmodel.CertificateCheckingStatus, error) {
+	return mpmodel.CertificateCheckingStatus{}, nil
+}
+
+func newFakeCommonService() common.Service {
+	client := fake.NewClientBuilder().Build()
+	scheme := client.Scheme()
+	clientgoscheme.AddToScheme(scheme)
+	nsxvmwarecomv1alpha1.AddToScheme(scheme)
+	service := common.Service{
+		Client: client,
+		NSXClient: &nsx.Client{
+			NsxConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{
+					Cluster: "k8scl-one:test",
+				},
+				NsxConfig: &config.NsxConfig{
+					NsxApiManagers: []string{"mgr1:443", "mgr2:443"},
+				},
+			},
+			RestConnector:              nil,
+			QueryClient:                &fakeQueryClient{},
+			GroupClient:                nil,
+			SecurityClient:             nil,
+			RuleClient:                 nil,
+			InfraClient:                nil,
+			ClusterControlPlanesClient: &fakeClusterControlPlanesClient{},
+			MPQueryClient:              &fakeMPQueryClient{},
+			CertificatesClient:         &fakeCertificatesClient{},
+			PrincipalIdentitiesClient:  &fakePrincipalIdentitiesClient{},
+			WithCertificateClient:      &fakeWithCertificateClient{},
+			NSXChecker:                 nsx.NSXHealthChecker{},
+			NSXVerChecker:              nsx.NSXVersionChecker{},
+		},
+		NSXConfig: &config.NSXOperatorConfig{
+			CoeConfig: &config.CoeConfig{
+				Cluster: "k8scl-one:test",
+			},
+			NsxConfig: &config.NsxConfig{
+				NsxApiManagers: []string{"mgr1:443", "mgr2:443"},
+			},
+		},
+	}
+	return service
+}
+
+func TestInitializeNSXServiceAccount(t *testing.T) {
+	tests := []struct {
+		name        string
+		prepareFunc func(*testing.T, *common.Service, context.Context) *gomonkey.Patches
+		wantErr     bool
+	}{
+		{
+			name: "error",
+			prepareFunc: func(t *testing.T, s *common.Service, ctx context.Context) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.QueryClient, "List", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.SearchResponse{}, fmt.Errorf("mock error")},
+					Times:  2,
+				}})
+				return patches
+			},
+			wantErr: true,
+		},
+		{
+			name: "success",
+			prepareFunc: func(t *testing.T, s *common.Service, ctx context.Context) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.QueryClient, "List", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.SearchResponse{}, nil},
+					Times:  2,
+				}})
+				return patches
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			commonService := newFakeCommonService()
+			patches := tt.prepareFunc(t, &commonService, ctx)
+			defer patches.Reset()
+			got, err := InitializeNSXServiceAccount(commonService)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("InitializeNSXServiceAccount() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got.Service, commonService) {
+				t.Errorf("InitializeNSXServiceAccount() got = %v, want %v", got.Service, commonService)
+			}
+		})
+	}
+}
+
+func TestNSXServiceAccountService_CreateOrUpdateNSXServiceAccount(t *testing.T) {
+	type args struct {
+		obj *v1alpha1.NSXServiceAccount
+	}
+	tests := []struct {
+		name        string
+		prepareFunc func(*testing.T, *NSXServiceAccountService, context.Context, *nsxvmwarecomv1alpha1.NSXServiceAccount) *gomonkey.Patches
+		args        args
+		wantErr     bool
+		wantSecret  bool
+		expectedCR  *nsxvmwarecomv1alpha1.NSXServiceAccount
+	}{
+		{
+			name: "GenerateCertificateError",
+			prepareFunc: func(t *testing.T, s *NSXServiceAccountService, ctx context.Context, obj *nsxvmwarecomv1alpha1.NSXServiceAccount) *gomonkey.Patches {
+				patches := gomonkey.ApplyFuncSeq(util.GenerateCertificate, []gomonkey.OutputCell{{
+					Values: gomonkey.Params{"", "", fmt.Errorf("mock error")},
+					Times:  1,
+				}})
+				return patches
+			},
+			args: args{
+				obj: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name1",
+						Namespace: "ns1",
+						UID:       "00000000-0000-0000-0000-000000000001",
+					},
+				},
+			},
+			wantErr:    true,
+			wantSecret: false,
+			expectedCR: nil,
+		},
+		{
+			name: "Success",
+			prepareFunc: func(t *testing.T, s *NSXServiceAccountService, ctx context.Context, obj *nsxvmwarecomv1alpha1.NSXServiceAccount) *gomonkey.Patches {
+				assert.NoError(t, s.Client.Create(ctx, obj))
+				normalizedClusterName := "k8scl-one_test-ns1-name1"
+				vpcPath := "/orgs/default/projects/k8scl-one:test/vpcs/vpc1"
+				piId := "Id1"
+				uid := "00000000-0000-0000-0000-000000000001"
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.WithCertificateClient, "Create", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{mpmodel.PrincipalIdentity{
+						IsProtected: &isProtectedTrue,
+						Name:        &normalizedClusterName,
+						NodeId:      &normalizedClusterName,
+						Role:        nil,
+						RolesForPaths: []mpmodel.RolesForPath{{
+							Path: &readerPath,
+							Roles: []mpmodel.Role{{
+								Role: &readerRole,
+							}},
+						}, {
+							Path: &vpcPath,
+							Roles: []mpmodel.Role{{
+								Role: &vpcRole,
+							}},
+						}},
+						Id: &piId,
+						Tags: []mpmodel.Tag{{
+							Scope: &tagScopeCluster,
+							Tag:   &s.NSXConfig.CoeConfig.Cluster,
+						}, {
+							Scope: &tagScopeNamespace,
+							Tag:   &obj.Namespace,
+						}, {
+							Scope: &tagScopeNSXServiceAccountCRName,
+							Tag:   &obj.Name,
+						}, {
+							Scope: &tagScopeNSXServiceAccountCRUID,
+							Tag:   &uid,
+						}},
+					}, nil},
+					Times: 1,
+				}})
+				nodeId := "clusterId1"
+				patches.ApplyMethodSeq(s.NSXClient.ClusterControlPlanesClient, "Update", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.ClusterControlPlane{
+						Id:           &normalizedClusterName,
+						NodeId:       &nodeId,
+						Revision:     &revision1,
+						ResourceType: &antreaClusterResourceType,
+						Certificate:  nil,
+						VhcPath:      &vpcPath,
+						Tags: []model.Tag{{
+							Scope: &tagScopeCluster,
+							Tag:   &s.NSXConfig.CoeConfig.Cluster,
+						}, {
+							Scope: &tagScopeNamespace,
+							Tag:   &obj.Namespace,
+						}, {
+							Scope: &tagScopeNSXServiceAccountCRName,
+							Tag:   &obj.Name,
+						}, {
+							Scope: &tagScopeNSXServiceAccountCRUID,
+							Tag:   &uid,
+						}},
+					}, nil},
+					Times: 1,
+				}})
+				return patches
+			},
+			args: args{
+				obj: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name1",
+						Namespace: "ns1",
+						UID:       "00000000-0000-0000-0000-000000000001",
+					},
+					Spec: nsxvmwarecomv1alpha1.NSXServiceAccountSpec{
+						VPCName: "vpc1",
+					},
+				},
+			},
+			wantErr:    false,
+			wantSecret: true,
+			expectedCR: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "name1",
+					Namespace:       "ns1",
+					UID:             "00000000-0000-0000-0000-000000000001",
+					ResourceVersion: "2",
+				},
+				Spec: nsxvmwarecomv1alpha1.NSXServiceAccountSpec{
+					VPCName: "vpc1",
+				},
+				Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{
+					Phase:          "realized",
+					Reason:         "Success.",
+					VPCPath:        "/orgs/default/projects/k8scl-one_test/vpcs/ns1-default-vpc",
+					NSXManagers:    []string{"mgr1:443", "mgr2:443"},
+					ProxyEndpoints: v1alpha1.NSXProxyEndpoint{},
+					ClusterID:      "clusterId1",
+					ClusterName:    "k8scl-one:test-ns1-name1",
+					Secrets:        []v1alpha1.NSXSecret{{Name: "name1-nsx-cert", Namespace: "ns1"}},
+				},
+			},
+		},
+		{
+			name: "LongNameSuccess",
+			prepareFunc: func(t *testing.T, s *NSXServiceAccountService, ctx context.Context, obj *nsxvmwarecomv1alpha1.NSXServiceAccount) *gomonkey.Patches {
+				assert.NoError(t, s.Client.Create(ctx, obj))
+				s.NSXConfig.CoeConfig.Cluster = "k8scl-one:1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+				normalizedClusterName := "k8scl-one_12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456-1a6417ee"
+				vpcPath := "/orgs/default/projects/k8scl-one:test/vpcs/ns1-default-vpc"
+				piId := "Id1"
+				uid := "00000000-0000-0000-0000-000000000001"
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.WithCertificateClient, "Create", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{mpmodel.PrincipalIdentity{
+						IsProtected: &isProtectedTrue,
+						Name:        &normalizedClusterName,
+						NodeId:      &normalizedClusterName,
+						Role:        nil,
+						RolesForPaths: []mpmodel.RolesForPath{{
+							Path: &readerPath,
+							Roles: []mpmodel.Role{{
+								Role: &readerRole,
+							}},
+						}, {
+							Path: &vpcPath,
+							Roles: []mpmodel.Role{{
+								Role: &vpcRole,
+							}},
+						}},
+						Id: &piId,
+						Tags: []mpmodel.Tag{{
+							Scope: &tagScopeCluster,
+							Tag:   &s.NSXConfig.CoeConfig.Cluster,
+						}, {
+							Scope: &tagScopeNamespace,
+							Tag:   &obj.Namespace,
+						}, {
+							Scope: &tagScopeNSXServiceAccountCRName,
+							Tag:   &obj.Name,
+						}, {
+							Scope: &tagScopeNSXServiceAccountCRUID,
+							Tag:   &uid,
+						}},
+					}, nil},
+					Times: 1,
+				}})
+				nodeId := "clusterId1"
+				patches.ApplyMethodSeq(s.NSXClient.ClusterControlPlanesClient, "Update", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.ClusterControlPlane{
+						Id:           &normalizedClusterName,
+						NodeId:       &nodeId,
+						Revision:     &revision1,
+						ResourceType: &antreaClusterResourceType,
+						Certificate:  nil,
+						VhcPath:      &vpcPath,
+						Tags: []model.Tag{{
+							Scope: &tagScopeCluster,
+							Tag:   &s.NSXConfig.CoeConfig.Cluster,
+						}, {
+							Scope: &tagScopeNamespace,
+							Tag:   &obj.Namespace,
+						}, {
+							Scope: &tagScopeNSXServiceAccountCRName,
+							Tag:   &obj.Name,
+						}, {
+							Scope: &tagScopeNSXServiceAccountCRUID,
+							Tag:   &uid,
+						}},
+					}, nil},
+					Times: 1,
+				}})
+				return patches
+			},
+			args: args{
+				obj: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name1",
+						Namespace: "ns1",
+						UID:       "00000000-0000-0000-0000-000000000001",
+					},
+				},
+			},
+			wantErr:    false,
+			wantSecret: true,
+			expectedCR: &nsxvmwarecomv1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "name1",
+					Namespace:       "ns1",
+					UID:             "00000000-0000-0000-0000-000000000001",
+					ResourceVersion: "2",
+				},
+				Spec: nsxvmwarecomv1alpha1.NSXServiceAccountSpec{},
+				Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{
+					Phase:          "realized",
+					Reason:         "Success.",
+					VPCPath:        "/orgs/default/projects/k8scl-one_12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456-e8ad9afc/vpcs/ns1-default-vpc",
+					NSXManagers:    []string{"mgr1:443", "mgr2:443"},
+					ProxyEndpoints: v1alpha1.NSXProxyEndpoint{},
+					ClusterID:      "clusterId1",
+					ClusterName:    "k8scl-one:1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890-ns1-name1",
+					Secrets:        []v1alpha1.NSXSecret{{Name: "name1-nsx-cert", Namespace: "ns1"}},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			commonService := newFakeCommonService()
+			s := &NSXServiceAccountService{Service: commonService}
+			s.SetUpStore()
+			patches := tt.prepareFunc(t, s, ctx, tt.args.obj)
+			defer patches.Reset()
+
+			if err := s.CreateOrUpdateNSXServiceAccount(ctx, tt.args.obj); (err != nil) != tt.wantErr {
+				t.Errorf("CreateOrUpdateNSXServiceAccount() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantSecret {
+				secret := &v1.Secret{}
+				assert.NoError(t, s.Client.Get(ctx, types.NamespacedName{
+					Namespace: tt.args.obj.Namespace,
+					Name:      tt.args.obj.Name + SecretSuffix,
+				}, secret))
+				assert.Equal(t, 2, len(secret.Data))
+			}
+			actualCR := &nsxvmwarecomv1alpha1.NSXServiceAccount{}
+			err := s.Client.Get(ctx, types.NamespacedName{
+				Namespace: tt.args.obj.Namespace,
+				Name:      tt.args.obj.Name,
+			}, actualCR)
+			if tt.expectedCR == nil {
+				assert.True(t, errors.IsNotFound(err))
+			} else {
+				assert.Equal(t, tt.expectedCR.ObjectMeta, actualCR.ObjectMeta)
+				assert.Equal(t, tt.expectedCR.Spec, actualCR.Spec)
+				assert.Equal(t, tt.expectedCR.Status, actualCR.Status)
+			}
+			if !tt.wantErr {
+				expectedKeys := []string{util.NormalizeId(s.getClusterName(tt.expectedCR.Namespace, tt.expectedCR.Name))}
+				assert.Equal(t, expectedKeys, s.PrincipalIdentityStore.ListKeys())
+				assert.Equal(t, expectedKeys, s.ClusterControlPlaneStore.ListKeys())
+			}
+		})
+	}
+}
+
+func TestNSXServiceAccountService_DeleteNSXServiceAccount(t *testing.T) {
+	type args struct {
+		namespacedName types.NamespacedName
+	}
+	tests := []struct {
+		name                              string
+		prepareFunc                       func(*testing.T, *NSXServiceAccountService, context.Context) *gomonkey.Patches
+		args                              args
+		wantErr                           bool
+		wantClusterControlPlaneStoreCount int
+		wantPrincipalIdentityStoreCount   int
+	}{
+		{
+			name: "success",
+			prepareFunc: func(t *testing.T, s *NSXServiceAccountService, ctx context.Context) *gomonkey.Patches {
+				normalizedClusterName := "k8scl-one_test-ns1-name1"
+				piId := "piId1"
+				certId := "certId1"
+				assert.NoError(t, s.ClusterControlPlaneStore.Add(model.ClusterControlPlane{Id: &normalizedClusterName}))
+				assert.NoError(t, s.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{Name: &normalizedClusterName, Id: &piId, CertificateId: &certId}))
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.ClusterControlPlanesClient, "Delete", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(s.NSXClient.PrincipalIdentitiesClient, "Delete", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(s.NSXClient.CertificatesClient, "Delete", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				return patches
+			},
+			args: args{
+				namespacedName: types.NamespacedName{
+					Namespace: "ns1",
+					Name:      "name1",
+				},
+			},
+			wantErr:                           false,
+			wantClusterControlPlaneStoreCount: 0,
+			wantPrincipalIdentityStoreCount:   0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			commonService := newFakeCommonService()
+			s := &NSXServiceAccountService{Service: commonService}
+			s.SetUpStore()
+			patches := tt.prepareFunc(t, s, ctx)
+			defer patches.Reset()
+
+			if err := s.DeleteNSXServiceAccount(ctx, tt.args.namespacedName); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteNSXServiceAccount() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.wantClusterControlPlaneStoreCount, len(s.ClusterControlPlaneStore.ListKeys()))
+			assert.Equal(t, tt.wantPrincipalIdentityStoreCount, len(s.PrincipalIdentityStore.ListKeys()))
+		})
+	}
+}
+
+func TestNSXServiceAccountService_ListNSXServiceAccountRealization(t *testing.T) {
+	tests := []struct {
+		name    string
+		piKeys  []string
+		ccpKeys []string
+		want    sets.String
+	}{
+		{
+			name:    "standard",
+			piKeys:  []string{"ns1-name1", "ns2-name2"},
+			ccpKeys: []string{"ns2-name2", "ns3-name3"},
+			want:    sets.NewString("ns1-name1-uid", "ns2-name2-uid", "ns3-name3-uid"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commonService := newFakeCommonService()
+			s := &NSXServiceAccountService{Service: commonService}
+			s.SetUpStore()
+			for _, piKey := range tt.piKeys {
+				piName := piKey
+				piId := piKey + "-id"
+				crUID := piKey + "-uid"
+				assert.NoError(t, s.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{
+					Id:   &piId,
+					Name: &piName,
+					Tags: []mpmodel.Tag{{
+						Scope: &tagScopeNSXServiceAccountCRUID,
+						Tag:   &crUID,
+					}},
+				}))
+			}
+			for _, ccpKey := range tt.ccpKeys {
+				ccpId := ccpKey
+				crUID := ccpKey + "-uid"
+				assert.NoError(t, s.ClusterControlPlaneStore.Add(model.ClusterControlPlane{
+					Id: &ccpId,
+					Tags: []model.Tag{{
+						Scope: &tagScopeNSXServiceAccountCRUID,
+						Tag:   &crUID,
+					}},
+				}))
+			}
+
+			if got := s.ListNSXServiceAccountRealization(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ListNSXServiceAccountRealization() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNSXServiceAccountService_GetNSXServiceAccountNameByUID(t *testing.T) {
+	type args struct {
+		uid string
+	}
+	tests := []struct {
+		name               string
+		piKeys             []types.NamespacedName
+		ccpKeys            []types.NamespacedName
+		args               args
+		wantNamespacedName types.NamespacedName
+	}{
+		{
+			name: "ByPI",
+			piKeys: []types.NamespacedName{{
+				Namespace: "name1",
+				Name:      "ns1",
+			}},
+			ccpKeys: []types.NamespacedName{},
+			args: args{
+				uid: "name1-ns1-uid",
+			},
+			wantNamespacedName: types.NamespacedName{
+				Namespace: "name1",
+				Name:      "ns1",
+			},
+		},
+		{
+			name:   "ByCCP",
+			piKeys: []types.NamespacedName{},
+			ccpKeys: []types.NamespacedName{{
+				Namespace: "name1",
+				Name:      "ns1",
+			}},
+			args: args{
+				uid: "name1-ns1-uid",
+			},
+			wantNamespacedName: types.NamespacedName{
+				Namespace: "name1",
+				Name:      "ns1",
+			},
+		},
+		{
+			name:    "Miss",
+			piKeys:  []types.NamespacedName{},
+			ccpKeys: []types.NamespacedName{},
+			args: args{
+				uid: "name1-ns1-uid",
+			},
+			wantNamespacedName: types.NamespacedName{
+				Namespace: "",
+				Name:      "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commonService := newFakeCommonService()
+			s := &NSXServiceAccountService{Service: commonService}
+			s.SetUpStore()
+			for _, piKey := range tt.piKeys {
+				piName := piKey.Namespace + "-" + piKey.Name
+				piId := piName + "-id"
+				crUID := piName + "-uid"
+				assert.NoError(t, s.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{
+					Id:   &piId,
+					Name: &piName,
+					Tags: []mpmodel.Tag{{
+						Scope: &tagScopeNamespace,
+						Tag:   &piKey.Namespace,
+					}, {
+						Scope: &tagScopeNSXServiceAccountCRName,
+						Tag:   &piKey.Name,
+					}, {
+						Scope: &tagScopeNSXServiceAccountCRUID,
+						Tag:   &crUID,
+					}},
+				}))
+			}
+			for _, ccpKey := range tt.ccpKeys {
+				ccpId := ccpKey.Namespace + "-" + ccpKey.Name
+				crUID := ccpId + "-uid"
+				assert.NoError(t, s.ClusterControlPlaneStore.Add(model.ClusterControlPlane{
+					Id: &ccpId,
+					Tags: []model.Tag{{
+						Scope: &tagScopeNamespace,
+						Tag:   &ccpKey.Namespace,
+					}, {
+						Scope: &tagScopeNSXServiceAccountCRName,
+						Tag:   &ccpKey.Name,
+					}, {
+						Scope: &tagScopeNSXServiceAccountCRUID,
+						Tag:   &crUID,
+					}},
+				}))
+			}
+
+			if gotNamespacedName := s.GetNSXServiceAccountNameByUID(tt.args.uid); !reflect.DeepEqual(gotNamespacedName, tt.wantNamespacedName) {
+				t.Errorf("GetNSXServiceAccountNameByUID() = %v, want %v", gotNamespacedName, tt.wantNamespacedName)
+			}
+		})
+	}
+}

--- a/pkg/nsx/services/nsxserviceaccount/store.go
+++ b/pkg/nsx/services/nsxserviceaccount/store.go
@@ -1,0 +1,95 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package nsxserviceaccount
+
+import (
+	"errors"
+	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+// PrincipalIdentityStore is a store for PrincipalIdentity
+type PrincipalIdentityStore struct {
+	common.ResourceStore
+}
+
+func (s *PrincipalIdentityStore) Operate(i interface{}) error {
+	pis := i.(*[]mpmodel.PrincipalIdentity)
+	for _, pi := range *pis {
+		// MP resource doesn't have MarkedForDelete tag.
+		err := s.Add(pi)
+		log.V(1).Info("add PI to store", "pi", pi)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *PrincipalIdentityStore) IsPolicyAPI() bool {
+	return false
+}
+
+// ClusterControlPlaneStore is a store for ClusterControlPlane
+type ClusterControlPlaneStore struct {
+	common.ResourceStore
+}
+
+func (s *ClusterControlPlaneStore) Operate(i interface{}) error {
+	pis := i.(*[]model.ClusterControlPlane)
+	for _, pi := range *pis {
+		if pi.MarkedForDelete != nil && *pi.MarkedForDelete {
+			err := s.Delete(pi)
+			log.V(1).Info("delete PI from store", "pi", pi)
+			if err != nil {
+				return err
+			}
+		} else {
+			err := s.Add(pi)
+			log.V(1).Info("add PI to store", "pi", pi)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// keyFunc returns the key of the object.
+func keyFunc(obj interface{}) (string, error) {
+	switch v := obj.(type) {
+	case model.ClusterControlPlane:
+		return *v.Id, nil
+	case mpmodel.PrincipalIdentity:
+		return *v.Name, nil
+	default:
+		return "", errors.New("keyFunc doesn't support unknown type")
+	}
+}
+
+// indexFunc is used to get index of a resource, usually, which is the UID of the CR controller reconciles,
+// index is used to filter out resources which are related to the CR
+func indexFunc(obj interface{}) ([]string, error) {
+	res := make([]string, 0, 5)
+	switch o := obj.(type) {
+	case model.ClusterControlPlane:
+		return filterTag(o.Tags), nil
+	case mpmodel.PrincipalIdentity:
+		return filterTag(common.ConvertMPTagsToTags(o.Tags)), nil
+	default:
+		return res, errors.New("indexFunc doesn't support unknown type")
+	}
+}
+
+var filterTag = func(v []model.Tag) []string {
+	res := make([]string, 0, 5)
+	for _, tag := range v {
+		if *tag.Scope == common.TagScopeNSXServiceAccountCRUID {
+			res = append(res, *tag.Tag)
+		}
+	}
+	return res
+}

--- a/pkg/nsx/services/nsxserviceaccount/store_test.go
+++ b/pkg/nsx/services/nsxserviceaccount/store_test.go
@@ -1,0 +1,77 @@
+package nsxserviceaccount
+
+import (
+	"reflect"
+	"testing"
+
+	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+func Test_indexFunc(t *testing.T) {
+	mId, mTag, mScope := "11111", "11111", "nsx-op/nsx_service_account_uid"
+	ccp := model.ClusterControlPlane{
+		Id:   &mId,
+		Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+	}
+	pi := mpmodel.PrincipalIdentity{
+		Id:   &mId,
+		Tags: []mpmodel.Tag{{Tag: &mTag, Scope: &mScope}},
+	}
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{"1", args{obj: ccp}, []string{"11111"}, false},
+		{"2", args{obj: pi}, []string{"11111"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := indexFunc(tt.args.obj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CRUIDScopeIndexFunc() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CRUIDScopeIndexFunc() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_keyFunc(t *testing.T) {
+	Id := "11111"
+	ccp := model.ClusterControlPlane{Id: &Id}
+	pi := mpmodel.PrincipalIdentity{Name: &Id}
+	o := model.UserInfo{}
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{"1", args{obj: ccp}, Id, false},
+		{"2", args{obj: pi}, Id, false},
+		{"0", args{obj: o}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := keyFunc(tt.args.obj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("keyFunc() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("keyFunc() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/util/crypto.go
+++ b/pkg/util/crypto.go
@@ -1,0 +1,77 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package util
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"time"
+)
+
+const (
+	DefaultRSABits = 2048
+	// For now the ClusterControlPlane API doesn't support rotating certificate. We set long valid time to avoid certificate expiration.
+	DefaultValidDays          = 3650
+	DefaultSerialNumberLength = 160
+)
+
+var (
+	DefaultSubject = pkix.Name{
+		Country:            []string{"US"},
+		Organization:       []string{"VMware"},
+		OrganizationalUnit: []string{"Antrea Cluster"},
+		Locality:           []string{"Palo Alto"},
+		Province:           []string{"CA"},
+		CommonName:         "dummy",
+	}
+)
+
+// GenerateCertificate returns generated certificate and private key in PEM format
+func GenerateCertificate(subject *pkix.Name, validDays int) (string, string, error) {
+	if subject == nil {
+		defaultSubject := DefaultSubject
+		subject = &defaultSubject
+	}
+	if validDays <= 0 {
+		validDays = DefaultValidDays
+	}
+
+	priv, err := rsa.GenerateKey(rand.Reader, DefaultRSABits)
+	if err != nil {
+		log.Error(err, "failed to generate RSA key")
+		return "", "", err
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), DefaultSerialNumberLength))
+	if err != nil {
+		log.Error(err, "failed to generate serial number")
+		return "", "", err
+	}
+	notBefore := time.Now()
+	notAfter := notBefore.AddDate(0, 0, validDays)
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject:      *subject,
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		log.Error(err, "failed to create certificate")
+		return "", "", err
+	}
+
+	certOut := &bytes.Buffer{}
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyOut := &bytes.Buffer{}
+	privBytes := x509.MarshalPKCS1PrivateKey(priv)
+	pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: privBytes})
+	return string(certOut.Bytes()), string(keyOut.Bytes()), nil
+}

--- a/pkg/util/crypto_test.go
+++ b/pkg/util/crypto_test.go
@@ -1,0 +1,86 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package util
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateCertificate(t *testing.T) {
+	type args struct {
+		subject   *pkix.Name
+		validDays int
+	}
+	var tests = []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "default",
+			args: args{
+				subject:   nil,
+				validDays: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "standard",
+			args: args{
+				subject: &pkix.Name{
+					Country:            []string{"US"},
+					Organization:       []string{"VMware"},
+					OrganizationalUnit: []string{"Antrea Cluster"},
+					Locality:           []string{"Palo Alto"},
+					Province:           []string{"CA"},
+					CommonName:         "standard",
+				},
+				validDays: 365,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := GenerateCertificate(tt.args.subject, tt.args.validDays)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateCertificate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			decodedGot, rest := pem.Decode([]byte(got))
+			assert.Equal(t, 0, len(rest))
+			cert, err := x509.ParseCertificate(decodedGot.Bytes)
+			assert.Nil(t, err)
+			assert.Equal(t, x509.SHA256WithRSA, cert.SignatureAlgorithm)
+			assert.Equal(t, 3, cert.Version)
+			assert.Equal(t, cert.Subject, cert.Issuer)
+			assert.True(t, time.Now().After(cert.NotBefore) && time.Now().Sub(cert.NotBefore) < time.Minute, "NotBefore is invalid")
+			validDays := tt.args.validDays
+			if validDays <= 0 {
+				validDays = DefaultValidDays
+			}
+			assert.True(t, cert.NotAfter == cert.NotBefore.AddDate(0, 0, validDays))
+			expectedSubject := tt.args.subject
+			if expectedSubject == nil {
+				expectedSubject = &DefaultSubject
+			}
+			actualSubject := cert.Subject
+			actualSubject.Names = nil
+			assert.Equal(t, *expectedSubject, actualSubject)
+
+			decodedGot1, rest := pem.Decode([]byte(got1))
+			assert.Equal(t, 0, len(rest))
+			priv, err := x509.ParsePKCS1PrivateKey(decodedGot1.Bytes)
+			assert.Nil(t, err)
+			assert.Equal(t, 2048, priv.Size()*8)
+		})
+	}
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -50,6 +50,20 @@ func NormalizeName(name string) string {
 	return newName
 }
 
+func NormalizeId(name string) string {
+	newName := strings.ReplaceAll(name, ":", "_")
+	if len(newName) <= common.MaxIdLength {
+		return newName
+	}
+	hashString := Sha1(name)
+	nameLength := common.MaxIdLength - HashLength - 1
+	for strings.ContainsAny(string(newName[nameLength-1]), "-._") {
+		nameLength--
+	}
+	newName = fmt.Sprintf("%s-%s", newName[:nameLength], hashString[:HashLength])
+	return newName
+}
+
 func Sha1(data string) string {
 	h := sha1.New()
 	h.Write([]byte(data))

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -209,3 +209,43 @@ func TestRemoveDuplicateStr(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeId(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "1",
+			args: args{
+				name: "k8scl-one-test",
+			},
+			want: "k8scl-one-test",
+		},
+		{
+			name: "2",
+			args: args{
+				name: "k8scl-one:test",
+			},
+			want: "k8scl-one_test",
+		},
+		{
+			name: "3",
+			args: args{
+				name: "k8scl-one:1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
+			},
+			want: "k8scl-one_12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456-e8ad9afc",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeId(tt.args.name); got != tt.want {
+				t.Errorf("NormalizeId() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Reconciler:
1. If NSXServiceAccount CR DeletionTimestamp is zero and Status.Phase is not "realized"
  a. Add NSXServiceAccount finalizer if not exists
  b. Generate certificate
  c. Create PrincipalIdentity with certificate and add to store
  d. Create ClusterControlPlane and add to store
  e. Create K8s Secret
  f. Update CR status

2. If NSXServiceAccount CR DeletionTimestamp is not zero and has NSXServiceAccount finalizer
  a. Delete K8s Secret
  b. Delete ClusterControlPlane and remove from store
  c. Delete PrincipalIdentity and remove from store
  d. Remove NSXServiceAccount finalizer

GC:
1. Get all CR UIDs from Tags of PrincipalIdentity and ClusterControlPlane from store
2. Get all NSXServiceAccount CRs
3. Get the UIDs which exists in NSX resource Tags and doesn't exist in CRs
4. Convert UIDs to Namespacednames
5. Run the same delete process in section Reconciler.2

Signed-off-by: gran <gran@vmware.com>