### PR TITLE
Use SubnetSet CR uid to filter NSX subnets when update tags

### DIFF
--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -26,7 +26,6 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnet"
-	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
 var (
@@ -84,7 +83,7 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		// update subnetset tags if labels of namespace changed
-		nsxSubnets := r.Service.SubnetStore.GetByIndex(servicecommon.TagScopeSubnetCRType, util.SubnetTypeSubnetSet)
+		nsxSubnets := r.Service.SubnetStore.GetByIndex(servicecommon.TagScopeSubnetSetCRUID, string(obj.UID))
 		if len(nsxSubnets) > 0 {
 			nsObj := &v1.Namespace{}
 			if err := r.Client.Get(ctx, client.ObjectKey{Name: obj.Namespace}, nsObj); err != nil {


### PR DESCRIPTION
There are two kinds of subnetset, vm subnetset and pod subnetset. And the two types of subnetset have different namespace tags(nsx-op/vm_namespace and nsx-op/namespace). So when updating subnetset tags, nsx-operator can't filter subnets by CR types, and instead CR uid should be used to filter subnets.