### PR TITLE
Refactor e2e test

### DIFF
--- a/test/e2e/nsx_ippool_test.go
+++ b/test/e2e/nsx_ippool_test.go
@@ -30,30 +30,30 @@ func TestIPPoolBasic(t *testing.T) {
 
 	// Check ippool status
 	err := testData.waitForCRReadyOrDeleted(defaultTimeout, IPPool, ns, name, Ready)
-	assert_nil(t, err, "Error when waiting for IPPool %s", name)
+	assertNil(t, err, "Error when waiting for IPPool %s", name)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPool, name, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_1, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_2, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_3, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Delete ippool
 	_ = deleteYAML(ippoolPath, ns)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPool, name, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_1, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_2, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_3, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 }
 
 // TestIPPoolAddDeleteSubnet verifies that it is as expected when adding or deleting some subnets.
@@ -73,17 +73,17 @@ func TestIPPoolAddDeleteSubnet(t *testing.T) {
 
 	// Check ippool status
 	err := testData.waitForCRReadyOrDeleted(defaultTimeout, IPPool, ns, name, Ready)
-	assert_nil(t, err, "Error when waiting for IPPool %s", name)
+	assertNil(t, err, "Error when waiting for IPPool %s", name)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPool, name, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_1, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_2, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_3, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Delete subnet_name_2 and subnet_name_3
 	ippoolDeletePath, _ := filepath.Abs("./manifest/testIPPool/ippool_delete.yaml")
@@ -91,36 +91,36 @@ func TestIPPoolAddDeleteSubnet(t *testing.T) {
 
 	// Check ippool status
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, IPPool, ns, name, Ready)
-	assert_nil(t, err, "Error when waiting for IPPool %s", name)
+	assertNil(t, err, "Error when waiting for IPPool %s", name)
 
 	// Check nsx-t resource existing and not existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPool, name, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	// Still existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_1, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	// Deleted
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_2, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	// Deleted
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_3, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Add back subnet_name_2 and subnet_name_3
 	_ = applyYAML(ippoolPath, ns)
 	// Check ippool status
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, IPPool, ns, name, Ready)
-	assert_nil(t, err, "Error when waiting for IPPool %s", name)
+	assertNil(t, err, "Error when waiting for IPPool %s", name)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPool, name, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_1, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_2, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPoolBlockSubnet, subnet_name_3, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 }
 
 // TestIPPoolBasic verifies that it could support when subnets are nil
@@ -137,16 +137,16 @@ func TestIPPoolSubnetsNil(t *testing.T) {
 
 	// Check ippool status
 	err := testData.waitForCRReadyOrDeleted(defaultTimeout, IPPool, ns, name, Ready)
-	assert_nil(t, err, "Error when waiting for IPPool %s", name)
+	assertNil(t, err, "Error when waiting for IPPool %s", name)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPool, name, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Delete ippool
 	_ = deleteYAML(ippoolPath, ns)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeIPPool, name, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 }

--- a/test/e2e/nsx_security_policy_test.go
+++ b/test/e2e/nsx_security_policy_test.go
@@ -47,46 +47,46 @@ func TestSecurityPolicyBasicTraffic(t *testing.T) {
 	// Wait for pods
 	ps, err := testData.podWaitForIPs(defaultTimeout, busybox, ns)
 	t.Logf("Pods are %v", ps)
-	assert_nil(t, err, "Error when waiting for IP for Pod %s", busybox)
+	assertNil(t, err, "Error when waiting for IP for Pod %s", busybox)
 	iPs, err := testData.podWaitForIPs(defaultTimeout, ncPod, ns)
 	t.Logf("Pods are %v", iPs)
-	assert_nil(t, err, "Error when waiting for IP for Pod %s", ncPod)
+	assertNil(t, err, "Error when waiting for IP for Pod %s", ncPod)
 
 	// Ping from pod
 	err = testData.runPingCommandFromPod(ns, busybox, iPs, 4)
-	assert_nil(t, err, "Error when running ping command from test Pod %s", busybox)
+	assertNil(t, err, "Error when running ping command from test Pod %s", busybox)
 
 	// Create security policy
 	nsIsolationPath, _ := filepath.Abs("./manifest/testSecurityPolicy/ns-isolation-policy.yaml")
 	_ = applyYAML(nsIsolationPath, ns)
 	defer deleteYAML(nsIsolationPath, ns)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, ns, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeRule, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Ping from pod
 	err = testData.runPingCommandFromPod(ns, busybox, iPs, 4)
-	assert_notnil(t, err, "Error when running ping command from test Pod %s", busybox)
+	assertNotNil(t, err, "Error when running ping command from test Pod %s", busybox)
 
 	// Delete security policy
 	_ = deleteYAML(nsIsolationPath, ns)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, ns, securityPolicyName, Deleted)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeRule, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Ping from pod
 	err = testData.runPingCommandFromPod(ns, busybox, iPs, 4)
