### PR TITLE
Fix SubnetSet CR status update failure

### DIFF
--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -276,7 +276,7 @@ func (r *SubnetSetReconciler) GarbageCollector(cancel chan bool, timeout time.Du
 }
 
 func (r *SubnetSetReconciler) DeleteSubnetForSubnetSet(obj v1alpha1.SubnetSet, updataStatus bool) error {
-	nsxSubnets := r.Service.SubnetStore.GetByIndex(servicecommon.TagScopeSubnetCRUID, string(obj.GetUID()))
+	nsxSubnets := r.Service.SubnetStore.GetByIndex(servicecommon.TagScopeSubnetSetCRUID, string(obj.GetUID()))
 	hitError := false
 	for _, subnet := range nsxSubnets {
 		portNums := len(common.ServiceMediator.GetPortsOfSubnet(*subnet.Id))

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -286,7 +286,7 @@ func (service *SubnetService) GetIPPoolUsage(subnet *v1alpha1.Subnet) (*model.Po
 
 func (service *SubnetService) UpdateSubnetSetStatus(obj *v1alpha1.SubnetSet) error {
 	var subnetInfoList []v1alpha1.SubnetInfo
-	nsxSubnets := service.SubnetStore.GetByIndex(common.TagScopeSubnetCRUID, string(obj.GetUID()))
+	nsxSubnets := service.SubnetStore.GetByIndex(common.TagScopeSubnetSetCRUID, string(obj.GetUID()))
 	for _, subnet := range nsxSubnets {
 		statusList, err := service.GetSubnetStatus(&subnet)
 		if err != nil {


### PR DESCRIPTION
Updates of NSX Subnet tags lead to the failure of updating SubnetSet CR status, update tags to fix this issue.