### PR TITLE
Remove empty items from thumbprint/nsxapimanagers

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -226,7 +226,20 @@ func (vcConfig *VCConfig) validate() error {
 	return nil
 }
 
+func removeEmptyItem(source []string) []string {
+	target := make([]string, 0)
+	for _, value := range source {
+		if len(value) == 0 {
+			continue
+		}
+		target = append(target, value)
+	}
+	return target
+}
+
 func (nsxConfig *NsxConfig) validate() error {
+	nsxConfig.NsxApiManagers = removeEmptyItem(nsxConfig.NsxApiManagers)
+	nsxConfig.Thumbprint = removeEmptyItem(nsxConfig.Thumbprint)
 	mCount := len(nsxConfig.NsxApiManagers)
 	if mCount == 0 {
 		err := errors.New("invalid field " + "NsxApiManagers")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -62,6 +62,11 @@ func TestConfig_NsxConfig(t *testing.T) {
 	expect = errors.New("thumbprint count not match manager count")
 	err = nsxConfig.validate()
 	assert.Equal(t, err, expect)
+
+	nsxConfig.NsxApiManagers = []string{"10.0.0.1", "", ""}
+	err = nsxConfig.validate()
+	assert.Equal(t, err, expect)
+
 }
 
 func TestConfig_NewNSXOperatorConfigFromFile(t *testing.T) {


### PR DESCRIPTION
If user input more comma than expected, some of items value may be empty. Remove those empty items