### PR TITLE
Support NSX thumbprint in SHA-256 format

### DIFF
--- a/pkg/nsx/cluster_test.go
+++ b/pkg/nsx/cluster_test.go
@@ -113,26 +113,6 @@ func TestCluster_createTransport(t *testing.T) {
 	assert.NotNil(t, c.createTransport(10))
 }
 
-func Test_calcFingerprint(t *testing.T) {
-	type args struct {
-		der []byte
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{"1", args{der: []byte("It is byte.")}, "5C:1D:AE:31:3A:EA:74:74:FE:69:BA:9F:0B:1D:86:5E:39:97:43:4F"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := calcFingerprint(tt.args.der); got != tt.want {
-				t.Errorf("calcFingerprint() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestCluster_Health(t *testing.T) {
 	cluster := &Cluster{}
 	addr := &address{host: "10.0.0.1", scheme: "https"}

--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -4,6 +4,9 @@
 package util
 
 import (
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -359,4 +362,30 @@ func castApiError(apiErrorDataValue *data.StructValue) *model.ApiError {
 
 func isEmptyAPIError(apiError model.ApiError) bool {
 	return (apiError.ErrorCode == nil && apiError.ErrorMessage == nil)
+}
+
+func VerifyNsxCertWithThumbprint(der []byte, thumbprint string) error {
+	tbRaw := strings.ToLower(strings.TrimSpace(strings.ReplaceAll(thumbprint, ":", "")))
+	var tbFromCert string
+	if len(tbRaw) == 40 {
+		// SHA-1
+		digest := sha1.Sum(der) // #nosec G401: not used
+		tbFromCert = hex.EncodeToString(digest[:])
+	} else if len(tbRaw) == 64 {
+		// SHA-256
+		digest := sha256.Sum256(der)
+		tbFromCert = hex.EncodeToString(digest[:])
+	} else {
+		err := errors.New("invalid thumbprint format")
+		log.Error(err, "unknown thumbprint length", "thumbprint", tbRaw)
+		return err
+	}
+
+	if strings.Compare(tbRaw, tbFromCert) == 0 {
+		return nil
+	}
+
+	err := errors.New("server certificate didn't match trusted fingerprint")
+	log.Error(err, "verify thumbprint", "server", tbFromCert, "local", tbRaw)
+	return err
 }

--- a/pkg/nsx/util/utils_test.go
+++ b/pkg/nsx/util/utils_test.go
@@ -192,3 +192,54 @@ func TestVCClient_handleHTTPResponse(t *testing.T) {
 	_, ok := err.(*json.UnmarshalTypeError)
 	assert.Equal(t, ok, true)
 }
+
+func TestVerifyNsxCertWithThumbprint(t *testing.T) {
+	type args struct {
+		der        []byte
+		thumbprint string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "SHA-1",
+			args: args{
+				der:        []byte("It is byte."),
+				thumbprint: "5C:1D:AE:31:3A:EA:74:74:FE:69:BA:9F:0B:1D:86:5E:39:97:43:4F"},
+			wantErr: false,
+		},
+		{
+			name: "SHA-256",
+			args: args{
+				der:        []byte("It is byte."),
+				thumbprint: "2F:CB:42:CD:71:96:A2:47:D2:BC:8B:A9:A6:2F:E0:97:BF:4A:5E:2C:45:8F:1C:BE:5B:1F:4D:36:8B:DD:06:25"},
+			wantErr: false,
+		},
+		{
+			name: "SHA mismatched",
+			args: args{
+				der:        []byte("It is another byte."),
+				thumbprint: "2F:CB:42:CD:71:96:A2:47:D2:BC:8B:A9:A6:2F:E0:97:BF:4A:5E:2C:45:8F:1C:BE:5B:1F:4D:36:8B:DD:06:25"},
+			wantErr: true,
+		},
+		{
+			name: "malformed fingerprint",
+			args: args{
+				der:        []byte("It is byte."),
+				thumbprint: "2F:CB:42:CD:71:96:A2:47:D2:BC:8B:A9:A6:2F:E0:97"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := VerifyNsxCertWithThumbprint(tt.args.der, tt.args.thumbprint)
+			if tt.wantErr {
+				assert.Error(t, err, "VerifyNsxCertWithThumbprint expected err returned")
+			} else {
+				assert.NoError(t, err, "VerifyNsxCertWithThumbprint expected no error returned")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is a cherry-pick of #428 into 4.1.2 branch for consumption with WCP main.