### PR TITLE
Add GOPROXY Env in Dockfile

### DIFF
--- a/build/image/photon/Dockerfile
+++ b/build/image/photon/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /source
 
 COPY . /source
 
+ENV GOPROXY=https://goproxy.io,direct
 RUN go build -o manager cmd/main.go
 
 


### PR DESCRIPTION
Adding GOPROXY Env in Dockfile, so that Docker can build NSX Operator
Docker image individually.