### PR TITLE
Fix bugs of updating NSX subnet managed by SubnetSet CR

### DIFF
--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -89,7 +89,6 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			}
 		}
 
-		var tags []model.Tag
 		namespace := &v1.Namespace{}
 		namespacedName := types.NamespacedName{
 			Name: req.Namespace,
@@ -99,11 +98,7 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			updateFail(r, &ctx, obj)
 			return ResultRequeue, err
 		}
-		namespace_uid := namespace.UID
-		// user create subnet CR, it is only for VM subnet, no need to add TagScopeNamespaceUID/TagScopeNamespace for pod subnet
-		tags = append(tags,
-			model.Tag{Scope: servicecommon.String(servicecommon.TagScopeVMNamespaceUID), Tag: servicecommon.String(string(namespace_uid))},
-			model.Tag{Scope: servicecommon.String(servicecommon.TagScopeVMNamespace), Tag: servicecommon.String(req.Namespace)})
+		tags := r.Service.GenerateSubnetNSTags(obj, string(nsObj.UID))
 		for k, v := range nsObj.Labels {
 			tags = append(tags, model.Tag{Scope: servicecommon.String(k), Tag: servicecommon.String(v)})
 		}

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -92,7 +92,7 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				log.Error(err, "")
 				return ResultRequeue, err
 			}
-			var tags []model.Tag
+			tags := r.Service.GenerateSubnetNSTags(obj, string(nsObj.UID))
 			for k, v := range nsObj.Labels {
 				tags = append(tags, model.Tag{Scope: servicecommon.String(k), Tag: servicecommon.String(v)})
 			}


### PR DESCRIPTION
A random index is added to NSX subnet ID when updating NSX subnet managed by SubnetSet CR. This will cause the issue that nsx-operator will create a new NSX subnet instead of updating the existing one as there is a different ID for each request. This patch fixes this issue with below case passed:
1. nsx-operator updates existing NSX subnet tags when related namespace labels are added/updated/deleted instead of creating new NSX subnet.