### PR TITLE
Update MaxNameLength and use GenerateTruncName to build subnet name

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -19,6 +19,7 @@ const (
 	MaxTagLength                    int    = 256
 	MaxIdLength                     int    = 255
 	MaxNameLength                   int    = 255
+	MaxSubnetNameLength             int    = 80
 	TagScopeNCPCluster              string = "ncp/cluster"
 	TagScopeNCPProjectUID           string = "ncp/project_uid"
 	TagScopeNCPVIFProjectUID        string = "ncp/vif_project_uid"

--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -33,11 +33,11 @@ func (service *SubnetService) buildSubnetSetID(subnetset *v1alpha1.SubnetSet, in
 }
 
 func (service *SubnetService) buildSubnetName(subnet *v1alpha1.Subnet) string {
-	return util.GenerateDisplayName(subnet.ObjectMeta.Name, SUBNETPREFIX, "", "", getCluster(service))
+	return util.GenerateTruncName(common.MaxSubnetNameLength, subnet.ObjectMeta.Name, SUBNETPREFIX, "", "", getCluster(service))
 }
 
 func (service *SubnetService) buildSubnetSetName(subnetset *v1alpha1.SubnetSet, index string) string {
-	return util.GenerateDisplayName(subnetset.ObjectMeta.Name, SUBNETPREFIX, index, "", getCluster(service))
+	return util.GenerateTruncName(common.MaxSubnetNameLength, subnetset.ObjectMeta.Name, SUBNETPREFIX, index, "", getCluster(service))
 }
 
 func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (*model.VpcSubnet, error) {


### PR DESCRIPTION
nsx-t limits the name to 80-byte.