### PR TITLE
Update VPC CRDs with print columns and upper case

### DIFF
--- a/build/yaml/crd/nsx.vmware.com_ippools.yaml
+++ b/build/yaml/crd/nsx.vmware.com_ippools.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -15,7 +16,16 @@ spec:
     singular: ippool
   scope: Namespaced
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - description: Type of IPPool
+      jsonPath: .spec.type
+      name: Type
+      type: string
+    - description: CIDRs for the Subnet
+      jsonPath: .status.subnets[*].cidr
+      name: Subnets
+      type: string
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: IPPool is the Schema for the ippools API.

--- a/build/yaml/crd/nsx.vmware.com_staticroutes.yaml
+++ b/build/yaml/crd/nsx.vmware.com_staticroutes.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -15,7 +16,16 @@ spec:
     singular: staticroute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Network in CIDR format
+      jsonPath: .spec.network
+      name: Network
+      type: string
+    - description: Next Hops
+      jsonPath: .spec.nextHops[*].ipAddress
+      name: NextHops
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: StaticRoute is the Schema for the staticroutes API.

--- a/build/yaml/crd/nsx.vmware.com_subnetports.yaml
+++ b/build/yaml/crd/nsx.vmware.com_subnetports.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -15,7 +16,20 @@ spec:
     singular: subnetport
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Attachment VIF ID owned by the SubnetPort
+      jsonPath: .status.vifID
+      name: VIFID
+      type: string
+    - description: IP Address of the SubnetPort
+      jsonPath: .status.ipAddresses[0].ip
+      name: IPAddress
+      type: string
+    - description: MAC Address of the SubnetPort
+      jsonPath: .status.macAddress
+      name: MACAddress
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SubnetPort is the Schema for the subnetports API.
@@ -72,7 +86,6 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
-                x-kubernetes-map-type: atomic
               subnet:
                 description: Subnet defines the parent Subnet name of the SubnetPort.
                 type: string

--- a/build/yaml/crd/nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/nsx.vmware.com_subnets.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -15,7 +16,20 @@ spec:
     singular: subnet
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Access mode of Subnet
+      jsonPath: .spec.accessMode
+      name: AccessMode
+      type: string
+    - description: Size of Subnet
+      jsonPath: .spec.ipv4SubnetSize
+      name: IPv4SubnetSize
+      type: string
+    - description: CIDRs for the Subnet
+      jsonPath: .status.ipAddresses[*]
+      name: IPAddresses
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Subnet is the Schema for the subnets API.
@@ -69,7 +83,7 @@ spec:
               accessMode:
                 default: Private
                 description: Access mode of Subnet, accessible only from within VPC
-                  or from outside VPC. Defaults to private.
+                  or from outside VPC. Defaults to Private.
                 enum:
                 - Private
                 - Public

--- a/build/yaml/crd/nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/nsx.vmware.com_subnetsets.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -15,7 +16,20 @@ spec:
     singular: subnetset
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Access mode of Subnet
+      jsonPath: .spec.accessMode
+      name: AccessMode
+      type: string
+    - description: Size of Subnet
+      jsonPath: .spec.ipv4SubnetSize
+      name: IPv4SubnetSize
+      type: string
+    - description: CIDRs for the Subnet
+      jsonPath: .status.subnets[*].ipAddresses[*]
+      name: IPAddresses
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SubnetSet is the Schema for the subnetsets API.
@@ -69,7 +83,7 @@ spec:
               accessMode:
                 default: Private
                 description: Access mode of Subnet, accessible only from within VPC
-                  or from outside VPC. Defaults to private.
+                  or from outside VPC. Defaults to Private.
                 enum:
                 - Private
                 - Public

--- a/build/yaml/crd/nsx.vmware.com_vpcnetworkconfigurations.yaml
+++ b/build/yaml/crd/nsx.vmware.com_vpcnetworkconfigurations.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -17,15 +18,15 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: NSXTProject the Namespace associated with
-      jsonPath: .spec.NSXTProject
+      jsonPath: .spec.nsxtProject
       name: NSXTProject
       type: string
     - description: ExternalIPv4Blocks assigned to the Namespace
-      jsonPath: .spec.ExternalIPv4Blocks
-      name: PublicIPv4Blocks
+      jsonPath: .spec.externalIPv4Blocks
+      name: ExternalIPv4Blocks
       type: string
     - description: PrivateIPv4CIDRs assigned to the Namespace
