### PR TITLE
Support pass in nsx username/password

### DIFF
--- a/cmd_clean/main.go
+++ b/cmd_clean/main.go
@@ -24,6 +24,8 @@ var (
 	vcEndpoint  string
 	vcUser      string
 	vcPasswd    string
+	nsxUser     string
+	nsxPasswd   string
 	vcSsoDomain string
 	vcHttpsPort int
 	thumbprint  string
@@ -35,10 +37,12 @@ func main() {
 	flag.StringVar(&vcEndpoint, "vc-endpoint", "", "nsx manager ip")
 	flag.StringVar(&vcSsoDomain, "vc-sso-domain", "", "nsx manager ip")
 	flag.StringVar(&mgrIp, "mgr-ip", "", "nsx manager ip")
-	flag.StringVar(&vcUser, "vc-user", "", "nsx username")
-	flag.StringVar(&vcPasswd, "vc-passwd", "", "nsx password")
-	flag.IntVar(&vcHttpsPort, "vc-https-port", 443, "nsx password")
+	flag.StringVar(&vcUser, "vc-user", "", "vc username")
+	flag.StringVar(&vcPasswd, "vc-passwd", "", "vc password")
+	flag.IntVar(&vcHttpsPort, "vc-https-port", 443, "vc https port")
 	flag.StringVar(&thumbprint, "thumbprint", "", "nsx thumbprint")
+	flag.StringVar(&nsxUser, "nsx-user", "", "nsx username")
+	flag.StringVar(&nsxPasswd, "nsx-passwd", "", "nsx password")
 	flag.StringVar(&caFile, "ca-file", "", "ca file")
 	flag.StringVar(&cluster, "cluster", "", "cluster name")
 	flag.IntVar(&config.LogLevel, "log-level", 0, "Use zap-core log system.")
@@ -49,6 +53,8 @@ func main() {
 	cf.VCUser = vcUser
 	cf.VCPassword = vcPasswd
 	cf.VCEndPoint = vcEndpoint
+	cf.NsxApiUser = nsxUser
+	cf.NsxApiPassword = nsxPasswd
 	cf.SsoDomain = vcSsoDomain
 	cf.HttpsPort = vcHttpsPort
 	cf.Thumbprint = []string{thumbprint}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -278,8 +278,8 @@ func (nsxConfig *NsxConfig) validateCert() error {
 	caCount := len(nsxConfig.CaFile)
 	// ca file has high priority than thumbprint
 	// ca file(thumbprint) == 1 or equal to manager count
-	if caCount == 0 && tpCount == 0 {
-		err := errors.New("no ca file or thumbprint provided")
+	if caCount == 0 && tpCount == 0 && nsxConfig.NsxApiUser == "" && nsxConfig.NsxApiPassword == "" {
+		err := errors.New("no ca file or thumbprint or nsx username/password provided")
 		configLog.Error(err, "validate NsxConfig failed")
 		return err
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -62,7 +62,7 @@ func TestConfig_NsxConfig(t *testing.T) {
 	assert.Equal(t, err, expect)
 
 	nsxConfig.NsxApiManagers = []string{"10.0.0.1"}
-	expect = errors.New("no ca file or thumbprint provided")
+	expect = errors.New("no ca file or thumbprint or nsx username/password provided")
 	err = nsxConfig.validate(false)
 	assert.Equal(t, err, expect)
 


### PR DESCRIPTION
In vanilla k8s environment, support cleanup nsx resources like `./bin/clean -cluster='' -mgr-ip="" -nsx-user='' -nsx-passwd=''`; In WCP environment, it is
`./bin/clean -cluster=''  -thumbprint="" -vc-user=$VC_USER -vc-passwd=$VC_PASS -vc-endpoint="" -vc-sso-domain="" -vc-https-port=443  -mgr-ip=""`.