### PR TITLE
Support external http.Client

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -177,7 +177,7 @@ func main() {
 	}
 
 	// nsxClient is used to interact with NSX API.
-	nsxClient := nsx.GetClient(cf)
+	nsxClient := nsx.GetClient(cf, nil)
 	if nsxClient == nil {
 		log.Error(err, "failed to get nsx client")
 		os.Exit(1)

--- a/cmd_clean/main.go
+++ b/cmd_clean/main.go
@@ -4,8 +4,11 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
+	"net/http"
 	"os"
+	"time"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -18,20 +21,37 @@ import (
 // ./bin/clean -cluster=''  -thumbprint="" -log-level=0 -vc-user="" -vc-passwd="" -vc-endpoint="" -vc-sso-domain="" -vc-https-port=443  -mgr-ip=""
 
 var (
-	log         = logger.Log
-	cf          *config.NSXOperatorConfig
-	mgrIp       string
-	vcEndpoint  string
-	vcUser      string
-	vcPasswd    string
-	nsxUser     string
-	nsxPasswd   string
-	vcSsoDomain string
-	vcHttpsPort int
-	thumbprint  string
-	caFile      string
-	cluster     string
+	log             = logger.Log
+	cf              *config.NSXOperatorConfig
+	mgrIp           string
+	vcEndpoint      string
+	vcUser          string
+	vcPasswd        string
+	nsxUser         string
+	nsxPasswd       string
+	vcSsoDomain     string
+	vcHttpsPort     int
+	thumbprint      string
+	caFile          string
+	cluster         string
+	useExternalHttp bool
 )
+
+type Transport struct {
+	Base http.RoundTripper
+}
+
+func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
+	log.V(1).Info("http request", "method", r.Method, "body", r.Body, "url", r.URL)
+	r.SetBasicAuth(nsxUser, nsxPasswd)
+	return t.base().RoundTrip(r)
+}
+func (t *Transport) base() http.RoundTripper {
+	if t.Base != nil {
+		return t.Base
+	}
+	return http.DefaultTransport
+}
 
 func main() {
 	flag.StringVar(&vcEndpoint, "vc-endpoint", "", "nsx manager ip")
@@ -46,6 +66,7 @@ func main() {
 	flag.StringVar(&caFile, "ca-file", "", "ca file")
 	flag.StringVar(&cluster, "cluster", "", "cluster name")
 	flag.IntVar(&config.LogLevel, "log-level", 0, "Use zap-core log system.")
+	flag.BoolVar(&useExternalHttp, "use-external-http", false, "Use wcp created http client")
 	flag.Parse()
 
 	cf = config.NewNSXOpertorConfig()
@@ -60,9 +81,29 @@ func main() {
 	cf.Thumbprint = []string{thumbprint}
 	cf.CaFile = []string{caFile}
 	cf.Cluster = cluster
+
 	logf.SetLogger(logger.ZapLogger(cf))
 
-	err := clean.Clean(cf)
+	// just a demo to show how to use customer http client
+	// customer http client should handle verify and authentication
+	// here using the basic user/password mode for authentication
+	// not handling verify
+	var err error
+	if useExternalHttp {
+		tr := &http.Transport{
+			IdleConnTimeout: 30 * time.Second,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+		httpClient := &http.Client{
+			Transport: &Transport{Base: tr},
+			Timeout:   30 * time.Second,
+		}
+		err = clean.Clean(cf, httpClient)
+	} else {
+		err = clean.Clean(cf, nil)
+	}
 	if err != nil {
 		log.Error(err, "failed to clean nsx resources")
 		os.Exit(1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -310,7 +310,7 @@ func (nsxConfig *NsxConfig) validateCert() error {
 		return err
 	}
 	if caCount > 0 {
-		configLog.Infof("validate CA file: %s", caCount)
+		configLog.Infof("validate CA file: %d", caCount)
 		if caCount > 1 && caCount != mCount {
 			err := errors.New("ca file count not match manager count")
 			configLog.Error(err, "validate NsxConfig failed", "ca file count", caCount, "manager count", mCount)
@@ -324,7 +324,7 @@ func (nsxConfig *NsxConfig) validateCert() error {
 			}
 		}
 	} else {
-		configLog.Infof("validate thumbprint: %s", tpCount)
+		configLog.Infof("validate thumbprint: %d", tpCount)
 		if tpCount > 1 && tpCount != mCount {
 			err := errors.New("thumbprint count not match manager count")
 			configLog.Error(err, "validate NsxConfig failed", "thumbprint count", tpCount, "manager count", mCount)

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -119,7 +119,7 @@ func restConnector(c *Cluster) *client.RestConnector {
 	return connector
 }
 
-func GetClient(cf *config.NSXOperatorConfig) *Client {
+func GetClient(cf *config.NSXOperatorConfig, client *http.Client) *Client {
 	// Set log level for vsphere-automation-sdk-go
 	logger := logrus.New()
 	vspherelog.SetLogger(logger)
@@ -129,7 +129,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 	}
 	c := NewConfig(strings.Join(cf.NsxApiManagers, ","), cf.NsxApiUser, cf.NsxApiPassword, cf.CaFile, 10, 3, defaultHttpTimeout, 20, true, true, true,
 		ratelimiter.AIMD, cf.GetTokenProvider(), nil, cf.Thumbprint)
-	cluster, _ := NewCluster(c)
+	cluster, _ := NewCluster(c, client)
 
 	queryClient := search.NewQueryClient(restConnector(cluster))
 	groupClient := domains.NewGroupsClient(restConnector(cluster))

--- a/pkg/nsx/client_test.go
+++ b/pkg/nsx/client_test.go
@@ -10,10 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/agiledragon/gomonkey"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	"github.com/agiledragon/gomonkey"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
@@ -22,7 +21,7 @@ import (
 func TestNSXHealthChecker_CheckNSXHealth(t *testing.T) {
 	host := "1.1.1.1"
 	config := NewConfig(host, "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := NewCluster(config)
+	cluster, _ := NewCluster(config, nil)
 	req := &http.Request{}
 
 	res := []ClusterHealth{GREEN, RED, ORANGE}
@@ -65,7 +64,7 @@ func TestNSXHealthChecker_CheckNSXHealth(t *testing.T) {
 func TestGetClient(t *testing.T) {
 	cf := config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{NsxApiUser: "1", NsxApiPassword: "1"}}
 	cf.VCConfig = &config.VCConfig{}
-	client := GetClient(&cf)
+	client := GetClient(&cf, nil)
 	assert.True(t, client != nil)
 
 	cluster := &Cluster{}
@@ -74,7 +73,7 @@ func TestGetClient(t *testing.T) {
 		return nsxVersion, nil
 	})
 
-	client = GetClient(&cf)
+	client = GetClient(&cf, nil)
 	patches.Reset()
 	assert.True(t, client != nil)
 	securityPolicySupported := client.NSXCheckVersion(SecurityPolicy)
@@ -87,7 +86,7 @@ func TestGetClient(t *testing.T) {
 		nsxVersion := &NsxVersion{NodeVersion: "3.2.1"}
 		return nsxVersion, nil
 	})
-	client = GetClient(&cf)
+	client = GetClient(&cf, nil)
 	patches.Reset()
 	assert.True(t, client != nil)
 	securityPolicySupported = client.NSXCheckVersion(SecurityPolicy)
@@ -100,7 +99,7 @@ func TestGetClient(t *testing.T) {
 		nsxVersion := &NsxVersion{NodeVersion: "4.1.0"}
 		return nsxVersion, nil
 	})
-	client = GetClient(&cf)
+	client = GetClient(&cf, nil)
 	patches.Reset()
 	assert.True(t, client != nil)
 	securityPolicySupported = client.NSXCheckVersion(SecurityPolicy)
@@ -113,7 +112,7 @@ func TestGetClient(t *testing.T) {
 		nsxVersion := &NsxVersion{NodeVersion: "4.1.2"}
 		return nsxVersion, nil
 	})
-	client = GetClient(&cf)
+	client = GetClient(&cf, nil)
 	patches.Reset()
 	assert.True(t, client != nil)
 	securityPolicySupported = client.NSXCheckVersion(SecurityPolicy)
@@ -126,7 +125,7 @@ func TestGetClient(t *testing.T) {
 		nsxVersion := &NsxVersion{NodeVersion: "4.1.3"}
 		return nsxVersion, nil
 	})
-	client = GetClient(&cf)
+	client = GetClient(&cf, nil)
 	patches.Reset()
 	assert.True(t, client != nil)
 	securityPolicySupported = client.NSXCheckVersion(SecurityPolicy)
@@ -143,7 +142,7 @@ func IsInstanceOf(objectPtr, typePtr interface{}) bool {
 func TestSRGetClient(t *testing.T) {
 	cf := config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{NsxApiUser: "admin", NsxApiPassword: "Admin!23Admin", NsxApiManagers: []string{"10.173.82.128"}}}
 	cf.VCConfig = &config.VCConfig{}
-	client := GetClient(&cf)
+	client := GetClient(&cf, nil)
 	st, error := client.StaticRouteClient.Get("default", "project-1", "vpc-2", "site1")
 	if error == nil {
 		fmt.Printf("sr %v\n", *st.ResourceType)

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -43,8 +43,8 @@ type Cluster struct {
 	config           *Config
 	endpoints        []*Endpoint
 	transport        *Transport
-	client           http.Client
-	noBalancerClient http.Client
+	client           *http.Client
+	noBalancerClient *http.Client
 	sync.Mutex
 }
 type NsxVersion struct {
@@ -58,16 +58,22 @@ var (
 )
 
 // NewCluster creates a cluster based on nsx Config.
-func NewCluster(config *Config) (*Cluster, error) {
+func NewCluster(config *Config, client *http.Client) (*Cluster, error) {
 	log.Info("creating cluster")
 	cluster := &Cluster{}
 	cluster.config = config
 	cluster.transport = cluster.createTransport(time.Duration(config.ConnIdleTimeout))
-	cluster.client = cluster.createHTTPClient(cluster.transport, time.Duration(config.HTTPTimeout))
-	cluster.noBalancerClient = cluster.createNoBalancerClient(time.Duration(config.HTTPTimeout), time.Duration(config.ConnIdleTimeout))
+	// if client created by third-party, set noBalancerClient to nil to disable keep alive for clean up
+	if client != nil {
+		cluster.client = client
+		cluster.noBalancerClient = client
+	} else {
+		cluster.client = cluster.createHTTPClient(cluster.transport, time.Duration(config.HTTPTimeout))
+		cluster.noBalancerClient = cluster.createNoBalancerClient(time.Duration(config.HTTPTimeout), time.Duration(config.ConnIdleTimeout))
+	}
 
 	r := ratelimiter.NewRateLimiter(config.APIRateMode)
-	eps, err := cluster.createEndpoints(config.APIManagers, &cluster.client, &cluster.noBalancerClient, r, config.TokenProvider)
+	eps, err := cluster.createEndpoints(config.APIManagers, cluster.client, cluster.noBalancerClient, r, config.TokenProvider)
 	if err != nil {
 		log.Error(err, "creating cluster failed")
 		return nil, err
@@ -94,7 +100,7 @@ func NewCluster(config *Config) (*Cluster, error) {
 // HeaderConfig is used to use http header for request, it could be ignored if no extra header needed.
 func (cluster *Cluster) NewRestConnector() (*policyclient.RestConnector, *HeaderConfig) {
 	// host will be replaced by target endpoint's host when sending request to backend
-	connector := policyclient.NewRestConnector(fmt.Sprintf("%s://%s", cluster.endpoints[0].Scheme(), cluster.endpoints[0].Host()), cluster.client)
+	connector := policyclient.NewRestConnector(fmt.Sprintf("%s://%s", cluster.endpoints[0].Scheme(), cluster.endpoints[0].Host()), *cluster.client)
 	header := CreateHeaderConfig(false, false, cluster.config.AllowOverwriteHeader)
 	return connector, header
 }
@@ -216,14 +222,14 @@ func calcFingerprint(der []byte) string {
 	return string(hex[:len(hex)-1])
 }
 
-func (cluster *Cluster) createHTTPClient(tr *Transport, timeout time.Duration) http.Client {
-	return http.Client{
+func (cluster *Cluster) createHTTPClient(tr *Transport, timeout time.Duration) *http.Client {
+	return &http.Client{
 		Transport: tr,
 		Timeout:   timeout * time.Second,
 	}
 }
 
-func (cluster *Cluster) createNoBalancerClient(timeout, idle time.Duration) http.Client {
+func (cluster *Cluster) createNoBalancerClient(timeout, idle time.Duration) *http.Client {
 	tlsConfig := tls.Config{InsecureSkipVerify: true}
 	transport := &http.Transport{
 		TLSClientConfig: &tlsConfig,
@@ -233,7 +239,7 @@ func (cluster *Cluster) createNoBalancerClient(timeout, idle time.Duration) http
 		Transport: transport,
 		Timeout:   timeout * time.Second,
 	}
-	return noBClient
+	return &noBClient
 }
 
 func (cluster *Cluster) createEndpoints(apiManagers []string, client *http.Client, noBClient *http.Client, r ratelimiter.RateLimiter, tokenProvider auth.TokenProvider) ([]*Endpoint, error) {

--- a/pkg/nsx/cluster_test.go
+++ b/pkg/nsx/cluster_test.go
@@ -32,7 +32,7 @@ func TestNewCluster(t *testing.T) {
 	a := ts.URL[index+2:]
 	thumbprint := []string{"123"}
 	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
-	_, err := NewCluster(config)
+	_, err := NewCluster(config, nil)
 	assert.True(t, err == nil, fmt.Sprintf("Created cluster failed %v", err))
 }
 
@@ -90,7 +90,7 @@ func TestCluster_NewRestConnector(t *testing.T) {
 	a := ts.URL[index+2:]
 	thumbprint := []string{"123"}
 	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
-	c, _ := NewCluster(config)
+	c, _ := NewCluster(config, nil)
 	con, _ := c.NewRestConnector()
 	assert.NotNil(t, con)
 }
@@ -109,7 +109,7 @@ func TestCluster_createTransport(t *testing.T) {
 	a := ts.URL[index+2:]
 	thumbprint := []string{"123"}
 	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
-	c, _ := NewCluster(config)
+	c, _ := NewCluster(config, nil)
 	assert.NotNil(t, c.createTransport(10))
 }
 
@@ -264,7 +264,7 @@ func TestCluster_getVersion(t *testing.T) {
 	index := strings.Index(ts.URL, "//")
 	a := ts.URL[index+2:]
 	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
-	cluster, _ := NewCluster(config)
+	cluster, _ := NewCluster(config, nil)
 	nsxVersion, err := cluster.GetVersion()
 	assert.True(t, err == nil)
 	assert.Equal(t, nsxVersion.NodeVersion, "3.1.3.3.0.18844962")

--- a/pkg/nsx/endpoint.go
+++ b/pkg/nsx/endpoint.go
@@ -107,6 +107,10 @@ type epHealthy struct {
 }
 
 func (ep *Endpoint) keepAlive() error {
+	// disable keepAlive for cleanup
+	if ep.noBalancerClient == ep.client {
+		return nil
+	}
 	req, err := http.NewRequest("GET", fmt.Sprintf(healthURL, ep.Scheme(), ep.Host()), nil)
 	if err != nil {
 		log.Error(err, "create keep alive request error")
@@ -255,7 +259,10 @@ func (ep *Endpoint) createAuthSession(certProvider auth.ClientCertProvider, toke
 		log.V(2).Info("Skipping session create with JWT based auth")
 		return nil
 	}
-
+	// disable createAuthSession for cleanup
+	if ep.noBalancerClient == ep.client {
+		return nil
+	}
 	u := &url.URL{Host: ep.Host(), Scheme: ep.Scheme()}
 	postValues := url.Values{}
 	postValues.Add("j_username", username)

--- a/pkg/nsx/endpoint_test.go
+++ b/pkg/nsx/endpoint_test.go
@@ -119,7 +119,7 @@ func TestCreateAuthSession(t *testing.T) {
 	client := cluster.createHTTPClient(tr, 30)
 	noBClient := cluster.createNoBalancerClient(90, 90)
 	rl := ratelimiter.NewFixRateLimiter(10)
-	ep, err := NewEndpoint("10.0.0.1", &client, &noBClient, rl, nil)
+	ep, err := NewEndpoint("10.0.0.1", client, noBClient, rl, nil)
 	assert.Nil(err, fmt.Sprintf("Endpoint create failed due to %v", err))
 
 	certProvider := createNcpPovider()
@@ -176,7 +176,7 @@ func TestKeepAlive(t *testing.T) {
 	client := cluster.createHTTPClient(tr, 30)
 	noBClient := cluster.createNoBalancerClient(90, 90)
 	rl := ratelimiter.NewFixRateLimiter(10)
-	ep, err := NewEndpoint(ts.URL[len("http://"):], &client, &noBClient, rl, nil)
+	ep, err := NewEndpoint(ts.URL[len("http://"):], client, noBClient, rl, nil)
 
 	assert.Nil(err, fmt.Sprintf("Endpoint create failed due to %v", err))
 	ep.setStatus(UP)

--- a/pkg/nsx/services/common/store_test.go
+++ b/pkg/nsx/services/common/store_test.go
@@ -135,7 +135,7 @@ var filterTag = func(v []model.Tag) []string {
 
 func Test_InitializeResourceStore(t *testing.T) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(config2)
+	cluster, _ := nsx.NewCluster(config2, nil)
 	rc, _ := cluster.NewRestConnector()
 
 	service := Service{

--- a/pkg/nsx/services/ippool/fake_test.go
+++ b/pkg/nsx/services/ippool/fake_test.go
@@ -60,7 +60,7 @@ func (f fakeRealizedEntitiesClient) List(_ string, _ string, _ string, _ *string
 
 func fakeService() *IPPoolService {
 	c := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(c)
+	cluster, _ := nsx.NewCluster(c, nil)
 	rc, _ := cluster.NewRestConnector()
 	ipPoolStore := &IPPoolStore{ResourceStore: common.ResourceStore{
 		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeIPPoolCRUID: indexFunc}),

--- a/pkg/nsx/services/securitypolicy/store_test.go
+++ b/pkg/nsx/services/securitypolicy/store_test.go
@@ -108,7 +108,7 @@ func Test_KeyFunc(t *testing.T) {
 
 func Test_InitializeRuleStore(t *testing.T) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(config2)
+	cluster, _ := nsx.NewCluster(config2, nil)
 	rc, _ := cluster.NewRestConnector()
 
 	service := SecurityPolicyService{
@@ -159,7 +159,7 @@ func Test_InitializeRuleStore(t *testing.T) {
 
 func Test_InitializeGroupStore(t *testing.T) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(config2)
+	cluster, _ := nsx.NewCluster(config2, nil)
 	rc, _ := cluster.NewRestConnector()
 
 	service := SecurityPolicyService{
@@ -210,7 +210,7 @@ func Test_InitializeGroupStore(t *testing.T) {
 
 func Test_InitializeSecurityPolicyStore(t *testing.T) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(config2)
+	cluster, _ := nsx.NewCluster(config2, nil)
 	rc, _ := cluster.NewRestConnector()
 
 	service := SecurityPolicyService{

--- a/pkg/nsx/services/securitypolicy/wrap_test.go
+++ b/pkg/nsx/services/securitypolicy/wrap_test.go
@@ -27,7 +27,7 @@ func (_ *fakeQueryClient) List(_ string, _ *string, _ *string, _ *int64, _ *bool
 
 func fakeService() *SecurityPolicyService {
 	c := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(c)
+	cluster, _ := nsx.NewCluster(c, nil)
 	rc, _ := cluster.NewRestConnector()
 	service = &SecurityPolicyService{
 		Service: common.Service{

--- a/pkg/nsx/services/staticroute/staticroute_test.go
+++ b/pkg/nsx/services/staticroute/staticroute_test.go
@@ -66,7 +66,7 @@ func (qIface *fakeQueryClient) List(queryParam string, cursorParam *string, incl
 func createService(t *testing.T) (*StaticRouteService, *gomock.Controller, *mocks.MockStaticRoutesClient) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 
-	cluster, _ := nsx.NewCluster(config2)
+	cluster, _ := nsx.NewCluster(config2, nil)
 	rc, _ := cluster.NewRestConnector()
 
 	mockCtrl := gomock.NewController(t)

--- a/pkg/nsx/services/subnet/store_test.go
+++ b/pkg/nsx/services/subnet/store_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
@@ -59,7 +58,7 @@ func Test_KeyFunc(t *testing.T) {
 
 func Test_InitializeSubnetStore(t *testing.T) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(config2)
+	cluster, _ := nsx.NewCluster(config2, nil)
 	rc, _ := cluster.NewRestConnector()
 
 	subnetCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSubnetCRUID: subnetIndexFunc})

--- a/pkg/nsx/services/subnet/wrap_test.go
+++ b/pkg/nsx/services/subnet/wrap_test.go
@@ -16,7 +16,7 @@ import (
 
 func fakeService() *SubnetService {
 	c := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(c)
+	cluster, _ := nsx.NewCluster(c, nil)
 	rc, _ := cluster.NewRestConnector()
 	service := &SubnetService{
 		Service: common.Service{

--- a/pkg/nsx/services/vpc/store_test.go
+++ b/pkg/nsx/services/vpc/store_test.go
@@ -87,7 +87,7 @@ func Test_KeyFunc(t *testing.T) {
 
 func Test_InitializeVPCStore(t *testing.T) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(config2)
+	cluster, _ := nsx.NewCluster(config2, nil)
 	rc, _ := cluster.NewRestConnector()
 
 	service := VPCService{

--- a/pkg/nsx/transport_test.go
+++ b/pkg/nsx/transport_test.go
@@ -58,9 +58,9 @@ func TestRoundTripRetry(t *testing.T) {
 	index := strings.Index(ts.URL, "//")
 	a := ts.URL[index+2:]
 	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, err := NewCluster(config)
+	cluster, err := NewCluster(config, nil)
 	assert.Nil(err, fmt.Sprintf("Create cluster error %v", err))
-	cluster.endpoints[0], _ = NewEndpoint(ts.URL, &cluster.client, &cluster.noBalancerClient, cluster.endpoints[0].ratelimiter, nil)
+	cluster.endpoints[0], _ = NewEndpoint(ts.URL, cluster.client, cluster.noBalancerClient, cluster.endpoints[0].ratelimiter, nil)
 	cluster.endpoints[0].keepAlive()
 	tr := cluster.transport
 	req, _ := http.NewRequest("GET", ts.URL, nil)
@@ -79,7 +79,7 @@ func TestSelectEndpoint(t *testing.T) {
 	client := cluster.createHTTPClient(tr, timeout)
 	noBClient := cluster.createNoBalancerClient(timeout, idleConnTimeout)
 	r := ratelimiter.NewRateLimiter(config.APIRateMode)
-	eps, _ := cluster.createEndpoints(config.APIManagers, &client, &noBClient, r, nil)
+	eps, _ := cluster.createEndpoints(config.APIManagers, client, noBClient, r, nil)
 	// all eps DOWN
 	ep, err := tr.selectEndpoint()
 	assert.NotNil(t, err, fmt.Sprintf("Select endpoint error %s", err))
@@ -156,7 +156,7 @@ func Test_handleRoundTripError(t *testing.T) {
 	client := cluster.createHTTPClient(tr, timeout)
 	noBClient := cluster.createNoBalancerClient(timeout, idleConnTimeout)
 	r := ratelimiter.NewRateLimiter(config.APIRateMode)
-	eps, _ := cluster.createEndpoints(config.APIManagers, &client, &noBClient, r, nil)
+	eps, _ := cluster.createEndpoints(config.APIManagers, client, noBClient, r, nil)
 	cluster.endpoints = eps
 	err := errors.New("connection refused")
 	assert.NotNil(t, handleRoundTripError(err, eps[0]))

--- a/test/e2e/nsxclient.go
+++ b/test/e2e/nsxclient.go
@@ -21,7 +21,7 @@ func NewNSXClient(configFile string) (*NSXClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	client := nsx.GetClient(cf)
+	client := nsx.GetClient(cf, nil)
 	if client == nil {
 		return nil, fmt.Errorf("failed to get nsx client")
 	}


### PR DESCRIPTION
Cleanup needs to support using external http.Client While using external http.Client, it will disable keepAlive.

It also give a sample for how to create a http.Client for cleanup. The sample uses insecure mode to make sample simple. external http.Client should be response for authentication. It should also be in charge of log for debug

Test Done:
non-wcp env by running:
./bin/clean -cluster='k8scl-one'  -mgr-ip="nsxt-mgr-1.vmware.com"  -nsx-user="admin" -nsx-passwd='xxxx'