### PR TITLE
Only get resources with marked_for_delete=false from NSX

### DIFF
--- a/pkg/nsx/services/common/store.go
+++ b/pkg/nsx/services/common/store.go
@@ -160,6 +160,7 @@ func (service *Service) InitializeCommonStore(wg *sync.WaitGroup, fatalErrors ch
 		pathUnescape, _ := url.PathUnescape("path%3A")
 		queryParam += " AND " + pathUnescape + path
 	}
+	queryParam += " AND marked_for_delete:false"
 
 	var cursor *string = nil
 	count := uint64(0)


### PR DESCRIPTION
After some resources are deleted by API, the resources may be still
on the NSX for a while and the property mark_for_delete is true.

So when we retrieve the NSX resources from NSX, we need to filter
the resources to avoid getting the resources that had been deleted.