### PR TITLE
Fix type issue of ippool

### DIFF
--- a/build/yaml/samples/nsx_v1alpha2_ippool.yaml
+++ b/build/yaml/samples/nsx_v1alpha2_ippool.yaml
@@ -4,7 +4,6 @@ metadata:
   name: guestcluster-ippool
   namespace: sc-a
 spec:
-  type: public
   subnets:
   - ipFamily: IPv4
     name: guestcluster1-workers-a

--- a/pkg/controllers/ippool/ippool_controller_test.go
+++ b/pkg/controllers/ippool/ippool_controller_test.go
@@ -107,7 +107,11 @@ func TestIPPoolReconciler_Reconcile(t *testing.T) {
 
 	// DeletionTimestamp.IsZero = ture, client update failed
 	sp := &v1alpha2.IPPool{}
-	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil)
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+		v1sp := obj.(*v1alpha2.IPPool)
+		v1sp.Spec.Type = "Public"
+		return nil
+	})
 	err = errors.New("Update failed")
 	k8sClient.EXPECT().Update(ctx, gomock.Any(), gomock.Any()).Return(err)
 	fakewriter := fakeStatusWriter{}
@@ -119,6 +123,7 @@ func TestIPPoolReconciler_Reconcile(t *testing.T) {
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 		v1sp := obj.(*v1alpha2.IPPool)
 		time := metav1.Now()
+		v1sp.Spec.Type = "Public"
 		v1sp.ObjectMeta.DeletionTimestamp = &time
 		return nil
 	})
@@ -138,6 +143,7 @@ func TestIPPoolReconciler_Reconcile(t *testing.T) {
 		v1sp := obj.(*v1alpha2.IPPool)
 		time := metav1.Now()
 		v1sp.ObjectMeta.DeletionTimestamp = &time
+		v1sp.Spec.Type = "Public"
 		v1sp.Finalizers = []string{common.IPPoolFinalizerName}
 		return nil
 	})
@@ -152,6 +158,7 @@ func TestIPPoolReconciler_Reconcile(t *testing.T) {
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 		v1sp := obj.(*v1alpha2.IPPool)
 		time := metav1.Now()
+		v1sp.Spec.Type = "Public"
 		v1sp.ObjectMeta.DeletionTimestamp = &time
 		v1sp.Finalizers = []string{common.IPPoolFinalizerName}
 		return nil
@@ -170,6 +177,7 @@ func TestIPPoolReconciler_Reconcile(t *testing.T) {
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 		v1sp := obj.(*v1alpha2.IPPool)
 		v1sp.ObjectMeta.DeletionTimestamp = nil
+		v1sp.Spec.Type = "Public"
 		v1sp.Finalizers = []string{common.IPPoolFinalizerName}
 		return nil
 	})


### PR DESCRIPTION
Move the logic of deciding type of ippool before add and delete,
or else it would fail to delete ippool if user doesn't specify
type field.