### PR TITLE
Change go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/nsx-operator
 
-go 1.21.5
+go 1.21
 
 replace (
 	github.com/vmware-tanzu/nsx-operator/pkg/apis => ./pkg/apis


### PR DESCRIPTION
This is to change go version in go.mod, for other components depends on nsx-operator module.