### PR TITLE
Fix ippool logic bug

### DIFF
--- a/pkg/controllers/ippool/ippool_controller.go
+++ b/pkg/controllers/ippool/ippool_controller.go
@@ -172,8 +172,10 @@ func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			updateFail(r, &ctx, obj, &err)
 			// if all ip blocks are exhausted, we should not retry
 			if errors.As(err, &util.IPBlockAllExhaustedError{}) {
-				log.Error(err, "ip blocks are all exhausted, would not retry", "ippool", req.NamespacedName)
-				return resultNormal, nil
+				log.Error(err, "ip blocks are all exhausted, would retry exponentially", "ippool", req.NamespacedName)
+				r.Service.ExhaustedIPBlock = []string{}
+				log.Info("Clear ExhaustedIPBlock: ", "ExhaustedIPBlock", r.Service.ExhaustedIPBlock)
+				return common.ResultRequeueAfter10sec, err
 			}
 			log.Error(err, "operate failed, would retry exponentially", "ippool", req.NamespacedName)
 			return resultRequeue, err

--- a/pkg/nsx/services/ippool/builder.go
+++ b/pkg/nsx/services/ippool/builder.go
@@ -93,8 +93,8 @@ func (service *IPPoolService) buildIPSubnet(IPPool *v1alpha2.IPPool, subnetReque
 	IpBlockPathList := make([]string, 0)
 	VPCInfo := commonctl.ServiceMediator.GetVPCsByNamespace(IPPool.Namespace)
 	if len(VPCInfo) == 0 {
-		log.Error(nil, "failed to find VPCInfo for IPPool CR", "IPPool", IPPool.Name, "namespace %s", IPPool.Namespace)
-		return &model.IpAddressPoolBlockSubnet{}
+		log.Error(nil, "failed to find VPCInfo for IPPool CR", "IPPool", IPPool.Name, "namespace", IPPool.Namespace)
+		return nil
 	}
 
 	if IPPool.Spec.Type == common.IPPoolTypePrivate {

--- a/pkg/nsx/services/ippool/ippool.go
+++ b/pkg/nsx/services/ippool/ippool.go
@@ -72,6 +72,10 @@ func InitializeIPPool(service common.Service) (*IPPoolService, error) {
 
 func (service *IPPoolService) CreateOrUpdateIPPool(obj *v1alpha2.IPPool) (bool, bool, error) {
 	nsxIPPool, nsxIPSubnets := service.BuildIPPool(obj)
+	if len(nsxIPSubnets) == 0 {
+		err := util.NoEffectiveOption{Desc: "no valid ip block for ippool"}
+		return false, false, err
+	}
 	for _, ipSubnet := range nsxIPSubnets {
 		if ipSubnet.IpBlockPath == nil || *ipSubnet.IpBlockPath == "" {
 			return false, false, util.IPBlockAllExhaustedError{Desc: "all ip blocks are exhausted"}


### PR DESCRIPTION
If namespace created and VPC not finished creating, ippool would report all ip blocks are all exhausted.
1. Modify it, if VPC not finished, just retry.
2. If all blocks are all exhausted, clear the state which saves the exhausted ipblock and retry exponentially.