-	assert_nil(t, err, "Error when running ping command from test Pod %s", busybox)
+	assertNil(t, err, "Error when running ping command from test Pod %s", busybox)
 }
 
 // TestSecurityPolicyAddDeleteRule verifies that when adding or deleting rule, the security policy will be updated.
@@ -105,37 +105,37 @@ func TestSecurityPolicyAddDeleteRule(t *testing.T) {
 	_ = applyYAML(nsIsolationPath, ns)
 	defer deleteYAML(nsIsolationPath, ns)
 	err := testData.waitForCRReadyOrDeleted(defaultTimeout, SP, ns, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeRule, ruleName0, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeRule, ruleName1, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Update security policy
 	nsIsolationPath, _ = filepath.Abs("./manifest/testSecurityPolicy/ns-isolation-policy-1.yaml")
 	_ = applyYAML(nsIsolationPath, ns)
 	defer deleteYAML(nsIsolationPath, ns)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, ns, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeRule, ruleName0, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeRule, ruleName1, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Delete security policy
 	_ = deleteYAML(nsIsolationPath, ns)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, ns, securityPolicyName, Deleted)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 }
 
 // TestSecurityPolicyMatchExpression verifies that the traffic of security policy when match expression applied.
@@ -158,55 +158,55 @@ func TestSecurityPolicyMatchExpression(t *testing.T) {
 	// Wait for pods
 	ps, err := testData.podWaitForIPs(defaultTimeout, clientA, ns)
 	t.Logf("Pods are %v", ps)
-	assert_nil(t, err, "Error when waiting for IP for Pod %s", clientA)
+	assertNil(t, err, "Error when waiting for IP for Pod %s", clientA)
 	psb, err := testData.podWaitForIPs(defaultTimeout, clientB, ns)
 	t.Logf("Pods are %v", psb)
-	assert_nil(t, err, "Error when waiting for IP for Pod %s", clientB)
+	assertNil(t, err, "Error when waiting for IP for Pod %s", clientB)
 	iPs, err := testData.podWaitForIPs(defaultTimeout, podA, ns)
 	t.Logf("Pods are %v", iPs)
-	assert_nil(t, err, "Error when waiting for IP for Pod %s", podA)
+	assertNil(t, err, "Error when waiting for IP for Pod %s", podA)
 
 	// Ping from pod
 	err = testData.runPingCommandFromPod(ns, clientA, iPs, 4)
-	assert_nil(t, err, "Error when running ping command from Pod %s", clientA)
+	assertNil(t, err, "Error when running ping command from Pod %s", clientA)
 	err = testData.runPingCommandFromPod(ns, clientB, iPs, 4)
-	assert_nil(t, err, "Error when running ping command from Pod %s", clientB)
+	assertNil(t, err, "Error when running ping command from Pod %s", clientB)
 
 	// Create security policy
 	nsIsolationPath, _ := filepath.Abs("./manifest/testSecurityPolicy/match-expression.yaml")
 	_ = applyYAML(nsIsolationPath, ns)
 	defer deleteYAML(nsIsolationPath, ns)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, ns, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeRule, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Ping from pod
 	err = testData.runPingCommandFromPod(ns, clientA, iPs, 4)
-	assert_nil(t, err, "Error when running ping command from Pod %s", clientA)
+	assertNil(t, err, "Error when running ping command from Pod %s", clientA)
 	err = testData.runPingCommandFromPod(ns, clientB, iPs, 4)
 	assert.NotNilf(t, err, "Error when running ping command from Pod %s", clientB)
 
 	// Delete security policy
 	_ = deleteYAML(nsIsolationPath, ns)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, ns, securityPolicyName, Deleted)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeRule, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Ping from pod
 	err = testData.runPingCommandFromPod(ns, clientA, iPs, 4)
