### PR TITLE
Fix issue when clean subnetport

### DIFF
--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -277,7 +277,7 @@ func (service *SubnetPortService) Cleanup(ctx context.Context) error {
 	subnetPorts := service.SubnetPortStore.List()
 	log.Info("cleanup subnetports", "count", len(subnetPorts))
 	for _, subnetPort := range subnetPorts {
-		subnetPortID := types.UID(*subnetPort.(model.VpcSubnetPort).Id)
+		subnetPortID := types.UID(*subnetPort.(*model.VpcSubnetPort).Id)
 		select {
 		case <-ctx.Done():
 			return errors.Join(nsxutil.TimeoutFailed, ctx.Err())


### PR DESCRIPTION
Report error below:
	/root/nsx-operator/cmd_clean/main.go:81 +0xa25
panic: interface conversion: interface {} is *model.VpcSubnetPort, not model.VpcSubnetPort [recovered]
	panic: interface conversion: interface {} is *model.VpcSubnetPort, not model.VpcSubnetPort