### PR TITLE
[NOT FOR REVIEW] Debug the subnetport realization error

### DIFF
--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -297,7 +297,7 @@ func (r *SubnetReconciler) Start(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
-	go r.GarbageCollector(make(chan bool), servicecommon.GCInterval)
+	// go r.GarbageCollector(make(chan bool), servicecommon.GCInterval)
 	return nil
 }
 

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -309,6 +309,6 @@ func (r *SubnetSetReconciler) Start(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
-	go r.GarbageCollector(make(chan bool), servicecommon.GCInterval)
+	// go r.GarbageCollector(make(chan bool), servicecommon.GCInterval)
 	return nil
 }

--- a/pkg/nsx/services/realizestate/realize_state.go
+++ b/pkg/nsx/services/realizestate/realize_state.go
@@ -11,7 +11,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+var (
+	log = logger.Log
 )
 
 type RealizeStateService struct {
@@ -45,6 +50,9 @@ func (service *RealizeStateService) CheckRealizeState(backoff wait.Backoff, inte
 		results, err := service.NSXClient.RealizedEntitiesClient.List(vpcInfo.OrgID, vpcInfo.ProjectID, intentPath, nil)
 		if err != nil {
 			return err
+		}
+		for _, result := range results.Results {
+			log.Info("checking result.State", "result", result, "result.State", result.State, "result.PublishStatusErrorDetails", result.PublishStatusErrorDetails, "result.ExtendedAttributes", result.ExtendedAttributes)
 		}
 		for _, result := range results.Results {
 			if *result.EntityType != entityType {

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -150,12 +150,13 @@ func (service *SubnetPortService) CheckSubnetPortState(obj interface{}, nsxSubne
 	if err := realizeService.CheckRealizeState(backoff, *nsxSubnetPort.Path, "RealizedLogicalPort"); err != nil {
 		log.Error(err, "failed to get realized status", "subnetport path", *nsxSubnetPort.Path)
 		if realizestate.IsRealizeStateError(err) {
-			log.Error(err, "the created subnet port is in error realization state, cleaning the resource", "subnetport", uid)
-			// only recreate subnet port on RealizationErrorStateError.
-			if err := service.DeleteSubnetPort(uid); err != nil {
-				log.Error(err, "cleanup error subnetport failed", "subnetport", uid)
-				return nil, err
-			}
+			panic(err)
+			// log.Error(err, "the created subnet port is in error realization state, cleaning the resource", "subnetport", uid)
+			// // only recreate subnet port on RealizationErrorStateError.
+			// if err := service.DeleteSubnetPort(uid); err != nil {
+			// 	log.Error(err, "cleanup error subnetport failed", "subnetport", uid)
+			// 	return nil, err
+			// }
 		}
 		return nil, err
 	}


### PR DESCRIPTION
1. Crash the NSX operator when the subnet port realization error is hit, to avoid the error port is cleaned.
2. Disable the GC collectors in subnet/subnetset controllers to reserve the NSX subnet.