-	assert_nil(t, err, "Error when running ping command from Pod %s", clientA)
+	assertNil(t, err, "Error when running ping command from Pod %s", clientA)
 	err = testData.runPingCommandFromPod(ns, clientB, iPs, 4)
-	assert_nil(t, err, "Error when running ping command from Pod %s", clientB)
+	assertNil(t, err, "Error when running ping command from Pod %s", clientB)
 }
 
 // TestSecurityPolicyNamedPort0 verifies that the traffic of security policy when named port applied.
@@ -235,35 +235,35 @@ func TestSecurityPolicyNamedPort0(t *testing.T) {
 	// Wait for pods
 	ps, err := testData.podWaitForIPs(defaultTimeout, clientA, nsClient)
 	t.Logf("Pods are %v", ps)
-	assert_nil(t, err, "Error when waiting for IP for Pod %s", clientA)
+	assertNil(t, err, "Error when waiting for IP for Pod %s", clientA)
 	psb, _, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsWeb, labelWeb)
 	t.Logf("Pods are %v", psb)
-	assert_nil(t, err, "Error when waiting for IP for Pod %s", webA)
+	assertNil(t, err, "Error when waiting for IP for Pod %s", webA)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Nc from pod
 	err = testData.runNetcatCommandFromPod(nsClient, clientA, clientA, psb[0], 80)
-	assert_nil(t, err, "Error when running nc command from Pod %s", clientA)
+	assertNil(t, err, "Error when running nc command from Pod %s", clientA)
 	err = testData.runNetcatCommandFromPod(nsClient, clientA, clientA, psb[1], 80)
-	assert_nil(t, err, "Error when running nc command from Pod %s", clientA)
+	assertNil(t, err, "Error when running nc command from Pod %s", clientA)
 
 	// Delete all
 	_ = deleteYAML(podPath, "")
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Deleted)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 }
 
 // TestSecurityPolicyNamedPort1 verifies that the traffic of security policy when named port applied.
@@ -292,35 +292,35 @@ func TestSecurityPolicyNamedPort1(t *testing.T) {
 	// Wait for pods
 	ps, err := testData.podWaitForIPs(defaultTimeout, clientA, nsClient)
 	t.Logf("Pods are %v", ps)
-	assert_nil(t, err, "Error when waiting for IP for Pod %s", clientA)
+	assertNil(t, err, "Error when waiting for IP for Pod %s", clientA)
 	psb, _, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsWeb, labelWeb)
 	t.Logf("Pods are %v", psb)
-	assert_nil(t, err, "Error when waiting for IP for Pod %s", webA)
+	assertNil(t, err, "Error when waiting for IP for Pod %s", webA)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Nc from pod
 	err = testData.runNetcatCommandFromPod(nsClient, clientA, clientA, psb[0], 80)
-	assert_nil(t, err, "Error when running nc command from Pod %s", clientA)
+	assertNil(t, err, "Error when running nc command from Pod %s", clientA)
 	err = testData.runNetcatCommandFromPod(nsClient, clientA, clientA, psb[1], 80)
-	assert_nil(t, err, "Error when running nc command from Pod %s", clientA)
+	assertNil(t, err, "Error when running nc command from Pod %s", clientA)
 
 	// Delete all
 	_ = deleteYAML(podPath, "")
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Deleted)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 }
 
 // TestSecurityPolicyNamedPort2 verifies that the traffic of security policy when named port applied.
@@ -349,40 +349,40 @@ func TestSecurityPolicyNamedPort2(t *testing.T) {
 	// Wait for pods
 	ps, err := testData.podWaitForIPs(defaultTimeout, clientA, nsClient)
 	t.Logf("Pods are %v", ps)
-	assert_nil(t, err, "Error when waiting for IP for Pod %s", clientA)
+	assertNil(t, err, "Error when waiting for IP for Pod %s", clientA)
 	psb, _, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsWeb, labelWeb)
 	t.Logf("Pods are %v", psb)
