### PR TITLE
Upgrade golang version to 1.19 in github workflow

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.19
         
     - name: Run build
       run: make build


### PR DESCRIPTION
Upgrade golang version to 1.19 in github workflow for main branch
since golang version in go mod has been upgrade to 1.19:
https://github.com/vmware-tanzu/nsx-operator/pull/180