### PR TITLE
Fix security policy controller start issue in non-VPC mode

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -170,8 +170,14 @@ func main() {
 
 	var vpcService *vpc.VPCService
 
-	if cf.CoeConfig.EnableVPCNetwork && commonService.NSXClient.NSXCheckVersion(nsx.VPC) {
-		log.V(1).Info("VPC mode enabled")
+	if cf.CoeConfig.EnableVPCNetwork {
+		// Check NSX version for VPC networking mode
+		if !commonService.NSXClient.NSXCheckVersion(nsx.VPC) {
+			log.Error(nil, "VPC mode cannot be enabled if NSX version is lower than 4.1.1")
+			os.Exit(1)
+		}
+		log.Info("VPC mode is enabled")
+
 		vpcService, err = vpc.InitializeVPC(commonService)
 		if err != nil {
 			log.Error(err, "failed to initialize vpc commonService", "controller", "VPC")
@@ -219,7 +225,7 @@ func main() {
 		StartIPPoolController(mgr, ipPoolService, vpcService)
 		networkpolicycontroller.StartNetworkPolicyController(mgr, commonService, vpcService)
 	}
-
+	// Start controllers which can run in non-VPC mode
 	securitypolicycontroller.StartSecurityPolicyController(mgr, commonService, vpcService)
 
 	// Start the NSXServiceAccount controller.


### PR DESCRIPTION
The security policy controller should not start if VPC mode is enabled,
but NSX doesn't meet the required version.

The security policy controller should only be started in the conditions:
either VPC mode is enabled and NSX meets the required version at the
same time or VPC mode is not enabled.