### PR TITLE
Use v0.0.1 tag of pkg/apis and pkg/client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 bin/
 .DS_Store
+go.work
+go.work.sum

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.19
 replace (
 	github.com/vmware-tanzu/nsx-operator/pkg/apis => ./pkg/apis
 	github.com/vmware-tanzu/nsx-operator/pkg/client => ./pkg/client
-	github.com/vmware/go-vmware-nsxt => github.com/mengdie-song/go-vmware-nsxt v0.0.0-20220921033217-dbd234470e30 // inventory-keeper includes all commits from github.com/gran-vmv/go-vmware-nsxt v0.0.0-20211206034609-cd7ffaf2c996
 )
 
 require (
@@ -24,7 +23,7 @@ require (
 	github.com/prometheus/client_golang v1.16.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.2
-	github.com/vmware-tanzu/nsx-operator/pkg/apis v1.0.0
+	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.1
 	github.com/vmware-tanzu/nsx-operator/pkg/client v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/vm-operator/api v1.8.2
 	github.com/vmware/govmomi v0.27.4

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -3,7 +3,7 @@ module github.com/vmware-tanzu/nsx-operator/pkg/client
 go 1.19
 
 require (
-	github.com/vmware-tanzu/nsx-operator/pkg/apis v1.0.0
+	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.1
 	k8s.io/apimachinery v0.28.4
 	k8s.io/client-go v0.28.4
 )

--- a/pkg/client/go.sum
+++ b/pkg/client/go.sum
@@ -70,8 +70,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/vmware-tanzu/nsx-operator/pkg/apis v1.0.0 h1:jmHI88hySjGqkpc/QUmSY5G5SsDvoXxmKFEK/GmcHWs=
-github.com/vmware-tanzu/nsx-operator/pkg/apis v1.0.0/go.mod h1:ZR/7rewflpAhnswQ6NVkFN0JmaqHgmvDyFVsJLmZ+pw=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.1 h1:z5hr4FZm2AGkmkwqRjk1QQr5JUBdU7YzN+t5mKaa76s=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.1/go.mod h1:j8vSYBnN83WIaLIW6BKD2IHiI0MMpd4lPxefpA00CzI=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
Has tagged v0.0.1 of pkg/apis and pkg/client, which are based on latest main branch, so update go.mod and pkg/client/go.mod.