### PR TITLE
Fix cleanup for subnet and ippool

### DIFF
--- a/pkg/clean/clean.go
+++ b/pkg/clean/clean.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	commonctl "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
@@ -58,6 +59,9 @@ func InitializeCleanupService(cf *config.NSXOperatorConfig) (*CleanupService, er
 		NSXConfig: cf,
 	}
 
+	vpcService, vpcErr := vpc.InitializeVPC(commonService)
+	commonctl.ServiceMediator.VPCService = vpcService
+
 	// initialize all the CR services
 	// Use Fluent Interface to escape error check hell
 
@@ -79,7 +83,7 @@ func InitializeCleanupService(cf *config.NSXOperatorConfig) (*CleanupService, er
 
 	wrapInitializeVPC := func(service common.Service) cleanupFunc {
 		return func() (cleanup, error) {
-			return vpc.InitializeVPC(service)
+			return vpcService, vpcErr
 		}
 	}
 

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -308,8 +308,9 @@ func (service *SubnetService) UpdateSubnetSetStatus(obj *v1alpha1.SubnetSet) err
 }
 
 func (service *SubnetService) ListSubnetID() sets.String {
-	subnetSet := service.SubnetStore.ListIndexFuncValues(common.TagScopeSubnetCRUID)
-	return subnetSet
+	subnets := service.SubnetStore.ListIndexFuncValues(common.TagScopeSubnetCRUID)
+	subnetSets := service.SubnetStore.ListIndexFuncValues(common.TagScopeSubnetSetCRUID)
+	return subnets.Union(subnetSets)
 }
 
 func (service *SubnetService) Cleanup() error {


### PR DESCRIPTION
1. Should delete subnet and subnetset, ListSubnetID should get them all.
2. Since ippool and staticroute rely on vpcService of serviceMediator, init vpc first, otherwise, it would report nil pointer when deleting ippool or staticroute.