### PR TITLE
Remove empty item from config.CAFile

### DIFF
--- a/pkg/clean/clean.go
+++ b/pkg/clean/clean.go
@@ -23,6 +23,9 @@ var log = logger.Log
 // return error if any, return nil if no error
 func Clean(cf *config.NSXOperatorConfig) error {
 	log.Info("starting NSX cleanup")
+	if err := cf.ValidateConfigFromCmd(); err != nil {
+		return fmt.Errorf("failed to validate config: %w", err)
+	}
 	if cleanupService, err := InitializeCleanupService(cf); err != nil {
 		return fmt.Errorf("failed to initialize cleanup service: %w", err)
 	} else if cleanupService.err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -315,3 +315,7 @@ func (coeConfig *CoeConfig) validate() error {
 	}
 	return nil
 }
+
+func (nsxConfig *NsxConfig) ValidateConfigFromCmd() error {
+	return nsxConfig.validate(true)
+}


### PR DESCRIPTION
If pass in default blank ca-file to clean cmd,
it would report error `no such file or directory`.