### PR TITLE
Install go tool by using go install instead of go get after golang 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
After golang 1.18, go get does not install binary by default, so controller-gen is not installed. Here should use go install.