### PR TITLE
Refactor loglevel based on debug in configmap

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,12 +40,12 @@ func init() {
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	config.AddFlags()
 
-	logf.SetLogger(logger.ZapLogger())
 	cf, err = config.NewNSXOperatorConfigFromFile()
 	if err != nil {
-		log.Error(err, "load config file error")
 		os.Exit(1)
 	}
+
+	logf.SetLogger(logger.ZapLogger(cf))
 
 	if os.Getenv("NSX_OPERATOR_NAMESPACE") != "" {
 		nsxOperatorNamespace = os.Getenv("NSX_OPERATOR_NAMESPACE")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -103,6 +103,10 @@ func TestConfig_NewNSXOperatorConfigFromFile(t *testing.T) {
 	configFilePath = "../mock/nsxop.ini"
 	_, err = NewNSXOperatorConfigFromFile()
 	assert.Equal(t, err, nil)
+
+	configFilePath = "../mock/nsxop_err.ini"
+	_, err = NewNSXOperatorConfigFromFile()
+	assert.NotNil(t, err)
 }
 
 func TestConfig_GetTokenProvider(t *testing.T) {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -29,7 +29,21 @@ func init() {
 	Log = logf.Log.WithName("nsx-operator")
 }
 
-func ZapLogger() logr.Logger {
+// If debug set in configmap, set log level to 1.
+// If loglevel set in command line and greater than debug log level, set it to command line level.
+func getLogLevel(cf *config.NSXOperatorConfig) int {
+	logLevel := 0
+	if cf.DefaultConfig.Debug {
+		logLevel = 1
+	}
+	realLogLevel := logLevel
+	if config.LogLevel > logLevel {
+		realLogLevel = config.LogLevel
+	}
+	return realLogLevel
+}
+
+func ZapLogger(cf *config.NSXOperatorConfig) logr.Logger {
 	encoderConf := zapcore.EncoderConfig{
 		CallerKey:      "caller_line",
 		LevelKey:       "level_name",
@@ -55,9 +69,10 @@ func ZapLogger() logr.Logger {
 	// In level.go of zapcore, higher levels are more important.
 	// However, in logr.go, a higher verbosity level means a log message is less important.
 	// So we need to reverse the order of the levels.
-	opts.Level = zapcore.Level(-1 * config.LogLevel)
+	logLevel := getLogLevel(cf)
+	opts.Level = zapcore.Level(-1 * logLevel)
 	opts.ZapOpts = append(opts.ZapOpts, zap.AddCaller(), zap.AddCallerSkip(0))
-	if config.LogLevel > 0 {
+	if logLevel > 0 {
 		opts.StacktraceLevel = zap.ErrorLevel
 	}
 

--- a/pkg/mock/nsxop_err.ini
+++ b/pkg/mock/nsxop_err.ini
@@ -1,0 +1,12 @@
+[DEFAULT]
+[coe]
+cluster =
+[ha]
+#enable=true
+[k8s]
+[nsx_v3]
+nsx_api_managers = 127.0.0.1
+nsx_api_password = admin
+nsx_api_user = admin
+thumbprint = 81:49:DD:B7:E8:79:55:5D:9E:75:A9:FA:A6:7D:CB:EA:A4:CA:12:C6
+[vc]


### PR DESCRIPTION
This PR is to fix Issue: https://github.com/vmware-tanzu/nsx-operator/issues/245

We hold these truths to be self-evident:
log.info -> info, log.v(1).info -> debug, log.error-> error, log.v(2).info-> develop level log

If config.Debug=true, then loglevel=1, if command is passed in loglevel and greater than debug loglevel, then the loglevel is overridden.