### PR TITLE
Implement cleaning up all nsx resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ test: manifests generate fmt vet envtest ## Run tests.
 build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/main.go
 
+.PHONY: clean
+clean: generate fmt vet ## Build clean binary.
+	go build -o bin/clean cmd_clean/main.go
+
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go

--- a/cmd_clean/main.go
+++ b/cmd_clean/main.go
@@ -1,0 +1,65 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package main
+
+import (
+	"flag"
+	"os"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/clean"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+)
+
+// usage:
+// ./bin/clean -cluster=''  -thumbprint="" -log-level=0 -vc-user="" -vc-passwd="" -vc-endpoint="" -vc-sso-domain="" -vc-https-port=443  -mgr-ip=""
+
+var (
+	log         = logger.Log
+	cf          *config.NSXOperatorConfig
+	mgrIp       string
+	vcEndpoint  string
+	vcUser      string
+	vcPasswd    string
+	vcSsoDomain string
+	vcHttpsPort int
+	thumbprint  string
+	caFile      string
+	cluster     string
+)
+
+func main() {
+	flag.StringVar(&vcEndpoint, "vc-endpoint", "", "nsx manager ip")
+	flag.StringVar(&vcSsoDomain, "vc-sso-domain", "", "nsx manager ip")
+	flag.StringVar(&mgrIp, "mgr-ip", "", "nsx manager ip")
+	flag.StringVar(&vcUser, "vc-user", "", "nsx username")
+	flag.StringVar(&vcPasswd, "vc-passwd", "", "nsx password")
+	flag.IntVar(&vcHttpsPort, "vc-https-port", 443, "nsx password")
+	flag.StringVar(&thumbprint, "thumbprint", "", "nsx thumbprint")
+	flag.StringVar(&caFile, "ca-file", "", "ca file")
+	flag.StringVar(&cluster, "cluster", "", "cluster name")
+	flag.IntVar(&config.LogLevel, "log-level", 0, "Use zap-core log system.")
+	flag.Parse()
+
+	logf.SetLogger(logger.ZapLogger())
+	cf = config.NewNSXOpertorConfig()
+	cf.NsxApiManagers = []string{mgrIp}
+	cf.VCUser = vcUser
+	cf.VCPassword = vcPasswd
+	cf.VCEndPoint = vcEndpoint
+	cf.SsoDomain = vcSsoDomain
+	cf.HttpsPort = vcHttpsPort
+	cf.Thumbprint = []string{thumbprint}
+	cf.CaFile = []string{caFile}
+	cf.Cluster = cluster
+
+	err := clean.Clean(cf)
+	if err != nil {
+		log.Error(err, "failed to clean nsx resources")
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/pkg/clean/clean.go
+++ b/pkg/clean/clean.go
@@ -1,0 +1,61 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package clean
+
+import (
+	"fmt"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy"
+)
+
+var log = logger.Log
+
+// Clean cleans up NSX resources,
+// including security policy, static route, subnet, subnet port, subnet set, vpc, ip pool, nsx service account
+// it is usually used when nsx-operator is uninstalled and remove all the resources created by nsx-operator
+// return error if any, return nil if no error
+func Clean(cf *config.NSXOperatorConfig) error {
+	log.Info("starting NSX cleanup")
+	if cleanupServices, err := InitializeCleanupServices(cf); err != nil {
+		return fmt.Errorf("failed to initialize cleanup service: %w", err)
+	} else {
+		for _, cleanupService := range cleanupServices {
+			if err := cleanupService.Cleanup(); err != nil {
+				return fmt.Errorf("failed to clean up: %w", err)
+			}
+		}
+	}
+	log.Info("cleanup NSX resources successfully")
+	return nil
+}
+
+// InitializeCleanupServices initializes all the CR services
+func InitializeCleanupServices(cf *config.NSXOperatorConfig) ([]cleanup, error) {
+	var cleanupServices []cleanup
+
+	nsxClient := nsx.GetClient(cf)
+	if nsxClient == nil {
+		return nil, fmt.Errorf("failed to get nsx client")
+	}
+
+	var commonService = common.Service{
+		NSXClient: nsxClient,
+		NSXConfig: cf,
+	}
+
+	// initialize all the CR services
+	securityService, err := securitypolicy.InitializeSecurityPolicy(commonService)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize security policy service: %w", err)
+	} else {
+		cleanupServices = append(cleanupServices, securityService)
+	}
+	// TODO: initialize other CR services
+
+	return cleanupServices, nil
+}

--- a/pkg/clean/types.go
+++ b/pkg/clean/types.go
@@ -1,0 +1,5 @@
+package clean
+
+type cleanup interface {
+	Cleanup() error
+}

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -246,3 +246,16 @@ func (service *SecurityPolicyService) ListSecurityPolicyID() sets.String {
 	policySet := service.securityPolicyStore.ListIndexFuncValues(common.TagScopeSecurityPolicyCRUID)
 	return groupSet.Union(policySet)
 }
+
+func (service *SecurityPolicyService) Cleanup() error {
+	// Delete all the security policies in store
+	uids := service.ListSecurityPolicyID()
+	log.Info("cleaning up security policies", "count", len(uids))
+	for uid := range uids {
+		err := service.DeleteSecurityPolicy(types.UID(uid))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Just run `./bin/clean -cluster=''  -thumbprint="" -log-level=0 -vc-user="" -vc-passwd="" -vc-endpoint="" -vc-sso-domain="" -vc-https-port=443  -mgr-ip=""
` to clean up all. Leverage the existing module to realize the logic more conveniently.