### PR TITLE
Set EnableHA default to true

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"flag"
 	"os"
 	"time"
 
@@ -29,39 +28,32 @@ import (
 )
 
 var (
-	scheme                 = runtime.NewScheme()
-	probeAddr, metricsAddr string
-	log                    = logger.Log
-	cf                     *config.NSXOperatorConfig
-	nsxOperatorNamespace   = "default"
-	enableHA               = true
+	scheme               = runtime.NewScheme()
+	log                  = logger.Log
+	cf                   *config.NSXOperatorConfig
+	nsxOperatorNamespace = "default"
 )
 
 func init() {
+	var err error
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8384", "The address the probe endpoint binds to.")
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8093", "The address the metrics endpoint binds to.")
 	config.AddFlags()
-	flag.Parse()
-	var err error
-
-	logf.SetLogger(logger.ZapLogger())
 	cf, err = config.NewNSXOperatorConfigFromFile()
 	if err != nil {
 		log.Error(err, "load config file error")
 		os.Exit(1)
 	}
 
+	logf.SetLogger(logger.ZapLogger())
+
 	if os.Getenv("NSX_OPERATOR_NAMESPACE") != "" {
 		nsxOperatorNamespace = os.Getenv("NSX_OPERATOR_NAMESPACE")
 	}
 
-	if cf.EnableHA == nil || *cf.EnableHA == true {
-		enableHA = true
+	if cf.HAEnabled() {
 		log.Info("HA mode enabled")
 	} else {
-		enableHA = false
 		log.Info("HA mode disabled")
 	}
 
@@ -111,9 +103,9 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,
-		HealthProbeBindAddress:  probeAddr,
-		MetricsBindAddress:      metricsAddr,
-		LeaderElection:          enableHA,
+		HealthProbeBindAddress:  config.ProbeAddr,
+		MetricsBindAddress:      config.MetricsAddr,
+		LeaderElection:          cf.HAEnabled(),
 		LeaderElectionNamespace: nsxOperatorNamespace,
 		LeaderElectionID:        "nsx-operator",
 	})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,8 +57,12 @@ func init() {
 		nsxOperatorNamespace = os.Getenv("NSX_OPERATOR_NAMESPACE")
 	}
 
