### PR TITLE
Fix ServerName set condition and add log for WCP cert check

### DIFF
--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -170,7 +170,8 @@ func (cluster *Cluster) createTransport(idle time.Duration) *Transport {
 					RootCAs: certPool,
 				}
 				// Bypass CN / SAN verification by setting tls config ServerName to the one in cert
-				if cn, err := util.GetCommonNameFromLeafCert(caCert); err != nil {
+				if cn, err := util.GetCommonNameFromLeafCert(caCert); err == nil {
+					log.Info("pinned common name for manager", "cn", cn, "addr", addr)
 					config.ServerName = cn
 				}
 			} else {


### PR DESCRIPTION
This change fixes an overlook of err check on main branch and adds a log message, making it in sync with the change on 4.1.2 branch.