-	assert_nil(t, err, "Error when waiting for IP for Pod %s", webA)
+	assertNil(t, err, "Error when waiting for IP for Pod %s", webA)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Label ns
 	cmd := fmt.Sprintf("kubectl label ns %s %s=%s --overwrite", clientA, "role", "client")
 	_, err = runCommand(cmd)
-	assert_nil(t, err, "Error when running command %s", cmd)
+	assertNil(t, err, "Error when running command %s", cmd)
 
 	// Nc from pod
 	err = testData.runNetcatCommandFromPod(nsClient, clientA, clientA, psb[0], 80)
-	assert_nil(t, err, "Error when running nc command from Pod %s", clientA)
+	assertNil(t, err, "Error when running nc command from Pod %s", clientA)
 	err = testData.runNetcatCommandFromPod(nsClient, clientA, clientA, psb[1], 80)
-	assert_nil(t, err, "Error when running nc command from Pod %s", clientA)
+	assertNil(t, err, "Error when running nc command from Pod %s", clientA)
 
 	// Delete all
 	_ = deleteYAML(podPath, "")
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Deleted)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 }
 
 // TestSecurityPolicyNamedPort3 verifies that the traffic of security policy when named port applied.
@@ -406,7 +406,7 @@ func TestSecurityPolicyNamedPort3(t *testing.T) {
 	// Label ns
 	cmd := fmt.Sprintf("kubectl label ns %s %s=%s --overwrite", nsDB, "role", "db")
 	_, err := runCommand(cmd)
-	assert_nil(t, err, "Error when running command %s", cmd)
+	assertNil(t, err, "Error when running command %s", cmd)
 
 	// Create all
 	podPath, _ := filepath.Abs("./manifest/testSecurityPolicy/rule-out-policy-applied-to-with-dst.yaml")
@@ -416,34 +416,34 @@ func TestSecurityPolicyNamedPort3(t *testing.T) {
 	// Wait for pods
 	ps, _, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsDB, labelDB)
 	t.Logf("Pods are %v", ps)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsDB)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsDB)
 
 	_, psb, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsWeb, labelWeb)
 	t.Logf("Pods are %v", psb)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsWeb)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsWeb)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Nc from pod
 	err = testData.runNetcatCommandFromPod(nsWeb, psb[0], containerName, ps[0], 3306)
-	assert_nil(t, err, "Error when running nc command from Pod %s", "web")
+	assertNil(t, err, "Error when running nc command from Pod %s", "web")
 
 	// Delete all
 	_ = deleteYAML(podPath, "")
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Deleted)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 }
 
 // TestSecurityPolicyNamedPort4 verifies that the traffic of security policy when named port applied.
@@ -467,7 +467,7 @@ func TestSecurityPolicyNamedPort4(t *testing.T) {
 	// Label ns
 	cmd := fmt.Sprintf("kubectl label ns %s %s=%s --overwrite", nsDB, "role", "db")
 	_, err := runCommand(cmd)
-	assert_nil(t, err, "Error when running command %s", cmd)
+	assertNil(t, err, "Error when running command %s", cmd)
 
 	// Create all
 	podPath, _ := filepath.Abs("./manifest/testSecurityPolicy/rule-out-rule-applied-to-with-dst.yaml")
@@ -477,34 +477,34 @@ func TestSecurityPolicyNamedPort4(t *testing.T) {
 	// Wait for pods
 	ps, _, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsDB, labelDB)
 	t.Logf("Pods are %v", ps)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsDB)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsDB)
 
 	_, psb, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsWeb, labelWeb)
 	t.Logf("Pods are %v", psb)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsWeb)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsWeb)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Nc from pod
 	err = testData.runNetcatCommandFromPod(nsWeb, psb[0], containerName, ps[0], 3306)
-	assert_nil(t, err, "Error when running nc command from Pod %s", "web")
+	assertNil(t, err, "Error when running nc command from Pod %s", "web")
 
 	// Delete all
 	_ = deleteYAML(podPath, "")
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Deleted)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 }
 
 // TestSecurityPolicyNamedPort5 verifies that the traffic of security policy when named port applied.
