### PR TITLE
Add golangci-lint for patches

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -17,6 +17,9 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.21
+
+    - name: Run golangci-lint
+      run: make golangci
         
     - name: Run build
       run: make build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,32 @@
+# golangci-lint configuration used for CI
+run:
+  tests: true
+  timeout: 15m
+  skip-dirs-use-default: true
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/vmware-tanzu/nsx-operator
+  revive:
+    ignore-generated-header: false
+    severity: warning
+    confidence: 0.8
+    rules:
+      - name: unreachable-code
+      - name: errorf
+      - name: range
+      - name: superfluous-else
+      - name: var-declaration
+      - name: duplicated-imports
+
+linters:
+  disable-all: true
+  enable:
+    - misspell
+    - gofmt
+    - unused
+    - staticcheck
+    - gosec
+    - goimports
+    - vet
+    - revive

--- a/build/yaml/crd/nsx.vmware.com_nsxserviceaccounts.yaml
+++ b/build/yaml/crd/nsx.vmware.com_nsxserviceaccounts.yaml
@@ -124,7 +124,6 @@ spec:
                   type: string
                 type: array
               phase:
-                description: 'Deprecated: Use Conditions instead.'
                 type: string
               proxyEndpoints:
                 properties:
@@ -151,7 +150,6 @@ spec:
                     type: array
                 type: object
               reason:
