### PR TITLE
Change tag on NSX subnet port for VM from nsx-op/namespace to nsx-op/vm_namespace

### DIFF
--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -92,11 +92,11 @@ func (service *SubnetPortService) buildBasicTags(obj interface{}, namespaceUID t
 				Tag:   String(getCluster(service)),
 			},
 			{
-				Scope: String(common.TagScopeNamespace),
+				Scope: String(common.TagScopeVMNamespace),
 				Tag:   String(o.ObjectMeta.Namespace),
 			},
 			{
-				Scope: String(common.TagScopeNamespaceUID),
+				Scope: String(common.TagScopeVMNamespaceUID),
 				Tag:   String(string(namespaceUID)),
 			},
 			{


### PR DESCRIPTION
This patch will change the following tags on the port created for VM:

1. nsx-op/namespace -> nsx-op/vm_namespace
2. nsx-op/namespace_uid -> nsx-op/vm_namespace_uid

This change is to statisfy the security policy requirement.