-      jsonPath: .spec.PrivateIPv4CIDRs
+      jsonPath: .spec.privateIPv4CIDRs
       name: PrivateIPv4CIDRs
       type: string
     name: v1alpha1
@@ -63,10 +64,10 @@ spec:
                 type: integer
               defaultSubnetAccessMode:
                 description: DefaultSubnetAccessMode defines the access mode of the
-                  default SubnetSet for PodVM and VM. Must be public or private.
+                  default SubnetSet for PodVM and VM. Must be Public or Private.
                 enum:
-                - public
-                - private
+                - Public
+                - Private
                 type: string
               edgeClusterPath:
                 description: Edge cluster path on which the networking elements will
@@ -91,7 +92,7 @@ spec:
                 description: NSX-T Project the Namespace associated with.
                 type: string
               privateIPv4CIDRs:
-                description: Private IPv4 CIDRs used to allocate private Subnets.
+                description: Private IPv4 CIDRs used to allocate Private Subnets.
                 items:
                   type: string
                 maxItems: 5

--- a/build/yaml/crd/nsx.vmware.com_vpcs.yaml
+++ b/build/yaml/crd/nsx.vmware.com_vpcs.yaml
@@ -16,7 +16,16 @@ spec:
     singular: vpc
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Default SNAT IP for Private Subnets
+      jsonPath: .status.defaultSNATIP
+      name: SNATIP
+      type: string
+    - description: CIDR for the load balancer Subnet
+      jsonPath: .status.lbSubnetCIDR
+      name: LBSubnetCIDR
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VPC is the Schema for the VPC API
@@ -68,7 +77,7 @@ spec:
                   type: object
                 type: array
               defaultSNATIP:
-                description: Default SNAT IP for private Subnets.
+                description: Default SNAT IP for Private Subnets.
                 type: string
               lbSubnetCIDR:
                 description: CIDR for the load balancer Subnet.
@@ -91,9 +100,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/build/yaml/samples/nsx_v1alpha1_vpcnetworkconfigurations.yaml
+++ b/build/yaml/samples/nsx_v1alpha1_vpcnetworkconfigurations.yaml
@@ -8,8 +8,8 @@ spec:
   defaultIPv4SubnetSize: 26
   nsxtProject: proj-1
   externalIPv4Blocks:
-    - /infra/ip-blocks/block1
+    - block1
   privateIPv4CIDRs:
     - 172.26.0.0/16
     - 172.36.0.0/16
-  defaultSubnetAccessMode: public
+  defaultSubnetAccessMode: Private

--- a/pkg/apis/v1alpha1/staticroute_types.go
+++ b/pkg/apis/v1alpha1/staticroute_types.go
@@ -1,4 +1,4 @@
-/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+/* Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0 */
 
 package v1alpha1