@@ -535,7 +535,7 @@ func TestSecurityPolicyNamedPort5(t *testing.T) {
 	// Label ns
 	cmd := fmt.Sprintf("kubectl label ns %s %s=%s --overwrite", nsDB, "role", "db")
 	_, err := runCommand(cmd)
-	assert_nil(t, err, "Error when running command %s", cmd)
+	assertNil(t, err, "Error when running command %s", cmd)
 
 	// Create all
 	podPath, _ := filepath.Abs("./manifest/testSecurityPolicy/rule-out-rule-applied-to-with-expression-selector.yaml")
@@ -545,57 +545,57 @@ func TestSecurityPolicyNamedPort5(t *testing.T) {
 	// Wait for pods
 	ps, _, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsDB, labelDB)
 	t.Logf("Pods are %v", ps)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsDB)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsDB)
 
 	ps2, _, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsDB2, labelDB2)
 	t.Logf("Pods are %v", ps2)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsDB2)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsDB2)
 
 	_, psb, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsWeb, labelWeb)
 	t.Logf("Pods are %v", psb)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsWeb)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsWeb)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Nc from pod
 	err = testData.runNetcatCommandFromPod(nsWeb, psb[0], containerName, ps2[0], 1234)
-	assert_notnil(t, err, "Error when running nc command from Pod %s", "web")
+	assertNotNil(t, err, "Error when running nc command from Pod %s", "web")
 	err = testData.runNetcatCommandFromPod(nsWeb, psb[0], containerName, ps[0], 3306)
-	assert_nil(t, err, "Error when running nc command from Pod %s", "web")
+	assertNil(t, err, "Error when running nc command from Pod %s", "web")
 
 	// Label ns
 	cmd = fmt.Sprintf("kubectl label ns %s %s=%s --overwrite", nsDB2, "role", "db")
 	_, err = runCommand(cmd)
-	assert_nil(t, err, "Error when running command %s", cmd)
+	assertNil(t, err, "Error when running command %s", cmd)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName1, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Nc from pod
 	err = testData.runNetcatCommandFromPod(nsWeb, psb[0], containerName, ps2[0], 1234)
-	assert_nil(t, err, "Error when running nc command from Pod %s", "web")
+	assertNil(t, err, "Error when running nc command from Pod %s", "web")
 	err = testData.runNetcatCommandFromPod(nsWeb, psb[0], containerName, ps[0], 3306)
-	assert_nil(t, err, "Error when running nc command from Pod %s", "web")
+	assertNil(t, err, "Error when running nc command from Pod %s", "web")
 
 	// Delete all
 	_ = deleteYAML(podPath, "")
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Deleted)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName1, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 }
 
 // TestSecurityPolicyNamedPort6 verifies that the traffic of security policy when named port applied.
@@ -628,10 +628,10 @@ func TestSecurityPolicyNamedPort6(t *testing.T) {
 	// Label ns
 	cmd := fmt.Sprintf("kubectl label ns %s %s=%s --overwrite", nsDB2, "role", "db")
 	_, err := runCommand(cmd)
-	assert_nil(t, err, "Error when running command %s", cmd)
+	assertNil(t, err, "Error when running command %s", cmd)
 	cmd = fmt.Sprintf("kubectl label ns %s %s=%s --overwrite", nsDB, "role", "db")
 	_, err = runCommand(cmd)
-	assert_nil(t, err, "Error when running command %s", cmd)
+	assertNil(t, err, "Error when running command %s", cmd)
 
 	// Create all
 	podPath, _ := filepath.Abs("./manifest/testSecurityPolicy/rule-out-rule-applied-to-with-dst-with-dup-port.yaml")
@@ -641,44 +641,44 @@ func TestSecurityPolicyNamedPort6(t *testing.T) {
 	// Wait for pods
 	ps, _, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsDB, labelDB)
 	t.Logf("Pods are %v", ps)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsDB)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsDB)
 
 	ps2, _, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsDB2, labelDB2)
 	t.Logf("Pods are %v", ps2)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsDB2)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsDB2)
 
 	_, psb, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsWeb, labelWeb)
 	t.Logf("Pods are %v", psb)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsWeb)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsWeb)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName1, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Nc from pod
 	err = testData.runNetcatCommandFromPod(nsWeb, psb[0], containerName, ps2[0], 3306)
-	assert_nil(t, err, "Error when running nc command from Pod %s", "web")
+	assertNil(t, err, "Error when running nc command from Pod %s", "web")
 	err = testData.runNetcatCommandFromPod(nsWeb, psb[0], containerName, ps[0], 3306)
