### PR TITLE
Add AVI allow rule when VPC created(#369)

### DIFF
--- a/pkg/clean/clean.go
+++ b/pkg/clean/clean.go
@@ -58,7 +58,6 @@ func InitializeCleanupService(cf *config.NSXOperatorConfig) (*CleanupService, er
 		NSXClient: nsxClient,
 		NSXConfig: cf,
 	}
-
 	vpcService, vpcErr := vpc.InitializeVPC(commonService)
 	commonctl.ServiceMediator.VPCService = vpcService
 

--- a/pkg/controllers/vpc/vpc_controller.go
+++ b/pkg/controllers/vpc/vpc_controller.go
@@ -70,6 +70,12 @@ func (r *VPCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			updateFail(r.Service.NSXConfig, &ctx, obj, &err, r.Client)
 			return common.ResultRequeueAfter10sec, err
 		}
+		err = r.Service.CreateOrUpdateAVIRule(createdVpc, obj.Namespace)
+		if err != nil {
+			log.Error(err, "operate failed, would retry exponentially", "VPC", req.NamespacedName)
+			updateFail(r.Service.NSXConfig, &ctx, obj, &err, r.Client)
+			return common.ResultRequeueAfter10sec, err
+		}
 
 		snatIP, path, cidr := "", "", ""
 		// currently, auto snat is not exposed, and use default value True

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -331,6 +331,9 @@ func (nsxVersion *NsxVersion) featureSupported(feature int) bool {
 	case ServiceAccountCertRotation:
 		minVersion = nsx413Version
 		validFeature = true
+	case VpcAviRule:
+		minVersion = nsx411Version
+		validFeature = true
 	}
 
 	if validFeature {

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -62,6 +62,7 @@ const (
 	TagValueGroupScope              string = "scope"
 	TagValueGroupSrc                string = "source"
 	TagValueGroupDst                string = "destination"
+	TagValueGroupAvi                string = "avi"
 	AnnotationVPCNetworkConfig      string = "nsx.vmware.com/vpc_network_config"
 	AnnotationVPCName               string = "nsx.vmware.com/vpc_name"
 	AnnotationPodMAC                string = "nsx.vmware.com/mac"

--- a/pkg/nsx/services/vpc/store.go
+++ b/pkg/nsx/services/vpc/store.go
@@ -147,3 +147,86 @@ func (is *IPBlockStore) GetByIndex(index string, value string) *model.IpAddressB
 	block := indexResults[0].((model.IpAddressBlock))
 	return &block
 }
+
+// keyFuncAVI is used to get the key of a AVI rule related resource
+func keyFuncAVI(obj interface{}) (string, error) {
+	switch v := obj.(type) {
+	case model.Rule:
+		return *v.Path, nil
+	case model.SecurityPolicy:
+		return *v.Path, nil
+	case model.Group:
+		return *v.Path, nil
+	case model.IpAddressBlock:
+		return *v.Path, nil
+	default:
+		return "", errors.New("keyFunc doesn't support unknown type")
+	}
+}
+
+// AviRuleStore is a store for saving AVI related Rules in VPCs
+type AviRuleStore struct {
+	common.ResourceStore
+}
+
+func (ruleStore *AviRuleStore) Apply(i interface{}) error {
+	return nil
+}
+func (ruleStore *AviRuleStore) GetByKey(key string) *model.Rule {
+	obj := ruleStore.ResourceStore.GetByKey(key)
+	if obj != nil {
+		rule := obj.(model.Rule)
+		return &rule
+	}
+	return nil
+}
+
+// PubIPblockStore is a store to query external ip blocks cidr
+type PubIPblockStore struct {
+	common.ResourceStore
+}
+
+func (ipBlockStore *PubIPblockStore) Apply(i interface{}) error {
+	return nil
+}
+func (ipBlockStore *PubIPblockStore) GetByKey(key string) *model.IpAddressBlock {
+	obj := ipBlockStore.ResourceStore.GetByKey(key)
+	if obj != nil {
+		ipblock := obj.(model.IpAddressBlock)
+		return &ipblock
+	}
+	return nil
+}
+
+type AviGroupStore struct {
+	common.ResourceStore
+}
+
+func (groupStore *AviGroupStore) Apply(i interface{}) error {
+	return nil
+}
+func (groupStore *AviGroupStore) GetByKey(key string) *model.Group {
+	obj := groupStore.ResourceStore.GetByKey(key)
+	if obj != nil {
+		group := obj.(model.Group)
+		return &group
+	}
+	return nil
+}
+
+type AviSecurityPolicyStore struct {
+	common.ResourceStore
+}
+
+func (securityPolicyStore *AviSecurityPolicyStore) Apply(i interface{}) error {
+	return nil
+}
+
+func (securityPolicyStore *AviSecurityPolicyStore) GetByKey(key string) *model.SecurityPolicy {
+	obj := securityPolicyStore.ResourceStore.GetByKey(key)
+	if obj != nil {
+		sp := obj.(model.SecurityPolicy)
+		return &sp
+	}
+	return nil
+}

--- a/pkg/nsx/services/vpc/store_test.go
+++ b/pkg/nsx/services/vpc/store_test.go
@@ -253,3 +253,102 @@ func TestVPCStore_CRUDResource_List(t *testing.T) {
 		})
 	}
 }
