### PR TITLE
change branch name for workflow in vpc branch

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,9 +2,9 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ vpc_dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ vpc_dev ]
 
 jobs:
   build:


### PR DESCRIPTION
This patch is to change branch name in github workflow make file
in order to make UT running in vpc_dev branch as well.