-	assert_nil(t, err, "Error when running nc command from Pod %s", "web")
+	assertNil(t, err, "Error when running nc command from Pod %s", "web")
 
 	// Delete all
 	_ = deleteYAML(podPath, "")
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Deleted)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName1, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 }
 
 // TestSecurityPolicyNamedPort7 verifies that the traffic of security policy when named port applied.
@@ -711,10 +711,10 @@ func TestSecurityPolicyNamedPort7(t *testing.T) {
 	// Label ns
 	cmd := fmt.Sprintf("kubectl label ns %s %s=%s --overwrite", nsDB2, "role", "db")
 	_, err := runCommand(cmd)
-	assert_nil(t, err, "Error when running command %s", cmd)
+	assertNil(t, err, "Error when running command %s", cmd)
 	cmd = fmt.Sprintf("kubectl label ns %s %s=%s --overwrite", nsDB, "role", "db")
 	_, err = runCommand(cmd)
-	assert_nil(t, err, "Error when running command %s", cmd)
+	assertNil(t, err, "Error when running command %s", cmd)
 
 	// Create all
 	podPath, _ := filepath.Abs("./manifest/testSecurityPolicy/rule-out-rule-applied-to-with-dst-with-dup-port-multi.yaml")
@@ -724,42 +724,42 @@ func TestSecurityPolicyNamedPort7(t *testing.T) {
 	// Wait for pods
 	ps, _, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsDB, labelDB)
 	t.Logf("Pods are %v", ps)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsDB)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsDB)
 
 	ps2, _, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsDB2, labelDB2)
 	t.Logf("Pods are %v", ps2)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsDB2)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsDB2)
 
 	_, psb, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsWeb, labelWeb)
 	t.Logf("Pods are %v", psb)
-	assert_nil(t, err, "Error when waiting for IP for Pod ns %s", nsWeb)
+	assertNil(t, err, "Error when waiting for IP for Pod ns %s", nsWeb)
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Ready)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName1, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	// Nc from pod
 	err = testData.runNetcatCommandFromPod(nsWeb, psb[0], containerName, ps2[0], 1234)
-	assert_nil(t, err, "Error when running nc command from Pod %s", "web")
+	assertNil(t, err, "Error when running nc command from Pod %s", "web")
 	err = testData.runNetcatCommandFromPod(nsWeb, psb[0], containerName, ps[0], 3306)
-	assert_nil(t, err, "Error when running nc command from Pod %s", "web")
+	assertNil(t, err, "Error when running nc command from Pod %s", "web")
 
 	// Delete all
 	_ = deleteYAML(podPath, "")
 	err = testData.waitForCRReadyOrDeleted(defaultTimeout, SP, nsWeb, securityPolicyName, Deleted)
-	assert_nil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
+	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyName)
 
 	// Check nsx-t resource not existing
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName1, false)
-	assert_nil(t, err)
+	assertNil(t, err)
 }

--- a/test/e2e/nsx_vpc_test.go
+++ b/test/e2e/nsx_vpc_test.go
@@ -35,7 +35,7 @@ func verifyVPCCRCreated(t *testing.T, ns string, expect int) (string, string) {
 		log.Printf("VPC list %s size not the same as expected %d", resources, expect)
 		panic("VPC CR creation verify failed")
 	}
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	var vpc_name, vpc_uid string = "", ""
 	// waiting for CR to be ready
