### PR TITLE
Fix named-port bug when deleting deployments(#217)

### DIFF
--- a/pkg/controllers/securitypolicy/pod_controller.go
+++ b/pkg/controllers/securitypolicy/pod_controller.go
@@ -112,7 +112,7 @@ var PredicateFuncsPod = predicate.Funcs{
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {
 		if p, ok := e.Object.(*v1.Pod); ok {
-			log.V(1).Info("receive pod create event", "namespace", p.Namespace, "name", p.Name)
+			log.V(1).Info("receive pod delete event", "namespace", p.Namespace, "name", p.Name)
 			return util.CheckPodHasNamedPort(*p, "delete")
 		}
 		return false

--- a/pkg/controllers/securitypolicy/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller.go
@@ -22,8 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -230,12 +228,6 @@ func getExistingConditionOfType(conditionType v1alpha1.ConditionType, existingCo
 func (r *SecurityPolicyReconciler) setupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.SecurityPolicy{}).
-		WithEventFilter(predicate.Funcs{
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				// Suppress Delete events to avoid filtering them out in the Reconcile function
-				return false
-			},
-		}).
 		WithOptions(
 			controller.Options{
 				MaxConcurrentReconciles: runtime.NumCPU(),

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -45,7 +45,10 @@ func InitializeSecurityPolicy(service common.Service) (*SecurityPolicyService, e
 		BindingType: model.SecurityPolicyBindingType(),
 	}}
 	securityPolicyService.groupStore = &GroupStore{ResourceStore: common.ResourceStore{
-		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSecurityPolicyCRUID: indexFunc}),
+		Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
+			common.TagScopeSecurityPolicyCRUID: indexFunc,
+			common.TagScopeRuleID:              indexGroupFunc,
+		}),
 		BindingType: model.GroupBindingType(),
 	}}
 	securityPolicyService.ruleStore = &RuleStore{ResourceStore: common.ResourceStore{
@@ -228,11 +231,11 @@ func (service *SecurityPolicyService) createOrUpdateGroups(nsxGroups []model.Gro
 		if err != nil {
 			return err
 		}
-		err = service.groupStore.Operate(group)
-		log.V(2).Info("add group to store", "group", group.Id)
-		if err != nil {
-			return err
-		}
+	}
+	
+	err := service.groupStore.Operate(&nsxGroups)
+	if err != nil {
+		return err
 	}
 	log.Info("successfully create or update group", "groups", nsxGroups)
 	return nil

--- a/pkg/nsx/services/securitypolicy/store.go
+++ b/pkg/nsx/services/securitypolicy/store.go
@@ -48,6 +48,26 @@ var filterTag = func(v []model.Tag) []string {
 	return res
 }
 
+func indexGroupFunc(obj interface{}) ([]string, error) {
+	res := make([]string, 0, 5)
+	switch o := obj.(type) {
+	case model.Group:
+		return filterGroupTag(o.Tags), nil
+	default:
+		return res, errors.New("indexGroupFunc doesn't support unknown type")
+	}
+}
+
+var filterGroupTag = func(v []model.Tag) []string {
+	res := make([]string, 0, 5)
+	for _, tag := range v {
+		if *tag.Scope == common.TagScopeRuleID {
+			res = append(res, *tag.Tag)
+		}
+	}
+	return res
+}
+
 // SecurityPolicyStore is a store for security policy
 type SecurityPolicyStore struct {
 	common.ResourceStore

--- a/pkg/nsx/util/errors.go
+++ b/pkg/nsx/util/errors.go
@@ -555,14 +555,6 @@ func (err PodNotRunning) Error() string {
 	return err.Desc
 }
 
-type NoFilteredPod struct {
-	Desc string
-}
-
-func (err NoFilteredPod) Error() string {
-	return err.Desc
-}
-
 type NoEffectiveOption struct {
 	Desc string
 }


### PR DESCRIPTION
When deleting deployments, the events sequences are as below: update event -> pod deleting -> pod deleted-> delete event So remove the EventFilter of DeleteFunc to let pod_controller handle delete event.
When just deleting pods and leaving security policy behind, there are stale ip set group, if all the corresponding pods are deleted, we should clear stale ips in the group and leave it as empty group.