### PR TITLE
Revert "Support external http.Client"

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -177,7 +177,7 @@ func main() {
 	}
 
 	// nsxClient is used to interact with NSX API.
-	nsxClient := nsx.GetClient(cf, nil)
+	nsxClient := nsx.GetClient(cf)
 	if nsxClient == nil {
 		log.Error(err, "failed to get nsx client")
 		os.Exit(1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -310,7 +310,7 @@ func (nsxConfig *NsxConfig) validateCert() error {
 		return err
 	}
 	if caCount > 0 {
-		configLog.Infof("validate CA file: %d", caCount)
+		configLog.Infof("validate CA file: %s", caCount)
 		if caCount > 1 && caCount != mCount {
 			err := errors.New("ca file count not match manager count")
 			configLog.Error(err, "validate NsxConfig failed", "ca file count", caCount, "manager count", mCount)
@@ -324,7 +324,7 @@ func (nsxConfig *NsxConfig) validateCert() error {
 			}
 		}
 	} else {
-		configLog.Infof("validate thumbprint: %d", tpCount)
+		configLog.Infof("validate thumbprint: %s", tpCount)
 		if tpCount > 1 && tpCount != mCount {
 			err := errors.New("thumbprint count not match manager count")
 			configLog.Error(err, "validate NsxConfig failed", "thumbprint count", tpCount, "manager count", mCount)

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -119,7 +119,7 @@ func restConnector(c *Cluster) *client.RestConnector {
 	return connector
 }
 
-func GetClient(cf *config.NSXOperatorConfig, client *http.Client) *Client {
+func GetClient(cf *config.NSXOperatorConfig) *Client {
 	// Set log level for vsphere-automation-sdk-go
 	logger := logrus.New()
 	vspherelog.SetLogger(logger)
@@ -129,7 +129,7 @@ func GetClient(cf *config.NSXOperatorConfig, client *http.Client) *Client {
 	}
 	c := NewConfig(strings.Join(cf.NsxApiManagers, ","), cf.NsxApiUser, cf.NsxApiPassword, cf.CaFile, 10, 3, defaultHttpTimeout, 20, true, true, true,
 		ratelimiter.AIMD, cf.GetTokenProvider(), nil, cf.Thumbprint)
-	cluster, _ := NewCluster(c, client)
+	cluster, _ := NewCluster(c)
 
 	queryClient := search.NewQueryClient(restConnector(cluster))
 	groupClient := domains.NewGroupsClient(restConnector(cluster))

--- a/pkg/nsx/client_test.go
+++ b/pkg/nsx/client_test.go
@@ -21,7 +21,7 @@ import (
 func TestNSXHealthChecker_CheckNSXHealth(t *testing.T) {
 	host := "1.1.1.1"
 	config := NewConfig(host, "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := NewCluster(config, nil)
+	cluster, _ := NewCluster(config)
 	req := &http.Request{}
 
 	res := []ClusterHealth{GREEN, RED, ORANGE}
@@ -64,7 +64,7 @@ func TestNSXHealthChecker_CheckNSXHealth(t *testing.T) {
 func TestGetClient(t *testing.T) {
 	cf := config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{NsxApiUser: "1", NsxApiPassword: "1"}}
 	cf.VCConfig = &config.VCConfig{}
-	client := GetClient(&cf, nil)
+	client := GetClient(&cf)
 	assert.True(t, client != nil)
 
 	cluster := &Cluster{}
@@ -73,7 +73,7 @@ func TestGetClient(t *testing.T) {
 		return nsxVersion, nil
 	})
 
-	client = GetClient(&cf, nil)
+	client = GetClient(&cf)
 	patches.Reset()
 	assert.True(t, client != nil)
 	securityPolicySupported := client.NSXCheckVersion(SecurityPolicy)
@@ -86,7 +86,7 @@ func TestGetClient(t *testing.T) {
 		nsxVersion := &NsxVersion{NodeVersion: "3.2.1"}
 		return nsxVersion, nil
 	})
-	client = GetClient(&cf, nil)
+	client = GetClient(&cf)
 	patches.Reset()
 	assert.True(t, client != nil)
 	securityPolicySupported = client.NSXCheckVersion(SecurityPolicy)
@@ -99,7 +99,7 @@ func TestGetClient(t *testing.T) {
 		nsxVersion := &NsxVersion{NodeVersion: "4.1.0"}
 		return nsxVersion, nil
 	})
-	client = GetClient(&cf, nil)
+	client = GetClient(&cf)
 	patches.Reset()
 	assert.True(t, client != nil)
 	securityPolicySupported = client.NSXCheckVersion(SecurityPolicy)
@@ -112,7 +112,7 @@ func TestGetClient(t *testing.T) {
 		nsxVersion := &NsxVersion{NodeVersion: "4.1.2"}
 		return nsxVersion, nil
 	})
-	client = GetClient(&cf, nil)
+	client = GetClient(&cf)
 	patches.Reset()
 	assert.True(t, client != nil)
 	securityPolicySupported = client.NSXCheckVersion(SecurityPolicy)
@@ -125,7 +125,7 @@ func TestGetClient(t *testing.T) {
 		nsxVersion := &NsxVersion{NodeVersion: "4.1.3"}
 		return nsxVersion, nil
 	})
-	client = GetClient(&cf, nil)
+	client = GetClient(&cf)
 	patches.Reset()
 	assert.True(t, client != nil)
 	securityPolicySupported = client.NSXCheckVersion(SecurityPolicy)
@@ -142,7 +142,7 @@ func IsInstanceOf(objectPtr, typePtr interface{}) bool {
 func TestSRGetClient(t *testing.T) {
 	cf := config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{NsxApiUser: "admin", NsxApiPassword: "Admin!23Admin", NsxApiManagers: []string{"10.173.82.128"}}}
 	cf.VCConfig = &config.VCConfig{}
-	client := GetClient(&cf, nil)
+	client := GetClient(&cf)
 	st, error := client.StaticRouteClient.Get("default", "project-1", "vpc-2", "site1")
 	if error == nil {
 		fmt.Printf("sr %v\n", *st.ResourceType)

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -58,19 +58,13 @@ var (
 )
 
 // NewCluster creates a cluster based on nsx Config.
-func NewCluster(config *Config, client *http.Client) (*Cluster, error) {
+func NewCluster(config *Config) (*Cluster, error) {
 	log.Info("creating cluster")
 	cluster := &Cluster{}
 	cluster.config = config
 	cluster.transport = cluster.createTransport(time.Duration(config.ConnIdleTimeout))
-	// if client created by third-party, set noBalancerClient to nil to disable keep alive for clean up
-	if client != nil {
-		cluster.client = client
-		cluster.noBalancerClient = client
-	} else {
-		cluster.client = cluster.createHTTPClient(cluster.transport, time.Duration(config.HTTPTimeout))
-		cluster.noBalancerClient = cluster.createNoBalancerClient(time.Duration(config.HTTPTimeout), time.Duration(config.ConnIdleTimeout))
-	}
+	cluster.client = cluster.createHTTPClient(cluster.transport, time.Duration(config.HTTPTimeout))
+	cluster.noBalancerClient = cluster.createNoBalancerClient(time.Duration(config.HTTPTimeout), time.Duration(config.ConnIdleTimeout))
 
 	r := ratelimiter.NewRateLimiter(config.APIRateMode)
 	eps, err := cluster.createEndpoints(config.APIManagers, cluster.client, cluster.noBalancerClient, r, config.TokenProvider)

--- a/pkg/nsx/cluster_test.go
+++ b/pkg/nsx/cluster_test.go
@@ -32,7 +32,7 @@ func TestNewCluster(t *testing.T) {
 	a := ts.URL[index+2:]
 	thumbprint := []string{"123"}
 	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
-	_, err := NewCluster(config, nil)
+	_, err := NewCluster(config)
 	assert.True(t, err == nil, fmt.Sprintf("Created cluster failed %v", err))
 }
 
@@ -90,7 +90,7 @@ func TestCluster_NewRestConnector(t *testing.T) {
 	a := ts.URL[index+2:]
 	thumbprint := []string{"123"}
 	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
-	c, _ := NewCluster(config, nil)
+	c, _ := NewCluster(config)
 	con, _ := c.NewRestConnector()
 	assert.NotNil(t, con)
 }
@@ -109,7 +109,7 @@ func TestCluster_createTransport(t *testing.T) {
 	a := ts.URL[index+2:]
 	thumbprint := []string{"123"}
 	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
-	c, _ := NewCluster(config, nil)
+	c, _ := NewCluster(config)
 	assert.NotNil(t, c.createTransport(10))
 }
 
@@ -244,7 +244,7 @@ func TestCluster_getVersion(t *testing.T) {
 	index := strings.Index(ts.URL, "//")
 	a := ts.URL[index+2:]
 	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
-	cluster, _ := NewCluster(config, nil)
+	cluster, _ := NewCluster(config)
 	nsxVersion, err := cluster.GetVersion()
 	assert.True(t, err == nil)
 	assert.Equal(t, nsxVersion.NodeVersion, "3.1.3.3.0.18844962")

--- a/pkg/nsx/endpoint.go
+++ b/pkg/nsx/endpoint.go
@@ -107,10 +107,6 @@ type epHealthy struct {
 }
 
 func (ep *Endpoint) keepAlive() error {
-	// disable keepAlive for cleanup
-	if ep.noBalancerClient == ep.client {
-		return nil
-	}
 	req, err := http.NewRequest("GET", fmt.Sprintf(healthURL, ep.Scheme(), ep.Host()), nil)
 	if err != nil {
 		log.Error(err, "create keep alive request error")
@@ -259,10 +255,7 @@ func (ep *Endpoint) createAuthSession(certProvider auth.ClientCertProvider, toke
 		log.V(2).Info("Skipping session create with JWT based auth")
 		return nil
 	}
-	// disable createAuthSession for cleanup
-	if ep.noBalancerClient == ep.client {
-		return nil
-	}
+
 	u := &url.URL{Host: ep.Host(), Scheme: ep.Scheme()}
 	postValues := url.Values{}
 	postValues.Add("j_username", username)

--- a/pkg/nsx/services/common/store_test.go
+++ b/pkg/nsx/services/common/store_test.go
@@ -136,7 +136,7 @@ var filterTag = func(v []model.Tag) []string {
 
 func Test_InitializeResourceStore(t *testing.T) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(config2, nil)
+	cluster, _ := nsx.NewCluster(config2)
 	rc, _ := cluster.NewRestConnector()
 
 	service := Service{

--- a/pkg/nsx/services/ippool/fake_test.go
+++ b/pkg/nsx/services/ippool/fake_test.go
@@ -53,7 +53,7 @@ func (f fakeRealizedEntitiesClient) List(_ string, _ string, _ string, _ *string
 
 func fakeService() *IPPoolService {
 	c := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(c, nil)
+	cluster, _ := nsx.NewCluster(c)
 	rc, _ := cluster.NewRestConnector()
 	ipPoolStore := &IPPoolStore{ResourceStore: common.ResourceStore{
 		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeIPPoolCRUID: indexFunc}),

--- a/pkg/nsx/services/securitypolicy/store_test.go
+++ b/pkg/nsx/services/securitypolicy/store_test.go
@@ -108,7 +108,7 @@ func Test_KeyFunc(t *testing.T) {
 
 func Test_InitializeRuleStore(t *testing.T) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(config2, nil)
+	cluster, _ := nsx.NewCluster(config2)
 	rc, _ := cluster.NewRestConnector()
 
 	service := SecurityPolicyService{
@@ -159,7 +159,7 @@ func Test_InitializeRuleStore(t *testing.T) {
 
 func Test_InitializeGroupStore(t *testing.T) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(config2, nil)
+	cluster, _ := nsx.NewCluster(config2)
 	rc, _ := cluster.NewRestConnector()
 
 	service := SecurityPolicyService{
@@ -210,7 +210,7 @@ func Test_InitializeGroupStore(t *testing.T) {
 
 func Test_InitializeSecurityPolicyStore(t *testing.T) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(config2, nil)
+	cluster, _ := nsx.NewCluster(config2)
 	rc, _ := cluster.NewRestConnector()
 
 	service := SecurityPolicyService{

--- a/pkg/nsx/services/securitypolicy/wrap_test.go
+++ b/pkg/nsx/services/securitypolicy/wrap_test.go
@@ -27,7 +27,7 @@ func (_ *fakeQueryClient) List(_ string, _ *string, _ *string, _ *int64, _ *bool
 
 func fakeService() *SecurityPolicyService {
 	c := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(c, nil)
+	cluster, _ := nsx.NewCluster(c)
 	rc, _ := cluster.NewRestConnector()
 	service = &SecurityPolicyService{
 		Service: common.Service{

--- a/pkg/nsx/services/staticroute/staticroute_test.go
+++ b/pkg/nsx/services/staticroute/staticroute_test.go
@@ -54,7 +54,7 @@ func (qIface *fakeQueryClient) List(queryParam string, cursorParam *string, incl
 func createService(t *testing.T) (*StaticRouteService, *gomock.Controller, *mocks.MockStaticRoutesClient) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 
-	cluster, _ := nsx.NewCluster(config2, nil)
+	cluster, _ := nsx.NewCluster(config2)
 	rc, _ := cluster.NewRestConnector()
 
 	mockCtrl := gomock.NewController(t)

--- a/pkg/nsx/services/subnet/store_test.go
+++ b/pkg/nsx/services/subnet/store_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
@@ -58,7 +59,7 @@ func Test_KeyFunc(t *testing.T) {
 
 func Test_InitializeSubnetStore(t *testing.T) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(config2, nil)
+	cluster, _ := nsx.NewCluster(config2)
 	rc, _ := cluster.NewRestConnector()
 
 	subnetCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSubnetCRUID: subnetIndexFunc})

--- a/pkg/nsx/services/subnet/wrap_test.go
+++ b/pkg/nsx/services/subnet/wrap_test.go
@@ -16,7 +16,7 @@ import (
 
 func fakeService() *SubnetService {
 	c := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(c, nil)
+	cluster, _ := nsx.NewCluster(c)
 	rc, _ := cluster.NewRestConnector()
 	service := &SubnetService{
 		Service: common.Service{

--- a/pkg/nsx/services/vpc/store_test.go
+++ b/pkg/nsx/services/vpc/store_test.go
@@ -87,7 +87,7 @@ func Test_KeyFunc(t *testing.T) {
 
 func Test_InitializeVPCStore(t *testing.T) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, _ := nsx.NewCluster(config2, nil)
+	cluster, _ := nsx.NewCluster(config2)
 	rc, _ := cluster.NewRestConnector()
 	vpcCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeVPCCRUID: indexFunc})
 	vpcStore := &VPCStore{ResourceStore: common.ResourceStore{

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -43,7 +43,7 @@ var (
 func createService(t *testing.T) (*VPCService, *gomock.Controller, *mocks.MockVpcsClient) {
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 
-	cluster, _ := nsx.NewCluster(config2, nil)
+	cluster, _ := nsx.NewCluster(config2)
 	rc, _ := cluster.NewRestConnector()
 
 	mockCtrl := gomock.NewController(t)

--- a/pkg/nsx/transport_test.go
+++ b/pkg/nsx/transport_test.go
@@ -57,7 +57,7 @@ func TestRoundTripRetry(t *testing.T) {
 	index := strings.Index(ts.URL, "//")
 	a := ts.URL[index+2:]
 	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
-	cluster, err := NewCluster(config, nil)
+	cluster, err := NewCluster(config)
 	assert.Nil(err, fmt.Sprintf("Create cluster error %v", err))
 	cluster.endpoints[0], _ = NewEndpoint(ts.URL, cluster.client, cluster.noBalancerClient, cluster.endpoints[0].ratelimiter, nil)
 	cluster.endpoints[0].keepAlive()

--- a/test/e2e/nsxclient.go
+++ b/test/e2e/nsxclient.go
@@ -21,7 +21,7 @@ func NewNSXClient(configFile string) (*NSXClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	client := nsx.GetClient(cf, nil)
+	client := nsx.GetClient(cf)
 	if client == nil {
 		return nil, fmt.Errorf("failed to get nsx client")
 	}


### PR DESCRIPTION
This reverts commit 2d7f460c9124d79558e035a885fcfde3915fc03a.
Remove http client from external
Using external http client will make it difficult to switch NSXT.
After discussed with wcp team, they agreed to use http client created by nsx-operator