### PR TITLE
Use error type instead of error code in cleanup

### DIFF
--- a/cmd_clean/main.go
+++ b/cmd_clean/main.go
@@ -63,9 +63,9 @@ func main() {
 
 	logf.SetLogger(logger.ZapLogger(cf.DefaultConfig.Debug, config.LogLevel))
 
-	status, err := clean.Clean(cf)
+	err := clean.Clean(cf)
 	if err != nil {
-		log.Error(err, "failed to clean nsx resources", "status", status)
+		log.Error(err, "failed to clean nsx resources", "status", err.Error())
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/pkg/clean/types.go
+++ b/pkg/clean/types.go
@@ -35,8 +35,11 @@ type Status struct {
 	Message string
 }
 
+func (s Status) Error() string {
+	return s.Message
+}
+
 var (
-	OK                       = Status{Code: 0, Message: "cleanup successfully"}
 	ValidationFailed         = Status{Code: 1, Message: "failed to validate config"}
 	GetNSXClientFailed       = Status{Code: 2, Message: "failed to get nsx client"}
 	InitCleanupServiceFailed = Status{Code: 3, Message: "failed to initialize cleanup service"}


### PR DESCRIPTION
1. Status impl error interface, so the return value of cleanup changed from status, error to error only.
2. Provide go doc on Cleanup func to provide more details about returned error type.
3. Remove OK status, when cleanup success, just return nil error.