### PR TITLE
Add shortID in VPCNetworkConfiguration CR

### DIFF
--- a/build/yaml/crd/nsx.vmware.com_vpcnetworkconfigurations.yaml
+++ b/build/yaml/crd/nsx.vmware.com_vpcnetworkconfigurations.yaml
@@ -89,6 +89,11 @@ spec:
                 maxItems: 5
                 minItems: 0
                 type: array
+              shortID:
+                description: ShortID specifies Identifier to use when displaying VPC
+                  context in logs. Less than equal to 8 characters.
+                maxLength: 8
+                type: string
             type: object
           status:
             description: VPCNetworkConfigurationStatus defines the observed state

--- a/pkg/apis/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/v1alpha1/vpcnetworkconfiguration_types.go
@@ -41,6 +41,11 @@ type VPCNetworkConfigurationSpec struct {
 	// Must be Public or Private.
 	// +kubebuilder:validation:Enum=Public;Private
 	DefaultSubnetAccessMode string `json:"defaultSubnetAccessMode,omitempty"`
+	// ShortID specifies Identifier to use when displaying VPC context in logs.
+	// Less than equal to 8 characters.
+	// +kubebuilder:validation:MaxLength=8
+	// +optional
+	ShortID string `json:"shortID,omitempty"`
 }
 
 // VPCNetworkConfigurationStatus defines the observed state of VPCNetworkConfiguration

--- a/pkg/controllers/vpc/vpc_utils.go
+++ b/pkg/controllers/vpc/vpc_utils.go
@@ -139,6 +139,7 @@ func buildNetworkConfigInfo(vpcConfigCR v1alpha1.VPCNetworkConfiguration) (*vpc.
 		PrivateIPv4CIDRs:        vpcConfigCR.Spec.PrivateIPv4CIDRs,
 		DefaultIPv4SubnetSize:   vpcConfigCR.Spec.DefaultIPv4SubnetSize,
 		DefaultSubnetAccessMode: vpcConfigCR.Spec.DefaultSubnetAccessMode,
+		ShortID:                 vpcConfigCR.Spec.ShortID,
 	}
 	return ninfo, nil
 }

--- a/pkg/nsx/services/vpc/builder.go
+++ b/pkg/nsx/services/vpc/builder.go
@@ -81,6 +81,9 @@ func buildNSXVPC(obj *v1alpha1.VPC, nc VPCNetworkConfigInfo, cluster string, pat
 	// update private/public blocks
 	vpc.ExternalIpv4Blocks = nc.ExternalIPv4Blocks
 	vpc.PrivateIpv4Blocks = util.GetMapValues(pathMap)
+	if nc.ShortID != "" {
+		vpc.ShortId = &nc.ShortID
+	}
 
 	return vpc, nil
 }

--- a/pkg/nsx/services/vpc/types.go
+++ b/pkg/nsx/services/vpc/types.go
@@ -10,4 +10,5 @@ type VPCNetworkConfigInfo struct {
 	PrivateIPv4CIDRs        []string
 	DefaultIPv4SubnetSize   int
 	DefaultSubnetAccessMode string
+	ShortID                 string
 }


### PR DESCRIPTION
Add shortID in VPCNetworkConfiguration CR for user to input short log identifer they want to use to isolate VPC logs.