### PR TITLE
Get default values of accessMode and ipv4SubnetSize from VPCNetworkCo…

### DIFF
--- a/build/yaml/crd/nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/nsx.vmware.com_subnets.yaml
@@ -81,9 +81,8 @@ spec:
                     type: boolean
                 type: object
               accessMode:
-                default: Private
                 description: Access mode of Subnet, accessible only from within VPC
-                  or from outside VPC. Defaults to Private.
+                  or from outside VPC.
                 enum:
                 - Private
                 - Public
@@ -110,9 +109,7 @@ spec:
                 minItems: 0
                 type: array
               ipv4SubnetSize:
-                default: 64
-                description: Size of Subnet based upon estimated workload count. Defaults
-                  to 64.
+                description: Size of Subnet based upon estimated workload count.
                 maximum: 65536
                 minimum: 16
                 type: integer

--- a/build/yaml/crd/nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/nsx.vmware.com_subnetsets.yaml
@@ -81,9 +81,8 @@ spec:
                     type: boolean
                 type: object
               accessMode:
-                default: Private
                 description: Access mode of Subnet, accessible only from within VPC
-                  or from outside VPC. Defaults to Private.
+                  or from outside VPC.
                 enum:
                 - Private
                 - Public
@@ -103,9 +102,7 @@ spec:
                     type: object
                 type: object
               ipv4SubnetSize:
-                default: 64
-                description: Size of Subnet based upon estimated workload count. Defaults
-                  to 64.
+                description: Size of Subnet based upon estimated workload count.
                 maximum: 65536
                 minimum: 16
                 type: integer

--- a/pkg/apis/v1alpha1/subnet_types.go
+++ b/pkg/apis/v1alpha1/subnet_types.go
@@ -12,14 +12,10 @@ type AccessMode string
 // SubnetSpec defines the desired state of Subnet.
 type SubnetSpec struct {
 	// Size of Subnet based upon estimated workload count.
-	// Defaults to 64.
-	// +kubebuilder:default:=64
 	// +kubebuilder:validation:Maximum:=65536
 	// +kubebuilder:validation:Minimum:=16
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// Access mode of Subnet, accessible only from within VPC or from outside VPC.
-	// Defaults to Private.
-	// +kubebuilder:default:=Private
 	// +kubebuilder:validation:Enum=Private;Public
 	AccessMode AccessMode `json:"accessMode,omitempty"`
 	// Subnet CIDRS.

--- a/pkg/apis/v1alpha1/subnetset_types.go
+++ b/pkg/apis/v1alpha1/subnetset_types.go
@@ -10,14 +10,10 @@ import (
 // SubnetSetSpec defines the desired state of SubnetSet.
 type SubnetSetSpec struct {
 	// Size of Subnet based upon estimated workload count.
-	// Defaults to 64.
-	// +kubebuilder:default:=64
 	// +kubebuilder:validation:Maximum:=65536
 	// +kubebuilder:validation:Minimum:=16
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// Access mode of Subnet, accessible only from within VPC or from outside VPC.
-	// Defaults to Private.
-	// +kubebuilder:default:=Private
 	// +kubebuilder:validation:Enum=Private;Public
 	AccessMode AccessMode `json:"accessMode,omitempty"`
 	// Subnet advanced configuration.


### PR DESCRIPTION
…nfiguration

Current fields `IPv4SubnetSize` and `AccessMode` are marked as default by kube-builder labels(// +kubebuilder:default:), and their default values are rendered by k8s api-server according to CRD definition. We need to change this behavior, and get default values of these two fields from VPCNetworkConfiguration CR. To implement this, we follow these steps:
- Remove kube-builder default labels of SubnetSet CRD definition.
- When `IPv4SubnetSize` and `AccessMode` are not set in spec of SubnetSet CRD, SubnetSet controller should: - Get current namespace, and get the VPCNetworkConfiguration that the namespace is using. - Get `IPv4SubnetSize` and `AccessMode` from VPCNetworkConfiguration and set them to SubnetSet CRD.