@@ -49,13 +49,13 @@ func verifyVPCCRCreated(t *testing.T, ns string, expect int) (string, string) {
 
 func verifyPrivateIPBlockCreated(t *testing.T, ns, id string) {
 	err := testData.waitForResourceExistById(ns, PrivateIPBlockNSXType, id, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 }
 
 func verifyVPCCRProperties(t *testing.T, ns, vpc_name string) {
 	for _, key := range verify_keys {
 		value, err := testData.getCRProperties(defaultTimeout, VPCCRType, vpc_name, ns, key)
-		assert_nil(t, err)
+		assertNil(t, err)
 		if strings.TrimSpace(value) == "" {
 			log.Printf("failed to read key %s for VPC %s", key, vpc_name)
 			panic("failed to read attribute from VPC CR")
@@ -79,13 +79,13 @@ func TestCustomizedVPC(t *testing.T) {
 	vpc_name, vpc_uid := verifyVPCCRCreated(t, ns, 1)
 
 	err := testData.waitForCRReadyOrDeleted(defaultTimeout, VPCCRType, ns, vpc_name, Ready)
-	assert_nil(t, err, "Error when waiting for VPC %s", vpc_name)
+	assertNil(t, err, "Error when waiting for VPC %s", vpc_name)
 
 	verifyVPCCRProperties(t, ns, vpc_name)
 
 	// Check nsx-t resource existing, nsx vpc is using vpc cr uid as id
 	err = testData.waitForResourceExistById(ns, VPCNSXType, vpc_uid, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	//verify private ipblocks created for vpc
 	p_ipb_id1 := vpc_uid + "_" + CustomizedPrivateCIDR1
@@ -101,13 +101,13 @@ func TestInfraVPC(t *testing.T) {
 	vpc_name, vpc_uid := verifyVPCCRCreated(t, InfraVPCNamespace, 1)
 
 	err := testData.waitForCRReadyOrDeleted(defaultTimeout, VPCCRType, InfraVPCNamespace, vpc_name, Ready)
-	assert_nil(t, err, "Error when waiting for VPC %s", vpc_name)
+	assertNil(t, err, "Error when waiting for VPC %s", vpc_name)
 
 	verifyVPCCRProperties(t, InfraVPCNamespace, vpc_name)
 
 	// Check nsx-t resource existing, nsx vpc is using vpc cr uid as id
 	err = testData.waitForResourceExistById(InfraVPCNamespace, VPCNSXType, vpc_uid, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	//verify private ipblocks created for vpc
 	p_ipb_id1 := vpc_uid + "_" + InfraPrivateCIDR1
@@ -132,13 +132,13 @@ func TestDefaultVPC(t *testing.T) {
 	vpc_name, vpc_uid := verifyVPCCRCreated(t, ns, 1)
 
 	err := testData.waitForCRReadyOrDeleted(defaultTimeout, VPCCRType, ns, vpc_name, Ready)
-	assert_nil(t, err, "Error when waiting for VPC %s", vpc_name)
+	assertNil(t, err, "Error when waiting for VPC %s", vpc_name)
 
 	verifyVPCCRProperties(t, ns, vpc_name)
 
 	// Check nsx-t resource existing, nsx vpc is using vpc cr uid as id
 	err = testData.waitForResourceExistById(ns, VPCNSXType, vpc_uid, true)
-	assert_nil(t, err)
+	assertNil(t, err)
 
 	//verify private ipblocks created for vpc
 	p_ipb_id1 := vpc_uid + "_" + DefaultPrivateCIDR1

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -23,29 +23,29 @@ func IsDirEmpty(name string) (bool, error) {
 	return false, err
 }
 
-func assert_nil(t *testing.T, object interface{}, msgAndArgs ...interface{}) bool {
+func assertNil(t *testing.T, object interface{}, msgAndArgs ...interface{}) bool {
 	if assert.Nil(t, object, msgAndArgs...) {
 		return true
 	}
 	panic("assertion failed")
 }
 
-func assert_notnil(t *testing.T, object interface{}, msgAndArgs ...interface{}) bool {
+func assertNotNil(t *testing.T, object interface{}, msgAndArgs ...interface{}) bool {
 	if assert.NotNil(t, object, msgAndArgs...) {
-		t.Logf("assert_notnil: %v", object)
+		t.Logf("assertNotNil: %v", object)
 		return true
 	}
 	panic("assertion failed")
 }
 
-func assert_true(t *testing.T, value bool, msgAndArgs ...interface{}) bool {
+func assertTrue(t *testing.T, value bool, msgAndArgs ...interface{}) bool {
 	if assert.True(t, value, msgAndArgs...) {
 		return true
 	}
 	panic("assertion failed")
 }
 
-func assert_false(t *testing.T, value bool, msgAndArgs ...interface{}) bool {
+func assertFalse(t *testing.T, value bool, msgAndArgs ...interface{}) bool {
 	if assert.False(t, value, msgAndArgs...) {
 		return true
 	}


### PR DESCRIPTION
1. Use camel case instead of snake case to align with nsx-operator code style.
2. Use t.Cleanup to register clean functions to ensure that cleanup can be performed when child test is executed in another goroutine.