### PR TITLE
Set staticIPAllocation enable true for e2e subnetset test yaml

### DIFF
--- a/test/e2e/manifest/testSubnet/subnetset.yaml
+++ b/test/e2e/manifest/testSubnet/subnetset.yaml
@@ -3,3 +3,7 @@ kind: SubnetSet
 metadata:
   name: user-pod-subnetset
   namespace: subnet-e2e
+spec:
+  advancedConfig:
+    staticIPAllocation:
+      enable: true


### PR DESCRIPTION
When realize subnet port, if enable is not true, nsx would report error LogicalSwitch 1c104366-7266-4035-856c-27a0e10500ce does not have IpPoolId needed by LogicalPort 'StaticIpAllocationDto{enabled='false'}'}'