### PR TITLE
Refactor loglevel based on debug in configmap

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,7 +46,7 @@ func init() {
 		os.Exit(1)
 	}
 
-	logf.SetLogger(logger.ZapLogger())
+	logf.SetLogger(logger.ZapLogger(cf))
 
 	if os.Getenv("NSX_OPERATOR_NAMESPACE") != "" {
 		nsxOperatorNamespace = os.Getenv("NSX_OPERATOR_NAMESPACE")

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -29,7 +29,21 @@ func init() {
 	Log = logf.Log.WithName("nsx-operator")
 }
 
-func ZapLogger() logr.Logger {
+// If debug set in configmap, set log level to 1.
+// If loglevel set in command line and greater than debug log level, set it to command line level.
+func getLogLevel(cf *config.NSXOperatorConfig) int {
+	logLevel := 0
+	if cf.DefaultConfig.Debug {
+		logLevel = 1
+	}
+	realLogLevel := logLevel
+	if config.LogLevel > logLevel {
+		realLogLevel = config.LogLevel
+	}
+	return realLogLevel
+}
+
+func ZapLogger(cf *config.NSXOperatorConfig) logr.Logger {
 	encoderConf := zapcore.EncoderConfig{
 		CallerKey:      "caller_line",
 		LevelKey:       "level_name",
@@ -55,9 +69,10 @@ func ZapLogger() logr.Logger {
 	// In level.go of zapcore, higher levels are more important.
 	// However, in logr.go, a higher verbosity level means a log message is less important.
 	// So we need to reverse the order of the levels.
-	opts.Level = zapcore.Level(-1 * config.LogLevel)
+	logLevel := getLogLevel(cf)
+	opts.Level = zapcore.Level(-1 * logLevel)
 	opts.ZapOpts = append(opts.ZapOpts, zap.AddCaller(), zap.AddCallerSkip(0))
-	if config.LogLevel > 0 {
+	if logLevel > 0 {
 		opts.StacktraceLevel = zap.ErrorLevel
 	}
 


### PR DESCRIPTION
We hold these truths to be self-evident:
log.info -> info, log.v(1).info -> debug, log.error-> error, log.v(2).info-> develop level log

If config.Debug=true, then loglevel=1, if command is passed in loglevel and greater than debug loglevel, then the loglevel is overridden.