### PR TITLE
Revert TagScopeSecurityPolicyCRName and TagScopeSecurityPolicyCRUID

### DIFF
--- a/pkg/nsx/services/common/store_test.go
+++ b/pkg/nsx/services/common/store_test.go
@@ -127,7 +127,7 @@ func indexFunc(obj interface{}) ([]string, error) {
 var filterTag = func(v []model.Tag) []string {
 	res := make([]string, 0, 5)
 	for _, tag := range v {
-		if *tag.Scope == TagScopeSecurityPolicyCRUID {
+		if *tag.Scope == TagValueScopeSecurityPolicyUID {
 			res = append(res, *tag.Tag)
 		}
 	}
@@ -156,7 +156,7 @@ func Test_InitializeResourceStore(t *testing.T) {
 		},
 	}
 
-	ruleCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{TagScopeSecurityPolicyCRUID: indexFunc})
+	ruleCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{TagValueScopeSecurityPolicyUID: indexFunc})
 	ruleStore := &ResourceStore{
 		Indexer:     ruleCacheIndexer,
 		BindingType: model.RuleBindingType(),

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -31,8 +31,10 @@ const (
 	TagScopeCluster                    string = "nsx-op/cluster"
 	TagScopeNamespace                  string = "nsx-op/namespace"
 	TagScopeNamespaceUID               string = "nsx-op/namespace_uid"
-	TagScopeSecurityPolicyCRName       string = "nsx-op/security_policy_name"
-	TagScopeSecurityPolicyCRUID        string = "nsx-op/security_policy_uid"
+	TagScopeSecurityPolicyCRName       string = "nsx-op/security_policy_cr_name"
+	TagScopeSecurityPolicyCRUID        string = "nsx-op/security_policy_cr_uid"
+	TagScopeSecurityPolicyName         string = "nsx-op/security_policy_name"
+	TagScopeSecurityPolicyUID          string = "nsx-op/security_policy_uid"
 	TagScopeNetworkPolicyName          string = "nsx-op/network_policy_name"
 	TagScopeNetworkPolicyUID           string = "nsx-op/network_policy_uid"
 	TagScopeStaticRouteCRName          string = "nsx-op/static_route_name"
@@ -108,6 +110,8 @@ const (
 )
 
 var TagValueVersion = []string{ValueMajorVersion, ValueMinorVersion, ValuePatchVersion}
+var TagValueScopeSecurityPolicyName = TagScopeSecurityPolicyCRName
+var TagValueScopeSecurityPolicyUID = TagScopeSecurityPolicyCRUID
 
 var (
 	ResourceType                    = "resource_type"

--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -219,10 +219,10 @@ func (service *SecurityPolicyService) buildTargetTags(obj *v1alpha1.SecurityPoli
 	return targetTags
 }
 
-// Todo, use the uitl basic func to generate basic tags
+// Todo, use the util basic func to generate basic tags
 func (service *SecurityPolicyService) buildBasicTags(obj *v1alpha1.SecurityPolicy, createdFor string) []model.Tag {
-	scopeOwnerName := common.TagScopeSecurityPolicyCRName
-	scopeOwnerUID := common.TagScopeSecurityPolicyCRUID
+	scopeOwnerName := common.TagValueScopeSecurityPolicyName
+	scopeOwnerUID := common.TagValueScopeSecurityPolicyUID
 	if createdFor == common.ResourceTypeNetworkPolicy {
 		scopeOwnerName = common.TagScopeNetworkPolicyName
 		scopeOwnerUID = common.TagScopeNetworkPolicyUID
@@ -1619,8 +1619,8 @@ func (service *SecurityPolicyService) buildShareID(nsxProjectName, groupID strin
 func (service *SecurityPolicyService) buildShareTags(obj *v1alpha1.SecurityPolicy, projectId string, group *model.Group, createdFor string) []model.Tag {
 	var scopeOwnerName, scopeOwnerUID string
 	if createdFor == common.ResourceTypeSecurityPolicy {
-		scopeOwnerName = common.TagScopeSecurityPolicyCRName
-		scopeOwnerUID = common.TagScopeSecurityPolicyCRUID
+		scopeOwnerName = common.TagValueScopeSecurityPolicyName
+		scopeOwnerUID = common.TagValueScopeSecurityPolicyUID
 	} else {
 		scopeOwnerName = common.TagScopeNetworkPolicyName
 		scopeOwnerUID = common.TagScopeNetworkPolicyUID

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -31,8 +31,8 @@ var (
 	tagScopeCluster              = common.TagScopeCluster
 	tagScopeNamespace            = common.TagScopeNamespace
 	tagScopeNamespaceUID         = common.TagScopeNamespaceUID
-	tagScopeSecurityPolicyCRName = common.TagScopeSecurityPolicyCRName
-	tagScopeSecurityPolicyCRUID  = common.TagScopeSecurityPolicyCRUID
+	tagScopeSecurityPolicyCRName = common.TagValueScopeSecurityPolicyName
+	tagScopeSecurityPolicyCRUID  = common.TagValueScopeSecurityPolicyUID
 	tagScopeRuleID               = common.TagScopeRuleID
 	tagScopeSelectorHash         = common.TagScopeSelectorHash
 	spName                       = "ns1-spA"
@@ -283,24 +283,24 @@ func TestListSecurityPolicyID(t *testing.T) {
 		Service: common.Service{NSXClient: nil},
 	}
 	service.securityPolicyStore = &SecurityPolicyStore{ResourceStore: common.ResourceStore{
-		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSecurityPolicyCRUID: indexBySecurityPolicyCRUID}),
+		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID}),
 		BindingType: model.SecurityPolicyBindingType(),
 	}}
 	service.groupStore = &GroupStore{ResourceStore: common.ResourceStore{
-		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSecurityPolicyCRUID: indexBySecurityPolicyCRUID}),
+		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID}),
 		BindingType: model.GroupBindingType(),
 	}}
 	service.ruleStore = &RuleStore{ResourceStore: common.ResourceStore{
-		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSecurityPolicyCRUID: indexBySecurityPolicyCRUID}),
+		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID}),
 		BindingType: model.RuleBindingType(),
 	}}
 	service.shareStore = &ShareStore{ResourceStore: common.ResourceStore{
-		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSecurityPolicyCRUID: indexBySecurityPolicyCRUID}),
+		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID}),
 		BindingType: model.ShareBindingType(),
 	}}
 
 	group := model.Group{}
