### PR TITLE
Avoid duplicate port creation/update for the subnet port CR

### DIFF
--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -309,7 +309,11 @@ func deleteSuccess(r *SubnetPortReconciler, _ *context.Context, _ *v1alpha1.Subn
 }
 
 func (r *SubnetPortReconciler) GetSubnetPathForSubnetPort(obj *v1alpha1.SubnetPort) (string, error) {
-	subnetPath := ""
+	subnetPath := r.Service.GetSubnetPathFromStoreByKey(string(obj.UID))
+	if len(subnetPath) > 0 {
+		log.V(1).Info("NSX subnet port had been created, returning the existing NSX subnet path", "subnetPort.UID", obj.UID, "subnetPath", subnetPath)
+		return subnetPath, nil
+	}
 	if len(obj.Spec.Subnet) > 0 {
 		subnet := &v1alpha1.Subnet{}
 		namespacedName := types.NamespacedName{

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -49,7 +49,7 @@ func (service *SubnetPortService) buildSubnetPort(obj *v1alpha1.SubnetPort, nsxS
 			// AppId:             common.String("nsx.ns-3.pod-5%"),
 			// ContextId:         common.String("95ccaad4-0dfb-469e-a1e6-27d815826382"),
 			Id:         common.String(nsxCIFID.String()),
-			TrafficTag: nil,
+			TrafficTag: common.Int64(0),
 			Type_:      common.String("STATIC"),
 		},
 		Tags: service.buildBasicTags(obj, namespace_uid),

--- a/pkg/nsx/services/subnetport/compare.go
+++ b/pkg/nsx/services/subnetport/compare.go
@@ -24,6 +24,18 @@ func (sp *SubnetPort) Value() data.DataValue {
 		Tags:        sp.Tags,
 		Attachment:  sp.Attachment,
 	}
+	if sp.Attachment != nil {
+		// Ignoring the fields BmsInterfaceConfig, ContextType, EvpnVlans, HyperbusMode
+		// because operator doesn't set them.
+		s.Attachment = &model.PortAttachment{
+			AllocateAddresses: sp.Attachment.AllocateAddresses,
+			AppId:             sp.Attachment.AppId,
+			ContextId:         sp.Attachment.ContextId,
+			Id:                sp.Attachment.Id,
+			TrafficTag:        sp.Attachment.TrafficTag,
+			Type_:             sp.Attachment.AllocateAddresses,
+		}
+	}
 	dataValue, _ := ComparableToSubnetPort(s).GetDataValue__()
 	return dataValue
 }


### PR DESCRIPTION
When the operator handle the subnetport CR event, it will try to get NSX subnet every time even though the NSX port has been created. That may cause the duplicate NSX port update with different parent NSX subnet if the subnet port CR references the subnetset with multiple NSX subnets.

This path will avoid the duplicate request if the NSX port already existed. It will also enhance the comparation function to avoid unnecessary update.