### PR TITLE
Support NSX thumbprint in SHA-256 format

### DIFF
--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -4,7 +4,6 @@
 package nsx
 
 import (
-	"crypto/sha1"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -180,12 +179,7 @@ func (cluster *Cluster) createTransport(idle time.Duration) *Transport {
 					VerifyConnection: func(cs tls.ConnectionState) error {
 						// not check thumbprint if no thumbprint config
 						if tpCount > 0 {
-							fingerprint := calcFingerprint(cs.PeerCertificates[0].Raw)
-							if strings.Compare(fingerprint, thumbprint) == 0 {
-								return nil
-							} else {
-								err := errors.New("server certificate didn't match trusted fingerprint")
-								log.Error(err, "verify thumbprint", "address", addr, "server thumbprint", fingerprint, "local thumbprint", thumbprint)
+							if err := util.VerifyNsxCertWithThumbprint(cs.PeerCertificates[0].Raw, thumbprint); err != nil {
 								return err
 							}
 						}
@@ -208,18 +202,6 @@ func (cluster *Cluster) createTransport(idle time.Duration) *Transport {
 		}
 	}
 	return &Transport{Base: tr}
-}
-
-func calcFingerprint(der []byte) string {
-	hash := sha1.Sum(der)
-	hex := make([]byte, len(hash)*3)
-	for i, data := range hash {
-		buf := []byte(fmt.Sprintf("%02X", data))
-		hex[i*3] = buf[0]
-		hex[i*3+1] = buf[1]
-		hex[i*3+2] = byte(':')
-	}
-	return string(hex[:len(hex)-1])
 }
 
 func (cluster *Cluster) createHTTPClient(tr *Transport, timeout time.Duration) *http.Client {

--- a/pkg/nsx/cluster_test.go
+++ b/pkg/nsx/cluster_test.go
@@ -113,26 +113,6 @@ func TestCluster_createTransport(t *testing.T) {
 	assert.NotNil(t, c.createTransport(10))
 }
 
-func Test_calcFingerprint(t *testing.T) {
-	type args struct {
-		der []byte
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{"1", args{der: []byte("It is byte.")}, "5C:1D:AE:31:3A:EA:74:74:FE:69:BA:9F:0B:1D:86:5E:39:97:43:4F"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := calcFingerprint(tt.args.der); got != tt.want {
-				t.Errorf("calcFingerprint() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestCluster_Health(t *testing.T) {
 	cluster := &Cluster{}
 	addr := &address{host: "10.0.0.1", scheme: "https"}

--- a/pkg/nsx/util/utils_test.go
+++ b/pkg/nsx/util/utils_test.go
@@ -194,3 +194,54 @@ func TestVCClient_handleHTTPResponse(t *testing.T) {
 	_, ok := err.(*json.UnmarshalTypeError)
 	assert.Equal(t, ok, true)
 }
+
+func TestVerifyNsxCertWithThumbprint(t *testing.T) {
+	type args struct {
+		der        []byte
+		thumbprint string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "SHA-1",
+			args: args{
+				der:        []byte("It is byte."),
+				thumbprint: "5C:1D:AE:31:3A:EA:74:74:FE:69:BA:9F:0B:1D:86:5E:39:97:43:4F"},
+			wantErr: false,
+		},
+		{
+			name: "SHA-256",
+			args: args{
+				der:        []byte("It is byte."),
+				thumbprint: "2F:CB:42:CD:71:96:A2:47:D2:BC:8B:A9:A6:2F:E0:97:BF:4A:5E:2C:45:8F:1C:BE:5B:1F:4D:36:8B:DD:06:25"},
+			wantErr: false,
+		},
+		{
+			name: "SHA mismatched",
+			args: args{
+				der:        []byte("It is another byte."),
+				thumbprint: "2F:CB:42:CD:71:96:A2:47:D2:BC:8B:A9:A6:2F:E0:97:BF:4A:5E:2C:45:8F:1C:BE:5B:1F:4D:36:8B:DD:06:25"},
+			wantErr: true,
+		},
+		{
+			name: "malformed fingerprint",
+			args: args{
+				der:        []byte("It is byte."),
+				thumbprint: "2F:CB:42:CD:71:96:A2:47:D2:BC:8B:A9:A6:2F:E0:97"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := VerifyNsxCertWithThumbprint(tt.args.der, tt.args.thumbprint)
+			if tt.wantErr {
+				assert.Error(t, err, "VerifyNsxCertWithThumbprint expected err returned")
+			} else {
+				assert.NoError(t, err, "VerifyNsxCertWithThumbprint expected no error returned")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR makes nsx-operator to support NSX thumbprint in both SHA-256 and SHA-1 format, which is already supported by NCP.

Verified on WCP env with configmap thumbprint set to SHA-256.