### PR TITLE
Fix default-pod-subnetset having no nsx-op/namespace

### DIFF
--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -41,7 +41,7 @@ func (service *SubnetService) buildSubnetSetName(subnetset *v1alpha1.SubnetSet, 
 }
 
 func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (*model.VpcSubnet, error) {
-	tags = util.AppendTags(service.buildBasicTags(obj), tags)
+	tags = append(service.buildBasicTags(obj), tags...)
 	var nsxSubnet *model.VpcSubnet
 	var staticIpAllocation bool
 	switch o := obj.(type) {

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -337,7 +337,7 @@ func (service *SubnetService) UpdateSubnetSetTags(ns string, vpcSubnetSets []mod
 		for _, tag := range vpcSubnetSet.Tags {
 			if *tag.Scope == common.TagScopeSubnetSetCRName {
 				name = *tag.Tag
-			} else if *tag.Scope == common.TagScopeNamespace {
+			} else if *tag.Scope == common.TagScopeNamespace || *tag.Scope == common.TagScopeVMNamespace{
 				namespace = *tag.Tag
 				if namespace != ns {
 					break


### PR DESCRIPTION
When default-pod-subnetset of a vpc is created, it misses the tag scope
nsx-op/namespace and nsx-op/namespace_uid, and then it leads to the
problem which failed to sync the labels of namespace updating event
to subnetset. The basic reason is that the function
`util.AppendTags` filters nsx-op/namespace and nsx-op/namespace_uid scope,
replace it with `append` should fix this issue.