### PR TITLE
Generate hash ID to make for security policy rule ID unique(#395)

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -34,6 +34,9 @@ const (
 	TagScopeNCPVNETInterface        string = "ncp/vnet_interface"
 	TagScopeVPCCRName               string = "nsx-op/vpc_cr_name"
 	TagScopeVPCCRUID                string = "nsx-op/vpc_cr_uid"
+	TagValueGroupScope              string = "scope"
+	TagValueGroupSource             string = "source"
+	TagValueGroupDestination        string = "destination"
 
 	GCInterval    = 60 * time.Second
 	FinalizerName = "securitypolicy.nsx.vmware.com/finalizer"

--- a/pkg/nsx/services/securitypolicy/expand.go
+++ b/pkg/nsx/services/securitypolicy/expand.go
@@ -21,7 +21,8 @@ import (
 // When a rule contains named port, we should consider whether the rule should be expanded to
 // multiple rules if the port name maps to conflicted port numbers.
 func (service *SecurityPolicyService) expandRule(obj *v1alpha1.SecurityPolicy, rule *v1alpha1.SecurityPolicyRule,
-	ruleIdx int) ([]*model.Group, []*model.Rule, error) {
+	ruleIdx int,
+) ([]*model.Group, []*model.Rule, error) {
 	var nsxRules []*model.Rule
 	var nsxGroups []*model.Group
 
@@ -44,7 +45,8 @@ func (service *SecurityPolicyService) expandRule(obj *v1alpha1.SecurityPolicy, r
 }
 
 func (service *SecurityPolicyService) expandRuleByPort(obj *v1alpha1.SecurityPolicy, rule *v1alpha1.SecurityPolicyRule,
-	ruleIdx int, port v1alpha1.SecurityPolicyPort, portIdx int) ([]*model.Group, []*model.Rule, error) {
+	ruleIdx int, port v1alpha1.SecurityPolicyPort, portIdx int,
+) ([]*model.Group, []*model.Rule, error) {
 	var err error
 	var startPort []nsxutil.PortAddress
 	var nsxGroups []*model.Group
@@ -63,7 +65,7 @@ func (service *SecurityPolicyService) expandRuleByPort(obj *v1alpha1.SecurityPol
 		if err != nil {
 			// In case there is no more valid ip set selected, so clear the stale ip set group in nsx if stale ips exist
 			if errors.As(err, &nsxutil.NoEffectiveOption{}) {
-				groups := service.groupStore.GetByIndex(common.TagScopeRuleID, service.buildRuleID(obj, ruleIdx))
+				groups := service.groupStore.GetByIndex(common.TagScopeRuleID, service.buildRuleID(obj, rule, ruleIdx))
 				var ipSetGroup model.Group
 				for _, group := range groups {
 					ipSetGroup = group
@@ -91,7 +93,8 @@ func (service *SecurityPolicyService) expandRuleByPort(obj *v1alpha1.SecurityPol
 }
 
 func (service *SecurityPolicyService) expandRuleByService(obj *v1alpha1.SecurityPolicy, rule *v1alpha1.SecurityPolicyRule, ruleIdx int,
-	port v1alpha1.SecurityPolicyPort, portIdx int, portAddress nsxutil.PortAddress, portAddressIdx int) ([]*model.Group, *model.Rule, error) {
+	port v1alpha1.SecurityPolicyPort, portIdx int, portAddress nsxutil.PortAddress, portAddressIdx int,
+) ([]*model.Group, *model.Rule, error) {
 	var nsxGroups []*model.Group
 
 	nsxRule, err := service.buildRuleBasicInfo(obj, rule, ruleIdx, portIdx, portAddressIdx)
@@ -123,7 +126,8 @@ func (service *SecurityPolicyService) expandRuleByService(obj *v1alpha1.Security
 // Resolve a named port to port number by rule and policy selector.
 // e.g. "http" -> [{"80":['1.1.1.1', '2.2.2.2']}, {"443":['3.3.3.3']}]
 func (service *SecurityPolicyService) resolveNamedPort(obj *v1alpha1.SecurityPolicy, rule *v1alpha1.SecurityPolicyRule,
-	spPort v1alpha1.SecurityPolicyPort) ([]nsxutil.PortAddress, error) {
+	spPort v1alpha1.SecurityPolicyPort,
+) ([]nsxutil.PortAddress, error) {
 	var portAddress []nsxutil.PortAddress
 
 	podSelectors, err := service.getPodSelectors(obj, rule)
@@ -184,14 +188,16 @@ func (service *SecurityPolicyService) resolvePodPort(pod v1.Pod, spPort *v1alpha
 
 // Build an ip set group for NSX.
 func (service *SecurityPolicyService) buildRuleIPSetGroup(obj *v1alpha1.SecurityPolicy, rule *v1alpha1.SecurityPolicyRule, ruleModel *model.Rule,
-	ips []string, ruleIdx int) *model.Group {
+	ips []string, ruleIdx int,
+) *model.Group {
 	ipSetGroup := model.Group{}
 
 	ipSetGroupID := fmt.Sprintf("%s_ipset", *ruleModel.Id)
 	ipSetGroup.Id = &ipSetGroupID
 	ipSetGroupName := fmt.Sprintf("%s-ipset", *ruleModel.DisplayName)
 	ipSetGroup.DisplayName = &ipSetGroupName
-	peerTags := service.BuildPeerTags(obj, &rule.Destinations, ruleIdx)
+	// IPSetGroup is always destination group for named port
+	peerTags := service.buildPeerTags(obj, rule, ruleIdx, false)
 	ipSetGroup.Tags = peerTags
 
 	addresses := data.NewListValue()

--- a/pkg/nsx/services/securitypolicy/expand_test.go
+++ b/pkg/nsx/services/securitypolicy/expand_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-	v12 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -20,9 +20,11 @@ import (
 )
 
 func TestSecurityPolicyService_buildRuleIPGroup(t *testing.T) {
-	sp := &v1alpha1.SecurityPolicy{}
-	r := v1alpha1.SecurityPolicyRule{}
-	rule := model.Rule{
+	sp := &v1alpha1.SecurityPolicy{
+		ObjectMeta: v1.ObjectMeta{Namespace: "ns1", Name: "spA", UID: "uidA"},
+	}
+	rule := v1alpha1.SecurityPolicyRule{}
+	nsxRule := model.Rule{
 		DisplayName:       &ruleNameWithPodSelector00,
 		Id:                &ruleIDPort000,
 		DestinationGroups: []string{"ANY"},
@@ -54,18 +56,9 @@ func TestSecurityPolicyService_buildRuleIPGroup(t *testing.T) {
 		Id:          &policyGroupID,
 		DisplayName: &policyGroupName,
 		Expression:  []*data.StructValue{blockExpression},
-		Tags:        []model.Tag{{Scope: nil, Tag: nil}},
+		// build ipgroup tags from input securitypolicy and securitypolicy rule
+		Tags: service.buildPeerTags(sp, &rule, 0, false),
 	}
-
-	var s *SecurityPolicyService
-	patches := gomonkey.ApplyMethod(reflect.TypeOf(s), "BuildPeerTags",
-		func(s *SecurityPolicyService, v *v1alpha1.SecurityPolicy, p *[]v1alpha1.SecurityPolicyPeer, i int) []model.Tag {
-			peerTags := []model.Tag{
-				{Scope: nil, Tag: nil},
-			}
-			return peerTags
-		})
-	defer patches.Reset()
 
 	type args struct {
 		obj *model.Rule
@@ -76,12 +69,11 @@ func TestSecurityPolicyService_buildRuleIPGroup(t *testing.T) {
 		args args
 		want *model.Group
 	}{
-		{"1", args{&rule, ips}, &ipGroup},
+		{"1", args{&nsxRule, ips}, &ipGroup},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			service := &SecurityPolicyService{}
-			assert.Equalf(t, tt.want, service.buildRuleIPSetGroup(sp, &r, tt.args.obj, tt.args.ips, 0), "buildRuleIPSetGroup(%v, %v)",
+			assert.Equalf(t, tt.want, service.buildRuleIPSetGroup(sp, &rule, tt.args.obj, tt.args.ips, 0), "buildRuleIPSetGroup(%v, %v)",
 				tt.args.obj, tt.args.ips)
 		})
 	}
@@ -179,9 +171,9 @@ func TestSecurityPolicyService_getPodSelectors(t *testing.T) {
 	labelSelector2, _ := v1.LabelSelectorAsSelector(podSelector2)
 	var s *SecurityPolicyService
 	patches := gomonkey.ApplyMethod(reflect.TypeOf(s), "ResolveNamespace",
-		func(s *SecurityPolicyService, _ *v1.LabelSelector) (*v12.NamespaceList, error) {
-			ns := v12.NamespaceList{
-				Items: []v12.Namespace{
+		func(s *SecurityPolicyService, _ *v1.LabelSelector) (*core_v1.NamespaceList, error) {
+			ns := core_v1.NamespaceList{
+				Items: []core_v1.Namespace{
 					{
 						TypeMeta: v1.TypeMeta{},
 						ObjectMeta: v1.ObjectMeta{

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -56,7 +56,8 @@ var (
 	nsxDirectionOut              = "OUT"
 	nsxActionDrop                = "DROP"
 	cluster                      = "k8scl-one"
-	tagValueScope                = "scope"
+	tagValueGroupScope           = common.TagValueGroupScope
+	tagValueGroupSource          = common.TagValueGroupSource
 	tagValueNS                   = "ns1"
 	tagValuePolicyCRName         = "spA"
 	tagValuePolicyCRUID          = "uidA"


### PR DESCRIPTION
CP from  https://github.com/vmware-tanzu/nsx-operator/pull/395

In certain case, SecurityPolicy cannot delete a rule when this rule is not last one.
For example, one SP with rule1, rule2 and rule3.
the rule ID is sp_spUID_0_0_0, sp_spUID_1_0_0, and sp_spUID_2_0_0, respectively.

When user is trying to delete rule 2, the deleting will fail. This issue is caused by the original rule2 ID: sp_spUID_1_0_0 will be regenerated by the original rule3, because rule3 becomes the new rule2, the new rule2 id will be sp_spUID_2_0_0. NSX will complain that groups in the deleted rule2 are still being referenced by sp_spUID_2_0_0.

The root cause for the issue is that we don't generate unique ID for the each rule.

Hence, this patch is to
1.Generate hash ID for security policy rule content and append this hash ID to the final generated rule ID to make each rule's ID unique. So, the final generated rule ID is: sp_spUID_rulehashID_ruleIndex_portIndex_portAddressIndex.

Also, plus following refactor changes:
2. Unify the applied group ID/name generation for policy and rule level.
3. Unify the source/destination group ID/name generation for rule level.

The testing Done:
1. Creating SP with rule1, rule2 and rule 3, deleting the rule2.
2. Creating SP with rule1, rule2 and rule 3, deleting the rule1.
3. Creating namedport SP with rule1 and rule2, and then adding rule2 in the middle to make the original rule2 becomes rule3.
4. Creating SPs without this patch, and staring NSX Operator again with this patch to verify that new generated rules with unique rule ID are created successfully. This is to test upgrade existing SPs.