### PR TITLE
Upgrade golang to 1.19.5

### DIFF
--- a/build/image/photon/Dockerfile
+++ b/build/image/photon/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.7 as golang-build
+FROM golang:1.19.5 as golang-build
 
 WORKDIR /source
 


### PR DESCRIPTION
Latest stable golang runtime version is 1.19.5, upgrade to 1.19.5 to fix CVE problems imported by golang 1.17.7.
CVE List :
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-30580   CVSS score : 7.8
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-24921   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-28327   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-24675   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-30634   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-32189   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-30635   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-30633   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-30632   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-30631   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-30630   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-29804   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-28131   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-27664   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-41715   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-2880   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-2879   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-41716   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-41720   CVSS score : 7.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-32148   CVSS score : 6.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-1705   CVSS score : 6.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-1962   CVSS score : 5.5
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-29526   CVSS score : 5.3
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-41717   CVSS score : 5.3
CVE : https://nvd.nist.gov/vuln/detail/CVE-2022-30629   CVSS score : 3.1