### PR TITLE
Fix bug of logger, log-level doesn't take effect

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
@@ -44,6 +45,7 @@ func init() {
 	if err != nil {
 		os.Exit(1)
 	}
+	logf.SetLogger(logger.ZapLogger())
 	if metrics.AreMetricsExposed(cf) {
 		metrics.InitializePrometheusMetrics()
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -26,7 +26,6 @@ var (
 
 func init() {
 	flag.IntVar(&logLevel, "log-level", 0, "Use zap-core log system.")
-	logf.SetLogger(ZapLogger())
 	Log = logf.Log.WithName("nsx-operator")
 }
 


### PR DESCRIPTION
This statement `logf.SetLogger(logger.ZapLogger())`` must called after `flag.Parse`,
otherwise, log-level option is always the default value,  so the the log-level we pass from command line
doesn't take effect as expected.
Besides, before this PR, there are redundant options prefixed with -zap in
command line, we don't need those, actually.