### PR TITLE
envoy support

### DIFF
--- a/cmd_clean/main.go
+++ b/cmd_clean/main.go
@@ -15,8 +15,17 @@ import (
 )
 
 // usage:
-// ./bin/clean -cluster=''  -thumbprint="" -log-level=0 -vc-user="" -vc-passwd="" -vc-endpoint="" -vc-sso-domain="" -vc-https-port=443  -mgr-ip=""
-
+// normal mode:
+//
+// ./bin/clean -cluster=”  -thumbprint="" -log-level=0 -vc-user="" -vc-passwd="" -vc-endpoint="" -vc-sso-domain="" -vc-https-port=443  -mgr-ip=""
+//
+// envoy ca file mode:
+//
+//	./clean -cluster=domain-c9:d75735a3-2847-45d2-a652-ef2d146afd54 -nsx-user=admin -nsx-passwd='xxx'  -mgr-ip=nsxmanager-ob-22386469-1-dev-integ-nsxt-8791 -envoyhost=localhost -envoyport=1080 -log-level=1 -ca-file=./ca.cert
+//
+// envoy thumbprint mode:
+//
+//	./clean -cluster=domain-c9:d75735a3-2847-45d2-a652-ef2d146afd54 -nsx-user=admin -nsx-passwd='xxx'  -mgr-ip=nsxmanager-ob-22386469-1-dev-integ-nsxt-8791 -envoyhost=localhost -envoyport=1080 -log-level=1 -thumbprint=8bc2fa2b5879c27b1180fa44e5f747832f2ded6be483e3c3d2c4816a38870868
 var (
 	log         = logger.Log
 	cf          *config.NSXOperatorConfig
@@ -31,12 +40,14 @@ var (
 	thumbprint  string
 	caFile      string
 	cluster     string
+	envoyHost   string
+	envoyPort   int
 )
 
 func main() {
-	flag.StringVar(&vcEndpoint, "vc-endpoint", "", "nsx manager ip")
-	flag.StringVar(&vcSsoDomain, "vc-sso-domain", "", "nsx manager ip")
-	flag.StringVar(&mgrIp, "mgr-ip", "", "nsx manager ip")
+	flag.StringVar(&vcEndpoint, "vc-endpoint", "", "vc endpoint")
+	flag.StringVar(&vcSsoDomain, "vc-sso-domain", "", "vc sso domain")
+	flag.StringVar(&mgrIp, "mgr-ip", "", "nsx manager ip, it should be host name if want to verify cert")
 	flag.StringVar(&vcUser, "vc-user", "", "vc username")
 	flag.StringVar(&vcPasswd, "vc-passwd", "", "vc password")
 	flag.IntVar(&vcHttpsPort, "vc-https-port", 443, "vc https port")
@@ -45,6 +56,8 @@ func main() {
 	flag.StringVar(&nsxPasswd, "nsx-passwd", "", "nsx password")
 	flag.StringVar(&caFile, "ca-file", "", "ca file")
 	flag.StringVar(&cluster, "cluster", "", "cluster name")
+	flag.StringVar(&envoyHost, "envoyhost", "", "envoy host")
+	flag.IntVar(&envoyPort, "envoyport", 0, "envoy port")
 	flag.IntVar(&config.LogLevel, "log-level", 0, "Use zap-core log system.")
 	flag.Parse()
 
@@ -60,6 +73,8 @@ func main() {
 	cf.Thumbprint = []string{thumbprint}
 	cf.CaFile = []string{caFile}
 	cf.Cluster = cluster
+	cf.EnvoyHost = envoyHost
+	cf.EnvoyPort = envoyPort
 
 	logf.SetLogger(logger.ZapLogger(cf.DefaultConfig.Debug, config.LogLevel))
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,6 +100,8 @@ type NsxConfig struct {
 	ExternalIPv4Blocks   []string `ini:"external_ipv4_blocks"`
 	DefaultSubnetSize    int      `ini:"default_subnet_size"`
 	DefaultTimeout       int      `ini:"default_timeout"`
+	EnvoyHost            string   `ini:"envoy_host"`
+	EnvoyPort            int      `ini:"envoy_port"`
 }
 
 type K8sConfig struct {
@@ -245,7 +247,7 @@ func (operatorConfig *NSXOperatorConfig) createTokenProvider() error {
 		// If operatorConfig.VCInsecure is false, tls will use the CA to verify the server
 		// certificate. If loading CA failed, tls will use the CA on local host
 		if err != nil {
-			configLog.Info("fail to load CA cert from file", "error", err)
+			configLog.Info("fail to load CA cert from file.", " error: ", err)
 		}
 	}
 
@@ -306,6 +308,11 @@ func (nsxConfig *NsxConfig) validateCert() error {
 	// ca file(thumbprint) == 1 or equal to manager count
 	if caCount == 0 && tpCount == 0 && nsxConfig.NsxApiUser == "" && nsxConfig.NsxApiPassword == "" {
 		err := errors.New("no ca file or thumbprint or nsx username/password provided")
+		configLog.Error(err, "validate NsxConfig failed")
+		return err
+	}
+	if nsxConfig.EnvoyPort != 0 && caCount == 0 && tpCount == 0 {
+		err := errors.New("no ca file or thumbprint while using envoy mode")
 		configLog.Error(err, "validate NsxConfig failed")
 		return err
 	}

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -129,6 +129,8 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 	}
 	c := NewConfig(strings.Join(cf.NsxApiManagers, ","), cf.NsxApiUser, cf.NsxApiPassword, cf.CaFile, 10, 3, defaultHttpTimeout, 20, true, true, true,
 		ratelimiter.AIMD, cf.GetTokenProvider(), nil, cf.Thumbprint)
+	c.EnvoyHost = cf.EnvoyHost
+	c.EnvoyPort = cf.EnvoyPort
 	cluster, _ := NewCluster(c)
 
 	queryClient := search.NewQueryClient(restConnector(cluster))

--- a/pkg/nsx/config.go
+++ b/pkg/nsx/config.go
@@ -55,6 +55,8 @@ type Config struct {
 	TokenProvider auth.TokenProvider
 	// None, or ClientCertProvider object. If specified, client cert will be used instead of basic authentication.
 	ClientCertProvider auth.ClientCertProvider
+	EnvoyHost          string
+	EnvoyPort          int
 }
 
 // NewConfig creates a nsx configuration. It provides default values for those items not in function parameters.

--- a/pkg/nsx/transport.go
+++ b/pkg/nsx/transport.go
@@ -42,8 +42,9 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 			ep.increaseConnNumber()
 			defer ep.decreaseConnNumber()
 
-			r.URL.Host = ep.Host()
+			util.UpdateRequestURL(r.URL, ep.Host(), ep.Thumbprint)
 			ep.UpdateHttpRequestAuth(r)
+			ep.UpdateCAforEnvoy(r)
 			start := time.Now()
 			ep.wait()
 			util.DumpHttpRequest(r)

--- a/pkg/nsx/util/utils_test.go
+++ b/pkg/nsx/util/utils_test.go
@@ -454,3 +454,25 @@ Lcw=
 		})
 	}
 }
+
+func TestUpdateRequestURL(t *testing.T) {
+	// updating host
+	a := "/test1/test2/test3"
+	c := strings.Split(a, "/")
+	assert.Equal(t, c[0], "")
+	reqUrl, _ := url.Parse("https://10.186.66.241/policy/api/v1/search/query")
+	newHost := "newhost"
+	newTP := "AA004DFC146CE84FE4B8B99DDF14170202DE1BDC"
+	UpdateRequestURL(reqUrl, newHost, newTP)
+	assert.Equal(t, newHost, reqUrl.Host)
+
+	// updating path, thumbprint
+	reqUrl, _ = url.Parse("http://localhost:1080/external-tp/http1/10.186.66.241/443/F8004DFC146CE84FE4B8B99DDF14170202DE1BDC")
+	UpdateRequestURL(reqUrl, newHost, newTP)
+	assert.Equal(t, "/external-tp/http1/newhost/443/AA004DFC146CE84FE4B8B99DDF14170202DE1BDC", reqUrl.Path)
+
+	// updating path, ca
+	reqUrl, _ = url.Parse("http://localhost:1080/external-cert/http1/10.186.66.241/443/policy/api/v1/search/")
+	UpdateRequestURL(reqUrl, newHost, newTP)
+	assert.Equal(t, "/external-cert/http1/newhost/443/policy/api/v1/search/", reqUrl.Path)
+}


### PR DESCRIPTION
Support using internal VC envoy.
if EnvoyPort != 0, create an url is which envoy specific 
Using ca to verify server cert needs ultra header.

Test Done:
    1. ca file mode:
    ./clean -cluster=domain-c9:d75735a3-2847-45d2-a652-ef2d146afd54 -nsx-user=admin -nsx-passwd='xxx'  -mgr-ip=nsxmanager-ob-22386469-1-dev-integ-nsxt-8791  -envoyhost=localhost -envoyport=1080 -log-level=1 -ca-file=./ca.cert
    2. thumbprint mode:
    ./clean -cluster=domain-c9:d75735a3-2847-45d2-a652-ef2d146afd54 -nsx-user=admin -nsx-passwd='xxx'  -mgr-ip=nsxmanager-ob-22386469-1-dev-integ-nsxt-8791  -envoyhost=localhost -envoyport=1080 -log-level=1 -thumbprint=8bc2fa2b5879c27b1180fa44e5f747832f2ded6be483e3c3d2c4816a38870868
