### PR TITLE
Update NSX Subnet's tags based on labels of subnetset

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -51,6 +51,8 @@ const (
 	TagScopeIPPoolCRUID             string = "nsx-op/ippool_cr_uid"
 	TagScopeIPPoolCRType            string = "nsx-op/ippool_cr_type"
 	TagScopeIPSubnetName            string = "nsx-op/ipsubnet_cr_name"
+	TagScopeVMNamespaceUID          string = "nsx-op/vm_namespace_uid"
+	TagScopeVMNamespace             string = "nsx-op/vm_namespace"
 	LabelDefaultSubnetSet           string = "nsxoperator.vmware.com/default-subnetset-for"
 	LabelDefaultVMSubnet            string = "VirtualMachine"
 	LabelDefaultPodSubnetSet        string = "Pod"

--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -6,9 +6,10 @@ import (
 	"github.com/google/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
 var (
@@ -85,10 +86,6 @@ func (service *SubnetService) buildBasicTags(obj client.Object) []model.Tag {
 		{
 			Scope: String(common.TagScopeSubnetCRUID),
 			Tag:   String(string(obj.GetUID())),
-		},
-		{
-			Scope: String(common.TagScopeNamespace),
-			Tag:   String(obj.GetNamespace()),
 		},
 	}
 	switch obj.(type) {


### PR DESCRIPTION
Get default-vm-subnetset and default-pod-subnetset from labels of SubnetSet to add tags to distinguish VM subnet or pod subnet,
and add tags to VM Subnet when subnetport_controller create or update Subnet.