### PR TITLE
Init logger before load operator config file(#242)

### DIFF
--- a/pkg/apis/v1alpha1/groupversion_info.go
+++ b/pkg/apis/v1alpha1/groupversion_info.go
@@ -1,8 +1,8 @@
 /* Copyright © 2021 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0 */
 
-//+kubebuilder:object:generate=true
-//+groupName=nsx.vmware.com
+// +kubebuilder:object:generate=true
+// +groupName=nsx.vmware.com
 package v1alpha1
 
 import (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/auth/jwt"
 )
 
-//TODO replace to yaml
+// TODO replace to yaml
 const (
 	nsxOperatorDefaultConf = "/etc/nsx-operator/nsxop.ini"
 	vcHostCACertPath       = "/etc/vmware/wcp/tls/vmca.pem"
@@ -27,8 +27,7 @@ var (
 	tokenProvider  auth.TokenProvider
 )
 
-//TODO delete unnecessary config
-
+// TODO delete unnecessary config
 type NSXOperatorConfig struct {
 	*DefaultConfig
 	*CoeConfig

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -7,15 +7,15 @@ import (
 	"github.com/go-logr/logr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	zapcr "sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 )
 
 const logTmFmtWithMS = "2006-01-02 15:04:05.000"
 
 var (
 	logLevel          int
+	Log               logr.Logger
 	customTimeEncoder = func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 		enc.AppendString(t.Format(logTmFmtWithMS))
 	}
@@ -26,10 +26,10 @@ var (
 
 func init() {
 	flag.IntVar(&logLevel, "log-level", 0, "Use zap-core log system.")
+	Log = logf.Log.WithName("nsx-operator")
 }
 
-func ZapLogger(cf *config.NSXOperatorConfig) logr.Logger {
-
+func ZapLogger() logr.Logger {
 	encoderConf := zapcore.EncoderConfig{
 		CallerKey:      "caller_line",
 		LevelKey:       "level_name",
@@ -52,15 +52,13 @@ func ZapLogger(cf *config.NSXOperatorConfig) logr.Logger {
 	}
 	opts.BindFlags(flag.CommandLine)
 
-	if cf.Debug == true {
-		// In level.go of zapcore, higher levels are more important.
-		// However, in logr.go, a higher verbosity level means a log message is less important.
-		// So we need to reverse the order of the levels.
-		opts.Level = zapcore.Level(-1 * logLevel)
-		opts.ZapOpts = append(opts.ZapOpts, zap.AddCaller(), zap.AddCallerSkip(0))
-		if logLevel > 0 {
-			opts.StacktraceLevel = zap.ErrorLevel
-		}
+	// In level.go of zapcore, higher levels are more important.
+	// However, in logr.go, a higher verbosity level means a log message is less important.
+	// So we need to reverse the order of the levels.
+	opts.Level = zapcore.Level(-1 * logLevel)
+	opts.ZapOpts = append(opts.ZapOpts, zap.AddCaller(), zap.AddCallerSkip(0))
+	if logLevel > 0 {
+		opts.StacktraceLevel = zap.ErrorLevel
 	}
 	return zapcr.New(zapcr.UseFlagOptions(&opts))
 }

--- a/pkg/nsx/services/builder.go
+++ b/pkg/nsx/services/builder.go
@@ -802,9 +802,9 @@ func (service *SecurityPolicyService) updateExpressionsMatchLabels(matchLabels m
 // this function iterates over input matchExpressions LabelSelectorRequirement
 // with same operator and Key, and merges them into one and values to a joined string
 // e.g.
-// - {key: k1, operator: NotIn, values: [a1, a2, a3]}
-// - {key: k1, operator: NotIn, values: [a2, a3, a4]}
-//  => {key: k1, operator: NotIn, values: [a1, a2, a3, a4]}
+//   - {key: k1, operator: NotIn, values: [a1, a2, a3]}
+//   - {key: k1, operator: NotIn, values: [a2, a3, a4]}
+//     => {key: k1, operator: NotIn, values: [a1, a2, a3, a4]}
 func (service *SecurityPolicyService) mergeSelectorMatchExpression(matchExpressions []v1.LabelSelectorRequirement) *[]v1.LabelSelectorRequirement {
 	mergedMatchExpressions := make([]v1.LabelSelectorRequirement, 0)
 	var mergedSelector v1.LabelSelectorRequirement
@@ -954,7 +954,8 @@ func (service *SecurityPolicyService) matchExpressionOpInExist(matchExpressions 
 // Currently NSX only supports 'EQUALS' not 'In'. So, we have to make each value to be AND with other expressions
 // and finally produce a union set to translate from K8s 'In' to NSX EQUALS'.
 // e.g. - {key: k1, operator: NotIn, values: [a1,a2]}
-//      - {key: k2, operator: In, values: [a3,a4]}
+//   - {key: k2, operator: In, values: [a3,a4]}
+//
 // The above two expressions will be translated to:
 // => {k1 NotIn [a1,a2]} AND {k2 EQUALS a3} OR {k1 NotIn [a1,a2]} AND {k2 EQUALS a4}
 func (service *SecurityPolicyService) updateExpressionsMatchExpression(matchExpressions []v1.LabelSelectorRequirement, matchLabels map[string]string,


### PR DESCRIPTION
CP https://github.com/vmware-tanzu/nsx-operator/pull/242

Initializing logger before loading operator config file, otherwise, the log info will not be logged.

Referring to https://github.com/vmware-tanzu/nsx-operator/pull/141 to fix log-level setting bug.

Also, change log info level in validating config and go-fmt files.