### PR TITLE
Refactor loglevel based on debug in configmap(#265)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,12 +55,12 @@ func init() {
 	utilruntime.Must(vmv1alpha1.AddToScheme(scheme))
 	config.AddFlags()
 
-	logf.SetLogger(logger.ZapLogger())
 	cf, err = config.NewNSXOperatorConfigFromFile()
 	if err != nil {
-		log.Error(err, "load config file error")
 		os.Exit(1)
 	}
+
+	logf.SetLogger(logger.ZapLogger(cf))
 
 	if os.Getenv("NSX_OPERATOR_NAMESPACE") != "" {
 		nsxOperatorNamespace = os.Getenv("NSX_OPERATOR_NAMESPACE")

--- a/cmd_clean/main.go
+++ b/cmd_clean/main.go
@@ -44,7 +44,6 @@ func main() {
 	flag.IntVar(&config.LogLevel, "log-level", 0, "Use zap-core log system.")
 	flag.Parse()
 
-	logf.SetLogger(logger.ZapLogger())
 	cf = config.NewNSXOpertorConfig()
 	cf.NsxApiManagers = []string{mgrIp}
 	cf.VCUser = vcUser
@@ -55,6 +54,7 @@ func main() {
 	cf.Thumbprint = []string{thumbprint}
 	cf.CaFile = []string{caFile}
 	cf.Cluster = cluster
+	logf.SetLogger(logger.ZapLogger(cf))
 
 	err := clean.Clean(cf)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"os"
 
+	"go.uber.org/zap"
 	ini "gopkg.in/ini.v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/auth"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/auth/jwt"
@@ -26,7 +26,7 @@ var (
 	LogLevel               int
 	ProbeAddr, MetricsAddr string
 	configFilePath         = ""
-	log                    = logf.Log.WithName("config")
+	configLog              *zap.SugaredLogger
 	tokenProvider          auth.TokenProvider
 )
 
@@ -38,6 +38,11 @@ type NSXOperatorConfig struct {
 	*K8sConfig
 	*VCConfig
 	*HAConfig
+}
+
+func init() {
+	zapLogger, _ := zap.NewProduction()
+	configLog = zapLogger.Sugar()
 }
 
 func (operatorConfig *NSXOperatorConfig) HAEnabled() bool {
@@ -116,7 +121,8 @@ func UpdateConfigFilePath(configFile string) {
 	configFilePath = configFile
 }
 
-func NewNSXOperatorConfigFromFile() (*NSXOperatorConfig, error) {
+func LoadConfigFromFile() (*NSXOperatorConfig, error) {
+	configLog.Infof("loading NSX Operator configuration file: %s", configFilePath)
 	nsxOperatorConfig := NewNSXOpertorConfig()
 
 	cfg := ini.Empty()
@@ -160,6 +166,15 @@ func NewNSXOperatorConfigFromFile() (*NSXOperatorConfig, error) {
 	return nsxOperatorConfig, nil
 }
 
+func NewNSXOperatorConfigFromFile() (*NSXOperatorConfig, error) {
+	nsxOperatorConfig, err := LoadConfigFromFile()
+	if err != nil {
+		configLog.Error("failed to load NSX Operator configuration file: %v", err)
+		return nil, err
+	}
+	return nsxOperatorConfig, nil
+}
+
 func NewNSXOpertorConfig() *NSXOperatorConfig {
 	defaultNSXOperatorConfig := &NSXOperatorConfig{
 		&DefaultConfig{},
@@ -192,7 +207,7 @@ func (operatorConfig *NSXOperatorConfig) GetTokenProvider() auth.TokenProvider {
 }
 
 func (operatorConfig *NSXOperatorConfig) createTokenProvider() error {
-	log.V(1).Info("try to load VC host CA")
+	configLog.Info("try to load VC host CA")
 	var vcCaCert []byte
 	var err error
 	if !operatorConfig.Insecure {
@@ -204,7 +219,7 @@ func (operatorConfig *NSXOperatorConfig) createTokenProvider() error {
 		// If operatorConfig.VCInsecure is false, tls will use the CA to verify the server
 		// certificate. If loading CA failed, tls will use the CA on local host
 		if err != nil {
-			log.Info("fail to load CA cert from file", "error", err)
+			configLog.Info("fail to load CA cert from file", "error", err)
 		}
 	}
 
@@ -217,25 +232,25 @@ func (operatorConfig *NSXOperatorConfig) createTokenProvider() error {
 func (vcConfig *VCConfig) validate() error {
 	if len(vcConfig.VCEndPoint) == 0 {
 		err := errors.New("invalid field " + "VcEndPoint")
-		log.Info("validate VcConfig failed", "VcEndPoint", vcConfig.VCEndPoint)
+		configLog.Info("validate VcConfig failed", "VcEndPoint", vcConfig.VCEndPoint)
 		return err
 	}
 
 	if len(vcConfig.SsoDomain) == 0 {
 		err := errors.New("invalid field " + "SsoDomain")
-		log.Info("validate VcConfig failed", "SsoDomain", vcConfig.SsoDomain)
+		configLog.Info("validate VcConfig failed", "SsoDomain", vcConfig.SsoDomain)
 		return err
 	}
 
 	if vcConfig.HttpsPort == 0 {
 		err := errors.New("invalid field " + "HttpsPort")
-		log.Info("validate VcConfig failed", "HttpsPort", vcConfig.HttpsPort)
+		configLog.Info("validate VcConfig failed", "HttpsPort", vcConfig.HttpsPort)
 		return err
 	}
 	// VCPassword, VCUser should be both empty or valid
 	if !((len(vcConfig.VCPassword) > 0) == (len(vcConfig.VCUser) > 0)) {
 		err := errors.New("invalid field " + "VCUser, VCPassword")
-		log.Info("validate VcConfig failed", "VCUser", vcConfig.VCUser, "VCPassword", vcConfig.VCPassword)
+		configLog.Info("validate VcConfig failed VCUser %s VCPassword %s", vcConfig.VCUser, vcConfig.VCPassword)
 		return err
 	}
 	return nil
@@ -265,28 +280,28 @@ func (nsxConfig *NsxConfig) validateCert() error {
 	// ca file(thumbprint) == 1 or equal to manager count
 	if caCount == 0 && tpCount == 0 {
 		err := errors.New("no ca file or thumbprint provided")
-		log.Error(err, "validate NsxConfig failed")
+		configLog.Error(err, "validate NsxConfig failed")
 		return err
 	}
 	if caCount > 0 {
-		log.V(1).Info("validate CA file", "CA file number", caCount)
+		configLog.Infof("validate CA file: %s", caCount)
 		if caCount > 1 && caCount != mCount {
 			err := errors.New("ca file count not match manager count")
-			log.Error(err, "validate NsxConfig failed", "ca file count", caCount, "manager count", mCount)
+			configLog.Error(err, "validate NsxConfig failed", "ca file count", caCount, "manager count", mCount)
 			return err
 		}
 		for _, file := range nsxConfig.CaFile {
 			if _, err := os.Stat(file); os.IsNotExist(err) {
 				err = fmt.Errorf("ca file does not exist %s", file)
-				log.Error(err, "validate NsxConfig failed")
+				configLog.Error(err, "validate NsxConfig failed")
 				return err
 			}
 		}
 	} else {
-		log.V(1).Info("validate thumbprint", "thumbprint number", tpCount)
+		configLog.Infof("validate thumbprint: %s", tpCount)
 		if tpCount > 1 && tpCount != mCount {
 			err := errors.New("thumbprint count not match manager count")
-			log.Error(err, "validate NsxConfig failed", "thumbprint count", tpCount, "manager count", mCount)
+			configLog.Error(err, "validate NsxConfig failed", "thumbprint count", tpCount, "manager count", mCount)
 			return err
 		}
 	}
@@ -298,7 +313,7 @@ func (nsxConfig *NsxConfig) validate(enableVPC bool) error {
 	mCount := len(nsxConfig.NsxApiManagers)
 	if mCount == 0 {
 		err := errors.New("invalid field " + "NsxApiManagers")
-		log.Error(err, "validate NsxConfig failed", "NsxApiManagers", nsxConfig.NsxApiManagers)
+		configLog.Error(err, "validate NsxConfig failed", "NsxApiManagers", nsxConfig.NsxApiManagers)
 		return err
 	}
 	if err := nsxConfig.validateCert(); err != nil {
@@ -310,7 +325,7 @@ func (nsxConfig *NsxConfig) validate(enableVPC bool) error {
 func (coeConfig *CoeConfig) validate() error {
 	if len(coeConfig.Cluster) == 0 {
 		err := errors.New("invalid field " + "Cluster")
-		log.Error(err, "validate coeConfig failed")
+		configLog.Error(err, "validate coeConfig failed")
 		return err
 	}
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -98,6 +98,10 @@ func TestConfig_NewNSXOperatorConfigFromFile(t *testing.T) {
 	configFilePath = "../mock/nsxop.ini"
 	_, err = NewNSXOperatorConfigFromFile()
 	assert.Equal(t, err, nil)
+
+	configFilePath = "../mock/nsxop_err.ini"
+	_, err = NewNSXOperatorConfigFromFile()
+	assert.NotNil(t, err)
 }
 
 func TestConfig_GetTokenProvider(t *testing.T) {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -29,7 +29,21 @@ func init() {
 	Log = logf.Log.WithName("nsx-operator")
 }
 
-func ZapLogger() logr.Logger {
+// If debug set in configmap, set log level to 1.
+// If loglevel set in command line and greater than debug log level, set it to command line level.
+func getLogLevel(cf *config.NSXOperatorConfig) int {
+	logLevel := 0
+	if cf.DefaultConfig.Debug {
+		logLevel = 1
+	}
+	realLogLevel := logLevel
+	if config.LogLevel > logLevel {
+		realLogLevel = config.LogLevel
+	}
+	return realLogLevel
+}
+
+func ZapLogger(cf *config.NSXOperatorConfig) logr.Logger {
 	encoderConf := zapcore.EncoderConfig{
 		CallerKey:      "caller_line",
 		LevelKey:       "level_name",
@@ -55,9 +69,10 @@ func ZapLogger() logr.Logger {
 	// In level.go of zapcore, higher levels are more important.
 	// However, in logr.go, a higher verbosity level means a log message is less important.
 	// So we need to reverse the order of the levels.
-	opts.Level = zapcore.Level(-1 * config.LogLevel)
+	logLevel := getLogLevel(cf)
+	opts.Level = zapcore.Level(-1 * logLevel)
 	opts.ZapOpts = append(opts.ZapOpts, zap.AddCaller(), zap.AddCallerSkip(0))
-	if config.LogLevel > 0 {
+	if logLevel > 0 {
 		opts.StacktraceLevel = zap.ErrorLevel
 	}
 

--- a/pkg/mock/nsxop_err.ini
+++ b/pkg/mock/nsxop_err.ini
@@ -1,0 +1,12 @@
+[DEFAULT]
+[coe]
+cluster =
+[ha]
+#enable=true
+[k8s]
+[nsx_v3]
+nsx_api_managers = 127.0.0.1
+nsx_api_password = admin
+nsx_api_user = admin
+thumbprint = 81:49:DD:B7:E8:79:55:5D:9E:75:A9:FA:A6:7D:CB:EA:A4:CA:12:C6
+[vc]


### PR DESCRIPTION
We hold these truths to be self-evident:
log.info -> info, log.v(1).info -> debug, log.error-> error, log.v(2).info-> develop level log

If config.Debug=true, then loglevel=1, if command is passed in loglevel and greater than debug loglevel, then the loglevel is overridden.
Use another log in config.go.