### PR TITLE
Add back enum validation for IPPool

### DIFF
--- a/pkg/apis/v1alpha2/ippool_types.go
+++ b/pkg/apis/v1alpha2/ippool_types.go
@@ -37,6 +37,7 @@ type IPPoolList struct {
 // IPPoolSpec defines the desired state of IPPool.
 type IPPoolSpec struct {
 	// Type defines the type of this IPPool, Public or Private.
+	// +kubebuilder:validation:Enum=Public;Private
 	// +optional
 	Type string `json:"type,omitempty"`
 	// Subnets defines set of subnets need to be allocated.


### PR DESCRIPTION
When running `make test`, the generated nsx.vmware.com_ippools.yaml is different from the current one, the CRD definition misses validation.