### PR TITLE
[NSXServiceAccount] Fix incorrect GC in restore case (#351)

### DIFF
--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
@@ -103,7 +103,7 @@ func (r *NSXServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			if err := r.Service.DeleteNSXServiceAccount(ctx, types.NamespacedName{
 				Namespace: obj.Namespace,
 				Name:      obj.Name,
-			}); err != nil {
+			}, obj.UID); err != nil {
 				log.Error(err, "deleting failed, would retry exponentially", "nsxserviceaccount", req.NamespacedName)
 				deleteFail(r, &ctx, obj, &err)
 				return ResultRequeue, err
@@ -195,10 +195,11 @@ func (r *NSXServiceAccountReconciler) garbageCollector(nsxServiceAccountUIDSet s
 		log.V(1).Info("gc collects NSXServiceAccount CR", "UID", nsxServiceAccountUID)
 		namespacedName := r.Service.GetNSXServiceAccountNameByUID(nsxServiceAccountUID)
 		if namespacedName.Namespace == "" || namespacedName.Name == "" {
+			log.Info("gc cannot get namespace/name, skip", "namespace", namespacedName.Namespace, "name", namespacedName.Name, "uid", nsxServiceAccountUID)
 			continue
 		}
 		metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, MetricResType)
-		err := r.Service.DeleteNSXServiceAccount(context.TODO(), namespacedName)
+		err := r.Service.DeleteNSXServiceAccount(context.TODO(), namespacedName, types.UID(nsxServiceAccountUID))
 		if err != nil {
 			gcErrorCount++
 			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteFailTotal, MetricResType)

--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
@@ -816,7 +816,7 @@ func TestNSXServiceAccountReconciler_garbageCollector(t *testing.T) {
 					}},
 				}))
 				count := 0
-				return gomonkey.ApplyMethodFunc(r.Service, "DeleteNSXServiceAccount", func(ctx context.Context, namespacedName types.NamespacedName) error {
+				return gomonkey.ApplyMethodFunc(r.Service, "DeleteNSXServiceAccount", func(ctx context.Context, namespacedName types.NamespacedName, uid types.UID) error {
 					count++
 					if count <= 2 {
 						if namespacedName.Namespace == "ns3" {


### PR DESCRIPTION
Add UID check when creating/deleting NSXServiceAccount to avoid unexpected PI/CCP/Secret operation.
After NSXT restore finished, PI/CCP will be restored to old state, and it may contains same cluster name if a cluster is deleted and re-created after backup point. UID validation is required on this case.