### PR TITLE
Add pod controller and node controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,9 @@ import (
 	commonctl "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	ippool2 "github.com/vmware-tanzu/nsx-operator/pkg/controllers/ippool"
 	namespacecontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/namespace"
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/node"
 	nsxserviceaccountcontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/nsxserviceaccount"
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/pod"
 	securitypolicycontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/securitypolicy"
 	staticroutecontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/staticroute"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/subnet"
@@ -197,8 +199,10 @@ func main() {
 			os.Exit(1)
 		}
 
+		node.StartNodeController(mgr, commonService)
 		staticroutecontroller.StartStaticRouteController(mgr, commonService)
 		subnetport.StartSubnetPortController(mgr, commonService)
+		pod.StartPodController(mgr, commonService)
 
 		StartNamespaceController(mgr, commonService)
 		StartVPCController(mgr, commonService)

--- a/pkg/controllers/common/types.go
+++ b/pkg/controllers/common/types.go
@@ -18,6 +18,11 @@ const (
 	MetricResTypeSubnetSet         = "subnetset"
 	MetricResTypeVPC               = "vpc"
 	MetricResTypeNamespace         = "namespace"
+	MetricResTypePod               = "pod"
+	MetricResTypeNode              = "node"
+
+	LabelK8sMasterRole  = "node-role.kubernetes.io/master"
+	LabelK8sControlRole = "node-role.kubernetes.io/control-plane"
 )
 
 var (

--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -1,0 +1,103 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+var (
+	log = logger.Log
+)
+
+func AllocateSubnetFromSubnetSet(subnetSet *v1alpha1.SubnetSet) (string, error) {
+	subnetPath, err := ServiceMediator.GetAvailableSubnet(subnetSet)
+	if err != nil {
+		log.Error(err, "failed to allocate Subnet")
+		return "", err
+	}
+	return subnetPath, nil
+}
+
+func getSharedNamespaceAndVpcForNamespace(client k8sclient.Client, ctx context.Context, namespaceName string) (string, string, error) {
+	namespace := &v1.Namespace{}
+	namespacedName := types.NamespacedName{Name: namespaceName}
+	if err := client.Get(ctx, namespacedName, namespace); err != nil {
+		log.Error(err, "failed to get target namespace during getting VPC for namespace")
+		return "", "", err
+	}
+	vpcAnnotation, exists := namespace.Annotations[servicecommon.AnnotationVPCName]
+	if !exists {
+		return "", "", nil
+	}
+	array := strings.Split(vpcAnnotation, "/")
+	if len(array) != 2 {
+		err := fmt.Errorf("invalid annotation value of '%s': %s", servicecommon.AnnotationVPCName, vpcAnnotation)
+		return "", "", err
+	}
+	sharedNamespaceName, sharedVpcName := array[0], array[1]
+	log.Info("got shared VPC for namespace", "current namespace", namespaceName, "shared VPC", sharedVpcName, "shared namespace", sharedNamespaceName)
+	return sharedNamespaceName, sharedVpcName, nil
+}
+
+func GetDefaultSubnetSet(client k8sclient.Client, ctx context.Context, namespace string) (*v1alpha1.SubnetSet, error) {
+	targetNamespace, _, err := getSharedNamespaceAndVpcForNamespace(client, ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	if targetNamespace == "" {
+		log.Info("namespace doesn't have shared VPC, searching the default subnetset in the current namespace", "namespace", namespace)
+		targetNamespace = namespace
+	}
+	subnetSet, err := getDefaultSubnetSetByNamespace(client, ctx, targetNamespace)
+	if err != nil {
+		return nil, err
+	}
+	return subnetSet, err
+}
+
+func getDefaultSubnetSetByNamespace(client k8sclient.Client, ctx context.Context, namespace string) (*v1alpha1.SubnetSet, error) {
+	subnetSetList := &v1alpha1.SubnetSetList{}
+	subnetSetSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			servicecommon.LabelDefaultSubnetSet: servicecommon.LabelDefaultPodSubnetSet,
+		},
+	}
+	labelSelector, _ := metav1.LabelSelectorAsSelector(subnetSetSelector)
+	opts := &k8sclient.ListOptions{
+		LabelSelector: labelSelector,
+		Namespace:     namespace,
+	}
+	if err := client.List(context.Background(), subnetSetList, opts); err != nil {
+		log.Error(err, "failed to list default subnetset CR", "namespace", namespace)
+		return nil, err
+	}
+	if len(subnetSetList.Items) == 0 {
+		return nil, errors.New("default subnetset not found")
+	} else if len(subnetSetList.Items) > 1 {
+		return nil, errors.New("multiple default subnetsets found")
+	}
+	subnetSet := subnetSetList.Items[0]
+	log.Info("got default subnetset", "subnetset.Name", subnetSet.Name, "subnetset.uid", subnetSet.UID)
+	return &subnetSet, nil
+
+}
+
+func NodeIsMaster(node *v1.Node) bool {
+	for k := range node.Labels {
+		if k == LabelK8sMasterRole || k == LabelK8sControlRole {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controllers/node/node_controller.go
+++ b/pkg/controllers/node/node_controller.go
@@ -1,0 +1,116 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package node
+
+import (
+	"context"
+	"os"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/node"
+)
+
+var (
+	log               = logger.Log
+	MetricResTypeNode = common.MetricResTypeNode
+)
+
+// NodeReconciler reconciles a Node object
+type NodeReconciler struct {
+	client.Client
+	Scheme  *apimachineryruntime.Scheme
+	Service *node.NodeService
+}
+
+func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	node := &v1.Node{}
+	deleted := false
+	log.Info("reconciling node", "node", req.NamespacedName)
+
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerSyncTotal, MetricResTypeNode)
+
+	if err := r.Client.Get(ctx, req.NamespacedName, node); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("node not found, may be deleted", "req", req.NamespacedName)
+			deleted = true
+		} else {
+			log.Error(err, "unable to fetch node", "req", req.NamespacedName)
+		}
+		return common.ResultNormal, client.IgnoreNotFound(err)
+	}
+	if common.NodeIsMaster(node) {
+		// For WCP supervisor cluster, the master node isn't a transport node.
+		log.Info("skipping handling master node", "node", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+	if !node.ObjectMeta.DeletionTimestamp.IsZero() {
+		log.Info("node is being deleted", "node", req.NamespacedName)
+		deleted = true
+	}
+
+	if err := r.Service.SyncNodeStore(node.Name, deleted); err != nil {
+		log.Error(err, "failed to sync node store", "req", req.NamespacedName)
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1.Node{}).
+		Complete(r)
+}
+
+func StartNodeController(mgr ctrl.Manager, commonService servicecommon.Service) {
+	nodePortReconciler := NodeReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+	if nodeService, err := node.InitializeNode(commonService); err != nil {
+		log.Error(err, "failed to initialize node commonService", "controller", "Node")
+		os.Exit(1)
+	} else {
+		nodePortReconciler.Service = nodeService
+		common.ServiceMediator.NodeService = nodePortReconciler.Service
+	}
+
+	if err := nodePortReconciler.Start(mgr); err != nil {
+		log.Error(err, "failed to create controller", "controller", "Node")
+		os.Exit(1)
+	}
+}
+
+func (r *NodeReconciler) Start(mgr ctrl.Manager) error {
+	err := r.SetupWithManager(mgr)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func updateFail(r *NodeReconciler, c *context.Context, o *v1.Node, e *error) {
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateFailTotal, MetricResTypeNode)
+}
+
+func deleteFail(r *NodeReconciler, c *context.Context, o *v1.Node, e *error) {
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteFailTotal, MetricResTypeNode)
+}
+
+func updateSuccess(r *NodeReconciler, c *context.Context, o *v1.Node) {
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateSuccessTotal, MetricResTypeNode)
+}
+
+func deleteSuccess(r *NodeReconciler, _ *context.Context, _ *v1.Node) {
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteSuccessTotal, MetricResTypeNode)
+}

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -1,0 +1,251 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package pod
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
+	v1 "k8s.io/api/core/v1"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
+)
+
+var (
+	log              = logger.Log
+	MetricResTypePod = common.MetricResTypePod
+)
+
+// PodReconciler reconciles a Pod object
+type PodReconciler struct {
+	client.Client
+	Scheme  *apimachineryruntime.Scheme
+	Service *subnetport.SubnetPortService
+}
+
+func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	pod := &v1.Pod{}
+	log.Info("reconciling pod", "pod", req.NamespacedName)
+
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerSyncTotal, MetricResTypePod)
+
+	if err := r.Client.Get(ctx, req.NamespacedName, pod); err != nil {
+		log.Error(err, "unable to fetch pod", "req", req.NamespacedName)
+		return common.ResultNormal, client.IgnoreNotFound(err)
+	}
+	if pod.Spec.HostNetwork {
+		log.Info("skipping handling hostnetwork pod", "pod", req.NamespacedName)
+		return common.ResultNormal, nil
+	}
+	if len(pod.Spec.NodeName) == 0 {
+		log.Info("pod is not scheduled on node yet, skipping", "pod", req.NamespacedName)
+		return common.ResultNormal, nil
+	}
+
+	if pod.ObjectMeta.DeletionTimestamp.IsZero() {
+		metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateTotal, MetricResTypePod)
+		if !controllerutil.ContainsFinalizer(pod, servicecommon.PodFinalizerName) {
+			controllerutil.AddFinalizer(pod, servicecommon.PodFinalizerName)
+			if err := r.Client.Update(ctx, pod); err != nil {
+				log.Error(err, "add finalizer", "pod", req.NamespacedName)
+				updateFail(r, &ctx, pod, &err)
+				return common.ResultRequeue, err
+			}
+			log.Info("added finalizer on pod", "pod", req.NamespacedName)
+		}
+
+		nsxSubnetPath, err := r.GetSubnetPathForPod(ctx, pod)
+		if err != nil {
+			log.Error(err, "failed to get NSX resource path from subnet", "pod.Name", pod.Name, "pod.UID", pod.UID)
+			return common.ResultRequeue, err
+		}
+		log.Info("got NSX subnet for pod", "NSX subnet path", nsxSubnetPath, "pod.Name", pod.Name, "pod.UID", pod.UID)
+		node, err := common.ServiceMediator.GetNodeByName(pod.Spec.NodeName)
+		if err != nil {
+			// The error at the very beginning of the operator startup is expected because at that time the node may be not cached yet. We can expect the retry to become normal.
+			log.Error(err, "failed to get node ID for pod", "pod.Name", req.NamespacedName, "pod.UID", pod.UID, "node", pod.Spec.NodeName)
+			return common.ResultRequeue, err
+		}
+		contextID := *node.Id
+		nsxSubnetPortState, err := r.Service.CreateOrUpdateSubnetPort(pod, nsxSubnetPath, contextID)
+		if err != nil {
+			log.Error(err, "failed to create or update NSX subnet port, would retry exponentially", "pod.Name", req.NamespacedName, "pod.UID", pod.UID)
+			updateFail(r, &ctx, pod, &err)
+			return common.ResultRequeue, err
+		}
+		podAnnotationChanges := map[string]string{
+			servicecommon.AnnotationPodMAC:        strings.Trim(*nsxSubnetPortState.RealizedBindings[0].Binding.MacAddress, "\""),
+			servicecommon.AnnotationPodAttachment: *nsxSubnetPortState.Attachment.Id,
+		}
+		err = util.UpdateK8sResourceAnnotation(r.Client, &ctx, pod, podAnnotationChanges)
+		if err != nil {
+			log.Error(err, "failed to update pod annotation", "pod.Name", req.NamespacedName, "pod.UID", pod.UID, "podAnnotationChanges", podAnnotationChanges)
+			return common.ResultNormal, err
+		}
+		updateSuccess(r, &ctx, pod)
+	} else {
+		if controllerutil.ContainsFinalizer(pod, servicecommon.PodFinalizerName) {
+			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, MetricResTypePod)
+			if err := r.Service.DeleteSubnetPort(pod.UID); err != nil {
+				log.Error(err, "deletion failed, would retry exponentially", "pod", req.NamespacedName)
+				deleteFail(r, &ctx, pod, &err)
+				return common.ResultRequeue, err
+			}
+			controllerutil.RemoveFinalizer(pod, servicecommon.PodFinalizerName)
+			if err := r.Client.Update(ctx, pod); err != nil {
+				log.Error(err, "deletion failed, would retry exponentially", "pod", req.NamespacedName)
+				deleteFail(r, &ctx, pod, &err)
+				return common.ResultRequeue, err
+			}
+			log.Info("removed finalizer", "pod", req.NamespacedName)
+			deleteSuccess(r, &ctx, pod)
+		} else {
+			log.Info("finalizers cannot be recognized", "pod", req.NamespacedName)
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1.Pod{}).
+		WithEventFilter(
+			predicate.Funcs{
+				DeleteFunc: func(e event.DeleteEvent) bool {
+					// Suppress Delete events to avoid filtering them out in the Reconcile function
+					return false
+				},
+			},
+		).
+		WithOptions(
+			controller.Options{
+				MaxConcurrentReconciles: runtime.NumCPU(),
+			}).
+		Complete(r)
+}
+
+func StartPodController(mgr ctrl.Manager, commonService servicecommon.Service) {
+	podPortReconciler := PodReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+	if subnetPortService, err := subnetport.InitializeSubnetPort(commonService); err != nil {
+		log.Error(err, "failed to initialize subnetport commonService", "controller", "Pod")
+		os.Exit(1)
+	} else {
+		podPortReconciler.Service = subnetPortService
+		common.ServiceMediator.SubnetPortService = podPortReconciler.Service
+	}
+	if err := podPortReconciler.Start(mgr); err != nil {
+		log.Error(err, "failed to create controller", "controller", "Pod")
+		os.Exit(1)
+	}
+}
+
+// Start setup manager and launch GC
+func (r *PodReconciler) Start(mgr ctrl.Manager) error {
+	err := r.SetupWithManager(mgr)
+	if err != nil {
+		return err
+	}
+	go r.GarbageCollector(make(chan bool), servicecommon.GCInterval)
+	return nil
+}
+
+// GarbageCollector collect Pod which has been removed from crd.
+// cancel is used to break the loop during UT
+func (r *PodReconciler) GarbageCollector(cancel chan bool, timeout time.Duration) {
+	ctx := context.Background()
+	log.Info("pod garbage collector started")
+	for {
+		select {
+		case <-cancel:
+			return
+		case <-time.After(timeout):
+		}
+		nsxSubnetPortSet := r.Service.ListNSXSubnetPortIDForPod()
+		if len(nsxSubnetPortSet) == 0 {
+			continue
+		}
+		podList := &v1.PodList{}
+		err := r.Client.List(ctx, podList)
+		if err != nil {
+			log.Error(err, "failed to list Pod")
+			continue
+		}
+
+		PodSet := sets.NewString()
+		for _, pod := range podList.Items {
+			PodSet.Insert(string(pod.UID))
+		}
+
+		for elem := range nsxSubnetPortSet {
+			if PodSet.Has(elem) {
+				continue
+			}
+			log.V(1).Info("GC collected Pod", "UID", elem)
+			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, MetricResTypePod)
+			err = r.Service.DeleteSubnetPort(types.UID(elem))
+			if err != nil {
+				metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteFailTotal, MetricResTypePod)
+			} else {
+				metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteSuccessTotal, MetricResTypePod)
+			}
+		}
+	}
+}
+
+func updateFail(r *PodReconciler, c *context.Context, o *v1.Pod, e *error) {
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateFailTotal, MetricResTypePod)
+}
+
+func deleteFail(r *PodReconciler, c *context.Context, o *v1.Pod, e *error) {
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteFailTotal, MetricResTypePod)
+}
+
+func updateSuccess(r *PodReconciler, c *context.Context, o *v1.Pod) {
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateSuccessTotal, MetricResTypePod)
+}
+
+func deleteSuccess(r *PodReconciler, _ *context.Context, _ *v1.Pod) {
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteSuccessTotal, MetricResTypePod)
+}
+
+func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (string, error) {
+	subnetPath := r.Service.GetSubnetPathForSubnetPortFromStore(string(pod.UID))
+	if len(subnetPath) > 0 {
+		log.V(1).Info("NSX subnet port had been created, returning the existing NSX subnet path", "pod.UID", pod.UID, "subnetPath", subnetPath)
+		return subnetPath, nil
+	}
+	subnetSet, err := common.GetDefaultSubnetSet(r.Service.Client, ctx, pod.Namespace)
+	if err != nil {
+		return "", err
+	}
+	log.Info("got default subnetset for pod, allocating the NSX subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "pod.Name", pod.Name, "pod.UID", pod.UID)
+	subnetPath, err = common.AllocateSubnetFromSubnetSet(subnetSet)
+	if err != nil {
+		return subnetPath, err
+	}
+	log.Info("allocated NSX subnet for pod", "nsxSubnetPath", subnetPath, "pod.Name", pod.Name, "pod.UID", pod.UID)
+	return subnetPath, nil
+}

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -16,7 +16,6 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -50,82 +49,81 @@ type SubnetPortReconciler struct {
 // +kubebuilder:rbac:groups=nsx.vmware.com,resources=subnetports/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=nsx.vmware.com,resources=subnetports/finalizers,verbs=update
 func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	obj := &v1alpha1.SubnetPort{}
+	subnetPort := &v1alpha1.SubnetPort{}
 	log.Info("reconciling subnetport CR", "subnetport", req.NamespacedName)
 
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerSyncTotal, MetricResTypeSubnetPort)
 
-	if err := r.Client.Get(ctx, req.NamespacedName, obj); err != nil {
+	if err := r.Client.Get(ctx, req.NamespacedName, subnetPort); err != nil {
 		log.Error(err, "unable to fetch subnetport CR", "req", req.NamespacedName)
 		return common.ResultNormal, client.IgnoreNotFound(err)
 	}
 
-	if len(obj.Spec.SubnetSet) > 0 && len(obj.Spec.Subnet) > 0 {
+	if len(subnetPort.Spec.SubnetSet) > 0 && len(subnetPort.Spec.Subnet) > 0 {
 		err := errors.New("subnet and subnetset should not be configured at the same time")
 		log.Error(err, "failed to get subnet/subnetset of the subnetport", "subnetport", req.NamespacedName)
 		return common.ResultNormal, err
 	}
 
-	if obj.ObjectMeta.DeletionTimestamp.IsZero() {
+	if subnetPort.ObjectMeta.DeletionTimestamp.IsZero() {
 		metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateTotal, MetricResTypeSubnetPort)
-		if !controllerutil.ContainsFinalizer(obj, servicecommon.SubnetPortFinalizerName) {
-			controllerutil.AddFinalizer(obj, servicecommon.SubnetPortFinalizerName)
-			if err := r.Client.Update(ctx, obj); err != nil {
+		if !controllerutil.ContainsFinalizer(subnetPort, servicecommon.SubnetPortFinalizerName) {
+			controllerutil.AddFinalizer(subnetPort, servicecommon.SubnetPortFinalizerName)
+			if err := r.Client.Update(ctx, subnetPort); err != nil {
 				log.Error(err, "add finalizer", "subnetport", req.NamespacedName)
-				updateFail(r, &ctx, obj, &err)
+				updateFail(r, &ctx, subnetPort, &err)
 				return common.ResultRequeue, err
 			}
 			log.Info("added finalizer on subnetport CR", "subnetport", req.NamespacedName)
 		}
 
-		// TODO: valid attachmentRef means the port for VM
-		// dhcpPort := false
-		// defaultVMSubnet := false
-		// attachmentRef := obj.Spec.AttachmentRef
-		// if attachmentRef.Name == "" {
-		// 	defaultVMSubnet = true
-		// }
-		old_status := obj.Status.DeepCopy()
-		nsxSubnetPath, err := r.GetSubnetPathForSubnetPort(obj)
+		old_status := subnetPort.Status.DeepCopy()
+		nsxSubnetPath, err := r.GetSubnetPathForSubnetPort(ctx, subnetPort)
 		if err != nil {
-			log.Error(err, "failed to get NSX resource path from subnet", "subnetport", obj)
+			log.Error(err, "failed to get NSX resource path from subnet", "subnetport", subnetPort)
 			return common.ResultRequeue, err
 		}
-		err = r.Service.CreateOrUpdateSubnetPort(obj, nsxSubnetPath)
+		nsxSubnetPortState, err := r.Service.CreateOrUpdateSubnetPort(subnetPort, nsxSubnetPath, "")
 		if err != nil {
 			log.Error(err, "failed to create or update NSX subnet port, would retry exponentially", "subnetport", req.NamespacedName)
-			updateFail(r, &ctx, obj, &err)
+			updateFail(r, &ctx, subnetPort, &err)
 			return common.ResultRequeue, err
 		}
-		err = r.updateSubnetStatusOnSubnetPort(obj, nsxSubnetPath)
-		if err != nil {
-			log.Error(err, "failed to retrieve subnet status for subnetport", "subnetport", obj, "nsxSubnetPath", nsxSubnetPath)
+		ipAddress := v1alpha1.SubnetPortIPAddress{
+			IP: *nsxSubnetPortState.RealizedBindings[0].Binding.IpAddress,
 		}
-		if reflect.DeepEqual(old_status, obj.Status) {
-			log.Info("status (without conditions) already matched", "new status", obj.Status, "existing status", old_status)
+		subnetPort.Status.IPAddresses = []v1alpha1.SubnetPortIPAddress{ipAddress}
+		subnetPort.Status.MACAddress = strings.Trim(*nsxSubnetPortState.RealizedBindings[0].Binding.MacAddress, "\"")
+		subnetPort.Status.VIFID = *nsxSubnetPortState.Attachment.Id
+		err = r.updateSubnetStatusOnSubnetPort(subnetPort, nsxSubnetPath)
+		if err != nil {
+			log.Error(err, "failed to retrieve subnet status for subnetport", "subnetport", subnetPort, "nsxSubnetPath", nsxSubnetPath)
+		}
+		if reflect.DeepEqual(old_status, subnetPort.Status) {
+			log.Info("status (without conditions) already matched", "new status", subnetPort.Status, "existing status", old_status)
 		} else {
 			// If the SubnetPort CR's status changed, let's clean the conditions, to ensure the r.Client.Status().Update in the following updateSuccess will be invoked at any time.
-			obj.Status.Conditions = nil
+			subnetPort.Status.Conditions = nil
 		}
-		updateSuccess(r, &ctx, obj)
+		updateSuccess(r, &ctx, subnetPort)
 	} else {
-		if controllerutil.ContainsFinalizer(obj, servicecommon.SubnetPortFinalizerName) {
+		if controllerutil.ContainsFinalizer(subnetPort, servicecommon.SubnetPortFinalizerName) {
 			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, MetricResTypeSubnetPort)
-			if err := r.Service.DeleteSubnetPort(obj.UID); err != nil {
+			if err := r.Service.DeleteSubnetPort(subnetPort.UID); err != nil {
 				log.Error(err, "deletion failed, would retry exponentially", "subnetport", req.NamespacedName)
-				deleteFail(r, &ctx, obj, &err)
+				deleteFail(r, &ctx, subnetPort, &err)
 				return common.ResultRequeue, err
 			}
-			controllerutil.RemoveFinalizer(obj, servicecommon.SubnetPortFinalizerName)
-			if err := r.Client.Update(ctx, obj); err != nil {
+			controllerutil.RemoveFinalizer(subnetPort, servicecommon.SubnetPortFinalizerName)
+			if err := r.Client.Update(ctx, subnetPort); err != nil {
 				log.Error(err, "deletion failed, would retry exponentially", "subnetport", req.NamespacedName)
-				deleteFail(r, &ctx, obj, &err)
+				deleteFail(r, &ctx, subnetPort, &err)
 				return common.ResultRequeue, err
 			}
-			log.Info("removed finalizer", "subnet", req.NamespacedName)
-			deleteSuccess(r, &ctx, obj)
+			log.Info("removed finalizer", "subnetport", req.NamespacedName)
+			deleteSuccess(r, &ctx, subnetPort)
 		} else {
-			log.Info("finalizers cannot be recognized", "subnet", req.NamespacedName)
+			log.Info("finalizers cannot be recognized", "subnetport", req.NamespacedName)
 		}
 	}
 	return ctrl.Result{}, nil
@@ -308,19 +306,19 @@ func deleteSuccess(r *SubnetPortReconciler, _ *context.Context, _ *v1alpha1.Subn
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteSuccessTotal, MetricResTypeSubnetPort)
 }
 
-func (r *SubnetPortReconciler) GetSubnetPathForSubnetPort(obj *v1alpha1.SubnetPort) (string, error) {
-	subnetPath := r.Service.GetSubnetPathFromStoreByKey(string(obj.UID))
+func (r *SubnetPortReconciler) GetSubnetPathForSubnetPort(ctx context.Context, subnetPort *v1alpha1.SubnetPort) (string, error) {
+	subnetPath := r.Service.GetSubnetPathForSubnetPortFromStore(string(subnetPort.UID))
 	if len(subnetPath) > 0 {
-		log.V(1).Info("NSX subnet port had been created, returning the existing NSX subnet path", "subnetPort.UID", obj.UID, "subnetPath", subnetPath)
+		log.V(1).Info("NSX subnet port had been created, returning the existing NSX subnet path", "subnetPort.UID", subnetPort.UID, "subnetPath", subnetPath)
 		return subnetPath, nil
 	}
-	if len(obj.Spec.Subnet) > 0 {
+	if len(subnetPort.Spec.Subnet) > 0 {
 		subnet := &v1alpha1.Subnet{}
 		namespacedName := types.NamespacedName{
-			Name:      obj.Spec.Subnet,
-			Namespace: obj.Namespace,
+			Name:      subnetPort.Spec.Subnet,
+			Namespace: subnetPort.Namespace,
 		}
-		if err := r.Client.Get(context.Background(), namespacedName, subnet); err != nil {
+		if err := r.Client.Get(ctx, namespacedName, subnet); err != nil {
 			log.Error(err, "subnet CR not found", "subnet CR", namespacedName)
 			return subnetPath, err
 		}
@@ -329,110 +327,37 @@ func (r *SubnetPortReconciler) GetSubnetPathForSubnetPort(obj *v1alpha1.SubnetPo
 			err := fmt.Errorf("empty NSX resource path from subnet %s", subnet.Name)
 			return subnetPath, err
 		}
-	} else if len(obj.Spec.SubnetSet) > 0 {
+	} else if len(subnetPort.Spec.SubnetSet) > 0 {
 		subnetSet := &v1alpha1.SubnetSet{}
 		namespacedName := types.NamespacedName{
-			Name:      obj.Spec.SubnetSet,
-			Namespace: obj.Namespace,
+			Name:      subnetPort.Spec.SubnetSet,
+			Namespace: subnetPort.Namespace,
 		}
 		if err := r.Client.Get(context.Background(), namespacedName, subnetSet); err != nil {
 			log.Error(err, "subnetSet CR not found", "subnet CR", namespacedName)
 			return subnetPath, err
 		}
-		subnetPath, err := r.AllocateSubnetFromSubnetSet(obj, subnetSet)
+		log.Info("got subnetset for subnetport CR, allocating the NSX subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
+		subnetPath, err := common.AllocateSubnetFromSubnetSet(subnetSet)
+		log.Info("allocated Subnet for Pod", "subnetPath", subnetPath, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 		if err != nil {
 			return subnetPath, err
 		}
 		return subnetPath, nil
 	} else {
-		subnetSet, err := r.GetDefaultSubnetSet(obj)
+		subnetSet, err := common.GetDefaultSubnetSet(r.Client, ctx, subnetPort.Namespace)
 		if err != nil {
 			return "", err
 		}
-		subnetPath, err := r.AllocateSubnetFromSubnetSet(obj, subnetSet)
+		log.Info("got default subnetset for subnetport CR, allocating the NSX subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
+		subnetPath, err := common.AllocateSubnetFromSubnetSet(subnetSet)
+		log.Info("allocated Subnet for Pod", "subnetPath", subnetPath, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 		if err != nil {
 			return subnetPath, err
 		}
 		return subnetPath, nil
 	}
 	return subnetPath, nil
-}
-
-func (r *SubnetPortReconciler) AllocateSubnetFromSubnetSet(subnetPort *v1alpha1.SubnetPort, subnetSet *v1alpha1.SubnetSet) (string, error) {
-	log.Info("allocating Subnet for SubnetPort", "subnetPort", subnetPort.Name, "subnetSet", subnetSet.Name)
-	subnetPath, err := common.ServiceMediator.GetAvailableSubnet(subnetSet)
-	if err != nil {
-		log.Error(err, "failed to allocate Subnet")
-	}
-	log.Info("allocated Subnet for SubnetPort", "subnetPath", subnetPath)
-	return subnetPath, nil
-}
-
-func (r *SubnetPortReconciler) GetDefaultSubnetSet(subnetPort *v1alpha1.SubnetPort) (*v1alpha1.SubnetSet, error) {
-	targetNamespace, _, err := r.getSharedNamespaceAndVpcForNamespace(subnetPort.Namespace)
-	if err != nil {
-		return nil, err
-	}
-	if targetNamespace == "" {
-		log.Info("subnetport's namespace doesn't have shared VPC, searching the default subnetset in the current namespace", "subnetPort.Name", subnetPort.Name, "subnetPort.Namespace", subnetPort.Namespace)
-		targetNamespace = subnetPort.Namespace
-	}
-	subnetSet, err := r.getDefaultSubnetSetByNamespace(subnetPort, targetNamespace)
-	if err != nil {
-		return nil, err
-	}
-	return subnetSet, err
-}
-
-func (r *SubnetPortReconciler) getSharedNamespaceAndVpcForNamespace(namespaceName string) (string, string, error) {
-	sharedNamespaceName := ""
-	sharedVpcName := ""
-	namespace := &v1.Namespace{}
-	namespacedName := types.NamespacedName{Name: namespaceName}
-	if err := r.Client.Get(context.Background(), namespacedName, namespace); err != nil {
-		log.Error(err, "failed to get target namespace during getting VPC for namespace")
-		return "", "", err
-	}
-	// TODO: import "nsx.vmware.com/vpc_name" as the constant from types afer VPC patch is merged.
-	vpcAnnotation, exists := namespace.Annotations["nsx.vmware.com/vpc_name"]
-	if !exists {
-		return "", "", nil
-	}
-	array := strings.Split(vpcAnnotation, "/")
-	if len(array) != 2 {
-		err := fmt.Errorf("invalid annotation value of 'nsx.vmware.com/vpc_name': %s", vpcAnnotation)
-		return "", "", err
-	}
-	sharedNamespaceName, sharedVpcName = array[0], array[1]
-	log.Info("got shared VPC for namespace", "current namespace", namespaceName, "shared VPC", sharedVpcName, "shared namespace", sharedNamespaceName)
-	return sharedNamespaceName, sharedVpcName, nil
-}
-
-func (r *SubnetPortReconciler) getDefaultSubnetSetByNamespace(subnetPort *v1alpha1.SubnetPort, namespace string) (*v1alpha1.SubnetSet, error) {
-	subnetSetList := &v1alpha1.SubnetSetList{}
-	subnetSetSelector := &metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			servicecommon.LabelDefaultSubnetSet: servicecommon.ResourceTypeVirtualMachine,
-		},
-	}
-	labelSelector, _ := metav1.LabelSelectorAsSelector(subnetSetSelector)
-	opts := &client.ListOptions{
-		LabelSelector: labelSelector,
-		Namespace:     namespace,
-	}
-	if err := r.Service.Client.List(context.Background(), subnetSetList, opts); err != nil {
-		log.Error(err, "failed to list default subnetset CR", "namespace", subnetPort.Namespace)
-		return nil, err
-	}
-	if len(subnetSetList.Items) == 0 {
-		return nil, errors.New("default subnetset not found")
-	} else if len(subnetSetList.Items) > 1 {
-		return nil, errors.New("multiple default subnetsets found")
-	}
-	subnetSet := subnetSetList.Items[0]
-	log.Info("got default subnetset", "subnetset.Name", subnetSet.Name, "subnetset.uid", subnetSet.UID)
-	return &subnetSet, nil
-
 }
 
 func (r *SubnetPortReconciler) updateSubnetStatusOnSubnetPort(subnetPort *v1alpha1.SubnetPort, nsxSubnetPath string) error {

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -53,6 +53,7 @@ type Client struct {
 	InfraClient    nsx_policy.InfraClient
 
 	ClusterControlPlanesClient enforcement_points.ClusterControlPlanesClient
+	HostTransPortNodesClient   enforcement_points.HostTransportNodesClient
 	SubnetStatusClient         subnets.StatusClient
 	RealizedEntitiesClient     realized_state.RealizedEntitiesClient
 	MPQueryClient              mpsearch.QueryClient
@@ -126,6 +127,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 	infraClient := nsx_policy.NewInfraClient(restConnector(cluster))
 
 	clusterControlPlanesClient := enforcement_points.NewClusterControlPlanesClient(restConnector(cluster))
+	hostTransportNodesClient := enforcement_points.NewHostTransportNodesClient(restConnector(cluster))
 	realizedEntitiesClient := realized_state.NewRealizedEntitiesClient(restConnector(cluster))
 	mpQueryClient := mpsearch.NewQueryClient(restConnector(cluster))
 	certificatesClient := trust_management.NewCertificatesClient(restConnector(cluster))
@@ -165,6 +167,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 		InfraClient:    infraClient,
 
 		ClusterControlPlanesClient: clusterControlPlanesClient,
+		HostTransPortNodesClient:   hostTransportNodesClient,
 		RealizedEntitiesClient:     realizedEntitiesClient,
 		MPQueryClient:              mpQueryClient,
 		CertificatesClient:         certificatesClient,

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -67,7 +67,11 @@ const (
 	TagValueVersion10               string = "1.0"
 	AnnotationVPCNetworkConfig      string = "nsx.vmware.com/vpc_network_config"
 	AnnotationVPCName               string = "nsx.vmware.com/vpc_name"
+	AnnotationPodMAC                string = "nsx.vmware.com/mac"
+	AnnotationPodAttachment         string = "nsx.vmware.com/attachment"
 	DefaultNetworkConfigName        string = "default"
+	TagScopePodName                 string = "nsx-op/pod_name"
+	TagScopePodUID                  string = "nsx-op/pod_uid"
 
 	GCInterval          = 60 * time.Second
 	RealizeTimeout      = 2 * time.Minute
@@ -85,9 +89,11 @@ const (
 	SubnetSetFinalizerName         = "subnetset.nsx.vmware.com/finalizer"
 	SubnetPortFinalizerName        = "subnetport.nsx.vmware.com/finalizer"
 	VPCFinalizerName               = "vpc.nsx.vmware.com/finalizer"
+	PodFinalizerName               = "pod.nsx.vmware.com/finalizer"
 
 	IndexKeySubnetID = "IndexKeySubnetID"
 	IndexKeyPathPath = "Path"
+	IndexKeyNodeName = "IndexKeyNodeName"
 )
 
 var (
@@ -114,6 +120,7 @@ var (
 	ResourceTypeSubnet            = "VpcSubnet"
 	ResourceTypeIPPool            = "IpAddressPool"
 	ResourceTypeIPPoolBlockSubnet = "IpAddressPoolBlockSubnet"
+	ResourceTypeNode              = "HostTransportNode"
 )
 
 type Service struct {

--- a/pkg/nsx/services/node/node.go
+++ b/pkg/nsx/services/node/node.go
@@ -1,0 +1,114 @@
+package node
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+var (
+	log              = logger.Log
+	ResourceTypeNode = servicecommon.ResourceTypeNode
+	MarkedForDelete  = true
+)
+
+type NodeService struct {
+	servicecommon.Service
+	NodeStore *NodeStore
+}
+
+func InitializeNode(service servicecommon.Service) (*NodeService, error) {
+	wg := sync.WaitGroup{}
+	wgDone := make(chan bool)
+	fatalErrors := make(chan error)
+
+	wg.Add(1)
+
+	nodeService := &NodeService{Service: service}
+
+	nodeService.NodeStore = &NodeStore{
+		ResourceStore: servicecommon.ResourceStore{
+			Indexer: cache.NewIndexer(
+				keyFunc,
+				cache.Indexers{
+					servicecommon.IndexKeyNodeName: nodeIndexByNodeName,
+				},
+			),
+			BindingType: model.HostTransportNodeBindingType(),
+		},
+	}
+	// TODO: confirm whether we can remove the following intialization because node doesn't have the cluster tag so it's a dry run
+	go nodeService.InitializeResourceStore(&wg, fatalErrors, ResourceTypeNode, nil, nodeService.NodeStore)
+
+	go func() {
+		wg.Wait()
+		close(wgDone)
+	}()
+
+	select {
+	case <-wgDone:
+		break
+	case err := <-fatalErrors:
+		close(fatalErrors)
+		return nodeService, err
+	}
+
+	return nodeService, nil
+
+}
+
+func (service *NodeService) SyncNodeStore(nodeName string, deleted bool) error {
+	nodes := service.NodeStore.GetByIndex(servicecommon.IndexKeyNodeName, nodeName)
+	if len(nodes) > 1 {
+		return fmt.Errorf("multiple nodes found for node name %s", nodeName)
+	}
+	// TODO: confirm whether we need to resync the node info from NSX
+	if len(nodes) == 1 {
+		log.Info("node alreay cached", "node.Fqdn", nodes[0].NodeDeploymentInfo.Fqdn, "node.Id", *nodes[0].Id)
+		// updatedNode, err := service.NSXClient.HostTransPortNodesClient.Get("default", "default", nodes[0].Id)
+		// if err != nil {
+		// 	return fmt.Errorf("failed to get HostTransPortNode for node %s: %s", nodeName, err)
+		// }
+		// node.NodeStore.Operate(updatedNode)
+	}
+	nodeResults, err := service.NSXClient.HostTransPortNodesClient.List("default", "default", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list HostTransportNodes: %s", err)
+	}
+	if deleted {
+		nodes := service.NodeStore.GetByIndex(servicecommon.IndexKeyNodeName, nodeName)
+		if len(nodes) == 0 {
+			log.Info("skip deleting node in store because the node is not in store", "nodeName", nodeName)
+			return nil
+		}
+		for _, node := range nodes {
+			*node.MarkedForDelete = true
+			service.NodeStore.Operate(node)
+		}
+	}
+	synced := false
+	for _, node := range nodeResults.Results {
+		if *node.NodeDeploymentInfo.Fqdn == nodeName {
+			if deleted {
+				// Retry until the NSX HostTransportNode is deleted.
+				return fmt.Errorf("node %s had beed deleted but HostTransportNodes still exists", nodeName)
+			}
+			err = service.NodeStore.Operate(&node)
+			if err != nil {
+				return fmt.Errorf("failed to sync node %s: %s", nodeName, err)
+			}
+			synced = true
+			break
+		}
+	}
+	if !synced && !deleted {
+		// Retry until the NSX HostTransportNode is available.
+		return fmt.Errorf("node %s not found yet in NSX side", nodeName)
+	}
+	return nil
+}

--- a/pkg/nsx/services/node/store.go
+++ b/pkg/nsx/services/node/store.go
@@ -1,0 +1,72 @@
+package node
+
+import (
+	"errors"
+
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+// NodeStore is a store for node (NSX HostTransportNode)
+type NodeStore struct {
+	common.ResourceStore
+}
+
+func (vs *NodeStore) Operate(i interface{}) error {
+	if i == nil {
+		return nil
+	}
+	node := i.(*model.HostTransportNode)
+	if node.MarkedForDelete != nil && *node.MarkedForDelete {
+		err := vs.Delete(*node)
+		log.V(1).Info("delete Node from store", "node", node)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := vs.Add(*node)
+		log.V(1).Info("add Node to store", "node", node)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (nodeStore *NodeStore) GetByKey(key string) *model.HostTransportNode {
+	var node model.HostTransportNode
+	obj := nodeStore.ResourceStore.GetByKey(key)
+	if obj != nil {
+		node = obj.(model.HostTransportNode)
+	}
+	return &node
+}
+
+func (nodeStore *NodeStore) GetByIndex(key string, value string) []model.HostTransportNode {
+	hostTransportNodes := make([]model.HostTransportNode, 0)
+	objs := nodeStore.ResourceStore.GetByIndex(key, value)
+	for _, node := range objs {
+		hostTransportNodes = append(hostTransportNodes, node.(model.HostTransportNode))
+	}
+	return hostTransportNodes
+}
+
+// keyFunc is used to get the key of a resource, usually, which is the ID of the resource
+func keyFunc(obj interface{}) (string, error) {
+	switch v := obj.(type) {
+	case model.HostTransportNode:
+		return *v.Id, nil
+	default:
+		return "", errors.New("keyFunc doesn't support unknown type")
+	}
+}
+
+func nodeIndexByNodeName(obj interface{}) ([]string, error) {
+	switch o := obj.(type) {
+	case model.HostTransportNode:
+		return []string{*o.NodeDeploymentInfo.Fqdn}, nil
+	default:
+		return nil, errors.New("nodeIndexByNodeName doesn't support unknown type")
+	}
+}

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -3,6 +3,7 @@ package subnet
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"sync"
 
@@ -106,8 +107,10 @@ func (service *SubnetService) CreateOrUpdateSubnet(obj client.Object, tags []mod
 		log.Error(err, "", "ns", obj.GetNamespace())
 		return "", err
 	}
-	vpcInfo, err := common.ParseVPCResourcePath(vpcList.Items[0].Status.NSXResourcePath)
+	vpc := vpcList.Items[0]
+	vpcInfo, err := common.ParseVPCResourcePath(vpc.Status.NSXResourcePath)
 	if err != nil {
+		err := fmt.Errorf("failed to parse NSX VPC path for VPC %s: %s", vpc.UID, err)
 		return "", err
 	}
 	uid := string(obj.GetUID())

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -19,41 +19,55 @@ var (
 	String = common.String
 )
 
-func (service *SubnetPortService) buildSubnetPort(obj *v1alpha1.SubnetPort, nsxSubnetPath string) (*model.SegmentPort, error) {
+func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnetPath string, contextID string) (*model.SegmentPort, error) {
+	var objName, objNamespace, uid, appId string
+	switch o := obj.(type) {
+	case *v1alpha1.SubnetPort:
+		objName = o.Name
+		objNamespace = o.Namespace
+		uid = string(o.UID)
+	case *corev1.Pod:
+		objName = o.Name
+		objNamespace = o.Namespace
+		uid = string(o.UID)
+		appId = string(o.UID)
+	}
 	allocateAddresses := "BOTH"
-	nsxSubnetPortName := fmt.Sprintf("port-%s", obj.Name)
-	nsxSubnetPortID := string(obj.UID)
+	nsxSubnetPortName := fmt.Sprintf("port-%s", objName)
+	nsxSubnetPortID := string(uid)
 	// use the subnetPort CR UID as the attachment uid generation to ensure the latter stable
 	nsxCIFID, err := uuid.NewRandomFromReader(bytes.NewReader([]byte(nsxSubnetPortID)))
 	if err != nil {
 		return nil, err
 	}
-	nsxSubnetPortPath := fmt.Sprintf("%s/ports/%s", nsxSubnetPath, obj.UID)
+	nsxSubnetPortPath := fmt.Sprintf("%s/ports/%s", nsxSubnetPath, uid)
 	if err != nil {
 		return nil, err
 	}
 	namespace := &corev1.Namespace{}
 	namespacedName := types.NamespacedName{
-		Name: obj.Namespace,
+		Name: objNamespace,
 	}
 	if err := service.Client.Get(context.Background(), namespacedName, namespace); err != nil {
 		return nil, err
 	}
 	namespace_uid := namespace.UID
-	// TODO: set AppId and ContextId for pod port.
 	nsxSubnetPort := &model.SegmentPort{
 		DisplayName: common.String(nsxSubnetPortName),
 		Id:          common.String(nsxSubnetPortID),
 		Attachment: &model.PortAttachment{
 			AllocateAddresses: &allocateAddresses,
-			// AppId:             common.String("nsx.ns-3.pod-5%"),
-			// ContextId:         common.String("95ccaad4-0dfb-469e-a1e6-27d815826382"),
-			Id:         common.String(nsxCIFID.String()),
-			TrafficTag: common.Int64(0),
-			Type_:      common.String("STATIC"),
+			Id:                common.String(nsxCIFID.String()),
+			TrafficTag:        common.Int64(0),
+			Type_:             common.String("STATIC"),
 		},
-		Tags: service.buildBasicTags(obj, namespace_uid),
-		Path: &nsxSubnetPortPath,
+		Tags:       service.buildBasicTags(obj, namespace_uid),
+		Path:       &nsxSubnetPortPath,
+		ParentPath: &nsxSubnetPath,
+	}
+	if appId != "" {
+		nsxSubnetPort.Attachment.AppId = &appId
+		nsxSubnetPort.Attachment.ContextId = &contextID
 	}
 	return nsxSubnetPort, nil
 }
@@ -62,28 +76,55 @@ func getCluster(service *SubnetPortService) string {
 	return service.NSXConfig.Cluster
 }
 
-func (service *SubnetPortService) buildBasicTags(obj *v1alpha1.SubnetPort, namespaceUID types.UID) []model.Tag {
-	tags := []model.Tag{
-		{
-			Scope: String(common.TagScopeCluster),
-			Tag:   String(getCluster(service)),
-		},
-		{
-			Scope: String(common.TagScopeNamespace),
-			Tag:   String(obj.ObjectMeta.Namespace),
-		},
-		{
-			Scope: String(common.TagScopeNamespaceUID),
-			Tag:   String(string(namespaceUID)),
-		},
-		{
-			Scope: String(common.TagScopeSubnetPortCRName),
-			Tag:   String(obj.ObjectMeta.Name),
-		},
-		{
-			Scope: String(common.TagScopeSubnetPortCRUID),
-			Tag:   String(string(obj.UID)),
-		},
+func (service *SubnetPortService) buildBasicTags(obj interface{}, namespaceUID types.UID) []model.Tag {
+	var tags []model.Tag
+	switch o := obj.(type) {
+	case *v1alpha1.SubnetPort:
+		tags = []model.Tag{
+			{
+				Scope: String(common.TagScopeCluster),
+				Tag:   String(getCluster(service)),
+			},
+			{
+				Scope: String(common.TagScopeNamespace),
+				Tag:   String(o.ObjectMeta.Namespace),
+			},
+			{
+				Scope: String(common.TagScopeNamespaceUID),
+				Tag:   String(string(namespaceUID)),
+			},
+			{
+				Scope: String(common.TagScopeSubnetPortCRName),
+				Tag:   String(o.ObjectMeta.Name),
+			},
+			{
+				Scope: String(common.TagScopeSubnetPortCRUID),
+				Tag:   String(string(o.UID)),
+			},
+		}
+	case *corev1.Pod:
+		tags = []model.Tag{
+			{
+				Scope: String(common.TagScopeCluster),
+				Tag:   String(getCluster(service)),
+			},
+			{
+				Scope: String(common.TagScopeNamespace),
+				Tag:   String(o.ObjectMeta.Namespace),
+			},
+			{
+				Scope: String(common.TagScopeNamespaceUID),
+				Tag:   String(string(namespaceUID)),
+			},
+			{
+				Scope: String(common.TagScopePodName),
+				Tag:   String(o.ObjectMeta.Name),
+			},
+			{
+				Scope: String(common.TagScopePodUID),
+				Tag:   String(string(o.UID)),
+			},
+		}
 	}
 	return tags
 }

--- a/pkg/nsx/services/subnetport/store.go
+++ b/pkg/nsx/services/subnetport/store.go
@@ -43,6 +43,15 @@ func subnetPortIndexByCRUID(obj interface{}) ([]string, error) {
 	}
 }
 
+func subnetPortIndexByPodUID(obj interface{}) ([]string, error) {
+	switch o := obj.(type) {
+	case model.SegmentPort:
+		return filterTag(o.Tags, common.TagScopePodUID), nil
+	default:
+		return nil, errors.New("subnetPortIndexByCRUID doesn't support unknown type")
+	}
+}
+
 func subnetPortIndexBySubnetID(obj interface{}) ([]string, error) {
 	switch o := obj.(type) {
 	case model.SegmentPort:

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -5,11 +5,12 @@ package subnetport
 
 import (
 	"errors"
-	"strings"
 
 	"sync"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -50,6 +51,7 @@ func InitializeSubnetPort(service servicecommon.Service) (*SubnetPortService, er
 			keyFunc,
 			cache.Indexers{
 				servicecommon.TagScopeSubnetPortCRUID: subnetPortIndexByCRUID,
+				servicecommon.TagScopePodUID:          subnetPortIndexByPodUID,
 				servicecommon.IndexKeySubnetID:        subnetPortIndexBySubnetID,
 			}),
 		BindingType: model.SegmentPortBindingType(),
@@ -73,93 +75,107 @@ func InitializeSubnetPort(service servicecommon.Service) (*SubnetPortService, er
 	return subnetPortService, nil
 }
 
-func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj *v1alpha1.SubnetPort, nsxSubnetPath string) error {
-
-	log.Info("Creating or updating subnetport", "subnetport", obj)
-	nsxSubnetPort, err := service.buildSubnetPort(obj, nsxSubnetPath)
-	if err != nil {
-		log.Error(err, "failed to build NSX subnet port")
-		return err
+func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxSubnetPath string, contextID string) (*model.SegmentPortState, error) {
+	var uid string
+	switch o := obj.(type) {
+	case *v1alpha1.SubnetPort:
+		uid = string(o.UID)
+	case *corev1.Pod:
+		uid = string(o.UID)
 	}
-
+	log.Info("Creating or updating subnetport", "nsxSubnetPort.Id", uid, "nsxSubnetPath", nsxSubnetPath)
+	nsxSubnetPort, err := service.buildSubnetPort(obj, nsxSubnetPath, contextID)
+	if err != nil {
+		log.Error(err, "failed to build NSX subnet port", "nsxSubnetPort.Id", uid, "nsxSubnetPath", nsxSubnetPath, "contextID", contextID)
+		return nil, err
+	}
 	subnetInfo, err := servicecommon.ParseVPCResourcePath(nsxSubnetPath)
 	if err != nil {
 		log.Error(err, "failed to parse NSX subnet path", "path", nsxSubnetPath)
+		return nil, err
 	}
 	existingSubnetPort := service.SubnetPortStore.GetByKey(*nsxSubnetPort.Id)
 	isChanged := servicecommon.CompareResource(SubnetPortToComparable(existingSubnetPort), SubnetPortToComparable(nsxSubnetPort))
 	if !isChanged {
-		log.Info("NSX subnet port not changed, skipping the update", "nsxSubnetPort.Id", nsxSubnetPort.Id)
+		log.Info("NSX subnet port not changed, skipping the update", "nsxSubnetPort.Id", nsxSubnetPort.Id, "nsxSubnetPath", nsxSubnetPath)
 		// We don't need to update it but still need to check realized state.
 	} else {
 		log.Info("updating the NSX subnet port", "existingSubnetPort", existingSubnetPort, "desiredSubnetPort", nsxSubnetPort)
 		err = service.NSXClient.PortClient.Patch(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, *nsxSubnetPort.Id, *nsxSubnetPort)
 		if err != nil {
-			log.Error(err, "failed to create or update subnet port", "nsxSubnetPort.Name", *nsxSubnetPort.DisplayName, "nsxSubnetPort.Id", *nsxSubnetPort.Id)
-			return err
+			log.Error(err, "failed to create or update subnet port", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPath", nsxSubnetPath)
+			return nil, err
 		}
 		err = service.SubnetPortStore.Operate(nsxSubnetPort)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if existingSubnetPort != nil {
-			log.Info("updated NSX subnet port", "subnetPort", nsxSubnetPort)
+			log.Info("updated NSX subnet port", "nsxSubnetPort.Path", *nsxSubnetPort.Path)
 		} else {
-			log.Info("created NSX subnet port", "subnetPort", nsxSubnetPort)
+			log.Info("created NSX subnet port", "nsxSubnetPort.Path", *nsxSubnetPort.Path)
 		}
 	}
-	if err := service.CheckSubnetPortState(obj, nsxSubnetPath); err != nil {
-		log.Error(err, "check and update NSX subnet port state failed, would retry exponentially", "subnetport", obj.UID)
-		return err
+	nsxSubnetPortState, err := service.CheckSubnetPortState(obj, nsxSubnetPath)
+	if err != nil {
+		log.Error(err, "check and update NSX subnet port state failed, would retry exponentially", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPath", nsxSubnetPath)
+		return nil, err
 	}
 	if isChanged {
-		log.Info("successfully created or updated subnetport", "subnetport", obj.UID)
+		log.Info("successfully created or updated subnetport", "nsxSubnetPort.Id", *nsxSubnetPort.Id)
 	} else {
-		log.Info("subnetport already existed", "subnetport", obj.UID)
+		log.Info("subnetport already existed", "subnetport", *nsxSubnetPort.Id)
 	}
-	return nil
+	return nsxSubnetPortState, nil
 }
 
 // CheckSubnetPortState will check the port realized status then get the port state to prepare the CR status.
-func (service *SubnetPortService) CheckSubnetPortState(obj *v1alpha1.SubnetPort, nsxSubnetPath string) error {
-	nsxSubnetPort := service.SubnetPortStore.GetByKey(string(obj.UID))
+func (service *SubnetPortService) CheckSubnetPortState(obj interface{}, nsxSubnetPath string) (*model.SegmentPortState, error) {
+	var uid types.UID
+	switch o := obj.(type) {
+	case *v1alpha1.SubnetPort:
+		uid = o.UID
+	case *v1.Pod:
+		uid = o.UID
+	}
+	nsxSubnetPort := service.SubnetPortStore.GetByKey(string(uid))
 	if nsxSubnetPort == nil {
-		return errors.New("failed to get subnet port from store")
+		return nil, errors.New("failed to get subnet port from store")
 	}
 	realizeService := realizestate.InitializeRealizeState(service.Service)
 	if err := realizeService.CheckRealizeState(retry.DefaultRetry, *nsxSubnetPort.Path, "RealizedLogicalPort"); err != nil {
 		log.Error(err, "failed to get realized status", "subnetport path", *nsxSubnetPort.Path)
 		if realizestate.IsRealizeStateError(err) {
-			log.Error(err, "the created subnet port is in error realization state, cleaning the resource", "subnetport", obj.UID)
+			log.Error(err, "the created subnet port is in error realization state, cleaning the resource", "subnetport", uid)
 			// only recreate subnet port on RealizationErrorStateError.
-			if err := service.DeleteSubnetPort(obj.UID); err != nil {
-				log.Error(err, "cleanup error subnetport failed", "subnetport", obj.UID)
-				return err
+			if err := service.DeleteSubnetPort(uid); err != nil {
+				log.Error(err, "cleanup error subnetport failed", "subnetport", uid)
+				return nil, err
 			}
 		}
-		return err
+		return nil, err
 	}
 	// TODO: avoid to get subnetport state again if we already got it.
 	nsxPortState, err := service.GetSubnetPortState(obj, nsxSubnetPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	log.Info("Got the NSX subnet port state", "nsxPortState.RealizedBindings", nsxPortState.RealizedBindings)
-
-	ipAddress := v1alpha1.SubnetPortIPAddress{
-		IP: *nsxPortState.RealizedBindings[0].Binding.IpAddress,
-	}
-	obj.Status.IPAddresses = []v1alpha1.SubnetPortIPAddress{ipAddress}
-	obj.Status.MACAddress = strings.Trim(*nsxPortState.RealizedBindings[0].Binding.MacAddress, "\"")
-	obj.Status.VIFID = *nsxPortState.Attachment.Id
-	return nil
+	return nsxPortState, nil
 }
 
-func (service *SubnetPortService) GetSubnetPortState(obj *v1alpha1.SubnetPort, nsxSubnetPath string) (*model.SegmentPortState, error) {
+func (service *SubnetPortService) GetSubnetPortState(obj interface{}, nsxSubnetPath string) (*model.SegmentPortState, error) {
+	var uid types.UID
+	switch o := obj.(type) {
+	case *v1alpha1.SubnetPort:
+		uid = o.UID
+	case *v1.Pod:
+		uid = o.UID
+	}
 	nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID := nsxutil.ParseVPCPath(nsxSubnetPath)
-	nsxSubnetPortState, err := service.NSXClient.PortStateClient.Get(nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID, string(obj.UID), nil, nil)
+	nsxSubnetPortState, err := service.NSXClient.PortStateClient.Get(nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID, string(uid), nil, nil)
 	if err != nil {
-		log.Error(err, "failed to get subnet port state", "nsxSubnetPortID", obj.UID)
+		log.Error(err, "failed to get subnet port state", "nsxSubnetPortID", uid, "nsxSubnetPath", nsxSubnetPath)
 		return nil, err
 	}
 	return &nsxSubnetPortState, nil
@@ -187,6 +203,12 @@ func (service *SubnetPortService) DeleteSubnetPort(uid types.UID) error {
 func (service *SubnetPortService) ListNSXSubnetPortIDForCR() sets.String {
 	log.V(2).Info("listing subnet port CR UIDs")
 	subnetPortSet := service.SubnetPortStore.ListIndexFuncValues(servicecommon.TagScopeSubnetPortCRUID)
+	return subnetPortSet
+}
+
+func (service *SubnetPortService) ListNSXSubnetPortIDForPod() sets.String {
+	log.V(2).Info("listing pod UIDs")
+	subnetPortSet := service.SubnetPortStore.ListIndexFuncValues(servicecommon.TagScopePodUID)
 	return subnetPortSet
 }
 
@@ -223,7 +245,7 @@ func (service *SubnetPortService) GetGatewayNetmaskForSubnetPort(obj *v1alpha1.S
 	return gateway, mask, nil
 }
 
-func (service *SubnetPortService) GetSubnetPathFromStoreByKey(nsxSubnetPortID string) string {
+func (service *SubnetPortService) GetSubnetPathForSubnetPortFromStore(nsxSubnetPortID string) string {
 	existingSubnetPort := service.SubnetPortStore.GetByKey(nsxSubnetPortID)
 	if existingSubnetPort.ParentPath == nil {
 		return ""


### PR DESCRIPTION
1. Add the pod controller to watch pod events and create/update/delete NSX subnet
   port.
2. Add the node controller to cache the host transport node info and provided
   the context id for port creation.

Tests done:

1. Create a pod and check the NSX subnet port creation and pod annotations.
2. Create multiple pods to ensure that there're multiple subnets being created.
3. Force delete the pod during operator downtime and ensure the related NSX
   subnet port is deleted after the operator restarts.
3. Observe the logs to ensure the worker nodes are cached.