### PR TITLE
Update ippool controller

### DIFF
--- a/build/yaml/crd/nsx.vmware.com_ippools.yaml
+++ b/build/yaml/crd/nsx.vmware.com_ippools.yaml
@@ -172,14 +172,11 @@ spec:
                   type: object
                 type: array
               type:
-                default: private
-                description: Type defines the type of this IPPool, public or private.
+                description: Type defines the type of this IPPool, Public or Private.
                 enum:
-                - public
-                - private
+                - Public
+                - Private
                 type: string
-            required:
-            - type
             type: object
           status:
             description: IPPoolStatus defines the observed state of IPPool.

--- a/pkg/apis/v1alpha2/ippool_types.go
+++ b/pkg/apis/v1alpha2/ippool_types.go
@@ -35,9 +35,9 @@ type IPPoolList struct {
 
 // IPPoolSpec defines the desired state of IPPool.
 type IPPoolSpec struct {
-	// Type defines the type of this IPPool, public or private.
-	// +kubebuilder:validation:Enum=public;private
-	// +kubebuilder:default=private
+	// Type defines the type of this IPPool, Public or Private.
+	// +kubebuilder:validation:Enum=Public;Private
+	// +optional
 	Type string `json:"type"`
 	// Subnets defines set of subnets need to be allocated.
 	// +optional

--- a/pkg/controllers/ippool/ippool_controller_test.go
+++ b/pkg/controllers/ippool/ippool_controller_test.go
@@ -186,6 +186,7 @@ func TestIPPoolReconciler_Reconcile(t *testing.T) {
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 		v1sp := obj.(*v1alpha2.IPPool)
 		v1sp.ObjectMeta.DeletionTimestamp = nil
+		v1sp.Spec.Type = "Public"
 		v1sp.Finalizers = []string{common.IPPoolFinalizerName}
 		return nil
 	})

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -74,10 +74,10 @@ const (
 	RealizeTimeout      = 2 * time.Minute
 	RealizeMaxRetries   = 3
 	IPPoolFinalizerName = "ippool.nsx.vmware.com/finalizer"
-	IPPoolTypePublic    = "public"
-	IPPoolTypePrivate   = "private"
 	DefaultSNATID       = "DEFAULT"
 	AVISubnetLBID       = "_AVI_SUBNET--LB"
+	IPPoolTypePublic    = "Public"
+	IPPoolTypePrivate   = "Private"
 
 	SecurityPolicyFinalizerName    = "securitypolicy.nsx.vmware.com/finalizer"
 	StaticRouteFinalizerName       = "staticroute.nsx.vmware.com/finalizer"

--- a/pkg/nsx/util/errors.go
+++ b/pkg/nsx/util/errors.go
@@ -570,3 +570,11 @@ type RestrictionError struct {
 func (err RestrictionError) Error() string {
 	return err.Desc
 }
+
+type IPBlockAllExhaustedError struct {
+	Desc string
+}
+
+func (err IPBlockAllExhaustedError) Error() string {
+	return err.Desc
+}


### PR DESCRIPTION
Update type of ippool to optional.
Overwrite DefaultSubnetAccessMode of vpcnetworkconfig to ippool's type.
Get private or public IpBlockPath from VPCInfo.
Update Type public/private to Public/Private.
Try next ipblock if the previous are exhausted
	If the error message contains `not have spare capacity to satisfy`,
	it shows the ip block has no more capacity, then try next ip block
	from the list of PrivateIpv4Blocks or ExternalIpv4Blocks
	to build IpBlockPath.