-	if cf.EnableHA == false {
+	if cf.EnableHA == nil || *cf.EnableHA == true {
+		enableHA = true
+		log.Info("HA mode enabled")
+	} else {
 		enableHA = false
+		log.Info("HA mode disabled")
 	}
 
 	if metrics.AreMetricsExposed(cf) {
@@ -104,10 +108,6 @@ func StartNSXServiceAccountController(mgr ctrl.Manager, commonService common.Ser
 
 func main() {
 	log.Info("starting NSX Operator")
-
-	if enableHA {
-		log.Info("HA mode enabled")
-	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,7 +77,7 @@ type VCConfig struct {
 }
 
 type HAConfig struct {
-	EnableHA bool `ini:"enable"`
+	EnableHA *bool `ini:"enable"`
 }
 
 type Validate interface {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,9 +22,11 @@ const (
 )
 
 var (
-	configFilePath = ""
-	log            = logf.Log.WithName("config")
-	tokenProvider  auth.TokenProvider
+	LogLevel               int
+	ProbeAddr, MetricsAddr string
+	configFilePath         = ""
+	log                    = logf.Log.WithName("config")
+	tokenProvider          auth.TokenProvider
 )
 
 //TODO delete unnecessary config
@@ -36,6 +38,13 @@ type NSXOperatorConfig struct {
 	*K8sConfig
 	*VCConfig
 	*HAConfig
+}
+
+func (operatorConfig *NSXOperatorConfig) HAEnabled() bool {
+	if operatorConfig.EnableHA == nil || *operatorConfig.EnableHA == true {
+		return true
+	}
+	return false
 }
 
 type DefaultConfig struct {
@@ -90,6 +99,10 @@ type NsxVersion struct {
 
 func AddFlags() {
 	flag.StringVar(&configFilePath, "nsxconfig", nsxOperatorDefaultConf, "NSX Operator configuration file path")
+	flag.StringVar(&ProbeAddr, "health-probe-bind-address", ":8384", "The address the probe endpoint binds to.")
+	flag.StringVar(&MetricsAddr, "metrics-bind-address", ":8093", "The address the metrics endpoint binds to.")
+	flag.IntVar(&LogLevel, "log-level", 0, "Use zap-core log system.")
+	flag.Parse()
 }
 
 func UpdateConfigFilePath(configFile string) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/ini.v1"
 )
 
 func TestConfig_VCConfig(t *testing.T) {
@@ -83,4 +84,27 @@ func TestConfig_GetTokenProvider(t *testing.T) {
 	nsxConfig := &NSXOperatorConfig{VCConfig: vcConfig, NsxConfig: &NsxConfig{}}
 	tokenProvider := nsxConfig.GetTokenProvider()
 	assert.NotNil(t, tokenProvider)
+}
+
+func TestConfig_GetHA(t *testing.T) {
+	configFilePath = "../mock/nsxop.ini"
+	cf := NewNSXOpertorConfig()
+
+	cfg := ini.Empty()
+	err := ini.ReflectFrom(cfg, cf)
+	assert.Equal(t, err, nil)
+	err = cfg.Section("ha").MapTo(cf.HAConfig)
+	assert.Equal(t, validateHAValue(cf.EnableHA), true)
+}
+
+func validateHAValue(haValue interface{}) bool {
+	// haValue could be nil, true or false
+	if haValue == nil {
+		return true
+	}
+	_, ok := haValue.(*bool)
+	if ok {
+		return true
+	}
+	return false
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/ini.v1"
 )
 
 func TestConfig_VCConfig(t *testing.T) {
@@ -88,23 +87,7 @@ func TestConfig_GetTokenProvider(t *testing.T) {
 
 func TestConfig_GetHA(t *testing.T) {
 	configFilePath = "../mock/nsxop.ini"
-	cf := NewNSXOpertorConfig()
-
-	cfg := ini.Empty()
-	err := ini.ReflectFrom(cfg, cf)
+	cf, err := NewNSXOperatorConfigFromFile()
 	assert.Equal(t, err, nil)
-	err = cfg.Section("ha").MapTo(cf.HAConfig)
-	assert.Equal(t, validateHAValue(cf.EnableHA), true)
-}
-
-func validateHAValue(haValue interface{}) bool {
-	// haValue could be nil, true or false
-	if haValue == nil {
-		return true
-	}
-	_, ok := haValue.(*bool)
-	if ok {
-		return true
-	}
-	return false
+	assert.Equal(t, cf.HAEnabled(), true)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -9,12 +9,13 @@ import (
 	"go.uber.org/zap/zapcore"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	zapcr "sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 )
 
 const logTmFmtWithMS = "2006-01-02 15:04:05.000"
 
 var (
-	logLevel          int
 	Log               logr.Logger
 	customTimeEncoder = func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 		enc.AppendString(t.Format(logTmFmtWithMS))
@@ -25,7 +26,6 @@ var (
 )
 
 func init() {
-	flag.IntVar(&logLevel, "log-level", 0, "Use zap-core log system.")
 	Log = logf.Log.WithName("nsx-operator")
 }
 
@@ -55,9 +55,9 @@ func ZapLogger() logr.Logger {
 	// In level.go of zapcore, higher levels are more important.
 	// However, in logr.go, a higher verbosity level means a log message is less important.
 	// So we need to reverse the order of the levels.
-	opts.Level = zapcore.Level(-1 * logLevel)
+	opts.Level = zapcore.Level(-1 * config.LogLevel)
 	opts.ZapOpts = append(opts.ZapOpts, zap.AddCaller(), zap.AddCallerSkip(0))
-	if logLevel > 0 {
+	if config.LogLevel > 0 {
 		opts.StacktraceLevel = zap.ErrorLevel
 	}
 

--- a/pkg/mock/nsxop.ini
+++ b/pkg/mock/nsxop.ini
@@ -1,11 +1,12 @@
+[DEFAULT]
 [coe]
 cluster = k8scl-one
-
+[ha]
+#enable=true
+[k8s]
 [nsx_v3]
 nsx_api_managers = 127.0.0.1
 nsx_api_password = admin
 nsx_api_user = admin
 thumbprint = 81:49:DD:B7:E8:79:55:5D:9E:75:A9:FA:A6:7D:CB:EA:A4:CA:12:C6
-
-[ha]
-#enable=true
+[vc]

--- a/pkg/mock/nsxop.ini
+++ b/pkg/mock/nsxop.ini
@@ -6,3 +6,6 @@ nsx_api_managers = 127.0.0.1
 nsx_api_password = admin
 nsx_api_user = admin
 thumbprint = 81:49:DD:B7:E8:79:55:5D:9E:75:A9:FA:A6:7D:CB:EA:A4:CA:12:C6
+
+[ha]
+#enable=true


### PR DESCRIPTION
If user forgets to set ha.enable but set replica 2, it would be confusing,
so set EnableHA default true to avoid this undefined behaviour.
Besides, NCP ha.enable default value is true, keep it aligned.