### PR TITLE
Fix error when search subnet by key

### DIFF
--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -158,7 +158,10 @@ func (r *SubnetReconciler) DeleteSubnet(obj v1alpha1.Subnet) error {
 }
 
 func (r *SubnetReconciler) updateSubnetStatus(obj *v1alpha1.Subnet) error {
-	nsxSubnet := r.Service.SubnetStore.GetByKey(string(obj.GetUID()))
+	nsxSubnet := r.Service.SubnetStore.GetByKey(r.Service.BuildSubnetID(obj))
+	if nsxSubnet == nil {
+		return errors.New("failed to get NSX Subnet from store")
+	}
 	obj.Status.IPAddresses = obj.Status.IPAddresses[:0]
 	statusList, err := r.Service.GetSubnetStatus(nsxSubnet)
 	if err != nil {

--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -24,7 +24,7 @@ func getCluster(service *SubnetService) string {
 	return service.NSXConfig.Cluster
 }
 
-func (service *SubnetService) buildSubnetID(subnet *v1alpha1.Subnet) string {
+func (service *SubnetService) BuildSubnetID(subnet *v1alpha1.Subnet) string {
 	return util.GenerateID(string(subnet.UID), SUBNETPREFIX, "", "")
 }
 
@@ -47,7 +47,7 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (
 	switch o := obj.(type) {
 	case *v1alpha1.Subnet:
 		nsxSubnet = &model.VpcSubnet{
-			Id:          String(service.buildSubnetID(o)),
+			Id:          String(service.BuildSubnetID(o)),
 			AccessMode:  String(util.Capitalize(string(o.Spec.AccessMode))),
 			DhcpConfig:  service.buildDHCPConfig(int64(o.Spec.IPv4SubnetSize - 4)),
 			DisplayName: String(service.buildSubnetName(o)),

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -122,8 +122,8 @@ func (service *SubnetService) CreateOrUpdateSubnet(obj client.Object, tags []mod
 		return "", err
 	}
 	// Only check whether needs update when obj is v1alpha1.Subnet
-	if _, ok := obj.(*v1alpha1.Subnet); ok {
-		existingSubnet := service.SubnetStore.GetByKey(uid)
+	if subnet, ok := obj.(*v1alpha1.Subnet); ok {
+		existingSubnet := service.SubnetStore.GetByKey(service.BuildSubnetID(subnet))
 		changed := false
 		if existingSubnet == nil {
 			changed = true
@@ -339,7 +339,7 @@ func (service *SubnetService) UpdateSubnetSetTags(ns string, vpcSubnetSets []mod
 		for _, tag := range vpcSubnetSet.Tags {
 			if *tag.Scope == common.TagScopeSubnetSetCRName {
 				name = *tag.Tag
-			} else if *tag.Scope == common.TagScopeNamespace || *tag.Scope == common.TagScopeVMNamespace{
+			} else if *tag.Scope == common.TagScopeNamespace || *tag.Scope == common.TagScopeVMNamespace {
 				namespace = *tag.Tag
 				if namespace != ns {
 					break


### PR DESCRIPTION
NSX subnet ID had been reformatted with prefix. To be compatible with the format, update parameter of searching NSX subnet by key.