### PR TITLE
Put the subnetport CR's port into correct subnetset default-vm-subnetset

### DIFF
--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -50,7 +50,7 @@ func getSharedNamespaceAndVpcForNamespace(client k8sclient.Client, ctx context.C
 	return sharedNamespaceName, sharedVpcName, nil
 }
 
-func GetDefaultSubnetSet(client k8sclient.Client, ctx context.Context, namespace string) (*v1alpha1.SubnetSet, error) {
+func GetDefaultSubnetSet(client k8sclient.Client, ctx context.Context, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
 	targetNamespace, _, err := getSharedNamespaceAndVpcForNamespace(client, ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -59,18 +59,18 @@ func GetDefaultSubnetSet(client k8sclient.Client, ctx context.Context, namespace
 		log.Info("namespace doesn't have shared VPC, searching the default subnetset in the current namespace", "namespace", namespace)
 		targetNamespace = namespace
 	}
-	subnetSet, err := getDefaultSubnetSetByNamespace(client, ctx, targetNamespace)
+	subnetSet, err := getDefaultSubnetSetByNamespace(client, ctx, targetNamespace, resourceType)
 	if err != nil {
 		return nil, err
 	}
 	return subnetSet, err
 }
 
-func getDefaultSubnetSetByNamespace(client k8sclient.Client, ctx context.Context, namespace string) (*v1alpha1.SubnetSet, error) {
+func getDefaultSubnetSetByNamespace(client k8sclient.Client, ctx context.Context, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
 	subnetSetList := &v1alpha1.SubnetSetList{}
 	subnetSetSelector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			servicecommon.LabelDefaultSubnetSet: servicecommon.LabelDefaultPodSubnetSet,
+			servicecommon.LabelDefaultSubnetSet: resourceType,
 		},
 	}
 	labelSelector, _ := metav1.LabelSelectorAsSelector(subnetSetSelector)

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -237,7 +237,7 @@ func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (s
 		log.V(1).Info("NSX subnet port had been created, returning the existing NSX subnet path", "pod.UID", pod.UID, "subnetPath", subnetPath)
 		return subnetPath, nil
 	}
-	subnetSet, err := common.GetDefaultSubnetSet(r.Service.Client, ctx, pod.Namespace)
+	subnetSet, err := common.GetDefaultSubnetSet(r.Service.Client, ctx, pod.Namespace, servicecommon.LabelDefaultPodSubnetSet)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -382,19 +382,19 @@ func (r *SubnetPortReconciler) GetSubnetPathForSubnetPort(ctx context.Context, s
 		}
 		log.Info("got subnetset for subnetport CR, allocating the NSX subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 		subnetPath, err := common.AllocateSubnetFromSubnetSet(subnetSet)
-		log.Info("allocated Subnet for Pod", "subnetPath", subnetPath, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
+		log.Info("allocated Subnet for SubnetPort", "subnetPath", subnetPath, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 		if err != nil {
 			return subnetPath, err
 		}
 		return subnetPath, nil
 	} else {
-		subnetSet, err := common.GetDefaultSubnetSet(r.Client, ctx, subnetPort.Namespace)
+		subnetSet, err := common.GetDefaultSubnetSet(r.Client, ctx, subnetPort.Namespace, servicecommon.LabelDefaultVMSubnetSet)
 		if err != nil {
 			return "", err
 		}
 		log.Info("got default subnetset for subnetport CR, allocating the NSX subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 		subnetPath, err := common.AllocateSubnetFromSubnetSet(subnetSet)
-		log.Info("allocated Subnet for Pod", "subnetPath", subnetPath, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
+		log.Info("allocated Subnet for SubnetPort", "subnetPath", subnetPath, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 		if err != nil {
 			return subnetPath, err
 		}

--- a/pkg/controllers/subnetset/vpc_handler.go
+++ b/pkg/controllers/subnetset/vpc_handler.go
@@ -21,7 +21,7 @@ import (
 // - VPC deletion: delete all SubnetSets under the VPC.
 
 var defaultSubnetSets = map[string]string{
-	"default-vm-subnetset":  common.LabelDefaultVMSubnet,
+	"default-vm-subnetset":  common.LabelDefaultVMSubnetSet,
 	"default-pod-subnetset": common.LabelDefaultPodSubnetSet,
 }
 

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -52,7 +52,7 @@ const (
 	TagScopeVMNamespaceUID          string = "nsx-op/vm_namespace_uid"
 	TagScopeVMNamespace             string = "nsx-op/vm_namespace"
 	LabelDefaultSubnetSet           string = "nsxoperator.vmware.com/default-subnetset-for"
-	LabelDefaultVMSubnet            string = "VirtualMachine"
+	LabelDefaultVMSubnetSet         string = "VirtualMachine"
 	LabelDefaultPodSubnetSet        string = "Pod"
 	TagScopeSubnetCRType            string = "nsx-op/subnet_cr_type"
 	TagScopeSubnetCRUID             string = "nsx-op/subnet_cr_uid"

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -188,7 +188,7 @@ func (service *SubnetPortService) DeleteSubnetPort(uid types.UID) error {
 	nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID := nsxutil.ParseVPCPath(*nsxSubnetPort.Path)
 	err := service.NSXClient.PortClient.Delete(nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID, string(uid))
 	if err != nil {
-		log.Error(err, "failed to delete subnetport", "nsxSubnetPortID", uid)
+		log.Error(err, "failed to delete subnetport", "nsxSubnetPort.Path", *nsxSubnetPort.Path)
 		return err
 	}
 	if err = service.SubnetPortStore.Delete(uid); err != nil {


### PR DESCRIPTION
In the previous code, the NSX subnet port created for subnetport CR was mistakenly
created in the NSX subnet for default-pod-subnetset. This patch will correct its
subnetset to default-vm-subnetset.

Tests done:

1. Create a new namespace and create some subnetport CRs without specifying subnet or subnetset in the namespace, ensure that the NSX subnet ports' parent has tag {"nsx-op/subnetset_cr_name": "default-vm-subnetset"}