-                description: 'Deprecated: Use Conditions instead.'
                 type: string
               secrets:
                 items:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -83,12 +83,12 @@ func StartSecurityPolicyController(mgr ctrl.Manager, commonService common.Servic
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}
-	if securityService, err := securitypolicy.InitializeSecurityPolicy(commonService); err != nil {
+	securityService, err := securitypolicy.InitializeSecurityPolicy(commonService)
+	if err != nil {
 		log.Error(err, "failed to initialize securitypolicy commonService", "controller", "SecurityPolicy")
 		os.Exit(1)
-	} else {
-		securityReconcile.Service = securityService
 	}
+	securityReconcile.Service = securityService
 	if err := securityReconcile.Start(mgr); err != nil {
 		log.Error(err, "failed to create controller", "controller", "SecurityPolicy")
 		os.Exit(1)
@@ -101,12 +101,12 @@ func StartNSXServiceAccountController(mgr ctrl.Manager, commonService common.Ser
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}
-	if nsxServiceAccountService, err := nsxserviceaccount.InitializeNSXServiceAccount(commonService); err != nil {
+	nsxServiceAccountService, err := nsxserviceaccount.InitializeNSXServiceAccount(commonService)
+	if err != nil {
 		log.Error(err, "failed to initialize service", "controller", "NSXServiceAccount")
 		os.Exit(1)
-	} else {
-		nsxServiceAccountReconcile.Service = nsxServiceAccountService
 	}
+	nsxServiceAccountReconcile.Service = nsxServiceAccountService
 	if err := nsxServiceAccountReconcile.Start(mgr); err != nil {
 		log.Error(err, "failed to create controller", "controller", "NSXServiceAccount")
 		os.Exit(1)
@@ -118,12 +118,13 @@ func StartIPPoolController(mgr ctrl.Manager, commonService common.Service) {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}
-	if ipPoolService, err := ippool.InitializeIPPool(commonService); err != nil {
+	ipPoolService, err := ippool.InitializeIPPool(commonService)
+	if err != nil {
 		log.Error(err, "failed to initialize ippool commonService", "controller", "IPPool")
 		os.Exit(1)
-	} else {
-		ippoolReconcile.Service = ipPoolService
 	}
+	ippoolReconcile.Service = ipPoolService
+
 	if err := ippoolReconcile.Start(mgr); err != nil {
 		log.Error(err, "failed to create controller", "controller", "IPPool")
 		os.Exit(1)
@@ -135,13 +136,13 @@ func StartVPCController(mgr ctrl.Manager, commonService common.Service) {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}
-	if vpcService, err := vpc.InitializeVPC(commonService); err != nil {
+	vpcService, err := vpc.InitializeVPC(commonService)
+	if err != nil {
 		log.Error(err, "failed to initialize vpc commonService", "controller", "VPC")
 		os.Exit(1)
-	} else {
-		vpcReconciler.Service = vpcService
-		commonctl.ServiceMediator.VPCService = vpcService
 	}
+	vpcReconciler.Service = vpcService
+	commonctl.ServiceMediator.VPCService = vpcService
 	if err := vpcReconciler.Start(mgr); err != nil {
 		log.Error(err, "failed to create vpc controller", "controller", "VPC")
 		os.Exit(1)

--- a/cmd_clean/main.go
+++ b/cmd_clean/main.go
@@ -88,11 +88,17 @@ func main() {
 	// customer http client should handle verify and authentication
 	// here using the basic user/password mode for authentication
 	// not handling verify
+	// the error roughly are:
+	// 1. failed to validate config
+	// 2. failed to get nsx client
+	// 3. failed to initialize cleanup service
+	// 4. failed to clean up specific resourc
 	var err error
 	var status clean.Status
 	if useExternalHttp {
 		tr := &http.Transport{
 			IdleConnTimeout: 30 * time.Second,
+			// #nosec G402: ignore insecure options
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},
@@ -105,12 +111,6 @@ func main() {
 	} else {
 		status, err = clean.Clean(cf, nil)
 	}
-	// the error roughly are:
-	// 1. failed to validate config
-	// 2. failed to get nsx client
-	// 3. failed to initialize cleanup service
-	// 4. failed to clean up specific resource
-	status, err = clean.Clean(cf, nil)
 	if err != nil {
 		log.Error(err, "failed to clean nsx resources", "status", status)
 		os.Exit(1)

--- a/hack/.spelling_failures
+++ b/hack/.spelling_failures
@@ -1,0 +1,4 @@
+CODE_OF_CONDUCT
+CONTRIBUTING
+go.mod
+go.sum

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# This script checks commonly misspelled English words. This script is inspired
+# by kubernetes/hack/verify-spelling.sh.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# if Go environment variable is set, use it as it is, otherwise default to "go"
+: "${GO:=go}"
+TOOL_VERSION="v0.3.4"
+
+GO_VERSION="$(${GO} version | awk '{print $3}')"
+function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1"; }
+
+if version_lt "${GO_VERSION}" "go1.16"; then
+    # See https://golang.org/doc/go-get-install-deprecation
+    echo "Running this script requires Go >= 1.16, please upgrade"
+    exit 1
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${ROOT}"
+
+TMP_DIR=$(mktemp -d)
+
+# cleanup
+exitHandler() (
+  echo "Cleaning up temporary directory"
+  rm -rf "${TMP_DIR}"
+)
+trap exitHandler EXIT
+
+GOBIN="${TMP_DIR}" ${GO} install "github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}"
+export PATH="${TMP_DIR}:${PATH}"
+
+# Check spelling and ignore skipped files.
+RES=0
+echo "Spell check start"
+ERROR_LOG="${TMP_DIR}/errors.log"
+skipping_file="${ROOT}/hack/.spelling_failures"
+failing_packages=$(sed "s| | -e |g" "${skipping_file}")
+git ls-files | grep -v -e "${failing_packages}"| xargs misspell > "${ERROR_LOG}"
+if [[ -s "${ERROR_LOG}" ]]; then
+  sed 's/^/error: /' "${ERROR_LOG}"
+  echo "Found spelling errors!"
+  RES=1
+fi
+exit "${RES}"

--- a/pkg/apis/nsx.vmware.com/v1alpha1/nsxserviceaccount_types.go
+++ b/pkg/apis/nsx.vmware.com/v1alpha1/nsxserviceaccount_types.go
@@ -56,12 +56,8 @@ const (
 
 // NSXServiceAccountStatus defines the observed state of NSXServiceAccount
 type NSXServiceAccountStatus struct {
-	// Deprecated: Use Conditions instead.
-	// +kubebuilder:deprecatedversion:warning="nsx.vmware.com/v1alpha1 Phase is deprecated"
-	Phase NSXServiceAccountPhase `json:"phase,omitempty"`
-	// Deprecated: Use Conditions instead.
-	// +kubebuilder:deprecatedversion:warning="nsx.vmware.com/v1alpha1 Reason is deprecated"
-	Reason string `json:"reason,omitempty"`
+	Phase  NSXServiceAccountPhase `json:"phase,omitempty"`
+	Reason string                 `json:"reason,omitempty"`
 	// Represents the realization status of a NSXServiceAccount's current state.
 	// Known .status.conditions.type is: "Realized"
 	Conditions     []metav1.Condition `json:"conditions,omitempty"`

--- a/pkg/apis/nsx.vmware.com/v1alpha1/vpc_types.go
+++ b/pkg/apis/nsx.vmware.com/v1alpha1/vpc_types.go
@@ -48,8 +48,8 @@ type VPCStatus struct {
 	LBSubnetPath string `json:"lbSubnetPath"`
 	// CIDR for the load balancer Subnet.
 	LBSubnetCIDR string `json:"lbSubnetCIDR"`
-        // Private CIDRs used for the VPC.
-        PrivateIPv4CIDRs []string `json:"privateIPv4CIDRs"`
+	// Private CIDRs used for the VPC.
+	PrivateIPv4CIDRs []string `json:"privateIPv4CIDRs"`
 }
 
 func init() {

--- a/pkg/apis/v1alpha1/nsxserviceaccount_types.go
+++ b/pkg/apis/v1alpha1/nsxserviceaccount_types.go
@@ -56,12 +56,8 @@ const (
 
 // NSXServiceAccountStatus defines the observed state of NSXServiceAccount
 type NSXServiceAccountStatus struct {
-	// Deprecated: Use Conditions instead.
-	// +kubebuilder:deprecatedversion:warning="nsx.vmware.com/v1alpha1 Phase is deprecated"
-	Phase NSXServiceAccountPhase `json:"phase,omitempty"`
-	// Deprecated: Use Conditions instead.
-	// +kubebuilder:deprecatedversion:warning="nsx.vmware.com/v1alpha1 Reason is deprecated"
-	Reason string `json:"reason,omitempty"`
+	Phase  NSXServiceAccountPhase `json:"phase,omitempty"`
+	Reason string                 `json:"reason,omitempty"`
 	// Represents the realization status of a NSXServiceAccount's current state.
 	// Known .status.conditions.type is: "Realized"
 	Conditions     []metav1.Condition `json:"conditions,omitempty"`

--- a/pkg/apis/v1alpha1/vpc_types.go
+++ b/pkg/apis/v1alpha1/vpc_types.go
@@ -48,8 +48,8 @@ type VPCStatus struct {
 	LBSubnetPath string `json:"lbSubnetPath"`
 	// CIDR for the load balancer Subnet.
 	LBSubnetCIDR string `json:"lbSubnetCIDR"`
-        // Private CIDRs used for the VPC.
-        PrivateIPv4CIDRs []string `json:"privateIPv4CIDRs"`
+	// Private CIDRs used for the VPC.
+	PrivateIPv4CIDRs []string `json:"privateIPv4CIDRs"`
 }
 
 func init() {

--- a/pkg/clean/types.go
+++ b/pkg/clean/types.go
@@ -36,9 +36,9 @@ type Status struct {
 }
 
 var (
-	OK                       Status = Status{Code: 0, Message: "cleanup successfully"}
-	ValidationFailed         Status = Status{Code: 1, Message: "failed to validate config"}
-	GetNSXClientFailed       Status = Status{Code: 2, Message: "failed to get nsx client"}
-	InitCleanupServiceFailed Status = Status{Code: 3, Message: "failed to initialize cleanup service"}
-	CleanupResourceFailed    Status = Status{Code: 4, Message: "failed to clean up"}
+	OK                       = Status{Code: 0, Message: "cleanup successfully"}
+	ValidationFailed         = Status{Code: 1, Message: "failed to validate config"}
+	GetNSXClientFailed       = Status{Code: 2, Message: "failed to get nsx client"}
+	InitCleanupServiceFailed = Status{Code: 3, Message: "failed to initialize cleanup service"}
+	CleanupResourceFailed    = Status{Code: 4, Message: "failed to clean up"}
 )

--- a/pkg/controllers/ippool/ippool_controller_test.go
+++ b/pkg/controllers/ippool/ippool_controller_test.go
@@ -220,8 +220,8 @@ func TestReconciler_GarbageCollector(t *testing.T) {
 			},
 		},
 	}
-	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "ListIPPoolID", func(_ *ippool.IPPoolService) sets.String {
-		a := sets.NewString()
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "ListIPPoolID", func(_ *ippool.IPPoolService) sets.Set[string] {
+		a := sets.New[string]()
 		a.Insert("1234")
 		a.Insert("2345")
 		return a
@@ -256,8 +256,8 @@ func TestReconciler_GarbageCollector(t *testing.T) {
 
 	// local store has same item as k8s cache
 	patch.Reset()
-	patch.ApplyMethod(reflect.TypeOf(service), "ListIPPoolID", func(_ *ippool.IPPoolService) sets.String {
-		a := sets.NewString()
+	patch.ApplyMethod(reflect.TypeOf(service), "ListIPPoolID", func(_ *ippool.IPPoolService) sets.Set[string] {
+		a := sets.New[string]()
 		a.Insert("1234")
 		return a
 	})
@@ -280,8 +280,8 @@ func TestReconciler_GarbageCollector(t *testing.T) {
 
 	// local store has no item
 	patch.Reset()
-	patch.ApplyMethod(reflect.TypeOf(service), "ListIPPoolID", func(_ *ippool.IPPoolService) sets.String {
-		a := sets.NewString()
+	patch.ApplyMethod(reflect.TypeOf(service), "ListIPPoolID", func(_ *ippool.IPPoolService) sets.Set[string] {
+		a := sets.New[string]()
 		return a
 	})
 	patch.ApplyMethod(reflect.TypeOf(service), "DeleteIPPool", func(_ *ippool.IPPoolService, UID interface{}) error {

--- a/pkg/controllers/namespace/builder.go
+++ b/pkg/controllers/namespace/builder.go
@@ -2,6 +2,7 @@ package namespace
 
 import (
 	"github.com/google/uuid"
+
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
 )
 

--- a/pkg/controllers/namespace/namespace_controller.go
+++ b/pkg/controllers/namespace/namespace_controller.go
@@ -68,13 +68,13 @@ func (r *NamespaceReconciler) createVPCCR(ctx *context.Context, obj client.Objec
 	//TODO: in next patch, remove this validation. If user did not provide private cidr
 	// use a hardcoded cidr to create a private ip block.
 	if !common.ServiceMediator.ValidateNetworkConfig(nc) {
-		// if netwrok config is not valid, no need to retry, skip processing
+		// if network config is not valid, no need to retry, skip processing
 		message := fmt.Sprintf("invalid network config %s for namespace %s, missing private cidr", ncName, ns)
 		r.namespaceError(ctx, obj, message, nil)
 		return nil, errors.New(message)
 	}
 
-	// create vpc cr with exisitng vpc network config
+	// create vpc cr with existing vpc network config
 	vpcCR := BuildVPCCR(ns, ncName, vpcName)
 	err := r.Client.Create(*ctx, vpcCR)
 	if err != nil {

--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
@@ -201,7 +201,8 @@ func (r *NSXServiceAccountReconciler) validateRealized(count uint16, ca []byte, 
 	// Validate ca at first time
 	// Validate client cert every GCValidationInterval
 	if count == 0 {
-		for _, nsxServiceAccount := range nsxServiceAccountList.Items {
+		for _, account := range nsxServiceAccountList.Items {
+			nsxServiceAccount := account
 			if nsxserviceaccount.IsNSXServiceAccountRealized(&nsxServiceAccount.Status) {
 				if err := r.Service.ValidateAndUpdateRealizedNSXServiceAccount(context.TODO(), &nsxServiceAccount, ca); err != nil {
 					log.Error(err, "Failed to update realized NSXServiceAccount", "namespace", nsxServiceAccount.Namespace, "name", nsxServiceAccount.Name)
@@ -217,7 +218,7 @@ func (r *NSXServiceAccountReconciler) validateRealized(count uint16, ca []byte, 
 	return count, ca
 }
 
-func (r *NSXServiceAccountReconciler) garbageCollector(nsxServiceAccountUIDSet sets.String, nsxServiceAccountList *nsxvmwarecomv1alpha1.NSXServiceAccountList) (gcSuccessCount, gcErrorCount uint32) {
+func (r *NSXServiceAccountReconciler) garbageCollector(nsxServiceAccountUIDSet sets.Set[string], nsxServiceAccountList *nsxvmwarecomv1alpha1.NSXServiceAccountList) (gcSuccessCount, gcErrorCount uint32) {
 	nsxServiceAccountCRUIDMap := map[string]types.NamespacedName{}
 	for _, nsxServiceAccount := range nsxServiceAccountList.Items {
 		nsxServiceAccountCRUIDMap[string(nsxServiceAccount.UID)] = types.NamespacedName{

--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
@@ -784,7 +784,7 @@ func TestNSXServiceAccountReconciler_garbageCollector(t *testing.T) {
 	tagScopeNSXServiceAccountCRName := servicecommon.TagScopeNSXServiceAccountCRName
 	tagScopeNSXServiceAccountCRUID := servicecommon.TagScopeNSXServiceAccountCRUID
 	type args struct {
-		nsxServiceAccountUIDSet sets.String
+		nsxServiceAccountUIDSet sets.Set[string]
 		nsxServiceAccountList   *nsxvmwarecomv1alpha1.NSXServiceAccountList
 	}
 	tests := []struct {
@@ -863,7 +863,7 @@ func TestNSXServiceAccountReconciler_garbageCollector(t *testing.T) {
 				})
 			},
 			args: args{
-				nsxServiceAccountUIDSet: sets.NewString("00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000003", "00000000-0000-0000-0000-000000000004"),
+				nsxServiceAccountUIDSet: sets.New[string]("00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000003", "00000000-0000-0000-0000-000000000004"),
 				nsxServiceAccountList: &nsxvmwarecomv1alpha1.NSXServiceAccountList{Items: []nsxvmwarecomv1alpha1.NSXServiceAccount{{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:  "ns1",

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -10,13 +10,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
-	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
 	v1 "k8s.io/api/core/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -149,13 +150,14 @@ func StartPodController(mgr ctrl.Manager, commonService servicecommon.Service) {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}
-	if subnetPortService, err := subnetport.InitializeSubnetPort(commonService); err != nil {
+	subnetPortService, err := subnetport.InitializeSubnetPort(commonService)
+	if err != nil {
 		log.Error(err, "failed to initialize subnetport commonService", "controller", "Pod")
 		os.Exit(1)
-	} else {
-		podPortReconciler.Service = subnetPortService
-		common.ServiceMediator.SubnetPortService = podPortReconciler.Service
 	}
+	podPortReconciler.Service = subnetPortService
+	common.ServiceMediator.SubnetPortService = podPortReconciler.Service
+
 	if err := podPortReconciler.Start(mgr); err != nil {
 		log.Error(err, "failed to create controller", "controller", "Pod")
 		os.Exit(1)

--- a/pkg/controllers/securitypolicy/namespace_handler.go
+++ b/pkg/controllers/securitypolicy/namespace_handler.go
@@ -1,4 +1,4 @@
-/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+/* Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0 */
 
 package securitypolicy

--- a/pkg/controllers/securitypolicy/pod_handler.go
+++ b/pkg/controllers/securitypolicy/pod_handler.go
@@ -76,8 +76,8 @@ func (e *EnqueueRequestForPod) Raw(evt interface{}, q workqueue.RateLimitingInte
 	}
 }
 
-func getAllPodPortNames(pods []v1.Pod) sets.String {
-	podPortNames := sets.NewString()
+func getAllPodPortNames(pods []v1.Pod) sets.Set[string] {
+	podPortNames := sets.New[string]()
 	for _, pod := range pods {
 		for _, container := range pod.Spec.Containers {
 			for _, port := range container.Ports {

--- a/pkg/controllers/securitypolicy/pod_hanlder_test.go
+++ b/pkg/controllers/securitypolicy/pod_hanlder_test.go
@@ -39,9 +39,9 @@ func Test_getAllPodPortNames(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want sets.String
+		want sets.Set[string]
 	}{
-		{"1", args{[]v1.Pod{pod}}, sets.NewString("test-port", "test-port-2")},
+		{"1", args{[]v1.Pod{pod}}, sets.New[string]("test-port", "test-port-2")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controllers/securitypolicy/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller.go
@@ -11,16 +11,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
-	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
-	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
-	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
-	_ "github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
-	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy"
-	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
-	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,6 +23,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
+	_ "github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
 var (

--- a/pkg/controllers/securitypolicy/securitypolicy_controller_test.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller_test.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/client-go/rest"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"testing"
 	"time"
+
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	gomonkey "github.com/agiledragon/gomonkey/v2"
 	"github.com/golang/mock/gomock"
@@ -220,8 +221,8 @@ func TestSecurityPolicyReconciler_GarbageCollector(t *testing.T) {
 			},
 		},
 	}
-	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "ListSecurityPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.String {
-		a := sets.NewString()
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "ListSecurityPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.Set[string] {
+		a := sets.New[string]()
 		a.Insert("1234")
 		a.Insert("2345")
 		return a
@@ -256,8 +257,8 @@ func TestSecurityPolicyReconciler_GarbageCollector(t *testing.T) {
 
 	// local store has same item as k8s cache
 	patch.Reset()
-	patch.ApplyMethod(reflect.TypeOf(service), "ListSecurityPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.String {
-		a := sets.NewString()
+	patch.ApplyMethod(reflect.TypeOf(service), "ListSecurityPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.Set[string] {
+		a := sets.New[string]()
 		a.Insert("1234")
 		return a
 	})
@@ -280,8 +281,8 @@ func TestSecurityPolicyReconciler_GarbageCollector(t *testing.T) {
 
 	// local store has no item
 	patch.Reset()
-	patch.ApplyMethod(reflect.TypeOf(service), "ListSecurityPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.String {
-		a := sets.NewString()
+	patch.ApplyMethod(reflect.TypeOf(service), "ListSecurityPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.Set[string] {
+		a := sets.New[string]()
 		return a
 	})
 	patch.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, UID interface{}, isVpcCleanup bool) error {

--- a/pkg/controllers/staticroute/staticroute_controller.go
+++ b/pkg/controllers/staticroute/staticroute_controller.go
@@ -237,7 +237,8 @@ func (r *StaticRouteReconciler) GarbageCollector(cancel chan bool, timeout time.
 			crdStaticRouteSet.Insert(string(sr.UID))
 		}
 
-		for _, elem := range nsxStaticRouteList {
+		for _, e := range nsxStaticRouteList {
+			elem := e
 			UID := r.Service.GetUID(&elem)
 			if UID == nil {
 				continue
@@ -265,12 +266,12 @@ func StartStaticRouteController(mgr ctrl.Manager, commonService commonservice.Se
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}
-	if staticRouteService, err := staticroute.InitializeStaticRoute(commonService); err != nil {
+	staticRouteService, err := staticroute.InitializeStaticRoute(commonService)
+	if err != nil {
 		log.Error(err, "failed to initialize staticroute commonService", "controller", "StaticRoute")
 		os.Exit(1)
-	} else {
-		staticRouteReconcile.Service = staticRouteService
 	}
+	staticRouteReconcile.Service = staticRouteService
 	if err := staticRouteReconcile.Start(mgr); err != nil {
 		log.Error(err, "failed to create controller", "controller", "StaticRoute")
 		os.Exit(1)

--- a/pkg/controllers/staticroute/staticroute_controller_test.go
+++ b/pkg/controllers/staticroute/staticroute_controller_test.go
@@ -323,7 +323,7 @@ func TestStaticRouteReconciler_GarbageCollector(t *testing.T) {
 		assert.FailNow(t, "should not be called")
 		return nil
 	})
-	k8sClient.EXPECT().List(gomock.Any(), srList).Return(nil).Do(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	k8sClient.EXPECT().List(ctx, srList).Return(nil).Do(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 		a := list.(*v1alpha1.StaticRouteList)
 		a.Items = append(a.Items, v1alpha1.StaticRoute{})
 		a.Items[0].ObjectMeta = metav1.ObjectMeta{}

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
-	commonctl "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
@@ -36,6 +35,7 @@ var (
 	ResultNormal            = common.ResultNormal
 	ResultRequeue           = common.ResultRequeue
 	ResultRequeueAfter5mins = common.ResultRequeueAfter5mins
+	ResultRequeueAfter10sec = common.ResultRequeueAfter10sec
 	MetricResTypeSubnet     = common.MetricResTypeSubnet
 )
 
@@ -74,7 +74,7 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			log.V(1).Info("added finalizer on subnet CR", "subnet", req.NamespacedName)
 		}
 		if obj.Spec.AccessMode == "" || obj.Spec.IPv4SubnetSize == 0 {
-			vpcNetworkConfig := commonctl.ServiceMediator.GetVPCNetworkConfigByNamespace(obj.Namespace)
+			vpcNetworkConfig := common.ServiceMediator.GetVPCNetworkConfigByNamespace(obj.Namespace)
 			if vpcNetworkConfig == nil {
 				err := fmt.Errorf("operate failed: cannot get configuration for Subnet CR")
 				log.Error(nil, "failed to find VPCNetworkConfig for Subnet CR", "subnet", req.NamespacedName, "namespace %s", obj.Namespace)
@@ -104,7 +104,7 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 		vpcInfo, err := common.ServiceMediator.GetNamespaceVPCInfo(req.Namespace)
 		if err != nil {
-			return commonctl.ResultRequeueAfter10sec, nil
+			return ResultRequeueAfter10sec, nil
 		}
 		if _, err := r.Service.CreateOrUpdateSubnet(obj, *vpcInfo, tags); err != nil {
 			log.Error(err, "operate failed, would retry exponentially", "subnet", req.NamespacedName)

--- a/pkg/controllers/subnet/subnet_controller_test.go
+++ b/pkg/controllers/subnet/subnet_controller_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
-	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnet"
 )
 
@@ -34,8 +33,8 @@ func TestSubnetReconciler_GarbageCollector(t *testing.T) {
 	// Subnet doesn't have TagScopeSubnetSetCRId (not  belong to SubnetSet)
 	// gc collect item "2345", local store has more item than k8s cache
 	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "ListSubnetCreatedBySubnet", func(_ *subnet.SubnetService, uid string) []model.VpcSubnet {
-		tags1 := []model.Tag{{Scope: common.String(servicecommon.TagScopeSubnetCRUID), Tag: common.String("2345")}}
-		tags2 := []model.Tag{{Scope: common.String(servicecommon.TagScopeSubnetCRUID), Tag: common.String("1234")}}
+		tags1 := []model.Tag{{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("2345")}}
+		tags2 := []model.Tag{{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("1234")}}
 		var a []model.VpcSubnet
 		id1 := "2345"
 		a = append(a, model.VpcSubnet{Id: &id1, Tags: tags1})
@@ -74,7 +73,7 @@ func TestSubnetReconciler_GarbageCollector(t *testing.T) {
 	// local store has same item as k8s cache
 	patch.Reset()
 	patch.ApplyMethod(reflect.TypeOf(service), "ListSubnetCreatedBySubnet", func(_ *subnet.SubnetService, uid string) []model.VpcSubnet {
-		tags := []model.Tag{{Scope: common.String(servicecommon.TagScopeSubnetCRUID), Tag: common.String("1234")}}
+		tags := []model.Tag{{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("1234")}}
 		var a []model.VpcSubnet
 		id := "1234"
 		a = append(a, model.VpcSubnet{Id: &id, Tags: tags})

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -25,10 +25,6 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
 
-	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
-	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
-	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -36,6 +32,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
 )
 
 var (
@@ -194,13 +195,13 @@ func StartSubnetPortController(mgr ctrl.Manager, commonService servicecommon.Ser
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}
-	if subnetPortService, err := subnetport.InitializeSubnetPort(commonService); err != nil {
+	subnetPortService, err := subnetport.InitializeSubnetPort(commonService)
+	if err != nil {
 		log.Error(err, "failed to initialize subnetport commonService", "controller", "SubnetPort")
 		os.Exit(1)
-	} else {
-		subnetPortReconciler.Service = subnetPortService
-		common.ServiceMediator.SubnetPortService = subnetPortReconciler.Service
 	}
+	subnetPortReconciler.Service = subnetPortService
+	common.ServiceMediator.SubnetPortService = subnetPortReconciler.Service
 	if err := subnetPortReconciler.Start(mgr); err != nil {
 		log.Error(err, "failed to create controller", "controller", "SubnetPort")
 		os.Exit(1)

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -258,8 +259,8 @@ func TestSubnetPortReconciler_GarbageCollector(t *testing.T) {
 		},
 	}
 	patchesListNSXSubnetPortIDForCR := gomonkey.ApplyFunc((*subnetport.SubnetPortService).ListNSXSubnetPortIDForCR,
-		func(s *subnetport.SubnetPortService) sets.String {
-			a := sets.NewString()
+		func(s *subnetport.SubnetPortService) sets.Set[string] {
+			a := sets.New[string]()
 			a.Insert("1234")
 			a.Insert("2345")
 			return a

--- a/pkg/controllers/vpc/vpc_controller.go
+++ b/pkg/controllers/vpc/vpc_controller.go
@@ -9,13 +9,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
-	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
-	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
-	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
-	_ "github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
-	commonservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -23,6 +16,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
+	_ "github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
+	commonservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
 )
 
 var (
@@ -219,12 +220,12 @@ func StartVPCController(mgr ctrl.Manager, commonService commonservice.Service) {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}
-	if vpcService, err := vpc.InitializeVPC(commonService); err != nil {
+	vpcService, err := vpc.InitializeVPC(commonService)
+	if err != nil {
 		log.Error(err, "failed to initialize VPC commonService")
 		os.Exit(1)
-	} else {
-		vpcReconcile.Service = vpcService
 	}
+	vpcReconcile.Service = vpcService
 	if err := vpcReconcile.Start(mgr); err != nil {
 		log.Error(err, "failed to create VPC controller")
 		os.Exit(1)

--- a/pkg/controllers/vpc/vpc_utils_test.go
+++ b/pkg/controllers/vpc/vpc_utils_test.go
@@ -3,9 +3,10 @@ package vpc
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
 	types "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/controllers/vpc/vpcnetworkconfig_handler.go
+++ b/pkg/controllers/vpc/vpcnetworkconfig_handler.go
@@ -3,10 +3,11 @@ package vpc
 import (
 	"context"
 
-	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"

--- a/pkg/nsx/auth/jwt/JWTtokenprovider.go
+++ b/pkg/nsx/auth/jwt/JWTtokenprovider.go
@@ -13,7 +13,8 @@ import (
 
 const (
 	VC_SVCACCOUNT_USER_PATH = "/etc/nsx-ujo/vc/username"
-	VC_SVCACCOUNT_PWD_PATH  = "/etc/nsx-ujo/vc/password"
+	// #nosec G101: false positive triggered by variable name which includes "pwd"
+	VC_SVCACCOUNT_PWD_PATH = "/etc/nsx-ujo/vc/password"
 )
 
 var (

--- a/pkg/nsx/auth/jwt/jwtcache_test.go
+++ b/pkg/nsx/auth/jwt/jwtcache_test.go
@@ -48,6 +48,7 @@ func TestJwtcache_GetJWT(t *testing.T) {
 
 	cache := NewJWTCache(tesClient, freshInterval)
 	cache.tesClient = tesClient
+	// #nosec G402: ignore insecure options
 	config := &tls.Config{InsecureSkipVerify: true}
 	tr := &http.Transport{
 		TLSClientConfig: config,
@@ -81,6 +82,7 @@ func TestJwtcache_GetJWTFailed(t *testing.T) {
 
 	cache := NewJWTCache(tesClient, freshInterval)
 	cache.tesClient = tesClient
+	// #nosec G402: ignore insecure options
 	config := &tls.Config{InsecureSkipVerify: true}
 	tr := &http.Transport{
 		TLSClientConfig: config,

--- a/pkg/nsx/auth/jwt/vcclient.go
+++ b/pkg/nsx/auth/jwt/vcclient.go
@@ -48,7 +48,7 @@ var (
 )
 
 func createHttpClient(insecureSkipVerify bool, caCertPem []byte) *http.Client {
-	tlsConfig := &tls.Config{InsecureSkipVerify: insecureSkipVerify}
+	tlsConfig := &tls.Config{InsecureSkipVerify: insecureSkipVerify} // #nosec G402: ignore insecure options
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,
 	}

--- a/pkg/nsx/auth/tokenprovider.go
+++ b/pkg/nsx/auth/tokenprovider.go
@@ -5,7 +5,7 @@ package auth
 
 // TokenProvider provides token.
 type TokenProvider interface {
-	// GetToken gets a JWT, parameter refreshToken indicats whether a new token value is to be retrieved.
+	// GetToken gets a JWT, parameter refreshToken indicates whether a new token value is to be retrieved.
 	GetToken(refreshToken bool) (string, error)
 	// GetHeaderValue gets token value from a JWT， the value format likes "Bearer %s".
 	HeaderValue(token string) string

--- a/pkg/nsx/endpoint.go
+++ b/pkg/nsx/endpoint.go
@@ -43,7 +43,7 @@ type Endpoint struct {
 	keepaliveperiod  int
 	connnumber       int32
 	stop             chan bool
-	// Used when JWT token is not avaiable, default value is 120s
+	// Used when JWT token is not available, default value is 120s
 	lockWait      time.Duration
 	user          string
 	password      string

--- a/pkg/nsx/ratelimiter/ratelimiter.go
+++ b/pkg/nsx/ratelimiter/ratelimiter.go
@@ -71,14 +71,6 @@ type AIMDRateLimter struct {
 	sync.Mutex
 }
 
-type rateLimiter struct {
-	apirateLimitPerEndpoint int
-}
-
-func (r *rateLimiter) SetMaxrate(maxrate int) {
-	r.apirateLimitPerEndpoint = maxrate
-}
-
 // NewRateLimiter creates rate limeter based on RateLimiterType
 func NewRateLimiter(rateLimiterType Type) RateLimiter {
 	if rateLimiterType == FIXRATE {

--- a/pkg/nsx/services/common/compare.go
+++ b/pkg/nsx/services/common/compare.go
@@ -41,9 +41,8 @@ func CompareResources(existing []Comparable, expected []Comparable) (changed []C
 		if existed_item, ok := existingMap[key]; ok {
 			if isChanged := CompareResource(existed_item, expected_item); !isChanged {
 				continue
-			} else {
-				log.V(1).Info("resource changed", "existing", existed_item, "expected", expected_item)
 			}
+			log.V(1).Info("resource changed", "existing", existed_item, "expected", expected_item)
 		}
 		changed = append(changed, expected_item)
 	}

--- a/pkg/nsx/services/common/store.go
+++ b/pkg/nsx/services/common/store.go
@@ -27,7 +27,7 @@ type Store interface {
 	// to specific nsx-t side resource and then add it to the store.
 	TransResourceToStore(obj *data.StructValue) error
 	// ListIndexFuncValues is the method to list all the values of the index
-	ListIndexFuncValues(key string) sets.String
+	ListIndexFuncValues(key string) sets.Set[string]
 	// Apply is the method to create, update and delete the resource to the store based
 	// on its tag MarkedForDelete.
 	Apply(obj interface{}) error
@@ -64,8 +64,8 @@ func DecrementPageSize(pageSize *int64) {
 	}
 }
 
-func (resourceStore *ResourceStore) ListIndexFuncValues(key string) sets.String {
-	values := sets.NewString()
+func (resourceStore *ResourceStore) ListIndexFuncValues(key string) sets.Set[string] {
+	values := sets.New[string]()
 	entities := resourceStore.Indexer.ListIndexFuncValues(key)
 	for _, entity := range entities {
 		values.Insert(entity)
@@ -135,7 +135,7 @@ func (service *Service) InitializeVPCResourceStore(wg *sync.WaitGroup, fatalErro
 type Filter func(interface{}) *data.StructValue
 
 func (service *Service) SearchResource(resourceTypeValue string, queryParam string, store Store, filter Filter) (uint64, error) {
-	var cursor *string = nil
+	var cursor *string
 	count := uint64(0)
 	for {
 		var err error

--- a/pkg/nsx/services/ippool/builder.go
+++ b/pkg/nsx/services/ippool/builder.go
@@ -90,13 +90,12 @@ func (service *IPPoolService) buildIPSubnetIntentPath(IPPool *v1alpha2.IPPool, s
 
 func (service *IPPoolService) buildIPSubnet(IPPool *v1alpha2.IPPool, subnetRequest v1alpha2.SubnetRequest) *model.IpAddressPoolBlockSubnet {
 	IpBlockPath := String("")
-	IpBlockPathList := make([]string, 0)
 	VPCInfo := commonctl.ServiceMediator.GetVPCsByNamespace(IPPool.Namespace)
 	if len(VPCInfo) == 0 {
 		log.Error(nil, "failed to find VPCInfo for IPPool CR", "IPPool", IPPool.Name, "namespace", IPPool.Namespace)
 		return nil
 	}
-
+	var IpBlockPathList []string
 	if IPPool.Spec.Type == common.IPPoolTypePrivate {
 		IpBlockPathList = VPCInfo[0].PrivateIpv4Blocks
 	} else {

--- a/pkg/nsx/services/ippool/builder_test.go
+++ b/pkg/nsx/services/ippool/builder_test.go
@@ -84,9 +84,6 @@ func TestIPPoolService_BuildIPPool(t *testing.T) {
 	})
 	defer patch.Reset()
 
-	type fields struct {
-		Service common.Service
-	}
 	type args struct {
 		IPPool *v1alpha2.IPPool
 	}

--- a/pkg/nsx/services/ippool/fake_test.go
+++ b/pkg/nsx/services/ippool/fake_test.go
@@ -14,18 +14,11 @@ import (
 type fakeQueryClient struct {
 }
 
-type fakeProjectQueryClient struct {
-}
-
-func (f fakeProjectQueryClient) List(orgIdParam string, projectIdParam string, queryParam string, cursorParam *string, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.SearchResponse, error) {
-	return model.SearchResponse{}, nil
-}
-
 func (qIface *fakeQueryClient) List(queryParam string, cursorParam *string, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.SearchResponse, error) {
 	cursor := "2"
 	resultCount := int64(2)
 	return model.SearchResponse{
-		Results: []*data.StructValue{&data.StructValue{}},
+		Results: []*data.StructValue{{}},
 		Cursor:  &cursor, ResultCount: &resultCount,
 	}, nil
 }

--- a/pkg/nsx/services/ippool/ippool.go
+++ b/pkg/nsx/services/ippool/ippool.go
@@ -164,7 +164,8 @@ func (service *IPPoolService) Apply(nsxIPPool *model.IpAddressPool, nsxIPSubnets
 func (service *IPPoolService) AcquireRealizedSubnetIP(obj *v1alpha2.IPPool) ([]v1alpha2.SubnetResult, bool, error) {
 	realizedSubnets := []v1alpha2.SubnetResult{}
 	subnetCidrUpdated := false
-	for _, subnetRequest := range obj.Spec.Subnets {
+	for _, subnet := range obj.Spec.Subnets {
+		subnetRequest := subnet
 		// check if the subnet is already realized
 		realized := false
 		realizedSubnet := v1alpha2.SubnetResult{Name: subnetRequest.Name}
@@ -256,7 +257,7 @@ func (service *IPPoolService) acquireCidr(obj *v1alpha2.IPPool, subnetRequest *v
 	}
 }
 
-func (service *IPPoolService) ListIPPoolID() sets.String {
+func (service *IPPoolService) ListIPPoolID() sets.Set[string] {
 	ipPoolSet := service.ipPoolStore.ListIndexFuncValues(common.TagScopeIPPoolCRUID)
 	ipPoolSubnetSet := service.ipPoolBlockSubnetStore.ListIndexFuncValues(common.TagScopeIPPoolCRUID)
 	return ipPoolSet.Union(ipPoolSubnetSet)

--- a/pkg/nsx/services/ippool/ippool_test.go
+++ b/pkg/nsx/services/ippool/ippool_test.go
@@ -30,9 +30,9 @@ func TestIPPoolService_ListIPPoolID(t *testing.T) {
 
 	tests := []struct {
 		name string
-		want sets.String
+		want sets.Set[string]
 	}{
-		{"test", sets.NewString("1")},
+		{"test", sets.New[string]("1")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/nsx/services/ippool/wrap_test.go
+++ b/pkg/nsx/services/ippool/wrap_test.go
@@ -12,7 +12,7 @@ import (
 func TestIPPoolService_WrapHierarchyIPPool(t *testing.T) {
 	service := fakeService()
 	iapbs := []*model.IpAddressPoolBlockSubnet{
-		&model.IpAddressPoolBlockSubnet{
+		{
 			Id: String("1"), DisplayName: String("1"),
 			Tags: []model.Tag{{Scope: String(common.TagScopeIPPoolCRUID), Tag: String("1")}}}}
 	iap := &model.IpAddressPool{Id: String("1"), DisplayName: String("1"),

--- a/pkg/nsx/services/node/node.go
+++ b/pkg/nsx/services/node/node.go
@@ -29,17 +29,18 @@ func InitializeNode(service servicecommon.Service) (*NodeService, error) {
 
 	wg.Add(1)
 
-	nodeService := &NodeService{Service: service}
-
-	nodeService.NodeStore = &NodeStore{
-		ResourceStore: servicecommon.ResourceStore{
-			Indexer: cache.NewIndexer(
-				keyFunc,
-				cache.Indexers{
-					servicecommon.IndexKeyNodeName: nodeIndexByNodeName,
-				},
-			),
-			BindingType: model.HostTransportNodeBindingType(),
+	nodeService := &NodeService{
+		Service: service,
+		NodeStore: &NodeStore{
+			ResourceStore: servicecommon.ResourceStore{
+				Indexer: cache.NewIndexer(
+					keyFunc,
+					cache.Indexers{
+						servicecommon.IndexKeyNodeName: nodeIndexByNodeName,
+					},
+				),
+				BindingType: model.HostTransportNodeBindingType(),
+			},
 		},
 	}
 	// TODO: confirm whether we can remove the following intialization because node doesn't have the cluster tag so it's a dry run
@@ -93,6 +94,7 @@ func (service *NodeService) SyncNodeStore(nodeName string, deleted bool) error {
 	}
 	synced := false
 	for _, node := range nodeResults.Results {
+		node := node
 		if *node.NodeDeploymentInfo.Fqdn == nodeName {
 			if deleted {
 				// Retry until the NSX HostTransportNode is deleted.

--- a/pkg/nsx/services/node/store.go
+++ b/pkg/nsx/services/node/store.go
@@ -13,19 +13,19 @@ type NodeStore struct {
 	common.ResourceStore
 }
 
-func (vs *NodeStore) Apply(i interface{}) error {
+func (nodeStore *NodeStore) Apply(i interface{}) error {
 	if i == nil {
 		return nil
 	}
 	node := i.(*model.HostTransportNode)
 	if node.MarkedForDelete != nil && *node.MarkedForDelete {
-		err := vs.Delete(*node)
+		err := nodeStore.Delete(*node)
 		log.V(1).Info("delete Node from store", "node", node)
 		if err != nil {
 			return err
 		}
 	} else {
-		err := vs.Add(*node)
+		err := nodeStore.Add(*node)
 		log.V(1).Info("add Node to store", "node", node)
 		if err != nil {
 			return err

--- a/pkg/nsx/services/nsxserviceaccount/cluster.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster.go
@@ -34,11 +34,12 @@ const (
 	enforcementpointId = "default"
 	PortRestAPI        = "rest-api"
 	PortNSXRPCFwdProxy = "nsx-rpc-fwd-proxy"
-	SecretSuffix       = "-nsx-cert"
-	SecretCAName       = "ca.crt"
-	SecretCertName     = "tls.crt"
-	SecretKeyName      = "tls.key"
-	CAName             = "ca.crt"
+	// #nosec G101: false positive triggered by variable name which includes "secret"
+	SecretSuffix   = "-nsx-cert"
+	SecretCAName   = "ca.crt"
+	SecretCertName = "tls.crt"
+	SecretKeyName  = "tls.key"
+	CAName         = "ca.crt"
 )
 
 var (
@@ -467,7 +468,7 @@ func (s *NSXServiceAccountService) updatePIAndCCPCert(normalizedClusterName, uid
 }
 
 // ListNSXServiceAccountRealization returns all existing realized or failed NSXServiceAccount on NSXT
-func (s *NSXServiceAccountService) ListNSXServiceAccountRealization() sets.String {
+func (s *NSXServiceAccountService) ListNSXServiceAccountRealization() sets.Set[string] {
 	// List PI
 	uidSet := s.PrincipalIdentityStore.ListIndexFuncValues(common.TagScopeNSXServiceAccountCRUID)
 

--- a/pkg/nsx/services/realizestate/realize_state.go
+++ b/pkg/nsx/services/realizestate/realize_state.go
@@ -55,6 +55,6 @@ func (service *RealizeStateService) CheckRealizeState(backoff wait.Backoff, inte
 			}
 			return errors.New(*result.State)
 		}
-		return errors.New(fmt.Sprintf("%s not realized", entityType))
+		return fmt.Errorf("%s not realized", entityType)
 	})
 }

--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -71,7 +71,8 @@ func (service *SecurityPolicyService) buildSecurityPolicy(obj *v1alpha1.Security
 		nsxGroups = append(nsxGroups, *policyGroup)
 	}
 
-	for ruleIdx, rule := range obj.Spec.Rules {
+	for ruleIdx, r := range obj.Spec.Rules {
+		rule := r
 		// A rule containing named port may expand to multiple rules if the name maps to multiple port numbers.
 		expandRules, ruleGroups, shares, err := service.buildRuleAndGroups(obj, &rule, ruleIdx)
 		if err != nil {
@@ -120,12 +121,12 @@ func (service *SecurityPolicyService) buildPolicyGroup(obj *v1alpha1.SecurityPol
 
 	targetGroupCriteriaCount, targetGroupTotalExprCount := 0, 0
 	criteriaCount, totalExprCount := 0, 0
-	var err error = nil
+	var err error
 	errorMsg := ""
-	for i, target := range appliedTo {
+	for i := range appliedTo {
 		criteriaCount, totalExprCount, err = service.updateTargetExpressions(
 			obj,
-			&target,
+			&appliedTo[i],
 			&policyAppliedGroup,
 			i,
 		)
@@ -299,7 +300,7 @@ func (service *SecurityPolicyService) buildExpression(resource_type, member_type
 }
 
 func (service *SecurityPolicyService) buildExpressionsMatchExpression(matchExpressions []v1.LabelSelectorRequirement, memberType string, expressions *data.ListValue) error {
-	var err error = nil
+	var err error
 	errorMsg := ""
 
 	for _, expr := range matchExpressions {
@@ -629,10 +630,10 @@ func (service *SecurityPolicyService) buildRuleAppliedGroupByRule(obj *v1alpha1.
 	ruleGroupCriteriaCount, ruleGroupTotalExprCount := 0, 0
 	criteriaCount, totalExprCount := 0, 0
 	errorMsg := ""
-	for i, target := range appliedTo {
+	for i := range appliedTo {
 		criteriaCount, totalExprCount, err = service.updateTargetExpressions(
 			obj,
-			&target,
+			&appliedTo[i],
 			&ruleAppliedGroup,
 			i,
 		)
@@ -746,10 +747,10 @@ func (service *SecurityPolicyService) buildRulePeerGroup(obj *v1alpha1.SecurityP
 	rulePeerGroupCriteriaCount, rulePeerGroupTotalExprCount := 0, 0
 	criteriaCount, totalExprCount := 0, 0
 	errorMsg := ""
-	for i, peer := range rulePeers {
+	for i := range rulePeers {
 		criteriaCount, totalExprCount, err = service.updatePeerExpressions(
 			obj,
-			&peer,
+			&rulePeers[i],
 			&rulePeerGroup,
 			i,
 			groupShared,
@@ -890,11 +891,11 @@ func (service *SecurityPolicyService) buildPeerTags(obj *v1alpha1.SecurityPolicy
 }
 
 func (service *SecurityPolicyService) updateTargetExpressions(obj *v1alpha1.SecurityPolicy, target *v1alpha1.SecurityPolicyTarget, group *model.Group, ruleIdx int) (int, int, error) {
-	var err error = nil
-	var tagValueExpression *data.StructValue = nil
+	var err error
+	var tagValueExpression *data.StructValue
 	var matchLabels map[string]string
-	var matchExpressions *[]v1.LabelSelectorRequirement = nil
-	var mergedMatchExpressions *[]v1.LabelSelectorRequirement = nil
+	var matchExpressions *[]v1.LabelSelectorRequirement
+	var mergedMatchExpressions *[]v1.LabelSelectorRequirement
 	opInValueCount, totalCriteriaCount, totalExprCount := 0, 0, 0
 	matchLabelsCount, matchExpressionsCount := 0, 0
 
@@ -1070,7 +1071,7 @@ func (service *SecurityPolicyService) mergeSelectorMatchExpression(matchExpressi
 func (service *SecurityPolicyService) validateSelectorOpIn(matchExpressions []v1.LabelSelectorRequirement, matchLabels map[string]string) (int, error) {
 	mexprInOpCount := 0
 	mexprInValueCount := 0
-	var err error = nil
+	var err error
 	errorMsg := ""
 	exists := false
 	var opInIndex int
@@ -1110,7 +1111,7 @@ func (service *SecurityPolicyService) validateSelectorOpIn(matchExpressions []v1
 }
 
 func (service *SecurityPolicyService) validateNsSelectorOpNotIn(nsMatchExpressions []v1.LabelSelectorRequirement) error {
-	var err error = nil
+	var err error
 	errorMsg := ""
 
 	for _, expr := range nsMatchExpressions {
@@ -1124,7 +1125,7 @@ func (service *SecurityPolicyService) validateNsSelectorOpNotIn(nsMatchExpressio
 }
 
 func (service *SecurityPolicyService) validateSelectorExpressions(matchLabelsCount int, matchExpressionsCount int, opInValueCount int, mixedCriteria bool) (int, int, error) {
-	var err error = nil
+	var err error
 	errorMsg := ""
 	totalExprCount := 0
 	totalCriteria := 0
@@ -1193,7 +1194,7 @@ func (service *SecurityPolicyService) matchExpressionOpInExist(
 func (service *SecurityPolicyService) updateExpressionsMatchExpression(matchExpressions []v1.LabelSelectorRequirement, matchLabels map[string]string,
 	policyExpression *[]*data.StructValue, clusterExpression *data.StructValue, tagValueExpression *data.StructValue, memberType string, expressions *data.ListValue,
 ) error {
-	var err error = nil
+	var err error
 	found, opInIdx := service.matchExpressionOpInExist(matchExpressions)
 	if !found {
 		err = service.buildExpressionsMatchExpression(matchExpressions, memberType, expressions)
@@ -1239,9 +1240,9 @@ func (service *SecurityPolicyService) updateMixedExpressionsMatchExpression(nsMa
 	policyExpression *[]*data.StructValue, clusterExpression *data.StructValue, tagValueExpression *data.StructValue,
 	expressions *data.ListValue,
 ) error {
-	var err error = nil
+	var err error
 	opInIdx := 0
-	var opInMatchExpressions []v1.LabelSelectorRequirement = nil
+	var opInMatchExpressions []v1.LabelSelectorRequirement
 	memberType := ""
 
 	nsFound, opInIdx1 := service.matchExpressionOpInExist(nsMatchExpressions)
@@ -1320,12 +1321,12 @@ func (service *SecurityPolicyService) updateMixedExpressionsMatchExpression(nsMa
 }
 
 func (service *SecurityPolicyService) updatePeerExpressions(obj *v1alpha1.SecurityPolicy, peer *v1alpha1.SecurityPolicyPeer, group *model.Group, ruleIdx int, groupShared bool) (int, int, error) {
-	var err error = nil
+	var err error
 	errorMsg := ""
-	var tagValueExpression *data.StructValue = nil
+	var tagValueExpression *data.StructValue
 	var matchLabels map[string]string
-	var matchExpressions *[]v1.LabelSelectorRequirement = nil
-	var mergedMatchExpressions *[]v1.LabelSelectorRequirement = nil
+	var matchExpressions *[]v1.LabelSelectorRequirement
+	var mergedMatchExpressions *[]v1.LabelSelectorRequirement
 	opInValueCount, totalCriteriaCount, totalExprCount := 0, 0, 0
 	matchLabelsCount, matchExpressionsCount := 0, 0
 	mixedNsSelector := false
@@ -1625,7 +1626,8 @@ func (service *SecurityPolicyService) buildSharedResource(shareId string, shared
 	resourceType := common.ResourceTypeSharedResource
 	includeChildren := false
 
-	for _, groupPath := range sharedGroupPath {
+	for _, path := range sharedGroupPath {
+		groupPath := path
 		resourceObject := model.ResourceObject{
 			IncludeChildren: &includeChildren,
 			ResourcePath:    &groupPath,

--- a/pkg/nsx/services/securitypolicy/expand.go
+++ b/pkg/nsx/services/securitypolicy/expand.go
@@ -137,7 +137,8 @@ func (service *SecurityPolicyService) resolveNamedPort(obj *v1alpha1.SecurityPol
 		return nil, err
 	}
 
-	for _, podSelector := range podSelectors {
+	for _, selector := range podSelectors {
+		podSelector := selector
 		podsList := &v1.PodList{}
 		log.V(2).Info("port", "podSelector", podSelector)
 		err := service.Client.List(context.Background(), podsList, &podSelector)
@@ -164,7 +165,8 @@ func (service *SecurityPolicyService) resolveNamedPort(obj *v1alpha1.SecurityPol
 // Check port name and protocol, only when the pod is really running, and it does have effective ip.
 func (service *SecurityPolicyService) resolvePodPort(pod v1.Pod, spPort *v1alpha1.SecurityPolicyPort) ([]nsxutil.PortAddress, error) {
 	var addr []nsxutil.PortAddress
-	for _, container := range pod.Spec.Containers {
+	for _, c := range pod.Spec.Containers {
+		container := c
 		for _, port := range container.Ports {
 			log.V(2).Info("resolvePodPort", "namespace", pod.Namespace, "pod_name", pod.Name,
 				"port_name", port.Name, "containerPort", port.ContainerPort,

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -52,7 +52,6 @@ var (
 	ruleID1                      = "sp_uidA_1"
 	ruleIDPort000                = "sp_uidA_0_0_0"
 	ruleIDPort100                = "sp_uidA_1_0_0"
-	ruleIDPort200                = "sp_uidA_2_0_0"
 	nsxDirectionIn               = "IN"
 	nsxActionAllow               = "ALLOW"
 	nsxDirectionOut              = "OUT"
@@ -347,7 +346,7 @@ func TestListSecurityPolicyID(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		want    sets.String
+		want    sets.Set[string]
 		wantErr bool
 	}{
 		{
@@ -356,7 +355,7 @@ func TestListSecurityPolicyID(t *testing.T) {
 		},
 	}
 
-	tests[0].want = sets.NewString()
+	tests[0].want = sets.New[string]()
 	tests[0].want.Insert(id)
 	tests[0].want.Insert(id1)
 	tests[0].want.Insert(id2)

--- a/pkg/nsx/services/securitypolicy/wrap.go
+++ b/pkg/nsx/services/securitypolicy/wrap.go
@@ -77,7 +77,8 @@ func (service *SecurityPolicyService) wrapDomainResource(children []*data.Struct
 
 func (service *SecurityPolicyService) wrapRules(rules []model.Rule) ([]*data.StructValue, error) {
 	var rulesChildren []*data.StructValue
-	for _, rule := range rules {
+	for _, r := range rules {
+		rule := r
 		rule.ResourceType = &common.ResourceTypeRule // InfraClient need this field to identify the resource type
 		childRule := model.ChildRule{                // We need to put child rule's id into upper level, otherwise, NSX-T will not find the child rule
 			ResourceType:    "ChildRule", // Children are not allowed for rule, so we don't need to wrap ServiceEntry into Children
@@ -96,7 +97,8 @@ func (service *SecurityPolicyService) wrapRules(rules []model.Rule) ([]*data.Str
 
 func (service *SecurityPolicyService) wrapGroups(groups []model.Group) ([]*data.StructValue, error) {
 	var groupsChildren []*data.StructValue
-	for _, group := range groups {
+	for _, g := range groups {
+		group := g
 		group.ResourceType = &common.ResourceTypeGroup // InfraClient need this field to identify the resource type
 		childGroup := model.ChildGroup{
 			ResourceType:    "ChildGroup",
@@ -244,7 +246,8 @@ func (service *SecurityPolicyService) wrapChildShares(shares []model.Share) ([]*
 	var sharesChildren []*data.StructValue
 	resourceType := common.ResourceTypeChildShare
 
-	for _, share := range shares {
+	for _, s := range shares {
+		share := s
 		childShare := model.ChildShare{
 			Id:              share.Id,
 			ResourceType:    resourceType,

--- a/pkg/nsx/services/securitypolicy/wrap_test.go
+++ b/pkg/nsx/services/securitypolicy/wrap_test.go
@@ -163,18 +163,6 @@ func TestSecurityPolicyService_wrapResourceReference(t *testing.T) {
 	type args struct {
 		children []*data.StructValue
 	}
-	var children []*data.StructValue
-	serviceEntry := data.NewStructValue(
-		"",
-		map[string]data.DataValue{
-			"l4_protocol":   data.NewStringValue("TCP"),
-			"resource_type": data.NewStringValue("L4PortSetServiceEntry"),
-			// adding the following default values to make it easy when compare the existing object from store and the new built object
-			"marked_for_delete": data.NewBooleanValue(false),
-			"overridden":        data.NewBooleanValue(false),
-		},
-	)
-	children = append(children, serviceEntry)
 	tests := []struct {
 		name    string
 		args    args

--- a/pkg/nsx/services/staticroute/staticroute_test.go
+++ b/pkg/nsx/services/staticroute/staticroute_test.go
@@ -32,7 +32,6 @@ var (
 	staticrouteID2            = "ns-staticroute-uid-2"
 	IPv4Type                  = "IPv4"
 	cluster                   = "k8scl-one"
-	tagValueNS                = "ns1"
 	tagScopeStaticRouteCRName = common.TagScopeStaticRouteCRName
 	tagScopeStaticRouteCRUID  = common.TagScopeStaticRouteCRUID
 	tagValueStaticRouteCRName = "staticrouteA"
@@ -40,17 +39,6 @@ var (
 	tagScopeCluster           = common.TagScopeCluster
 	tagScopeNamespace         = common.TagScopeNamespace
 )
-
-type fakeVPCQueryClient struct {
-}
-
-func (qIface *fakeVPCQueryClient) List(_ string, _ string, _ string, _ *string, _ *string, _ *int64, _ *bool, _ *string) (model.SearchResponse, error) {
-	resultCount := int64(1)
-	return model.SearchResponse{
-		Results: []*data.StructValue{},
-		Cursor:  nil, ResultCount: &resultCount,
-	}, nil
-}
 
 type fakeQueryClient struct {
 }

--- a/pkg/nsx/services/staticroute/store_test.go
+++ b/pkg/nsx/services/staticroute/store_test.go
@@ -151,10 +151,6 @@ func TestStaticRouteStore_GetByKey(t *testing.T) {
 	}
 
 	staticRouteStore := &StaticRouteStore{ResourceStore: resourceStore}
-	type args struct {
-		i interface{}
-		j interface{}
-	}
 	ns1 := "test-ns-1"
 	tag1 := []model.Tag{
 		{

--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -89,12 +89,6 @@ func (service *SubnetService) buildDHCPConfig(poolSize int64) *model.VpcSubnetDh
 	return dhcpConfig
 }
 
-func (service *SubnetService) buildDNSClientConfig(obj *v1alpha1.DNSClientConfig) *model.DnsClientConfig {
-	dnsClientConfig := &model.DnsClientConfig{}
-	dnsClientConfig.DnsServerIps = append(dnsClientConfig.DnsServerIps, obj.DNSServersIPs...)
-	return dnsClientConfig
-}
-
 func (service *SubnetService) buildBasicTags(obj client.Object) []model.Tag {
 	return util.BuildBasicTags(getCluster(service), obj, "")
 }

--- a/pkg/nsx/services/subnet/store_test.go
+++ b/pkg/nsx/services/subnet/store_test.go
@@ -26,7 +26,7 @@ func (qIface *fakeQueryClient) List(_ string, _ *string, _ *string, _ *int64, _ 
 	cursor := "2"
 	resultCount := int64(2)
 	return model.SearchResponse{
-		Results: []*data.StructValue{&data.StructValue{}},
+		Results: []*data.StructValue{{}},
 		Cursor:  &cursor, ResultCount: &resultCount,
 	}, nil
 }

--- a/pkg/nsx/services/subnet/wrap.go
+++ b/pkg/nsx/services/subnet/wrap.go
@@ -108,38 +108,3 @@ func (service *SubnetService) wrapSubnet(subnet *model.VpcSubnet) ([]*data.Struc
 	}
 	return []*data.StructValue{dataValue.(*data.StructValue)}, nil
 }
-
-// wrapDHCPStaticBindingConfig wraps DHCPStaticBindingConfig as children of VPCSubnet.
-func (service *SubnetService) wrapDHCPStaticBindingConfig(config model.DhcpStaticBindingConfig) ([]*data.StructValue, error) {
-	configValue, errors := NewConverter().ConvertToVapi(config, model.ChildDhcpStaticBindingConfigBindingType())
-	if len(errors) > 0 {
-		return nil, errors[0]
-	}
-	configChild := model.ChildDhcpStaticBindingConfig{
-		ResourceType:            "ChildDhcpStaticBindingConfig",
-		Id:                      config.Id,
-		DhcpStaticBindingConfig: configValue.(*data.StructValue),
-		MarkedForDelete:         config.MarkedForDelete,
-	}
-	configChildValue, errors := NewConverter().ConvertToVapi(configChild, model.ChildDhcpStaticBindingConfigBindingType())
-	if len(errors) > 0 {
-		return nil, errors[0]
-	}
-	return []*data.StructValue{configChildValue.(*data.StructValue)}, nil
-}
-
-// wrapSegmentPort wraps SegmentPort as children of VPCSubnet.
-// A reserved function for creating SegmentPorts, currently not used.
-func (service *SubnetService) wrapSegmentPort(port model.SegmentPort) ([]*data.StructValue, error) {
-	portChild := model.ChildSegmentPort{
-		ResourceType:    "ChildSegmentPort",
-		Id:              port.Id,
-		SegmentPort:     &port,
-		MarkedForDelete: port.MarkedForDelete,
-	}
-	dataValue, errors := NewConverter().ConvertToVapi(portChild, model.ChildSegmentBindingType())
-	if len(errors) > 0 {
-		return nil, errors[0]
-	}
-	return []*data.StructValue{dataValue.(*data.StructValue)}, nil
-}

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -8,19 +8,19 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/realizestate"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
 )
 
 var (
@@ -78,7 +78,7 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 	switch o := obj.(type) {
 	case *v1alpha1.SubnetPort:
 		uid = string(o.UID)
-	case *corev1.Pod:
+	case *v1.Pod:
 		uid = string(o.UID)
 	}
 	log.Info("creating or updating subnetport", "nsxSubnetPort.Id", uid, "nsxSubnetPath", nsxSubnetPath)
@@ -207,13 +207,13 @@ func (service *SubnetPortService) DeleteSubnetPort(uid types.UID) error {
 	return nil
 }
 
-func (service *SubnetPortService) ListNSXSubnetPortIDForCR() sets.String {
+func (service *SubnetPortService) ListNSXSubnetPortIDForCR() sets.Set[string] {
 	log.V(2).Info("listing subnet port CR UIDs")
 	subnetPortSet := service.SubnetPortStore.ListIndexFuncValues(servicecommon.TagScopeSubnetPortCRUID)
 	return subnetPortSet
 }
 
-func (service *SubnetPortService) ListNSXSubnetPortIDForPod() sets.String {
+func (service *SubnetPortService) ListNSXSubnetPortIDForPod() sets.Set[string] {
 	log.V(2).Info("listing pod UIDs")
 	subnetPortSet := service.SubnetPortStore.ListIndexFuncValues(servicecommon.TagScopePodUID)
 	return subnetPortSet

--- a/pkg/nsx/services/vpc/store_test.go
+++ b/pkg/nsx/services/vpc/store_test.go
@@ -27,7 +27,7 @@ func (qIface *fakeQueryClient) List(_ string, _ *string, _ *string, _ *int64, _ 
 	cursor := "2"
 	resultCount := int64(2)
 	return model.SearchResponse{
-		Results: []*data.StructValue{&data.StructValue{}},
+		Results: []*data.StructValue{{}},
 		Cursor:  &cursor, ResultCount: &resultCount,
 	}, nil
 }
@@ -134,7 +134,7 @@ func Test_InitializeVPCStore(t *testing.T) {
 
 	service.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypeVpc, nil, vpcStore)
 	assert.Empty(t, fatalErrors)
-	assert.Equal(t, sets.String(sets.String{}), vpcStore.ListIndexFuncValues(common.TagScopeVPCCRUID))
+	assert.Equal(t, sets.New[string](), vpcStore.ListIndexFuncValues(common.TagScopeVPCCRUID))
 }
 
 func TestVPCStore_CRUDResource(t *testing.T) {

--- a/pkg/nsx/transport_test.go
+++ b/pkg/nsx/transport_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/auth"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
 )
 
@@ -81,13 +80,13 @@ func TestSelectEndpoint(t *testing.T) {
 	r := ratelimiter.NewRateLimiter(config.APIRateMode)
 	eps, _ := cluster.createEndpoints(config.APIManagers, client, noBClient, r, nil)
 	// all eps DOWN
-	ep, err := tr.selectEndpoint()
+	_, err := tr.selectEndpoint()
 	assert.NotNil(t, err, fmt.Sprintf("Select endpoint error %s", err))
 	// one ep UP
 	eps[0].status = UP
 	tr.endpoints = eps
 
-	ep, err = tr.selectEndpoint()
+	ep, err := tr.selectEndpoint()
 	assert.Nil(err, fmt.Sprintf("Select endpoint failed due to %v", err))
 	assert.Equal(ep.Host(), eps[0].Host(), "Select endpoint error, ep is %s, error is %s", ep.Host(), err)
 
@@ -112,10 +111,9 @@ func TestSelectEndpoint(t *testing.T) {
 
 func TestTransport_RoundTrip(t *testing.T) {
 	type fields struct {
-		Base          http.RoundTripper
-		endpoints     []*Endpoint
-		tokenProvider auth.TokenProvider
-		config        *Config
+		Base      http.RoundTripper
+		endpoints []*Endpoint
+		config    *Config
 	}
 	type args struct {
 		r *http.Request
@@ -168,10 +166,9 @@ func Test_handleRoundTripError(t *testing.T) {
 
 func TestTransport_base(t *testing.T) {
 	type fields struct {
-		Base          http.RoundTripper
-		endpoints     []*Endpoint
-		tokenProvider auth.TokenProvider
-		config        *Config
+		Base      http.RoundTripper
+		endpoints []*Endpoint
+		config    *Config
 	}
 	tests := []struct {
 		name   string
@@ -196,10 +193,9 @@ func TestTransport_base(t *testing.T) {
 
 func TestTransport_selectEndpoint(t *testing.T) {
 	type fields struct {
-		Base          http.RoundTripper
-		endpoints     []*Endpoint
-		tokenProvider auth.TokenProvider
-		config        *Config
+		Base      http.RoundTripper
+		endpoints []*Endpoint
+		config    *Config
 	}
 	tests := []struct {
 		name    string

--- a/pkg/nsx/util/errors.go
+++ b/pkg/nsx/util/errors.go
@@ -25,13 +25,13 @@ func (impl *nsxErrorImpl) setDetail(detail *ErrorDetail) {
 	impl.ErrorDetail = *detail
 	if len(detail.RelatedErrorCodes) > 0 {
 		impl.ErrorDetail.RelatedErrorCodes = []int{}
-		for index, _ := range detail.RelatedErrorCodes {
+		for index := range detail.RelatedErrorCodes {
 			impl.ErrorDetail.RelatedErrorCodes = append(impl.ErrorDetail.RelatedErrorCodes, detail.RelatedErrorCodes[index])
 		}
 	}
 	if len(detail.RelatedStatusCodes) > 0 {
 		impl.ErrorDetail.RelatedStatusCodes = []string{}
-		for index, _ := range detail.RelatedStatusCodes {
+		for index := range detail.RelatedStatusCodes {
 			impl.ErrorDetail.RelatedStatusCodes = append(impl.ErrorDetail.RelatedStatusCodes, detail.RelatedStatusCodes[index])
 		}
 	}
@@ -189,8 +189,7 @@ func CreateRealizationError(operation string, argVal string, argName string) *Re
 }
 
 type RealizationErrorStateError struct {
-	msg    string `parent:"RealizationError"`
-	detail *ErrorDetail
+	msg string `parent:"RealizationError"`
 }
 
 func CreateRealizationErrorStateError(resourceType string, resourceID string, error string) *RealizationErrorStateError {
@@ -200,8 +199,7 @@ func CreateRealizationErrorStateError(resourceType string, resourceID string, er
 }
 
 type RealizationTimeoutError struct {
-	msg    string `parent:"RealizationError"`
-	detail *ErrorDetail
+	msg string `parent:"RealizationError"`
 }
 
 func CreateRealizationTimeoutError(resourceType string, resourceID string, attempts string, sleep string) *RealizationTimeoutError {
@@ -211,8 +209,7 @@ func CreateRealizationTimeoutError(resourceType string, resourceID string, attem
 }
 
 type DetailedRealizationTimeoutError struct {
-	msg    string `parent:"RealizationError"`
-	detail *ErrorDetail
+	msg string `parent:"RealizationError"`
 }
 
 func CreateDetailedRealizationTimeoutError(resourceType string, resourceID string, realizedType string, relatedType string, relatedID string, attempts string, sleep string) *DetailedRealizationTimeoutError {
@@ -239,8 +236,7 @@ type ServerBusy interface {
 
 type ServerBusyImpl struct {
 	managerErrorImpl
-	msg    string
-	detail *ErrorDetail
+	msg string
 }
 
 func (ServerBusyImpl) serverBusy() {}

--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -5,7 +5,7 @@ package util
 
 import (
 	"bytes"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505: not used for security purposes
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"

--- a/pkg/nsx/util/utils_test.go
+++ b/pkg/nsx/util/utils_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -184,12 +183,12 @@ func TestVCClient_handleHTTPResponse(t *testing.T) {
 	assert.Equal(t, err, nil)
 
 	// 	response.StatusCode = 200， body content correct
-	response.Body = ioutil.NopCloser(bytes.NewReader([]byte(`{"value": "hello"}`)))
+	response.Body = io.NopCloser(bytes.NewReader([]byte(`{"value": "hello"}`)))
 	err, _ = HandleHTTPResponse(response, &sessionData, false)
 	assert.Equal(t, err, nil)
 
 	// 	response.StatusCode = 200， body content invalid
-	response.Body = ioutil.NopCloser(bytes.NewReader([]byte(`{"value": 4}`)))
+	response.Body = io.NopCloser(bytes.NewReader([]byte(`{"value": 4}`)))
 	err, _ = HandleHTTPResponse(response, &sessionData, false)
 	_, ok := err.(*json.UnmarshalTypeError)
 	assert.Equal(t, ok, true)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -5,7 +5,7 @@ package util
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505: not used for security purposes
 	"errors"
 	"fmt"
 	"net"
@@ -102,7 +102,7 @@ func NormalizeId(name string) string {
 }
 
 func Sha1(data string) string {
-	h := sha1.New()
+	h := sha1.New() // #nosec G401: not used for security purposes
 	h.Write([]byte(data))
 	sum := h.Sum(nil)
 	return fmt.Sprintf("%x", sum)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -6,10 +6,8 @@ package e2e
 import (
 	"flag"
 	"log"
-	"math/rand"
 	"os"
 	"testing"
-	"time"
 )
 
 // setupLogging creates a temporary directory to export the test logs if necessary. If a directory
@@ -70,17 +68,15 @@ func testMain(m *testing.M) int {
 	log.Println("Collecting information about K8s cluster")
 	if err := collectClusterInfo(); err != nil {
 		log.Fatalf("Error when collecting information about K8s cluster: %v", err)
-	} else {
-		if clusterInfo.podV4NetworkCIDR != "" {
-			log.Printf("Pod IPv4 network: '%s'", clusterInfo.podV4NetworkCIDR)
-		}
-		if clusterInfo.podV6NetworkCIDR != "" {
-			log.Printf("Pod IPv6 network: '%s'", clusterInfo.podV6NetworkCIDR)
-		}
-		log.Printf("Num nodes: %d", clusterInfo.numNodes)
 	}
+	if clusterInfo.podV4NetworkCIDR != "" {
+		log.Printf("Pod IPv4 network: '%s'", clusterInfo.podV4NetworkCIDR)
+	}
+	if clusterInfo.podV6NetworkCIDR != "" {
+		log.Printf("Pod IPv6 network: '%s'", clusterInfo.podV6NetworkCIDR)
+	}
+	log.Printf("Num nodes: %d", clusterInfo.numNodes)
 
-	rand.Seed(time.Now().UnixNano())
 	ret := m.Run()
 	return ret
 }

--- a/test/e2e/nsx_subnet_test.go
+++ b/test/e2e/nsx_subnet_test.go
@@ -87,6 +87,7 @@ func defaultSubnetSet(t *testing.T) {
 	// 4. Check NSX subnet allocation.
 	subnetPath := subnetSet.Status.Subnets[0].NSXResourcePath
 	vpcInfo, err := common.ParseVPCResourcePath(subnetPath)
+	assert_nil(t, err, "Failed to parse VPC resource path %s", subnetPath)
 	vpcSubnet, err := testData.nsxClient.SubnetsClient.Get(vpcInfo.OrgID, vpcInfo.ProjectID, vpcInfo.VPCID, vpcInfo.ID)
 	assert_nil(t, err, "Failed to get VPC subnet %s", vpcInfo.ID)
 
@@ -128,7 +129,7 @@ func defaultSubnetSet(t *testing.T) {
 
 	// 7. Check deleting NSX subnet tags.
 	delete(ns.Labels, labelKey)
-	ns, err = testData.clientset.CoreV1().Namespaces().Update(context.TODO(), ns, v1.UpdateOptions{})
+	_, err = testData.clientset.CoreV1().Namespaces().Update(context.TODO(), ns, v1.UpdateOptions{})
 	time.Sleep(5 * time.Second)
 	assert_nil(t, err)
 	vpcSubnet, err = testData.nsxClient.SubnetsClient.Get(vpcInfo.OrgID, vpcInfo.ProjectID, vpcInfo.VPCID, vpcInfo.ID)
@@ -147,6 +148,7 @@ func userSubnetSet(t *testing.T) {
 	// 1. Check SubnetSet created by user.
 	subnetSetPath, _ := filepath.Abs("./manifest/testSubnet/subnetset.yaml")
 	err := applyYAML(subnetSetPath, E2ENamespace)
+	assert_nil(t, err)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SubnetSetCRType, E2ENamespace, UserSubnetSet, Ready)
 	assert_nil(t, err)
 
@@ -166,6 +168,7 @@ func userSubnetSet(t *testing.T) {
 	// 4. Check NSX subnet allocation.
 	subnetPath := subnetSet.Status.Subnets[0].NSXResourcePath
 	vpcInfo, err := common.ParseVPCResourcePath(subnetPath)
+	assert_nil(t, err, "Failed to parse VPC resource path %s", subnetPath)
 	_, err = testData.nsxClient.SubnetsClient.Get(vpcInfo.OrgID, vpcInfo.ProjectID, vpcInfo.VPCID, vpcInfo.ID)
 	assert_nil(t, err, "Failed to get VPC subnet %s", vpcInfo.ID)
 }

--- a/test/e2e/providers/remote.go
+++ b/test/e2e/providers/remote.go
@@ -56,7 +56,7 @@ func convertConfig(inConfig *ssh_config.Config, name string) (string, *ssh.Clien
 	if err != nil {
 		return "", nil, fmt.Errorf("unable to parse private key from file '%s': %v", identityFile, err)
 	}
-
+	// #nosec G106: we are using ssh.InsecureIgnoreHostKey, but this is test code
 	config := &ssh.ClientConfig{
 		User:            values["User"],
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},


### PR DESCRIPTION
Tests done:
lxiaopei@lxiaopei05N6R nsx-operator % make golangci
===> Running golangci (linux) <===
lxiaopei@lxiaopei05N6R nsx-operator % make build
/Users/lxiaopei/go_project/nsx-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."

===> Formatting Go files <===
go vet ./...
GOOS=linux go build -o /Users/lxiaopei/go_project/nsx-operator/bin  -ldflags '' cmd/main.go
lxiaopei@lxiaopei05N6R nsx-operator % make all
/Users/lxiaopei/go_project/nsx-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."

===> Formatting Go files <===
go vet ./...
GOOS=linux go build -o /Users/lxiaopei/go_project/nsx-operator/bin  -ldflags '' cmd/main.go