### PR TITLE
Update CRD client

### DIFF
--- a/pkg/apis/nsx.vmware.com/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/nsx.vmware.com/v1alpha1/vpcnetworkconfiguration_types.go
@@ -50,6 +50,7 @@ type VPCNetworkConfigurationStatus struct {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:storageversion

--- a/pkg/apis/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/v1alpha1/vpcnetworkconfiguration_types.go
@@ -50,6 +50,7 @@ type VPCNetworkConfigurationStatus struct {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:storageversion

--- a/pkg/client/clientset/versioned/typed/nsx.vmware.com/v1alpha1/fake/fake_nsx.vmware.com_client.go
+++ b/pkg/client/clientset/versioned/typed/nsx.vmware.com/v1alpha1/fake/fake_nsx.vmware.com_client.go
@@ -47,8 +47,8 @@ func (c *FakeNsxV1alpha1) VPCs(namespace string) v1alpha1.VPCInterface {
 	return &FakeVPCs{c, namespace}
 }
 
-func (c *FakeNsxV1alpha1) VPCNetworkConfigurations(namespace string) v1alpha1.VPCNetworkConfigurationInterface {
-	return &FakeVPCNetworkConfigurations{c, namespace}
+func (c *FakeNsxV1alpha1) VPCNetworkConfigurations() v1alpha1.VPCNetworkConfigurationInterface {
+	return &FakeVPCNetworkConfigurations{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/client/clientset/versioned/typed/nsx.vmware.com/v1alpha1/fake/fake_vpcnetworkconfiguration.go
+++ b/pkg/client/clientset/versioned/typed/nsx.vmware.com/v1alpha1/fake/fake_vpcnetworkconfiguration.go
@@ -19,7 +19,6 @@ import (
 // FakeVPCNetworkConfigurations implements VPCNetworkConfigurationInterface
 type FakeVPCNetworkConfigurations struct {
 	Fake *FakeNsxV1alpha1
-	ns   string
 }
 
 var vpcnetworkconfigurationsResource = v1alpha1.SchemeGroupVersion.WithResource("vpcnetworkconfigurations")
@@ -29,8 +28,7 @@ var vpcnetworkconfigurationsKind = v1alpha1.SchemeGroupVersion.WithKind("VPCNetw
 // Get takes name of the vPCNetworkConfiguration, and returns the corresponding vPCNetworkConfiguration object, and an error if there is any.
 func (c *FakeVPCNetworkConfigurations) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.VPCNetworkConfiguration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(vpcnetworkconfigurationsResource, c.ns, name), &v1alpha1.VPCNetworkConfiguration{})
-
+		Invokes(testing.NewRootGetAction(vpcnetworkconfigurationsResource, name), &v1alpha1.VPCNetworkConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -40,8 +38,7 @@ func (c *FakeVPCNetworkConfigurations) Get(ctx context.Context, name string, opt
 // List takes label and field selectors, and returns the list of VPCNetworkConfigurations that match those selectors.
 func (c *FakeVPCNetworkConfigurations) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.VPCNetworkConfigurationList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(vpcnetworkconfigurationsResource, vpcnetworkconfigurationsKind, c.ns, opts), &v1alpha1.VPCNetworkConfigurationList{})
-
+		Invokes(testing.NewRootListAction(vpcnetworkconfigurationsResource, vpcnetworkconfigurationsKind, opts), &v1alpha1.VPCNetworkConfigurationList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -62,15 +59,13 @@ func (c *FakeVPCNetworkConfigurations) List(ctx context.Context, opts v1.ListOpt
 // Watch returns a watch.Interface that watches the requested vPCNetworkConfigurations.
 func (c *FakeVPCNetworkConfigurations) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(vpcnetworkconfigurationsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(vpcnetworkconfigurationsResource, opts))
 }
 
 // Create takes the representation of a vPCNetworkConfiguration and creates it.  Returns the server's representation of the vPCNetworkConfiguration, and an error, if there is any.
 func (c *FakeVPCNetworkConfigurations) Create(ctx context.Context, vPCNetworkConfiguration *v1alpha1.VPCNetworkConfiguration, opts v1.CreateOptions) (result *v1alpha1.VPCNetworkConfiguration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(vpcnetworkconfigurationsResource, c.ns, vPCNetworkConfiguration), &v1alpha1.VPCNetworkConfiguration{})
-
+		Invokes(testing.NewRootCreateAction(vpcnetworkconfigurationsResource, vPCNetworkConfiguration), &v1alpha1.VPCNetworkConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -80,8 +75,7 @@ func (c *FakeVPCNetworkConfigurations) Create(ctx context.Context, vPCNetworkCon
 // Update takes the representation of a vPCNetworkConfiguration and updates it. Returns the server's representation of the vPCNetworkConfiguration, and an error, if there is any.
 func (c *FakeVPCNetworkConfigurations) Update(ctx context.Context, vPCNetworkConfiguration *v1alpha1.VPCNetworkConfiguration, opts v1.UpdateOptions) (result *v1alpha1.VPCNetworkConfiguration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(vpcnetworkconfigurationsResource, c.ns, vPCNetworkConfiguration), &v1alpha1.VPCNetworkConfiguration{})
-
+		Invokes(testing.NewRootUpdateAction(vpcnetworkconfigurationsResource, vPCNetworkConfiguration), &v1alpha1.VPCNetworkConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -92,8 +86,7 @@ func (c *FakeVPCNetworkConfigurations) Update(ctx context.Context, vPCNetworkCon
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeVPCNetworkConfigurations) UpdateStatus(ctx context.Context, vPCNetworkConfiguration *v1alpha1.VPCNetworkConfiguration, opts v1.UpdateOptions) (*v1alpha1.VPCNetworkConfiguration, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(vpcnetworkconfigurationsResource, "status", c.ns, vPCNetworkConfiguration), &v1alpha1.VPCNetworkConfiguration{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(vpcnetworkconfigurationsResource, "status", vPCNetworkConfiguration), &v1alpha1.VPCNetworkConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -103,14 +96,13 @@ func (c *FakeVPCNetworkConfigurations) UpdateStatus(ctx context.Context, vPCNetw
 // Delete takes name of the vPCNetworkConfiguration and deletes it. Returns an error if one occurs.
 func (c *FakeVPCNetworkConfigurations) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(vpcnetworkconfigurationsResource, c.ns, name, opts), &v1alpha1.VPCNetworkConfiguration{})
-
+		Invokes(testing.NewRootDeleteActionWithOptions(vpcnetworkconfigurationsResource, name, opts), &v1alpha1.VPCNetworkConfiguration{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeVPCNetworkConfigurations) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(vpcnetworkconfigurationsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(vpcnetworkconfigurationsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.VPCNetworkConfigurationList{})
 	return err
@@ -119,8 +111,7 @@ func (c *FakeVPCNetworkConfigurations) DeleteCollection(ctx context.Context, opt
 // Patch applies the patch and returns the patched vPCNetworkConfiguration.
 func (c *FakeVPCNetworkConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.VPCNetworkConfiguration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(vpcnetworkconfigurationsResource, c.ns, name, pt, data, subresources...), &v1alpha1.VPCNetworkConfiguration{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(vpcnetworkconfigurationsResource, name, pt, data, subresources...), &v1alpha1.VPCNetworkConfiguration{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset/versioned/typed/nsx.vmware.com/v1alpha1/nsx.vmware.com_client.go
+++ b/pkg/client/clientset/versioned/typed/nsx.vmware.com/v1alpha1/nsx.vmware.com_client.go
@@ -63,8 +63,8 @@ func (c *NsxV1alpha1Client) VPCs(namespace string) VPCInterface {
 	return newVPCs(c, namespace)
 }
 
-func (c *NsxV1alpha1Client) VPCNetworkConfigurations(namespace string) VPCNetworkConfigurationInterface {
-	return newVPCNetworkConfigurations(c, namespace)
+func (c *NsxV1alpha1Client) VPCNetworkConfigurations() VPCNetworkConfigurationInterface {
+	return newVPCNetworkConfigurations(c)
 }
 
 // NewForConfig creates a new NsxV1alpha1Client for the given config.

--- a/pkg/client/clientset/versioned/typed/nsx.vmware.com/v1alpha1/vpcnetworkconfiguration.go
+++ b/pkg/client/clientset/versioned/typed/nsx.vmware.com/v1alpha1/vpcnetworkconfiguration.go
@@ -20,7 +20,7 @@ import (
 // VPCNetworkConfigurationsGetter has a method to return a VPCNetworkConfigurationInterface.
 // A group's client should implement this interface.
 type VPCNetworkConfigurationsGetter interface {
-	VPCNetworkConfigurations(namespace string) VPCNetworkConfigurationInterface
+	VPCNetworkConfigurations() VPCNetworkConfigurationInterface
 }
 
 // VPCNetworkConfigurationInterface has methods to work with VPCNetworkConfiguration resources.
@@ -40,14 +40,12 @@ type VPCNetworkConfigurationInterface interface {
 // vPCNetworkConfigurations implements VPCNetworkConfigurationInterface
 type vPCNetworkConfigurations struct {
 	client rest.Interface
-	ns     string
 }
 
 // newVPCNetworkConfigurations returns a VPCNetworkConfigurations
-func newVPCNetworkConfigurations(c *NsxV1alpha1Client, namespace string) *vPCNetworkConfigurations {
+func newVPCNetworkConfigurations(c *NsxV1alpha1Client) *vPCNetworkConfigurations {
 	return &vPCNetworkConfigurations{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newVPCNetworkConfigurations(c *NsxV1alpha1Client, namespace string) *vPCNet
 func (c *vPCNetworkConfigurations) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.VPCNetworkConfiguration, err error) {
 	result = &v1alpha1.VPCNetworkConfiguration{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("vpcnetworkconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *vPCNetworkConfigurations) List(ctx context.Context, opts v1.ListOptions
 	}
 	result = &v1alpha1.VPCNetworkConfigurationList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("vpcnetworkconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *vPCNetworkConfigurations) Watch(ctx context.Context, opts v1.ListOption
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("vpcnetworkconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *vPCNetworkConfigurations) Watch(ctx context.Context, opts v1.ListOption
 func (c *vPCNetworkConfigurations) Create(ctx context.Context, vPCNetworkConfiguration *v1alpha1.VPCNetworkConfiguration, opts v1.CreateOptions) (result *v1alpha1.VPCNetworkConfiguration, err error) {
 	result = &v1alpha1.VPCNetworkConfiguration{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("vpcnetworkconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(vPCNetworkConfiguration).
@@ -113,7 +107,6 @@ func (c *vPCNetworkConfigurations) Create(ctx context.Context, vPCNetworkConfigu
 func (c *vPCNetworkConfigurations) Update(ctx context.Context, vPCNetworkConfiguration *v1alpha1.VPCNetworkConfiguration, opts v1.UpdateOptions) (result *v1alpha1.VPCNetworkConfiguration, err error) {
 	result = &v1alpha1.VPCNetworkConfiguration{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("vpcnetworkconfigurations").
 		Name(vPCNetworkConfiguration.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *vPCNetworkConfigurations) Update(ctx context.Context, vPCNetworkConfigu
 func (c *vPCNetworkConfigurations) UpdateStatus(ctx context.Context, vPCNetworkConfiguration *v1alpha1.VPCNetworkConfiguration, opts v1.UpdateOptions) (result *v1alpha1.VPCNetworkConfiguration, err error) {
 	result = &v1alpha1.VPCNetworkConfiguration{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("vpcnetworkconfigurations").
 		Name(vPCNetworkConfiguration.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *vPCNetworkConfigurations) UpdateStatus(ctx context.Context, vPCNetworkC
 // Delete takes name of the vPCNetworkConfiguration and deletes it. Returns an error if one occurs.
 func (c *vPCNetworkConfigurations) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("vpcnetworkconfigurations").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *vPCNetworkConfigurations) DeleteCollection(ctx context.Context, opts v1
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("vpcnetworkconfigurations").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *vPCNetworkConfigurations) DeleteCollection(ctx context.Context, opts v1
 func (c *vPCNetworkConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.VPCNetworkConfiguration, err error) {
 	result = &v1alpha1.VPCNetworkConfiguration{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("vpcnetworkconfigurations").
 		Name(name).
 		SubResource(subresources...).

--- a/pkg/client/informers/externalversions/nsx.vmware.com/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/nsx.vmware.com/v1alpha1/interface.go
@@ -84,5 +84,5 @@ func (v *version) VPCs() VPCInformer {
 
 // VPCNetworkConfigurations returns a VPCNetworkConfigurationInformer.
 func (v *version) VPCNetworkConfigurations() VPCNetworkConfigurationInformer {
-	return &vPCNetworkConfigurationInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &vPCNetworkConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/pkg/client/informers/externalversions/nsx.vmware.com/v1alpha1/vpcnetworkconfiguration.go
+++ b/pkg/client/informers/externalversions/nsx.vmware.com/v1alpha1/vpcnetworkconfiguration.go
@@ -29,33 +29,32 @@ type VPCNetworkConfigurationInformer interface {
 type vPCNetworkConfigurationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewVPCNetworkConfigurationInformer constructs a new informer for VPCNetworkConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewVPCNetworkConfigurationInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredVPCNetworkConfigurationInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewVPCNetworkConfigurationInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredVPCNetworkConfigurationInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredVPCNetworkConfigurationInformer constructs a new informer for VPCNetworkConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredVPCNetworkConfigurationInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredVPCNetworkConfigurationInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NsxV1alpha1().VPCNetworkConfigurations(namespace).List(context.TODO(), options)
+				return client.NsxV1alpha1().VPCNetworkConfigurations().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NsxV1alpha1().VPCNetworkConfigurations(namespace).Watch(context.TODO(), options)
+				return client.NsxV1alpha1().VPCNetworkConfigurations().Watch(context.TODO(), options)
 			},
 		},
 		&nsxvmwarecomv1alpha1.VPCNetworkConfiguration{},
@@ -65,7 +64,7 @@ func NewFilteredVPCNetworkConfigurationInformer(client versioned.Interface, name
 }
 
 func (f *vPCNetworkConfigurationInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredVPCNetworkConfigurationInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredVPCNetworkConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *vPCNetworkConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/listers/nsx.vmware.com/v1alpha1/expansion_generated.go
+++ b/pkg/client/listers/nsx.vmware.com/v1alpha1/expansion_generated.go
@@ -72,7 +72,3 @@ type VPCNamespaceListerExpansion interface{}
 // VPCNetworkConfigurationListerExpansion allows custom methods to be added to
 // VPCNetworkConfigurationLister.
 type VPCNetworkConfigurationListerExpansion interface{}
-
-// VPCNetworkConfigurationNamespaceListerExpansion allows custom methods to be added to
-// VPCNetworkConfigurationNamespaceLister.
-type VPCNetworkConfigurationNamespaceListerExpansion interface{}

--- a/pkg/client/listers/nsx.vmware.com/v1alpha1/vpcnetworkconfiguration.go
+++ b/pkg/client/listers/nsx.vmware.com/v1alpha1/vpcnetworkconfiguration.go
@@ -18,8 +18,9 @@ type VPCNetworkConfigurationLister interface {
 	// List lists all VPCNetworkConfigurations in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.VPCNetworkConfiguration, err error)
-	// VPCNetworkConfigurations returns an object that can list and get VPCNetworkConfigurations.
-	VPCNetworkConfigurations(namespace string) VPCNetworkConfigurationNamespaceLister
+	// Get retrieves the VPCNetworkConfiguration from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.VPCNetworkConfiguration, error)
 	VPCNetworkConfigurationListerExpansion
 }
 
@@ -41,41 +42,9 @@ func (s *vPCNetworkConfigurationLister) List(selector labels.Selector) (ret []*v
 	return ret, err
 }
 
-// VPCNetworkConfigurations returns an object that can list and get VPCNetworkConfigurations.
-func (s *vPCNetworkConfigurationLister) VPCNetworkConfigurations(namespace string) VPCNetworkConfigurationNamespaceLister {
-	return vPCNetworkConfigurationNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// VPCNetworkConfigurationNamespaceLister helps list and get VPCNetworkConfigurations.
-// All objects returned here must be treated as read-only.
-type VPCNetworkConfigurationNamespaceLister interface {
-	// List lists all VPCNetworkConfigurations in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.VPCNetworkConfiguration, err error)
-	// Get retrieves the VPCNetworkConfiguration from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.VPCNetworkConfiguration, error)
-	VPCNetworkConfigurationNamespaceListerExpansion
-}
-
-// vPCNetworkConfigurationNamespaceLister implements the VPCNetworkConfigurationNamespaceLister
-// interface.
-type vPCNetworkConfigurationNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all VPCNetworkConfigurations in the indexer for a given namespace.
-func (s vPCNetworkConfigurationNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.VPCNetworkConfiguration, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.VPCNetworkConfiguration))
-	})
-	return ret, err
-}
-
-// Get retrieves the VPCNetworkConfiguration from the indexer for a given namespace and name.
-func (s vPCNetworkConfigurationNamespaceLister) Get(name string) (*v1alpha1.VPCNetworkConfiguration, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the VPCNetworkConfiguration from the index for a given name.
+func (s *vPCNetworkConfigurationLister) Get(name string) (*v1alpha1.VPCNetworkConfiguration, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For cluster-wide resources, `// +genclient:nonNamespaced` is required to generate CRD client. Otherwise, it will be treated as namespace scope resource.