### PR TITLE
Init logger before load operator config file

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,13 +39,13 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	config.AddFlags()
+
+	logf.SetLogger(logger.ZapLogger())
 	cf, err = config.NewNSXOperatorConfigFromFile()
 	if err != nil {
 		log.Error(err, "load config file error")
 		os.Exit(1)
 	}
-
-	logf.SetLogger(logger.ZapLogger())
 
 	if os.Getenv("NSX_OPERATOR_NAMESPACE") != "" {
 		nsxOperatorNamespace = os.Getenv("NSX_OPERATOR_NAMESPACE")
@@ -122,7 +122,7 @@ func main() {
 	}
 
 	//  Embed the common commonService to sub-services.
-	var commonService = common.Service{
+	commonService := common.Service{
 		Client:    mgr.GetClient(),
 		NSXClient: nsxClient,
 		NSXConfig: cf,

--- a/pkg/apis/v1alpha2/groupversion_info.go
+++ b/pkg/apis/v1alpha2/groupversion_info.go
@@ -14,10 +14,10 @@ import (
 var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "nsx.vmware.com", Version: "v1alpha2"}
-	
+
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
-	
+
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,8 +29,7 @@ var (
 	tokenProvider          auth.TokenProvider
 )
 
-//TODO delete unnecessary config
-
+// TODO delete unnecessary config
 type NSXOperatorConfig struct {
 	*DefaultConfig
 	*CoeConfig
@@ -187,7 +186,7 @@ func (operatorConfig *NSXOperatorConfig) GetTokenProvider() auth.TokenProvider {
 }
 
 func (operatorConfig *NSXOperatorConfig) createTokenProvider() error {
-	log.V(2).Info("try to load VC host CA")
+	log.V(1).Info("try to load VC host CA")
 	var vcCaCert []byte
 	var err error
 	if !operatorConfig.Insecure {

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -232,7 +232,7 @@ func (service *SecurityPolicyService) createOrUpdateGroups(nsxGroups []model.Gro
 			return err
 		}
 	}
-	
+
 	err := service.groupStore.Operate(&nsxGroups)
 	if err != nil {
 		return err


### PR DESCRIPTION
Initializing logger before loading operator config file, otherwise, the log info will not be logged

Also, change log info level in validating config and go-fmt files