### PR TITLE
Fix the concurrency issue in subnet port creation

### DIFF
--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,10 +18,14 @@ import (
 )
 
 var (
-	log = logger.Log
+	log  = logger.Log
+	lock = &sync.Mutex{}
 )
 
 func AllocateSubnetFromSubnetSet(subnetSet *v1alpha1.SubnetSet) (string, error) {
+	// TODO: For now, this is a global lock. In the future, we need to narrow its scope down to improve the performance.
+	lock.Lock()
+	defer lock.Unlock()
 	subnetPath, err := ServiceMediator.GetAvailableSubnet(subnetSet)
 	if err != nil {
 		log.Error(err, "failed to allocate Subnet")

--- a/pkg/nsx/services/mediator/mediator.go
+++ b/pkg/nsx/services/mediator/mediator.go
@@ -58,7 +58,7 @@ func (m *ServiceMediator) GetVPCNetworkConfigByNamespace(ns string) *vpc.VPCNetw
 
 // GetAvailableSubnet returns available Subnet under SubnetSet, and creates Subnet if necessary.
 func (serviceMediator *ServiceMediator) GetAvailableSubnet(subnetSet *v1alpha1.SubnetSet) (string, error) {
-	subnetList := serviceMediator.SubnetStore.GetByIndex(common.TagScopeSubnetCRUID, string(subnetSet.GetUID()))
+	subnetList := serviceMediator.SubnetStore.GetByIndex(common.TagScopeSubnetSetCRUID, string(subnetSet.GetUID()))
 	for _, nsxSubnet := range subnetList {
 		portNums := len(serviceMediator.GetPortsOfSubnet(*nsxSubnet.Id))
 		totalIP := int(*nsxSubnet.Ipv4SubnetSize)

--- a/pkg/nsx/services/subnet/store.go
+++ b/pkg/nsx/services/subnet/store.go
@@ -49,6 +49,16 @@ func subnetTypeIndexFunc(obj interface{}) ([]string, error) {
 	}
 }
 
+// subnetIndexFunc is used to filter out NSX Subnets which are tagged with CR UID.
+func subnetSetIndexFunc(obj interface{}) ([]string, error) {
+	switch o := obj.(type) {
+	case model.VpcSubnet:
+		return filterTag(o.Tags, common.TagScopeSubnetSetCRUID), nil
+	default:
+		return nil, errors.New("subnetSetIndexFunc doesn't support unknown type")
+	}
+}
+
 // SubnetStore is a store for subnet.
 type SubnetStore struct {
 	common.ResourceStore

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -72,8 +72,9 @@ func InitializeSubnetService(service common.Service) (*SubnetService, error) {
 		SubnetStore: &SubnetStore{
 			ResourceStore: common.ResourceStore{
 				Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
-					common.TagScopeSubnetCRUID:  subnetIndexFunc,
-					common.TagScopeSubnetCRType: subnetTypeIndexFunc,
+					common.TagScopeSubnetCRUID:    subnetIndexFunc,
+					common.TagScopeSubnetCRType:   subnetTypeIndexFunc,
+					common.TagScopeSubnetSetCRUID: subnetSetIndexFunc,
 				}),
 				BindingType: model.VpcSubnetBindingType(),
 			},


### PR DESCRIPTION
The patch will add a lock when creating a new NSX subnet for the
subnetport event to avoid creating multiple NSX subnet for different
subnetports in the same time.

It also changes the search index for the existing NSX subnets because
the NSX subnet tag for subnetset CR was changed from nsx-op/subnet_cr_uid
to nsx-op/subnetset_cr_uid:<subnetset CR uid>.

Tests done:

1. create 20 subnetport CRs in a short time and ensure that all of
   the NSX subnet ports are created in the same subnet (the subnet has
   enough capacity for the ports)