### PR TITLE
Do not requeue when can not find ns resource

### DIFF
--- a/pkg/controllers/namespace/namespace_controller.go
+++ b/pkg/controllers/namespace/namespace_controller.go
@@ -129,7 +129,7 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if err := r.Client.Get(ctx, req.NamespacedName, obj); err != nil {
 		log.Error(err, "unable to fetch namespace", "req", req.NamespacedName)
-		return common.ResultRequeueAfter5mins, err
+		return common.ResultNormal, client.IgnoreNotFound(err)
 	}
 
 	// processing create/update event


### PR DESCRIPTION
In e2e CI testing, one issue observed that if namespace add event not handled correctly, it will be requeue to reconciler, but after namespace deleted, the event is still in the queue, and will keep looping.