### PR TITLE
Fix errors when validate VPC options

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -127,7 +127,7 @@ func NewNSXOperatorConfigFromFile() (*NSXOperatorConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if err := nsxOperatorConfig.validate(); err != nil {
 		return nil, err
 	}
@@ -138,9 +138,7 @@ func NewNSXOperatorConfigFromFile() (*NSXOperatorConfig, error) {
 func NewNSXOpertorConfig() *NSXOperatorConfig {
 	defaultNSXOperatorConfig := &NSXOperatorConfig{
 		&DefaultConfig{},
-		&CoeConfig{
-			"",
-		},
+		&CoeConfig{},
 		&NsxConfig{},
 		&K8sConfig{},
 		&VCConfig{},
@@ -152,7 +150,7 @@ func (operatorConfig *NSXOperatorConfig) validate() error {
 	if err := operatorConfig.CoeConfig.validate(); err != nil {
 		return err
 	}
-	if err := operatorConfig.NsxConfig.validate(); err != nil {
+	if err := operatorConfig.NsxConfig.validate(operatorConfig.CoeConfig.EnableVPCNetwork); err != nil {
 		return err
 	}
 	// TODO, verify if user&pwd, cert, jwt has any of them provided
@@ -207,7 +205,7 @@ func (vcConfig *VCConfig) validate() error {
 	return nil
 }
 
-func (nsxConfig *NsxConfig) validate() error {
+func (nsxConfig *NsxConfig) validate(enableVPC bool) error {
 	mCount := len(nsxConfig.NsxApiManagers)
 	if mCount == 0 {
 		err := errors.New("invalid field " + "NsxApiManagers")
@@ -228,7 +226,6 @@ func (nsxConfig *NsxConfig) validate() error {
 		log.Error(err, "validate NsxConfig failed", "thumbprint count", tpCount, "manager count", mCount)
 		return err
 	}
-	enableVPC := coeConfig.EnableVPCNetwork
 	if enableVPC {
 		if nsxConfig.DefaultProject == "" || len(nsxConfig.ExternalIPv4Blocks) == 0 {
 			err := errors.New("default_project is none or external_ipv4_blocks is empty")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -47,20 +47,20 @@ func TestConfig_CoeConfig(t *testing.T) {
 func TestConfig_NsxConfig(t *testing.T) {
 	nsxConfig := &NsxConfig{}
 	expect := errors.New("invalid field " + "NsxApiManagers")
-	err := nsxConfig.validate()
+	err := nsxConfig.validate(false)
 	assert.Equal(t, err, expect)
 
 	nsxConfig.NsxApiManagers = []string{"10.0.0.1"}
-	err = nsxConfig.validate()
+	err = nsxConfig.validate(false)
 	assert.Equal(t, err, nil)
 
 	nsxConfig.Thumbprint = []string{"0a:fc"}
-	err = nsxConfig.validate()
+	err = nsxConfig.validate(false)
 	assert.Equal(t, err, nil)
 
 	nsxConfig.Thumbprint = []string{"0a:fc", "ob:fd"}
 	expect = errors.New("thumbprint count not match manager count")
-	err = nsxConfig.validate()
+	err = nsxConfig.validate(false)
 	assert.Equal(t, err, expect)
 }
 


### PR DESCRIPTION
Need to pass param for enable_vpc_network when validate VPC options under NsxConfig.