### PR TITLE
Workaround to set StaticIPAllocation for NSX subnet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/vmware/go-vmware-nsxt => github.com/mengdie-song/go-vmware-nsxt v0.0.0-20220921033217-dbd234470e30 // inventory-keeper includes all commits from github.com/gran-vmv/go-vmware-nsxt v0.0.0-20211206034609-cd7ffaf2c996
 	github.com/vmware/vsphere-automation-sdk-go/lib => github.com/TaoZou1/vsphere-automation-sdk-go/lib v0.5.4
 	github.com/vmware/vsphere-automation-sdk-go/runtime => github.com/TaoZou1/vsphere-automation-sdk-go/runtime v0.5.4
-	github.com/vmware/vsphere-automation-sdk-go/services/nsxt => github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt v0.9.8 // update it from 0.9.5 to 0.9.8 to workaround the relization error for subnetport
+	github.com/vmware/vsphere-automation-sdk-go/services/nsxt => github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt v0.9.5
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp => github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt-mp v0.3.1-0.20221020082725-84e89979deb6
 )
 
@@ -80,6 +80,7 @@ require (
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
+	gitlab.eng.vmware.com/vapi-sdk/vsphere-automation-sdk-go/runtime v0.7.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/TaoZou1/vsphere-automation-sdk-go/lib v0.5.4 h1:DlmdgfnJZBf3xKVlIzV8h
 github.com/TaoZou1/vsphere-automation-sdk-go/lib v0.5.4/go.mod h1:QJG7MJEjc8SJuo6p++sLJha7Sqt0tzyxjK1peikCB/E=
 github.com/TaoZou1/vsphere-automation-sdk-go/runtime v0.5.4 h1:HfPCC2OxVMZjMgfRFD6txpgynbua+roPkMT3f+SoHbA=
 github.com/TaoZou1/vsphere-automation-sdk-go/runtime v0.5.4/go.mod h1:GqC85noyNzapJN4vIAO9jJ1EKVo3+jCW4/2VTaMvuSg=
-github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt v0.9.8 h1:l8DRN/HDjLyTnePixRhM9Ey5U9RekYXvOcCeOwNwuRk=
-github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt v0.9.8/go.mod h1:r6vXdrxnApdHWL8zxnKrWXinGoP8HEXvMVLxKcarV8c=
+github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt v0.9.5 h1:TfXvc3C/LLrIqkxcJVdOsrDp9NDmq8dRqxxUoUBXZnA=
+github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt v0.9.5/go.mod h1:r6vXdrxnApdHWL8zxnKrWXinGoP8HEXvMVLxKcarV8c=
 github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt-mp v0.3.1-0.20221020082725-84e89979deb6 h1:sFObhyzxRrFCQvvZgVbWwAGyxUvhlom14Axv0Cjix90=
 github.com/TaoZou1/vsphere-automation-sdk-go/services/nsxt-mp v0.3.1-0.20221020082725-84e89979deb6/go.mod h1:75a9Rt4zCs3FA+pFi5HIMdNvl+5AHUDMCNblLZiErg4=
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
@@ -321,6 +321,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+gitlab.eng.vmware.com/vapi-sdk/vsphere-automation-sdk-go/runtime v0.7.0 h1:4pU2NElWcqwIq02gN/H4l3yYwIiPQpbnlQGYkLmthNA=
+gitlab.eng.vmware.com/vapi-sdk/vsphere-automation-sdk-go/runtime v0.7.0/go.mod h1:v4Cynf6AVS1n+80DxMrbE+POcG6tguWgBWAf5FZNM8w=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -40,7 +40,7 @@ func (service *SubnetService) buildSubnetSetName(subnetset *v1alpha1.SubnetSet, 
 	return util.GenerateTruncName(common.MaxSubnetNameLength, subnetset.ObjectMeta.Name, SUBNETPREFIX, index, "", getCluster(service))
 }
 
-func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (*model.VpcSubnet, error) {
+func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (*model.VpcSubnet, bool, error) {
 	tags = append(service.buildBasicTags(obj), tags...)
 	var nsxSubnet *model.VpcSubnet
 	var staticIpAllocation bool
@@ -63,15 +63,10 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (
 		}
 		staticIpAllocation = o.Spec.AdvancedConfig.StaticIPAllocation.Enable
 	default:
-		return nil, SubnetTypeError
+		return nil, staticIpAllocation, SubnetTypeError
 	}
 	nsxSubnet.Tags = tags
-	nsxSubnet.AdvancedConfig = &model.SubnetAdvancedConfig{
-		StaticIpAllocation: &model.StaticIpAllocation{
-			Enabled: &staticIpAllocation,
-		},
-	}
-	return nsxSubnet, nil
+	return nsxSubnet, staticIpAllocation, nil
 }
 
 func (service *SubnetService) buildDHCPConfig(poolSize int64) *model.VpcSubnetDhcpConfig {

--- a/pkg/nsx/services/subnet/wrap_test.go
+++ b/pkg/nsx/services/subnet/wrap_test.go
@@ -63,7 +63,7 @@ func TestSubnetService_wrapSubnet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := service.wrapSubnet(tt.args.subnet)
+			got, _ := service.wrapSubnet(tt.args.subnet, true)
 			for _, v := range got {
 				subnet, _ := Converter.ConvertToGolang(v, model.ChildVpcSubnetBindingType())
 				child := subnet.(model.ChildVpcSubnet)


### PR DESCRIPTION
In NSX 4.1.2, the property static_ip_allocation in NSX subnet creation API is hidden. We need this workaround to set it.

The property will be available in NSX 4.1.3 then we can revert it.

Tests done:
1. create subnet CR with StaticIPAllocation.Enable=true and check the created NSX subnet.
2. create subnet CR with StaticIPAllocation.Enable=false and check the created NSX subnet.