-	scope := "nsx-op/security_policy_uid"
+	scope := "nsx-op/security_policy_cr_uid"
 	uuid := "111111111"
 	id := "1234"
 	group.Id = &id

--- a/pkg/nsx/services/securitypolicy/store.go
+++ b/pkg/nsx/services/securitypolicy/store.go
@@ -34,20 +34,20 @@ func filterTag(tags []model.Tag, tagScope string) []string {
 	return res
 }
 
-// indexBySecurityPolicyCRUID is used to get index of a resource, usually, which is the UID of the CR controller reconciles,
+// indexBySecurityPolicyUID is used to get index of a resource, usually, which is the UID of the CR controller reconciles,
 // index is used to filter out resources which are related to the CR
-func indexBySecurityPolicyCRUID(obj interface{}) ([]string, error) {
+func indexBySecurityPolicyUID(obj interface{}) ([]string, error) {
 	switch o := obj.(type) {
 	case *model.SecurityPolicy:
-		return filterTag(o.Tags, common.TagScopeSecurityPolicyCRUID), nil
+		return filterTag(o.Tags, common.TagValueScopeSecurityPolicyUID), nil
 	case *model.Group:
-		return filterTag(o.Tags, common.TagScopeSecurityPolicyCRUID), nil
+		return filterTag(o.Tags, common.TagValueScopeSecurityPolicyUID), nil
 	case *model.Rule:
-		return filterTag(o.Tags, common.TagScopeSecurityPolicyCRUID), nil
+		return filterTag(o.Tags, common.TagValueScopeSecurityPolicyUID), nil
 	case *model.Share:
-		return filterTag(o.Tags, common.TagScopeSecurityPolicyCRUID), nil
+		return filterTag(o.Tags, common.TagValueScopeSecurityPolicyUID), nil
 	default:
-		return nil, errors.New("indexBySecurityPolicyCRUID doesn't support unknown type")
+		return nil, errors.New("indexBySecurityPolicyUID doesn't support unknown type")
 	}
 }
 

--- a/pkg/nsx/services/securitypolicy/store_test.go
+++ b/pkg/nsx/services/securitypolicy/store_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func Test_indexBySecurityPolicyCRUID(t *testing.T) {
-	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_uid"
+	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_cr_uid"
 	m := &model.Group{
 		Id:   &mId,
 		Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
@@ -34,28 +34,28 @@ func Test_indexBySecurityPolicyCRUID(t *testing.T) {
 		Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
 	}
 	t.Run("1", func(t *testing.T) {
-		got, _ := indexBySecurityPolicyCRUID(s)
+		got, _ := indexBySecurityPolicyUID(s)
 		if !reflect.DeepEqual(got, []string{"11111"}) {
-			t.Errorf("indexBySecurityPolicyCRUID() = %v, want %v", got, model.Tag{Tag: &mTag, Scope: &mScope})
+			t.Errorf("indexBySecurityPolicyUID() = %v, want %v", got, model.Tag{Tag: &mTag, Scope: &mScope})
 		}
 	})
 	t.Run("2", func(t *testing.T) {
-		got, _ := indexBySecurityPolicyCRUID(m)
+		got, _ := indexBySecurityPolicyUID(m)
 		if !reflect.DeepEqual(got, []string{"11111"}) {
-			t.Errorf("indexBySecurityPolicyCRUID() = %v, want %v", got, model.Tag{Tag: &mTag, Scope: &mScope})
+			t.Errorf("indexBySecurityPolicyUID() = %v, want %v", got, model.Tag{Tag: &mTag, Scope: &mScope})
 		}
 	})
 	t.Run("3", func(t *testing.T) {
-		got, _ := indexBySecurityPolicyCRUID(r)
+		got, _ := indexBySecurityPolicyUID(r)
 		if !reflect.DeepEqual(got, []string{"11111"}) {
-			t.Errorf("indexBySecurityPolicyCRUID() = %v, want %v", got, model.Tag{Tag: &mTag, Scope: &mScope})
+			t.Errorf("indexBySecurityPolicyUID() = %v, want %v", got, model.Tag{Tag: &mTag, Scope: &mScope})
 		}
 	})
 }
 
 func Test_filterTag(t *testing.T) {
-	tagScope := common.TagScopeSecurityPolicyCRUID
-	tags1 := []model.Tag{{Tag: common.String("sp-uid"), Scope: common.String(common.TagScopeSecurityPolicyCRUID)}}
+	tagScope := common.TagValueScopeSecurityPolicyUID
+	tags1 := []model.Tag{{Tag: common.String("sp-uid"), Scope: common.String(common.TagValueScopeSecurityPolicyUID)}}
 	tags2 := []model.Tag{{Tag: common.String("cluster-id"), Scope: common.String("cluster")}}
 	var emptyRes []string
 	type args struct {
@@ -127,7 +127,7 @@ func Test_InitializeRuleStore(t *testing.T) {
 			},
 		},
 	}
-	ruleCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSecurityPolicyCRUID: indexBySecurityPolicyCRUID})
+	ruleCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID})
 	ruleStore := &RuleStore{ResourceStore: common.ResourceStore{
 		Indexer:     ruleCacheIndexer,
 		BindingType: model.RuleBindingType(),
@@ -178,7 +178,7 @@ func Test_InitializeGroupStore(t *testing.T) {
 			},
 		},
 	}
