### PR TITLE
Subnet service refactor

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/ippool"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/nsxserviceaccount"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy"
+	subnetservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnet"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
 )
 
@@ -196,15 +197,20 @@ func main() {
 			log.Error(err, "failed to initialize vpc commonService", "controller", "VPC")
 			os.Exit(1)
 		}
+		subnetService, err := subnetservice.InitializeSubnetService(commonService)
+		if err != nil {
+			log.Error(err, "failed to initialize subnet commonService")
+			os.Exit(1)
+		}
 		commonctl.ServiceMediator.VPCService = vpcService
 		// Start controllers which only supports VPC
 		StartVPCController(mgr, vpcService)
 		StartNamespaceController(mgr, vpcService)
 		// Start subnet/subnetset controller.
-		if err := subnet.StartSubnetController(mgr, commonService); err != nil {
+		if err := subnet.StartSubnetController(mgr, subnetService); err != nil {
 			os.Exit(1)
 		}
-		if err := subnetset.StartSubnetSetController(mgr, commonService); err != nil {
+		if err := subnetset.StartSubnetSetController(mgr, subnetService); err != nil {
 			os.Exit(1)
 		}
 

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -285,12 +285,12 @@ func (r *SubnetReconciler) setupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func StartSubnetController(mgr ctrl.Manager, commonService servicecommon.Service) error {
+func StartSubnetController(mgr ctrl.Manager, subnetService *subnet.SubnetService) error {
 	subnetReconciler := &SubnetReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}
-	subnetReconciler.Service = subnet.GetSubnetService(commonService)
+	subnetReconciler.Service = subnetService
 	common.ServiceMediator.SubnetService = subnetReconciler.Service
 	if err := subnetReconciler.Start(mgr); err != nil {
 		log.Error(err, "failed to create controller", "controller", "Subnet")

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -300,12 +300,12 @@ func (r *SubnetSetReconciler) DeleteSubnetForSubnetSet(obj v1alpha1.SubnetSet, u
 	return nil
 }
 
-func StartSubnetSetController(mgr ctrl.Manager, commonService servicecommon.Service) error {
+func StartSubnetSetController(mgr ctrl.Manager, subnetService *subnet.SubnetService) error {
 	subnetsetReconciler := &SubnetSetReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}
-	subnetsetReconciler.Service = subnet.GetSubnetService(commonService)
+	subnetsetReconciler.Service = subnetService
 	if err := subnetsetReconciler.Start(mgr); err != nil {
 		log.Error(err, "failed to create controller", "controller", "Subnet")
 		return err

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -42,25 +41,6 @@ type SubnetParameters struct {
 	OrgID     string
 	ProjectID string
 	VPCID     string
-}
-
-var subnetService *SubnetService
-var lock = &sync.Mutex{}
-
-// GetSubnetService get singleton SubnetService instance, subnet/subnetset controller share the same instance.
-func GetSubnetService(service common.Service) *SubnetService {
-	if subnetService == nil {
-		lock.Lock()
-		defer lock.Unlock()
-		if subnetService == nil {
-			var err error
-			if subnetService, err = InitializeSubnetService(service); err != nil {
-				log.Error(err, "failed to initialize subnet commonService")
-				os.Exit(1)
-			}
-		}
-	}
-	return subnetService
 }
 
 // InitializeSubnetService initialize Subnet service.


### PR DESCRIPTION
Initialize subnet service once then inject it to multiple reconcilers instead of initializing service in different reconcilers with a lock ensuring the initialization is invoked once.

https://github.com/tnqn/nsx-operator/pull/1#discussion_r1293271402