### PR TITLE
Generate hash ID to make for security policy rule ID unique

### DIFF
--- a/pkg/controllers/securitypolicy_controller_test.go
+++ b/pkg/controllers/securitypolicy_controller_test.go
@@ -199,7 +199,7 @@ func TestSecurityPolicyReconciler_Reconcile(t *testing.T) {
 	defer patches.Reset()
 
 	//  DeletionTimestamp.IsZero = false, Finalizers doesn't include util.FinalizerName
-	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 		v1sp := obj.(*v1alpha1.SecurityPolicy)
 		time := metav1.Now()
 		v1sp.ObjectMeta.DeletionTimestamp = &time
@@ -209,13 +209,13 @@ func TestSecurityPolicyReconciler_Reconcile(t *testing.T) {
 		assert.FailNow(t, "should not be called")
 		return nil
 	})
-	k8sClient.EXPECT().Update(ctx, gomock.Any()).Return(nil)
+	k8sClient.EXPECT().Update(ctx, gomock.Any(), gomock.Any()).Return(nil)
 	_, ret = r.Reconcile(ctx, req)
 	assert.Equal(t, ret, nil)
 	patch.Reset()
 
 	//  DeletionTimestamp.IsZero = false, Finalizers include util.FinalizerName
-	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 		v1sp := obj.(*v1alpha1.SecurityPolicy)
 		time := metav1.Now()
 		v1sp.ObjectMeta.DeletionTimestamp = &time

--- a/pkg/nsx/services/firewall_test.go
+++ b/pkg/nsx/services/firewall_test.go
@@ -55,7 +55,8 @@ var (
 	nsxDirectionOut              = "OUT"
 	nsxActionDrop                = "DROP"
 	cluster                      = "k8scl-one"
-	tagValueScope                = "scope"
+	tagValueGroupScope           = util.TagValueGroupScope
+	tagValueGroupSource          = util.TagValueGroupSrc
 	tagValueNS                   = "ns1"
 	tagValuePolicyCRName         = "spA"
 	tagValuePolicyCRUID          = "uidA"

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -20,6 +20,9 @@ const (
 	TagScopeNCPVIFProject        string = "ncp/vif_project"
 	TagScopeNCPPod               string = "ncp/pod"
 	TagScopeNCPVNETInterface     string = "ncp/vnet_interface"
+	TagValueGroupScope           string = "scope"
+	TagValueGroupSrc             string = "source"
+	TagValueGroupDst             string = "destination"
 
 	GCInterval    = 60 * time.Second
 	FinalizerName = "securitypolicy.nsx.vmware.com/finalizer"


### PR DESCRIPTION
In certain case, SecurityPolicy cannot delete a rule when this rule is not last one.
For example, one SP with rule1, rule2 and rule3.
the rule ID is sp_spUID_0, sp_spUID_1, and sp_spUID_2, respectively.

When user is trying to delete rule 2, the deleting will fail. This issue is caused by the original rule2 ID: sp_spUID_1_0_0 will be regenerated by the original rule3, because rule3 becomes the new rule2, the new rule2 id will be sp_spUID_2. NSX will complain that groups in the deleted rule2 are still being referenced by sp_spUID_2.

The root cause for the issue is that we don't generate unique ID for the each rule.

Hence, this patch is to
1.Generate hash ID for security policy rule content and append this hash ID to the final generated rule ID to make each rule's ID unique. So, the final generated rule ID is: sp_<spUID>_<rule hash ID>_ruleIndex.

Also, plus following refactor changes:
2. Unify the applied group ID/name generation for policy and rule level.
3. Unify the source/destination group ID/name generation for rule level.

The testing Done:
1. Creating SP with rule1, rule2 and rule 3, deleting the rule2.
2. Creating SP with rule1, rule2 and rule 3, deleting the rule1.
3. Creating SPs without this patch, and staring NSX Operator again with this patch to verify that new generated rules with unique rule ID are created successfully. This is to test upgrade existing SPs.