### PR TITLE
Add make clean library in Dockerfile

### DIFF
--- a/build/image/photon/Dockerfile
+++ b/build/image/photon/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /source
 
 COPY . /source
 RUN CGO_ENABLED=0 go build -o manager cmd/main.go
+RUN CGO_ENABLED=0 go build -o clean cmd_clean/main.go
 
 FROM photon
 
@@ -11,6 +12,7 @@ RUN tdnf -y install shadow && \
     useradd -s /bin/bash nsx-operator
 
 COPY --from=golang-build /source/manager /usr/local/bin/
+COPY --from=golang-build /source/clean /usr/local/bin/
 
 USER nsx-operator
 


### PR DESCRIPTION
The background is we want to run clean process in e2e CI pipeline, so make the binary in Dockerfile and it would be triggered in the container of testbed when running e2e pipeline.