-	groupCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSecurityPolicyCRUID: indexBySecurityPolicyCRUID})
+	groupCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID})
 	groupStore := &GroupStore{ResourceStore: common.ResourceStore{
 		Indexer:     groupCacheIndexer,
 		BindingType: model.GroupBindingType(),
@@ -229,7 +229,7 @@ func Test_InitializeSecurityPolicyStore(t *testing.T) {
 			},
 		},
 	}
-	securityPolicyCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSecurityPolicyCRUID: indexBySecurityPolicyCRUID})
+	securityPolicyCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID})
 	securityPolicyStore := &SecurityPolicyStore{ResourceStore: common.ResourceStore{
 		Indexer:     securityPolicyCacheIndexer,
 		BindingType: model.SecurityPolicyBindingType(),
@@ -258,7 +258,7 @@ func Test_InitializeSecurityPolicyStore(t *testing.T) {
 }
 
 func TestSecurityPolicyStore_Apply(t *testing.T) {
-	securityPolicyCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSecurityPolicyCRUID: indexBySecurityPolicyCRUID})
+	securityPolicyCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID})
 	resourceStore := common.ResourceStore{
 		Indexer:     securityPolicyCacheIndexer,
 		BindingType: model.SecurityPolicyBindingType(),
@@ -282,7 +282,7 @@ func TestSecurityPolicyStore_Apply(t *testing.T) {
 }
 
 func TestRuleStore_Apply(t *testing.T) {
-	ruleCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSecurityPolicyCRUID: indexBySecurityPolicyCRUID})
+	ruleCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID})
 	resourceStore := common.ResourceStore{
 		Indexer:     ruleCacheIndexer,
 		BindingType: model.RuleBindingType(),
@@ -338,7 +338,7 @@ func TestRuleStore_Apply(t *testing.T) {
 }
 
 func TestGroupStore_Apply(t *testing.T) {
-	groupCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagScopeSecurityPolicyCRUID: indexBySecurityPolicyCRUID})
+	groupCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID})
 	resourceStore := common.ResourceStore{
 		Indexer:     groupCacheIndexer,
 		BindingType: model.GroupBindingType(),

--- a/pkg/nsx/services/securitypolicy/wrap_test.go
+++ b/pkg/nsx/services/securitypolicy/wrap_test.go
@@ -53,7 +53,7 @@ func fakeService() *SecurityPolicyService {
 func TestSecurityPolicyService_wrapSecurityPolicy(t *testing.T) {
 	Converter := bindings.NewTypeConverter()
 	service := fakeService()
-	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_uid"
+	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_cr_uid"
 	markDelete := true
 	s := model.SecurityPolicy{
 		Id:              &mId,
@@ -88,7 +88,7 @@ func TestSecurityPolicyService_wrapSecurityPolicy(t *testing.T) {
 func TestSecurityPolicyService_wrapGroups(t *testing.T) {
 	Converter := bindings.NewTypeConverter()
 	service := fakeService()
-	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_uid"
+	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_cr_uid"
 	markDelete := true
 	m := model.Group{
 		Id:              &mId,
@@ -124,7 +124,7 @@ func TestSecurityPolicyService_wrapGroups(t *testing.T) {
 func TestSecurityPolicyService_wrapRules(t *testing.T) {
 	Converter := bindings.NewTypeConverter()
 	service := fakeService()
-	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_uid"
+	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_cr_uid"
 	markDelete := true
 	r := model.Rule{
 		Id:              &mId,

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -40,7 +40,7 @@ var (
 	basicTags = []string{
 		common.TagScopeCluster, common.TagScopeVersion,
 		common.TagScopeStaticRouteCRName, common.TagScopeStaticRouteCRUID,
-		common.TagScopeSecurityPolicyCRName, common.TagScopeSecurityPolicyCRUID,
+		common.TagValueScopeSecurityPolicyName, common.TagValueScopeSecurityPolicyUID,
 		common.TagScopeNetworkPolicyName, common.TagScopeNetworkPolicyUID,
 		common.TagScopeSubnetCRName, common.TagScopeSubnetCRUID,
 		common.TagScopeSubnetPortCRName, common.TagScopeSubnetPortCRUID,
@@ -455,8 +455,8 @@ func BuildBasicTags(cluster string, obj interface{}, namespaceID types.UID) []mo
 		tags = append(tags, model.Tag{Scope: String(common.TagScopeStaticRouteCRUID), Tag: String(string(i.UID))})
 	case *v1alpha1.SecurityPolicy:
 		tags = append(tags, model.Tag{Scope: String(common.TagScopeNamespace), Tag: String(i.ObjectMeta.Namespace)})
-		tags = append(tags, model.Tag{Scope: String(common.TagScopeSecurityPolicyCRName), Tag: String(i.ObjectMeta.Name)})
-		tags = append(tags, model.Tag{Scope: String(common.TagScopeSecurityPolicyCRUID), Tag: String(string(i.UID))})
+		tags = append(tags, model.Tag{Scope: String(common.TagValueScopeSecurityPolicyName), Tag: String(i.ObjectMeta.Name)})
+		tags = append(tags, model.Tag{Scope: String(common.TagValueScopeSecurityPolicyUID), Tag: String(string(i.UID))})
 	case *networkingv1.NetworkPolicy:
 		tags = append(tags, model.Tag{Scope: String(common.TagScopeNamespace), Tag: String(i.ObjectMeta.Namespace)})
 		tags = append(tags, model.Tag{Scope: String(common.TagScopeNetworkPolicyName), Tag: String(i.ObjectMeta.Name)})


### PR DESCRIPTION
This patch is to revert TagScopeSecurityPolicyCRName to
previous "nsx-op/security_policy_cr_name" and TagScopeSecurityPolicyCRUID to previous
"nsx-op/security_policy_cr_uid" in order to keep upgrade compatibility
with V4.1.2 release.

And, using TagScopeSecurityPolicyName = "nsx-op/security_policy_name"
and TagScopeSecurityPolicyUID = "nsx-op/security_policy_uid" for VPC
mode. By introducing a global var to define which tag values are to be
used in non-VPC mode and VCP mode.

Test done:
1. Create a Securitypolicy in v4.1.2, and then start nsx operator with this PR to see SP is working well and 
SP is tagged with TagScopeSecurityPolicyCRName and agScopeSecurityPolicyCRUID as in v4.1.2

2. Create a Securitypolicy in main branch with this patch to see SP is working well and
SP is tagged with TagScopeSecurityPolicyName and TagScopeSecurityPolicyUID for vpc mode.

3. GC in non-VPC mode

4. GC in VPC mode.