@@ -41,6 +41,8 @@ type StaticRouteStatus struct {
 //+kubebuilder:storageversion
 
 // StaticRoute is the Schema for the staticroutes API.
+// +kubebuilder:printcolumn:name="Network",type=string,JSONPath=`.spec.network`,description="Network in CIDR format"
+// +kubebuilder:printcolumn:name="NextHops",type=string,JSONPath=`.spec.nextHops[*].ipAddress`,description="Next Hops"
 type StaticRoute struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/v1alpha1/subnet_types.go
+++ b/pkg/apis/v1alpha1/subnet_types.go
@@ -1,4 +1,4 @@
-/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+/* Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0 */
 
 package v1alpha1
@@ -18,7 +18,7 @@ type SubnetSpec struct {
 	// +kubebuilder:validation:Minimum:=16
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// Access mode of Subnet, accessible only from within VPC or from outside VPC.
-	// Defaults to private.
+	// Defaults to Private.
 	// +kubebuilder:default:=Private
 	// +kubebuilder:validation:Enum=Private;Public
 	AccessMode AccessMode `json:"accessMode,omitempty"`
@@ -44,6 +44,9 @@ type SubnetStatus struct {
 //+kubebuilder:subresource:status
 
 // Subnet is the Schema for the subnets API.
+// +kubebuilder:printcolumn:name="AccessMode",type=string,JSONPath=`.spec.accessMode`,description="Access mode of Subnet"
+// +kubebuilder:printcolumn:name="IPv4SubnetSize",type=string,JSONPath=`.spec.ipv4SubnetSize`,description="Size of Subnet"
+// +kubebuilder:printcolumn:name="IPAddresses",type=string,JSONPath=`.status.ipAddresses[*]`,description="CIDRs for the Subnet"
 type Subnet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/v1alpha1/subnetport_types.go
+++ b/pkg/apis/v1alpha1/subnetport_types.go
@@ -1,4 +1,4 @@
-/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+/* Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0 */
 
 package v1alpha1
@@ -43,6 +43,9 @@ type SubnetPortIPAddress struct {
 //+kubebuilder:subresource:status
 
 // SubnetPort is the Schema for the subnetports API.
+// +kubebuilder:printcolumn:name="VIFID",type=string,JSONPath=`.status.vifID`,description="Attachment VIF ID owned by the SubnetPort"
+// +kubebuilder:printcolumn:name="IPAddress",type=string,JSONPath=`.status.ipAddresses[0].ip`,description="IP Address of the SubnetPort"
+// +kubebuilder:printcolumn:name="MACAddress",type=string,JSONPath=`.status.macAddress`,description="MAC Address of the SubnetPort"
 type SubnetPort struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/v1alpha1/subnetset_types.go
+++ b/pkg/apis/v1alpha1/subnetset_types.go
@@ -1,4 +1,4 @@
-/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+/* Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0 */
 
 package v1alpha1
@@ -16,7 +16,7 @@ type SubnetSetSpec struct {
 	// +kubebuilder:validation:Minimum:=16
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// Access mode of Subnet, accessible only from within VPC or from outside VPC.
-	// Defaults to private.
+	// Defaults to Private.
 	// +kubebuilder:default:=Private
 	// +kubebuilder:validation:Enum=Private;Public
 	AccessMode AccessMode `json:"accessMode,omitempty"`
@@ -43,6 +43,9 @@ type SubnetSetStatus struct {
 //+kubebuilder:subresource:status
 
 // SubnetSet is the Schema for the subnetsets API.
+// +kubebuilder:printcolumn:name="AccessMode",type=string,JSONPath=`.spec.accessMode`,description="Access mode of Subnet"
+// +kubebuilder:printcolumn:name="IPv4SubnetSize",type=string,JSONPath=`.spec.ipv4SubnetSize`,description="Size of Subnet"
+// +kubebuilder:printcolumn:name="IPAddresses",type=string,JSONPath=`.status.subnets[*].ipAddresses[*]`,description="CIDRs for the Subnet"
 type SubnetSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/v1alpha1/vpc_types.go
+++ b/pkg/apis/v1alpha1/vpc_types.go
@@ -1,4 +1,4 @@
-/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+/* Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0 */
 
 package v1alpha1
@@ -13,6 +13,8 @@ import (
 //+kubebuilder:storageversion
 
 // VPC is the Schema for the VPC API
+// +kubebuilder:printcolumn:name="SNATIP",type=string,JSONPath=`.status.defaultSNATIP`,description="Default SNAT IP for Private Subnets"
+// +kubebuilder:printcolumn:name="LBSubnetCIDR",type=string,JSONPath=`.status.lbSubnetCIDR`,description="CIDR for the load balancer Subnet"
 type VPC struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -39,7 +41,7 @@ type VPCStatus struct {
 	Conditions []Condition `json:"conditions"`
 	// NSX VPC Policy API resource path.
 	NSXResourcePath string `json:"nsxResourcePath"`
-	// Default SNAT IP for private Subnets.
+	// Default SNAT IP for Private Subnets.
 	DefaultSNATIP string `json:"defaultSNATIP"`
 	// NSX PolicyPath for the load balancer Subnet.
 	LBSubnetPath string `json:"lbSubnetPath"`

--- a/pkg/apis/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/v1alpha1/vpcnetworkconfiguration_types.go
@@ -1,4 +1,4 @@
-/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+/* Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0 */
 
 // +kubebuilder:object:generate=true
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	AccessModePublic  string = "public"
-	AccessModePrivate string = "private"
+	AccessModePublic  string = "Public"
+	AccessModePrivate string = "Private"
 )
 
 // Load balancer endpoint configuration.
@@ -38,7 +38,7 @@ type VPCNetworkConfigurationSpec struct {
 	// +kubebuilder:validation:MinItems=0
 	// +kubebuilder:validation:MaxItems=5
 	ExternalIPv4Blocks []string `json:"externalIPv4Blocks,omitempty"`
-	// Private IPv4 CIDRs used to allocate private Subnets.
+	// Private IPv4 CIDRs used to allocate Private Subnets.
 	// +kubebuilder:validation:MinItems=0
 	// +kubebuilder:validation:MaxItems=5
 	PrivateIPv4CIDRs []string `json:"privateIPv4CIDRs,omitempty"`
@@ -47,8 +47,8 @@ type VPCNetworkConfigurationSpec struct {
 	// +kubebuilder:default=26
 	DefaultIPv4SubnetSize int `json:"defaultIPv4SubnetSize,omitempty"`
 	// DefaultSubnetAccessMode defines the access mode of the default SubnetSet for PodVM and VM.
-	// Must be public or private.
-	// +kubebuilder:validation:Enum=public;private
+	// Must be Public or Private.
+	// +kubebuilder:validation:Enum=Public;Private
 	DefaultSubnetAccessMode string `json:"defaultSubnetAccessMode,omitempty"`
 }
 
@@ -64,9 +64,9 @@ type VPCNetworkConfigurationStatus struct {
 
 // VPCNetworkConfiguration is the Schema for the vpcnetworkconfigurations API.
 // +kubebuilder:resource:scope="Cluster"
-// +kubebuilder:printcolumn:name="NSXTProject",type=string,JSONPath=`.spec.NSXTProject`,description="NSXTProject the Namespace associated with"
-// +kubebuilder:printcolumn:name="PublicIPv4Blocks",type=string,JSONPath=`.spec.ExternalIPv4Blocks`,description="ExternalIPv4Blocks assigned to the Namespace"
-// +kubebuilder:printcolumn:name="PrivateIPv4CIDRs",type=string,JSONPath=`.spec.PrivateIPv4CIDRs`,description="PrivateIPv4CIDRs assigned to the Namespace"
+// +kubebuilder:printcolumn:name="NSXTProject",type=string,JSONPath=`.spec.nsxtProject`,description="NSXTProject the Namespace associated with"
+// +kubebuilder:printcolumn:name="ExternalIPv4Blocks",type=string,JSONPath=`.spec.externalIPv4Blocks`,description="ExternalIPv4Blocks assigned to the Namespace"
+// +kubebuilder:printcolumn:name="PrivateIPv4CIDRs",type=string,JSONPath=`.spec.privateIPv4CIDRs`,description="PrivateIPv4CIDRs assigned to the Namespace"
 type VPCNetworkConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/v1alpha2/ippool_types.go
+++ b/pkg/apis/v1alpha2/ippool_types.go
@@ -13,6 +13,8 @@ import (
 //+kubebuilder:subresource:status
 
 // IPPool is the Schema for the ippools API.
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`,description="Type of IPPool"
+// +kubebuilder:printcolumn:name="Subnets",type=string,JSONPath=`.status.subnets[*].cidr`,description="CIDRs for the Subnet"
 type IPPool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`


### PR DESCRIPTION
This patch makes the below changes:
1. add print columns for VPC CRDs
2. update VPC CRD defaultAccessMode to upper case

Below are the outputs:
root@421b6a3f68385d75875d19d7dcb07636 [ ~ ]# kubectl get subnetset  -n testns
NAME                    ACCESSMODE   IPV4SUBNETSIZE   IPADDRESSES
default-pod-subnetset   Private      64
default-vm-subnetset    Private      64               172.27.0.128/26
root@421b6a3f68385d75875d19d7dcb07636 [ ~ ]# kubectl get subnetset default-vm-subnetset -n testns
NAME                   ACCESSMODE   IPV4SUBNETSIZE   IPADDRESSES
default-vm-subnetset   Private      64               172.27.0.128/26
root@421b6a3f68385d75875d19d7dcb07636 [ ~ ]# kubectl get subnetport -n testns
NAME                VIFID                                  IPADDRESS      MACADDRESS
sunq-test-port-01   31643336-3432-4466-ad31-3930612d3437   172.27.0.131   04:50:56:00:b0:01
root@421b6a3f68385d75875d19d7dcb07636 [ ~ ]# kubectl get vpc -n testns
NAME                                       SNATIP   LBSUBNETCIDR
vpc-c8485ff3-086d-40e3-a410-ecaebd31cb07
root@421b6a3f68385d75875d19d7dcb07636 [ ~ ]# kubectl get vpcnetworkconfigurations infra
NAME    NSXTPROJECT       EXTERNALIPV4BLOCKS                  PRIVATEIPV4CIDRS
infra   project-quality   ["ipblock-10.246.0.0-netmask-16"]   ["172.27.0.0/16","172.37.0.0/16"]