### PR TITLE
[NSXServiceAccount] Support CA validation and client cert rotation (#311)

### DIFF
--- a/build/yaml/crd/nsx.vmware.com_nsxserviceaccounts.yaml
+++ b/build/yaml/crd/nsx.vmware.com_nsxserviceaccounts.yaml
@@ -35,6 +35,10 @@ spec:
           spec:
             description: NSXServiceAccountSpec defines the desired state of NSXServiceAccount
             properties:
+              enableCertRotation:
+                description: EnableCertRotation enables cert rotation feature in this
+                  cluster when NSXT >=4.1.3
+                type: boolean
               vpcName:
                 type: string
             type: object

--- a/pkg/apis/v1alpha1/nsxserviceaccount_types.go
+++ b/pkg/apis/v1alpha1/nsxserviceaccount_types.go
@@ -10,6 +10,8 @@ import (
 // NSXServiceAccountSpec defines the desired state of NSXServiceAccount
 type NSXServiceAccountSpec struct {
 	VPCName string `json:"vpcName,omitempty"`
+	// EnableCertRotation enables cert rotation feature in this cluster when NSXT >=4.1.3
+	EnableCertRotation bool `json:"enableCertRotation,omitempty"`
 }
 
 type NSXProxyEndpointAddress struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ type NSXOperatorConfig struct {
 	*K8sConfig
 	*VCConfig
 	*HAConfig
+	configCache configCache
 }
 
 func init() {
@@ -50,6 +51,29 @@ func (operatorConfig *NSXOperatorConfig) HAEnabled() bool {
 		return true
 	}
 	return false
+}
+
+func (operatorConfig *NSXOperatorConfig) GetCACert() []byte {
+	ca := operatorConfig.configCache.nsxCA
+	if ca == nil {
+		ca = []byte{}
+		for _, caFile := range operatorConfig.CaFile {
+			caCert, err := os.ReadFile(caFile)
+			if err != nil || len(caCert) == 0 {
+				configLog.Errorf("Failed to read CA file %s, err=%v, skip", caFile, err)
+				continue
+			}
+			ca = append(ca, caCert...)
+			ca = append(ca, []byte("\n")...)
+		}
+		operatorConfig.configCache.nsxCA = ca
+	}
+	return ca
+}
+
+type configCache struct {
+	// nsxCA stores all file contents of NsxConfig.CaFile in a byte slice
+	nsxCA []byte
 }
 
 type DefaultConfig struct {
@@ -181,6 +205,7 @@ func NewNSXOpertorConfig() *NSXOperatorConfig {
 		&K8sConfig{},
 		&VCConfig{},
 		&HAConfig{},
+		configCache{},
 	}
 	return defaultNSXOperatorConfig
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@ package config
 import (
 	"errors"
 	"io/fs"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -124,4 +125,59 @@ func TestConfig_GetHA(t *testing.T) {
 	cf, err := NewNSXOperatorConfigFromFile()
 	assert.Equal(t, err, nil)
 	assert.Equal(t, cf.HAEnabled(), true)
+}
+
+func TestNSXOperatorConfig_GetCACert(t *testing.T) {
+	caFile, _ := os.CreateTemp("", "config_test")
+	caFile.Write([]byte("dummy file"))
+	caFile.Close()
+	defer os.Remove(caFile.Name())
+	caFile2, _ := os.CreateTemp("", "config_test")
+	caFile2.Write([]byte("dummy file2"))
+	caFile2.Close()
+	defer os.Remove(caFile2.Name())
+	type fields struct {
+		nsxCA  []byte
+		caFile []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []byte
+	}{
+		{
+			name: "no",
+			fields: fields{
+				nsxCA:  nil,
+				caFile: nil,
+			},
+			want: []byte{},
+		},
+		{
+			name: "cached",
+			fields: fields{
+				nsxCA:  []byte("dummy\n"),
+				caFile: nil,
+			},
+			want: []byte("dummy\n"),
+		},
+		{
+			name: "readFile",
+			fields: fields{
+				nsxCA:  nil,
+				caFile: []string{caFile.Name(), caFile2.Name()},
+			},
+			want: []byte("dummy file\ndummy file2\n"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			operatorConfig := &NSXOperatorConfig{
+				NsxConfig:   &NsxConfig{CaFile: tt.fields.caFile},
+				configCache: configCache{nsxCA: tt.fields.nsxCA},
+			}
+			assert.Equalf(t, tt.want, operatorConfig.GetCACert(), "GetCACert()")
+			assert.Equalf(t, tt.want, operatorConfig.configCache.nsxCA, "GetCACert()")
+		})
+	}
 }

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -30,11 +30,12 @@ const (
 	SecurityPolicy
 	ServiceAccount
 	ServiceAccountRestore
+	ServiceAccountCertRotation
 	StaticRoute
 	AllFeatures
 )
 
-var FeaturesName = [AllFeatures]string{"VPC", "SECURITY_POLICY", "NSX_SERVICE_ACCOUNT", "NSX_SERVICE_ACCOUNT_RESTORE", "STATIC_ROUTE"}
+var FeaturesName = [AllFeatures]string{"VPC", "SECURITY_POLICY", "NSX_SERVICE_ACCOUNT", "NSX_SERVICE_ACCOUNT_RESTORE", "NSX_SERVICE_ACCOUNT_CERT_ROTATION", "STATIC_ROUTE"}
 
 type Client struct {
 	NsxConfig     *config.NSXOperatorConfig
@@ -60,6 +61,7 @@ type Client struct {
 var nsx320Version = [3]int64{3, 2, 0}
 var nsx401Version = [3]int64{4, 0, 1}
 var nsx412Version = [3]int64{4, 1, 2}
+var nsx413Version = [3]int64{4, 1, 3}
 
 type NSXHealthChecker struct {
 	cluster *Cluster
@@ -146,6 +148,10 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 	if !nsxClient.NSXCheckVersion(ServiceAccountRestore) {
 		err := errors.New("NSXServiceAccountRestore feature support check failed")
 		log.Error(err, "initial NSX version check for NSXServiceAccountRestore got error")
+	}
+	if !nsxClient.NSXCheckVersion(ServiceAccountCertRotation) {
+		err := errors.New("ServiceAccountCertRotation feature support check failed")
+		log.Error(err, "initial NSX version check for ServiceAccountCertRotation got error")
 	}
 
 	return nsxClient

--- a/pkg/nsx/client_test.go
+++ b/pkg/nsx/client_test.go
@@ -78,6 +78,7 @@ func TestGetClient(t *testing.T) {
 	assert.True(t, securityPolicySupported == false)
 	assert.False(t, client.NSXCheckVersion(ServiceAccount))
 	assert.False(t, client.NSXCheckVersion(ServiceAccountRestore))
+	assert.False(t, client.NSXCheckVersion(ServiceAccountCertRotation))
 
 	patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
 		nsxVersion := &NsxVersion{NodeVersion: "3.2.1"}
@@ -90,6 +91,7 @@ func TestGetClient(t *testing.T) {
 	assert.True(t, securityPolicySupported == true)
 	assert.False(t, client.NSXCheckVersion(ServiceAccount))
 	assert.False(t, client.NSXCheckVersion(ServiceAccountRestore))
+	assert.False(t, client.NSXCheckVersion(ServiceAccountCertRotation))
 
 	patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
 		nsxVersion := &NsxVersion{NodeVersion: "4.1.0"}
@@ -102,6 +104,7 @@ func TestGetClient(t *testing.T) {
 	assert.True(t, securityPolicySupported == true)
 	assert.True(t, client.NSXCheckVersion(ServiceAccount))
 	assert.False(t, client.NSXCheckVersion(ServiceAccountRestore))
+	assert.False(t, client.NSXCheckVersion(ServiceAccountCertRotation))
 
 	patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
 		nsxVersion := &NsxVersion{NodeVersion: "4.1.2"}
@@ -114,6 +117,20 @@ func TestGetClient(t *testing.T) {
 	assert.True(t, securityPolicySupported == true)
 	assert.True(t, client.NSXCheckVersion(ServiceAccount))
 	assert.True(t, client.NSXCheckVersion(ServiceAccountRestore))
+	assert.False(t, client.NSXCheckVersion(ServiceAccountCertRotation))
+
+	patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
+		nsxVersion := &NsxVersion{NodeVersion: "4.1.3"}
+		return nsxVersion, nil
+	})
+	client = GetClient(&cf)
+	patches.Reset()
+	assert.True(t, client != nil)
+	securityPolicySupported = client.NSXCheckVersion(SecurityPolicy)
+	assert.True(t, securityPolicySupported == true)
+	assert.True(t, client.NSXCheckVersion(ServiceAccount))
+	assert.True(t, client.NSXCheckVersion(ServiceAccountRestore))
+	assert.True(t, client.NSXCheckVersion(ServiceAccountCertRotation))
 }
 
 func IsInstanceOf(objectPtr, typePtr interface{}) bool {

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -317,6 +317,9 @@ func (nsxVersion *NsxVersion) featureSupported(feature int) bool {
 	case ServiceAccountRestore:
 		minVersion = nsx412Version
 		validFeature = true
+	case ServiceAccountCertRotation:
+		minVersion = nsx413Version
+		validFeature = true
 	}
 
 	if validFeature {

--- a/pkg/nsx/cluster_test.go
+++ b/pkg/nsx/cluster_test.go
@@ -167,38 +167,52 @@ func TestCluster_enableFeature(t *testing.T) {
 	assert.False(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
+	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
 	nsxVersion.NodeVersion = "3.2.0.3.0.18844962"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
+	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
 	nsxVersion.NodeVersion = "3.11.0.3.0.18844962"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
+	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
 	nsxVersion.NodeVersion = "4.0.0"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
+	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
 	nsxVersion.NodeVersion = "4.0.1"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
+	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
 	nsxVersion.NodeVersion = "4.1.0"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
+	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
 	nsxVersion.NodeVersion = "4.1.2"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccountRestore))
+	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
+	nsxVersion.NodeVersion = "4.1.3"
+	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
+	assert.True(t, nsxVersion.featureSupported(ServiceAccount))
+	assert.True(t, nsxVersion.featureSupported(ServiceAccountRestore))
+	assert.True(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
 	nsxVersion.NodeVersion = "3.2.0"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
+	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
 	nsxVersion.NodeVersion = "4.2.0"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccountRestore))
+	assert.True(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
 
 	// Test case for invalid feature
 	feature := 3

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -38,7 +38,8 @@ const (
 	GCInterval    = 60 * time.Second
 	FinalizerName = "securitypolicy.nsx.vmware.com/finalizer"
 
-	NSXServiceAccountFinalizerName = "nsxserviceaccount.nsx.vmware.com/finalizer"
+	NSXServiceAccountFinalizerName        = "nsxserviceaccount.nsx.vmware.com/finalizer"
+	GCValidationInterval           uint16 = 720
 )
 
 var (

--- a/pkg/util/crypto.go
+++ b/pkg/util/crypto.go
@@ -17,8 +17,10 @@ import (
 const (
 	DefaultRSABits = 2048
 	// For now the ClusterControlPlane API doesn't support rotating certificate. We set long valid time to avoid certificate expiration.
-	DefaultValidDays          = 3650
-	DefaultSerialNumberLength = 160
+	DefaultValidDays             = 3650
+	DefaultValidDaysWithRotation = 365
+	DefaultRotateDays            = 7
+	DefaultSerialNumberLength    = 160
 )
 
 var (


### PR DESCRIPTION
Add EnableCertRotation property in NSXServiceAccount.Spec.
Cache CA content in memory.
Populate CA content to Secret when processing NSXServiceAccount create event.
Check all Secrets' ca.crt are up-to-date when first NSXServiceAccount GC finished. Update if needed.
Check all Secrets' client cert need renew every 720 GC interval.
Renew client cert if cert will expire in 7d when rotation is supported (NSXT >=4.1.3 and EnableCertRotation is true).
Use 365d instead of 3650d for new client cert when rotation is supported (NSXT >=4.1.3 and EnableCertRotation is true).