### PR TITLE
Fix staticroute bugs

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -50,6 +50,7 @@ const (
 	TagScopeSubnetCRUID             string = "nsx-op/subnet_cr_uid"
 	TagScopeSubnetCRName            string = "nsx-op/subnet_cr_name"
 	TagScopeSubnetSetCRName         string = "nsx-op/subnetset_cr_name"
+	TagScopeSubnetSetCRUID          string = "nsx-op/subnetset_cr_uid"
 	AnnotationVPCNetworkConfig      string = "nsx.vmware.com/vpc_network_config"
 	AnnotationVPCName               string = "nsx.vmware.com/vpc_name"
 	DefaultNetworkConfigName        string = "default"

--- a/pkg/nsx/services/staticroute/builder.go
+++ b/pkg/nsx/services/staticroute/builder.go
@@ -7,7 +7,7 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
 func validateStaticRoute(obj *v1alpha1.StaticRoute) error {
@@ -48,24 +48,5 @@ func (service *StaticRouteService) buildStaticRoute(obj *v1alpha1.StaticRoute) (
 }
 
 func (service *StaticRouteService) buildBasicTags(obj *v1alpha1.StaticRoute) []model.Tag {
-	tags := []model.Tag{
-		{
-			Scope: String(common.TagScopeCluster),
-			Tag:   String(service.NSXConfig.Cluster),
-		},
-		{
-			Scope: String(common.TagScopeNamespace),
-			Tag:   String(obj.ObjectMeta.Namespace),
-		},
-		// TODO: get namespace uid
-		{
-			Scope: String(common.TagScopeStaticRouteCRName),
-			Tag:   String(obj.ObjectMeta.Name),
-		},
-		{
-			Scope: String(common.TagScopeStaticRouteCRUID),
-			Tag:   String(string(obj.UID)),
-		},
-	}
-	return tags
+	return util.BuildBasicTags(service.Service, obj, "")
 }

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -267,3 +267,150 @@ func TestNormalizeId(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateID(t *testing.T) {
+	type args struct {
+		res_id string
+		prefix string
+		suffix string
+		index  string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test-1",
+			args: args{
+				res_id: "1234-456",
+				prefix: "sp",
+				suffix: "",
+				index:  "",
+			},
+			want: "sp_1234-456",
+		},
+		{
+			name: "test-subfix",
+			args: args{
+				res_id: "1234-456",
+				prefix: "sp",
+				suffix: "scope",
+				index:  "",
+			},
+			want: "sp_1234-456_scope",
+		},
+		{
+			name: "test-index",
+			args: args{
+				res_id: "1234-456",
+				prefix: "sp",
+				suffix: "scope",
+				index:  "4",
+			},
+			want: "sp_1234-456_4_scope",
+		},
+		{
+			name: "test-scope",
+			args: args{
+				res_id: "1234-456",
+				prefix: "",
+				suffix: "scope",
+				index:  "",
+			},
+			want: "1234-456_scope",
+		},
+		{
+			name: "test-complex-index",
+			args: args{
+				res_id: "1234-456",
+				prefix: "",
+				suffix: "scope",
+				index:  "6_7",
+			},
+			want: "1234-456_6_7_scope",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenerateID(tt.args.res_id, tt.args.prefix, tt.args.suffix, tt.args.index); got != tt.want {
+				t.Errorf("GenerateID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateDisplayName(t *testing.T) {
+	type args struct {
+		res_name string
+		prefix   string
+		suffix   string
+		project  string
+		cluster  string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test-1",
+			args: args{
+				res_name: "1234-456",
+				prefix:   "sp",
+				suffix:   "",
+				project:  "",
+			},
+			want: "sp-1234-456",
+		},
+		{
+			name: "test-subfix",
+			args: args{
+				res_name: "1234-456",
+				prefix:   "sp",
+				suffix:   "scope",
+				project:  "",
+			},
+			want: "sp-1234-456-scope",
+		},
+		{
+			name: "test-index",
+			args: args{
+				res_name: "1234-456",
+				prefix:   "sp",
+				suffix:   "scope",
+				project:  "test",
+			},
+			want: "sp-test-1234-456-scope",
+		},
+		{
+			name: "test-cluster",
+			args: args{
+				res_name: "1234-456",
+				prefix:   "",
+				suffix:   "scope",
+				project:  "",
+				cluster:  "k8scl-one",
+			},
+			want: "k8scl-one-1234-456-scope",
+		},
+		{
+			name: "test-project-cluster",
+			args: args{
+				res_name: "1234-456",
+				prefix:   "",
+				suffix:   "scope",
+				project:  "test",
+				cluster:  "k8scl-one",
+			},
+			want: "test-k8scl-one-1234-456-scope",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenerateDisplayName(tt.args.res_name, tt.args.prefix, tt.args.suffix, tt.args.project, tt.args.cluster); got != tt.want {
+				t.Errorf("GenerateDisplayName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
StaticRoute uses one copy of ServiceMediator which is not initialized. Use ServiceMediator directly
StaticRoute GC uses the Path, so using Get API to get the sr and store it