### PR TITLE
Support passing user/pass/ca from parameter

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -30,6 +30,17 @@ func TestConfig_VCConfig(t *testing.T) {
 	vcConfig.HttpsPort = 443
 	err = vcConfig.validate()
 	assert.Equal(t, err, nil)
+
+	vcConfig.VCUser = ""
+	vcConfig.VCPassword = "test"
+	err = vcConfig.validate()
+	assert.NotEqual(t, err, nil)
+
+	vcConfig.VCUser = "test1"
+	vcConfig.VCPassword = "test"
+	err = vcConfig.validate()
+	assert.Equal(t, err, nil)
+
 }
 
 func TestConfig_CoeConfig(t *testing.T) {

--- a/pkg/nsx/auth/jwt/JWTtokenprovider.go
+++ b/pkg/nsx/auth/jwt/JWTtokenprovider.go
@@ -6,8 +6,9 @@ package jwt
 import (
 	"time"
 
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/auth"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/auth"
 )
 
 const (
@@ -31,9 +32,9 @@ func (provider *JWTTokenProvider) HeaderValue(token string) string {
 	return "Bearer " + token
 }
 
-func NewTokenProvider(vcEndpoint string, port int, ssoDomain string, caCert []byte, insecure bool) (auth.TokenProvider, error) {
+func NewTokenProvider(vcEndpoint string, port int, ssoDomain, user, password string, caCert []byte, insecure bool) (auth.TokenProvider, error) {
 	// not load username/password, not create vapi session, defer them to cache.refreshJWT
-	tesClient, err := NewTESClient(vcEndpoint, port, ssoDomain, "", "", caCert, insecure)
+	tesClient, err := NewTESClient(vcEndpoint, port, ssoDomain, user, password, caCert, insecure)
 	if err != nil {
 		log.Error(err, "failed to create tes client")
 		return nil, err

--- a/pkg/nsx/auth/jwt/JWTtokenprovider_test.go
+++ b/pkg/nsx/auth/jwt/JWTtokenprovider_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestJWTTokenprovider_NewTokenProvider(t *testing.T) {
-	_, err := NewTokenProvider("127.0.0.1", 443, "vsphere.local", []byte{}, false)
+	_, err := NewTokenProvider("127.0.0.1", 443, "vsphere.local", "", "", []byte{}, false)
 	_, ok := err.(*url.Error)
 	assert.Equal(t, ok, false)
 

--- a/pkg/nsx/auth/jwt/vcclient_test.go
+++ b/pkg/nsx/auth/jwt/vcclient_test.go
@@ -125,8 +125,14 @@ func TestVCClient_reloadUsernamePass(t *testing.T) {
 	userName := "admin"
 	password := "admin"
 	ssoDomain := "vsphere.local"
+	// reload == false
 	vcClient, _ := NewVCClient(host, port, ssoDomain, userName, password, nil, true)
 	err := vcClient.reloadUsernamePass()
+	assert.Nil(t, err)
+
+	// reload == true
+	vcClient, _ = NewVCClient(host, port, ssoDomain, "", "", nil, true)
+	err = vcClient.reloadUsernamePass()
 	assert.NotNil(t, err)
 
 	patch := gomonkey.ApplyFunc(os.ReadFile, func(filename string) ([]byte, error) {


### PR DESCRIPTION
Default nsx-operator reloads user/name/ca from file. Support to pass user/pass/ca from parameter