+
+func TestRuleStore_GetByKey(t *testing.T) {
+	vpcRuleCacheIndexer := cache.NewIndexer(keyFuncAVI, nil)
+	resourceStore := common.ResourceStore{
+		Indexer:     vpcRuleCacheIndexer,
+		BindingType: model.RuleBindingType(),
+	}
+	ruleStore := &AviRuleStore{ResourceStore: resourceStore}
+	service := &VPCService{
+		Service: common.Service{NSXClient: nil},
+	}
+	service.RuleStore = ruleStore
+
+	path1 := "/org/default/project/project_1/vpcs/vpc1/security-policies/default-section/rules/rule1"
+	path2 := "/org/default/project/project_1/vpcs/vpc2/security-policies/default-section/rules/rule1"
+	rule1 := model.Rule{
+		Path: &path1,
+	}
+	rule2 := model.Rule{
+		Path: &path2,
+	}
+	ruleStore.Add(rule1)
+
+	rule := ruleStore.GetByKey(path1)
+	assert.Equal(t, rule.Path, rule1.Path)
+
+	rule = ruleStore.GetByKey(path2)
+	assert.True(t, rule == nil)
+
+	ruleStore.Add(rule2)
+	rule = ruleStore.GetByKey(path2)
+	assert.Equal(t, rule.Path, rule2.Path)
+}
+
+func TestGroupStore_GetByKey(t *testing.T) {
+	groupCacheIndexer := cache.NewIndexer(keyFuncAVI, nil)
+	resourceStore := common.ResourceStore{
+		Indexer:     groupCacheIndexer,
+		BindingType: model.GroupBindingType(),
+	}
+	groupStore := &AviGroupStore{ResourceStore: resourceStore}
+	service := &VPCService{
+		Service: common.Service{NSXClient: nil},
+	}
+	service.GroupStore = groupStore
+
+	path1 := "/org/default/project/project_1/vpcs/vpc1/groups/group1"
+	path2 := "/org/default/project/project_1/vpcs/vpc2/groups/group2"
+	group1 := model.Group{
+		Path: &path1,
+	}
+	group2 := model.Group{
+		Path: &path2,
+	}
+	groupStore.Add(group1)
+
+	group := groupStore.GetByKey(path1)
+	assert.Equal(t, group.Path, group1.Path)
+
+	group = groupStore.GetByKey(path2)
+	assert.True(t, group == nil)
+
+	groupStore.Add(group2)
+	group = groupStore.GetByKey(path2)
+	assert.Equal(t, group.Path, group2.Path)
+}
+
+func TestSecurityPolicyStore_GetByKey(t *testing.T) {
+	spCacheIndexer := cache.NewIndexer(keyFuncAVI, nil)
+	resourceStore := common.ResourceStore{
+		Indexer:     spCacheIndexer,
+		BindingType: model.SecurityPolicyBindingType(),
+	}
+	spStore := &AviSecurityPolicyStore{ResourceStore: resourceStore}
+	service := &VPCService{
+		Service: common.Service{NSXClient: nil},
+	}
+	service.SecurityPolicyStore = spStore
+
+	path1 := "/org/default/project/project_1/vpcs/vpc1/security-policies/default-section"
+	path2 := "/org/default/project/project_1/vpcs/vpc2/security-policies/default-section"
+	sp1 := model.SecurityPolicy{
+		Path: &path1,
+	}
+	sp2 := model.SecurityPolicy{
+		Path: &path2,
+	}
+	spStore.Add(sp1)
+
+	sp := spStore.GetByKey(path1)
+	assert.Equal(t, sp.Path, sp1.Path)
+
+	sp = spStore.GetByKey(path2)
+	assert.True(t, sp == nil)
+
+	spStore.Add(sp2)
+	sp = spStore.GetByKey(path2)
+	assert.Equal(t, sp.Path, sp2.Path)
+}

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -4,20 +4,33 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"strings"
 	"sync"
 
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/realizestate"
+)
+
+const (
+	AviSEIngressAllowRuleId    = "avi-se-ingress-allow-rule"
+	VPCAviSEGroupId            = "avi-se-vms"
+	VpcDefaultSecurityPolicyId = "default-layer3-section"
+	GroupKey                   = "/orgs/%s/projects/%s/vpcs/%s/groups/%s"
+	SecurityPolicyKey          = "/orgs/%s/projects/%s/vpcs/%s/security-policies/%s"
+	RuleKey                    = "/orgs/%s/projects/%s/vpcs/%s/security-policies/%s/rules/%s"
 )
 
 var (
@@ -39,12 +52,20 @@ var (
 	resourceType              = "resource_type"
 	EnforceRevisionCheckParam = false
 	MarkedForDelete           = true
+	enableAviAllowRule        = false
 )
 
 type VPCService struct {
 	common.Service
 	VpcStore     *VPCStore
 	IpblockStore *IPBlockStore
+	AVIAllowRule
+}
+type AVIAllowRule struct {
+	GroupStore          *AviGroupStore
+	RuleStore           *AviRuleStore
+	SecurityPolicyStore *AviSecurityPolicyStore
+	PubIpblockStore     *PubIPblockStore
 }
 
 func (s *VPCService) RegisterVPCNetworkConfig(ncCRName string, info VPCNetworkConfigInfo) {
@@ -106,10 +127,15 @@ func InitializeVPC(service common.Service) (*VPCService, error) {
 	wgDone := make(chan bool)
 	fatalErrors := make(chan error)
 
-	wg.Add(2)
-
 	VPCService := &VPCService{Service: service}
-
+	enableAviAllowRule = service.NSXClient.FeatureEnabled(nsx.VpcAviRule)
+	if enableAviAllowRule {
+		log.Info("support avi allow rule")
+		wg.Add(5)
+	} else {
+		log.Info("disable avi allow rule")
+		wg.Add(2)
+	}
 	VPCService.VpcStore = &VPCStore{ResourceStore: common.ResourceStore{
 		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeVPCCRUID: indexFunc}),
 		BindingType: model.VpcBindingType(),
@@ -125,6 +151,31 @@ func InitializeVPC(service common.Service) (*VPCService, error) {
 	//initialize vpc store and ip blocks store
 	go VPCService.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypeVpc, nil, VPCService.VpcStore)
 	go VPCService.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypeIPBlock, nil, VPCService.IpblockStore)
+
+	//initalize avi rule related store
+	if enableAviAllowRule {
+		VPCService.RuleStore = &AviRuleStore{ResourceStore: common.ResourceStore{
+			Indexer:     cache.NewIndexer(keyFuncAVI, nil),
+			BindingType: model.RuleBindingType(),
+		}}
+		VPCService.GroupStore = &AviGroupStore{ResourceStore: common.ResourceStore{
+			Indexer:     cache.NewIndexer(keyFuncAVI, nil),
+			BindingType: model.GroupBindingType(),
+		}}
+		VPCService.SecurityPolicyStore = &AviSecurityPolicyStore{ResourceStore: common.ResourceStore{
+			Indexer:     cache.NewIndexer(keyFuncAVI, nil),
+			BindingType: model.SecurityPolicyBindingType(),
+		}}
+		VPCService.PubIpblockStore = &PubIPblockStore{ResourceStore: common.ResourceStore{
+			Indexer:     cache.NewIndexer(keyFuncAVI, nil),
+			BindingType: model.IpAddressBlockBindingType(),
+		}}
+		go VPCService.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypeGroup, nil, VPCService.GroupStore)
+		go VPCService.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypeRule, nil, VPCService.RuleStore)
+
+		query := fmt.Sprintf("%s:%s AND visibility:EXTERNAL", common.ResourceType, common.ResourceTypeIPBlock)
+		go VPCService.PopulateResourcetoStore(&wg, fatalErrors, common.ResourceTypeIPBlock, query, VPCService.PubIpblockStore, nil)
+	}
 
 	go func() {
 		wg.Wait()
@@ -360,19 +411,19 @@ func (s *VPCService) CreateorUpdateVPC(obj *v1alpha1.VPC) (*model.Vpc, *VPCNetwo
 	}
 
 	// read corresponding vpc network config from store
-	nc_name, err := s.getNetworkconfigNameFromNS(obj.Namespace)
+	ncName, err := s.getNetworkconfigNameFromNS(obj.Namespace)
 	if err != nil {
 		log.Error(err, "failed to get network config name for VPC when creating NSX VPC", "VPC", obj.Name)
 		return nil, nil, err
 	}
-	nc, _exist := s.GetVPCNetworkConfig(nc_name)
+	nc, _exist := s.GetVPCNetworkConfig(ncName)
 	if !_exist {
-		message := fmt.Sprintf("failed to read network config %s when creating NSX VPC", nc_name)
+		message := fmt.Sprintf("failed to read network config %s when creating NSX VPC", ncName)
 		log.Info(message)
 		return nil, nil, errors.New(message)
 	}
 
-	log.Info("read network config from store", "NetworkConfig", nc_name)
+	log.Info("read network config from store", "NetworkConfig", ncName)
 
 	paths, err := s.CreatOrUpdatePrivateIPBlock(obj, nc)
 	if err != nil {
@@ -468,4 +519,233 @@ func (s *VPCService) Cleanup() error {
 	}
 
 	return nil
+}
+
+func (service *VPCService) needUpdateRule(rule *model.Rule, externalCIDRs []string) bool {
+	des := rule.DestinationGroups
+	currentDesSet := sets.Set[string]{}
+	for _, group := range des {
+		currentDesSet.Insert(group)
+	}
+	if len(externalCIDRs) != len(currentDesSet) {
+		return true
+	}
+	for _, cidr := range externalCIDRs {
+		if !currentDesSet.Has(cidr) {
+			return true
+		}
+	}
+	return false
+}
+
+func (service *VPCService) getIpblockCidr(blocks []string) (result []string, err error) {
+	for _, cidr := range blocks {
+		ipblock := service.PubIpblockStore.GetByKey(cidr)
+		if ipblock == nil {
+			// in case VPC using the new ipblock, search the ipblock from nsxt
+			// return error, and retry next time when the ipblock is synced into store
+			err = errors.New("ipblock not found")
+			log.Error(err, "failed to get public ipblock", "path", cidr)
+			query := fmt.Sprintf("%s:%s AND visibility:EXTERNAL", common.ResourceType, common.ResourceTypeIPBlock)
+			count, searcherr := service.SearchResource(common.ResourceTypeIPBlock, query, service.PubIpblockStore, nil)
+			if searcherr != nil {
+				log.Error(searcherr, "failed to query public ipblock", "query", query)
+			} else {
+				log.V(1).Info("query public ipblock", "count", count)
+			}
+			return
+		} else {
+			result = append(result, *ipblock.Cidr)
+		}
+	}
+	return
+}
+
+func (service *VPCService) CreateOrUpdateAVIRule(vpc *model.Vpc, namespace string) error {
+	if !enableAviAllowRule {
+		return nil
+	}
+	vpcInfo, err := common.ParseVPCResourcePath(*vpc.Path)
+	orgId := vpcInfo.OrgID
+	projectId := vpcInfo.ProjectID
+	ruleId := AviSEIngressAllowRuleId
+	groupId := VPCAviSEGroupId
+	spId := VpcDefaultSecurityPolicyId
+
+	if !service.checkAVISecurityPolicyExist(orgId, projectId, *vpc.Id, spId) {
+		return errors.New("avi security policy not found")
+	}
+	allowrule, err := service.getAVIAllowRule(orgId, projectId, *vpc.Id, spId, ruleId)
+	externalCIDRs, err := service.getIpblockCidr(vpc.ExternalIpv4Blocks)
+	if err != nil {
+		return err
+	} else {
+		log.Info("avi rule get external cidr", "cidr", externalCIDRs)
+	}
+
+	if allowrule != nil {
+		if !service.needUpdateRule(allowrule, externalCIDRs) {
+			log.Info("avi rule is not changed, skip updating avi rulee")
+			return nil
+		} else {
+			log.Info("avi rule changed", "previous", allowrule.DestinationGroups, "current", externalCIDRs)
+		}
+	}
+
+	group, err := service.getorCreateAVIGroup(orgId, projectId, *vpc.Id, groupId)
+	if err != nil {
+		log.Error(err, "failed to get avi group", "group", groupId)
+		return err
+	}
+
+	newrule, err := service.buildAVIAllowRule(vpc, externalCIDRs, *group.Path, ruleId, projectId)
+	log.Info("creating avi rule", "rule", newrule)
+	if err != nil {
+		log.Error(err, "failed to build avi rule", "rule", newrule)
+		return err
+	}
+
+	err = service.NSXClient.VPCRuleClient.Patch(orgId, projectId, *vpc.Id, spId, *newrule.Id, *newrule)
+	if err != nil {
+		log.Error(err, "failed to create avi rule", "rule", newrule)
+		return err
+	}
+	nsxrule, err := service.NSXClient.VPCRuleClient.Get(orgId, projectId, *vpc.Id, spId, *newrule.Id)
+	if err != nil {
+		log.Error(err, "failed to get avi rule", "rule", nsxrule)
+		return err
+	}
+	service.RuleStore.Add(nsxrule)
+	log.Info("created avi rule successfully")
+	return nil
+}
+
+func (service *VPCService) getorCreateAVIGroup(orgId string, projectId string, vpcId string, groupId string) (*model.Group, error) {
+	group, err := service.getAVIGroup(orgId, projectId, vpcId, groupId)
+	if err != nil {
+		log.Info("create avi group", "group", groupId)
+		group, err = service.createAVIGroup(orgId, projectId, vpcId, groupId)
+		if err != nil {
+			log.Error(err, "failed to create avi group", "group", groupId)
+			return group, err
+		}
+		service.GroupStore.Add(group)
+	}
+	return group, err
+}
+
+func (service *VPCService) buildAVIGroupTag(vpcId string) []model.Tag {
+	return []model.Tag{
+		{
+			Scope: common.String(common.TagScopeCluster),
+			Tag:   common.String(service.NSXConfig.Cluster),
+		},
+		{
+			Scope: common.String(common.TagScopeVersion),
+			Tag:   common.String(strings.Join(common.TagValueVersion, ".")),
+		},
+		{
+			Scope: common.String(common.TagScopeVPCCRUID),
+			Tag:   common.String(vpcId),
+		},
+		{
+			Scope: common.String(common.TagScopeGroupType),
+			Tag:   common.String(common.TagValueGroupAvi),
+		},
+	}
+}
+
+func (service *VPCService) createAVIGroup(orgId string, projectId string, vpcId string, groupId string) (*model.Group, error) {
+	group := model.Group{}
+	group.Tags = service.buildAVIGroupTag(vpcId)
+	expression := service.buildExpression("Condition", "VpcSubnet", "AVI_SUBNET_LB|", "Tag", "EQUALS", "EQUALS")
+	group.Expression = []*data.StructValue{expression}
+	group.DisplayName = common.String(groupId)
+
+	err := service.NSXClient.VpcGroupClient.Patch(orgId, projectId, vpcId, groupId, group)
+	if err != nil {
+		return &group, err
+	}
+	nsxgroup, err := service.NSXClient.VpcGroupClient.Get(orgId, projectId, vpcId, groupId)
+	return &nsxgroup, err
+}
+
+func (service *VPCService) buildExpression(resource_type, member_type, value, key, operator, scope_op string) *data.StructValue {
+	return data.NewStructValue(
+		"",
+		map[string]data.DataValue{
+			"resource_type":  data.NewStringValue(resource_type),
+			"member_type":    data.NewStringValue(member_type),
+			"value":          data.NewStringValue(value),
+			"key":            data.NewStringValue(key),
+			"operator":       data.NewStringValue(operator),
+			"scope_operator": data.NewStringValue(scope_op),
+		},
+	)
+}
+
+func (service *VPCService) buildAVIAllowRule(obj *model.Vpc, externalCIDRs []string, groupId, ruleId, projectId string) (*model.Rule, error) {
+	rule := &model.Rule{}
+	rule.Action = common.String(model.Rule_ACTION_ALLOW)
+	rule.Direction = common.String(model.Rule_DIRECTION_IN_OUT)
+	rule.Scope = append(rule.Scope, groupId)
+	rule.SequenceNumber = common.Int64(math.MaxInt32 - 1)
+	rule.DestinationGroups = externalCIDRs
+	rule.SourceGroups = append(rule.SourceGroups, "Any")
+	name := fmt.Sprintf("PROJECT-%s-VPC-%s-%s", projectId, *obj.Id, ruleId)
+	rule.DisplayName = common.String(name)
+	rule.Id = common.String(ruleId)
+	rule.Services = []string{"ANY"}
+	rule.IsDefault = common.Bool(true)
+	tags := []model.Tag{
+		{
+			Scope: common.String(common.TagScopeCluster),
+			Tag:   common.String(service.NSXConfig.Cluster),
+		},
+		{
+			Scope: common.String(common.TagScopeVersion),
+			Tag:   common.String(strings.Join(common.TagValueVersion, ".")),
+		},
+	}
+	rule.Tags = tags
+	return rule, nil
+}
+
+func (service *VPCService) getAVIAllowRule(orgId string, projectId string, vpcId string, spId string, ruleId string) (*model.Rule, error) {
+	key := fmt.Sprintf(RuleKey, orgId, projectId, vpcId, spId, ruleId)
+	rule := service.RuleStore.GetByKey(key)
+	if rule == nil {
+		log.Info("avi rule not found", "key", key)
+		return nil, errors.New("avi rule not found")
+	}
+	return rule, nil
+}
+
+func (service *VPCService) getAVIGroup(orgId string, projectId string, vpcId string, groupId string) (*model.Group, error) {
+	key := fmt.Sprintf(GroupKey, orgId, projectId, vpcId, groupId)
+	group := service.GroupStore.GetByKey(key)
+	var err error
+	if group == nil {
+		log.Info("avi se group not found", "key", key)
+		err = errors.New("avi se group not found")
+	}
+	return group, err
+}
+
+// checkAVISecurityPolicyExist returns true if security policy for that VPC already exists
+// this security policy created by NSXT once VPC created
+// if not found, wait until it created
+func (service *VPCService) checkAVISecurityPolicyExist(orgId string, projectId string, vpcId string, spId string) bool {
+	key := fmt.Sprintf(SecurityPolicyKey, orgId, projectId, vpcId, spId)
+	sp := service.SecurityPolicyStore.GetByKey(key)
+	if sp != nil {
+		return true
+	}
+	nsxtsp, err := service.NSXClient.VPCSecurityClient.Get(orgId, projectId, vpcId, spId)
+	if err != nil {
+		log.Error(err, "failed to get avi security policy", "key", key)
+		return false
+	}
+	service.SecurityPolicyStore.Add(nsxtsp)
+	return true
 }

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -1,12 +1,18 @@
 package vpc
 
 import (
+	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
@@ -126,6 +132,7 @@ func TestVPC_GetVPCsByNamespace(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			vpcStore.Apply(&vpc1)
+			vpcStore.GetByKey(vpcID1)
 			vpcStore.Apply(&vpc2)
 			got := vpcStore.List()
 			if len(got) != 2 {
@@ -141,4 +148,226 @@ func TestVPC_GetVPCsByNamespace(t *testing.T) {
 			}
 		})
 	}
+}
+
+type MockSecurityPoliciesClient struct {
+	SP  model.SecurityPolicy
+	Err error
+}
+
+func (spClient *MockSecurityPoliciesClient) Delete(orgIdParam string, projectIdParam string, vpcIdParam string, groupIdParam string) error {
+	return spClient.Err
+}
+
+func (spClient *MockSecurityPoliciesClient) Get(orgIdParam string, projectIdParam string, vpcIdParam string, securityPolicyIdParam string) (model.SecurityPolicy, error) {
+	return spClient.SP, spClient.Err
+}
+
+func (spClient *MockSecurityPoliciesClient) List(orgIdParam string, projectIdParam string, vpcIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includeRuleCountParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.SecurityPolicyListResult, error) {
+	return model.SecurityPolicyListResult{}, spClient.Err
+}
+
+func (spClient *MockSecurityPoliciesClient) Patch(orgIdParam string, projectIdParam string, vpcIdParam string, securityPolicyIdParam string, securityPolicyParam model.SecurityPolicy) error {
+	return spClient.Err
+}
+func (spClient *MockSecurityPoliciesClient) Update(orgIdParam string, projectIdParam string, vpcIdParam string, securityPolicyIdParam string, securityPolicyParam model.SecurityPolicy) (model.SecurityPolicy, error) {
+	return spClient.SP, spClient.Err
+}
+func (spClient *MockSecurityPoliciesClient) Revise(orgIdParam string, projectIdParam string, vpcIdParam string, securityPolicyIdParam string, securityPolicyParam model.SecurityPolicy, anchorPathParam *string, operationParam *string) (model.SecurityPolicy, error) {
+	return model.SecurityPolicy{}, spClient.Err
+}
+
+type MockGroupClient struct {
+	Group model.Group
+	Err   error
+}
+
+func (groupClient *MockGroupClient) Delete(orgIdParam string, projectIdParam string, vpcIdParam string, groupIdParam string) error {
+	return groupClient.Err
+}
+
+func (groupClient *MockGroupClient) Get(orgIdParam string, projectIdParam string, vpcIdParam string, groupIdParam string) (model.Group, error) {
+	return groupClient.Group, groupClient.Err
+}
+
+func (groupClient *MockGroupClient) List(orgIdParam string, projectIdParam string, vpcIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, memberTypesParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.GroupListResult, error) {
+	return model.GroupListResult{}, groupClient.Err
+}
+
+func (groupClient *MockGroupClient) Patch(orgIdParam string, projectIdParam string, vpcIdParam string, groupIdParam string, groupParam model.Group) error {
+	return groupClient.Err
+}
+func (groupClient *MockGroupClient) Update(orgIdParam string, projectIdParam string, vpcIdParam string, groupIdParam string, groupParam model.Group) (model.Group, error) {
+	return groupClient.Group, groupClient.Err
+}
+
+type MockRuleClient struct {
+	Rule model.Rule
+	Err  error
+}
+
+func (ruleClient *MockRuleClient) Delete(orgIdParam string, projectIdParam string, vpcIdParam string, securityPolicyIdParam string, ruleIdParam string) error {
+	return ruleClient.Err
+}
+
+func (ruleClient *MockRuleClient) Get(orgIdParam string, projectIdParam string, vpcIdParam string, securityPolicyIdParam string, ruleIdParam string) (model.Rule, error) {
+	return ruleClient.Rule, ruleClient.Err
+}
+func (ruleClient *MockRuleClient) List(orgIdParam string, projectIdParam string, vpcIdParam string, securityPolicyIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.RuleListResult, error) {
+	return model.RuleListResult{}, ruleClient.Err
+}
+
+func (ruleClient *MockRuleClient) Patch(orgIdParam string, projectIdParam string, vpcIdParam string, securityPolicyIdParam string, ruleIdParam string, ruleParam model.Rule) error {
+	return ruleClient.Err
+}
+
+func (ruleClient *MockRuleClient) Update(orgIdParam string, projectIdParam string, vpcIdParam string, securityPolicyIdParam string, ruleIdParam string, ruleParam model.Rule) (model.Rule, error) {
+	return ruleClient.Rule, ruleClient.Err
+}
+
+func (ruleClient *MockRuleClient) Revise(orgIdParam string, projectIdParam string, vpcIdParam string, securityPolicyIdParam string, ruleIdParam string, ruleParam model.Rule, anchorPathParam *string, operationParam *string) (model.Rule, error) {
+	return model.Rule{}, ruleClient.Err
+}
+
+func TestVPC_CreateOrUpdateAVIRule(t *testing.T) {
+	aviRuleCacheIndexer := cache.NewIndexer(keyFuncAVI, nil)
+	resourceStore := common.ResourceStore{
+		Indexer:     aviRuleCacheIndexer,
+		BindingType: model.VpcBindingType(),
+	}
+	ruleStore := &AviRuleStore{ResourceStore: resourceStore}
+	resourceStore1 := common.ResourceStore{
+		Indexer:     aviRuleCacheIndexer,
+		BindingType: model.GroupBindingType(),
+	}
+	groupStore := &AviGroupStore{ResourceStore: resourceStore1}
+	resourceStore2 := common.ResourceStore{
+		Indexer:     aviRuleCacheIndexer,
+		BindingType: model.SecurityPolicyBindingType(),
+	}
+	spStore := &AviSecurityPolicyStore{ResourceStore: resourceStore2}
+
+	service := &VPCService{
+		Service: common.Service{NSXClient: nil},
+	}
+
+	service.RuleStore = ruleStore
+	service.GroupStore = groupStore
+	service.SecurityPolicyStore = spStore
+
+	ns1 := "test-ns-1"
+	tag1 := []model.Tag{
+		{
+			Scope: &tagScopeCluster,
+			Tag:   &cluster,
+		},
+		{
+			Scope: &tagScopeNamespace,
+			Tag:   &ns1,
+		},
+		{
+			Scope: &tagScopeVPCCRName,
+			Tag:   &tagValueVPCCRName,
+		},
+		{
+			Scope: &tagScopeVPCCRUID,
+			Tag:   &tagValueVPCCRUID,
+		},
+	}
+	path1 := "/orgs/default/projects/project_1/vpcs/vpc1"
+	vpc1 := model.Vpc{
+		Path:               &path1,
+		DisplayName:        &vpcName1,
+		Id:                 &vpcID1,
+		Tags:               tag1,
+		IpAddressType:      &IPv4Type,
+		PrivateIpv4Blocks:  []string{"1.1.1.0/24"},
+		ExternalIpv4Blocks: []string{"2.2.2.0/24"},
+	}
+
+	// feature not supported
+	enableAviAllowRule = false
+	err := service.CreateOrUpdateAVIRule(&vpc1, ns1)
+	assert.Equal(t, err, nil)
+
+	// enable feature
+	enableAviAllowRule = true
+	spClient := MockSecurityPoliciesClient{}
+
+	service.NSXClient = &nsx.Client{}
+	service.NSXClient.VPCSecurityClient = &spClient
+	service.NSXConfig = &config.NSXOperatorConfig{}
+	service.NSXConfig.CoeConfig = &config.CoeConfig{}
+	service.NSXConfig.Cluster = "k8scl_one"
+	sppath1 := "/orgs/default/projects/project_1/vpcs/vpc1/security-policies/sp1"
+	sp := model.SecurityPolicy{
+		Path: &sppath1,
+	}
+
+	// security policy not found
+	spClient.SP = sp
+	notFound := errors.New("avi security policy not found")
+	spClient.Err = notFound
+	err = service.CreateOrUpdateAVIRule(&vpc1, ns1)
+	assert.Equal(t, err, notFound)
+
+	// security policy found, get rule, failed to get external CIDR
+	rulepath1 := fmt.Sprintf("/orgs/default/projects/project_1/vpcs/ns-vpc-uid-1/security-policies/default-layer3-section/rules/%s", AviSEIngressAllowRuleId)
+	rule := model.Rule{
+		Path:              &rulepath1,
+		DestinationGroups: []string{"2.2.2.0/24"},
+	}
+	ruleStore.Add(rule)
+	spClient.Err = nil
+	resulterr := errors.New("get external ipblock failed")
+	patch := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "getIpblockCidr", func(_ *VPCService, cidr []string) ([]string, error) {
+		return []string{}, resulterr
+	})
+	err = service.CreateOrUpdateAVIRule(&vpc1, ns1)
+	patch.Reset()
+	assert.Equal(t, err, resulterr)
+
+	// security policy found, get rule, get external CIDR which matched
+	spClient.Err = nil
+	resulterr = errors.New("get external ipblock failed")
+	patch = gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "getIpblockCidr", func(_ *VPCService, cidr []string) ([]string, error) {
+		return []string{"2.2.2.0/24"}, nil
+	})
+	err = service.CreateOrUpdateAVIRule(&vpc1, ns1)
+	patch.Reset()
+	assert.Equal(t, err, nil)
+
+	// security policy found, get external CIDR, create group failed
+	patch = gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "getIpblockCidr", func(_ *VPCService, cidr []string) ([]string, error) {
+		return []string{"192.168.0.0/16"}, nil
+	})
+	defer patch.Reset()
+	groupClient := MockGroupClient{Err: nil}
+	service.NSXClient.VpcGroupClient = &groupClient
+	grouppath1 := "/orgs/default/projects/project_1/vpcs/vpc1/groups/group1"
+	group := model.Group{
+		Path: &grouppath1,
+	}
+	groupClient.Group = group
+	groupClient.Err = errors.New("create avi group error")
+	service.NSXConfig = &config.NSXOperatorConfig{}
+	service.NSXConfig.CoeConfig = &config.CoeConfig{}
+	service.NSXConfig.Cluster = "k8scl-one"
+	err = service.CreateOrUpdateAVIRule(&vpc1, ns1)
+	assert.Equal(t, err, groupClient.Err)
+
+	// security policy found, get external CIDR, create group, create rule failed
+	groupClient.Err = nil
+	ruleClient := MockRuleClient{}
+	service.NSXClient.VPCRuleClient = &ruleClient
+
+	ruleClient.Rule = rule
+	ruleClient.Err = errors.New("create avi rule error")
+	err = service.CreateOrUpdateAVIRule(&vpc1, ns1)
+	assert.Equal(t, err, ruleClient.Err)
+
+	// security policy found, get external CIDR, create group, create rule
+	ruleClient.Err = nil
+	err = service.CreateOrUpdateAVIRule(&vpc1, ns1)
+	assert.Equal(t, err, nil)
 }


### PR DESCRIPTION
cherry pick from  #369 
Add AVI allow rule when VPC created so VIP of AVI lb could be accessed outside the VPC
It will check nsxt version to enable it

Test Done:
Create lb service in one VPC, create pod in other VPC
1. Run the nsx-operator, check if the rule has been added
2. Visit lb service ip from other VPC pod
3. Restart the nsx-operator, check if the rule skip to update since CIDR is the same