### PR TITLE
check license from nsxt side

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,10 @@ import (
 const (
 	nsxOperatorDefaultConf = "/etc/nsx-operator/nsxop.ini"
 	vcHostCACertPath       = "/etc/vmware/wcp/tls/vmca.pem"
+	// LicenseInterval is the timeout for checking license status
+	LicenseInterval = 86400
+	// LicenseIntervalForDFW is the timeout for checking license status while no DFW license enabled
+	LicenseIntervalForDFW = 1800
 )
 
 var (
@@ -85,16 +89,17 @@ type CoeConfig struct {
 }
 
 type NsxConfig struct {
-	NsxApiUser           string   `ini:"nsx_api_user"`
-	NsxApiPassword       string   `ini:"nsx_api_password"`
-	NsxApiCertFile       string   `ini:"nsx_api_cert_file"`
-	NsxApiPrivateKeyFile string   `ini:"nsx_api_private_key_file"`
-	NsxApiManagers       []string `ini:"nsx_api_managers"`
-	CaFile               []string `ini:"ca_file"`
-	Thumbprint           []string `ini:"thumbprint"`
-	Insecure             bool     `ini:"insecure"`
-	SingleTierSrTopology bool     `ini:"single_tier_sr_topology"`
-	EnforcementPoint     string   `ini:"enforcement_point"`
+	NsxApiUser                string   `ini:"nsx_api_user"`
+	NsxApiPassword            string   `ini:"nsx_api_password"`
+	NsxApiCertFile            string   `ini:"nsx_api_cert_file"`
+	NsxApiPrivateKeyFile      string   `ini:"nsx_api_private_key_file"`
+	NsxApiManagers            []string `ini:"nsx_api_managers"`
+	CaFile                    []string `ini:"ca_file"`
+	Thumbprint                []string `ini:"thumbprint"`
+	Insecure                  bool     `ini:"insecure"`
+	SingleTierSrTopology      bool     `ini:"single_tier_sr_topology"`
+	EnforcementPoint          string   `ini:"enforcement_point"`
+	LicenseValidationInterval int      `ini:"license_validation_interval"`
 }
 
 type K8sConfig struct {

--- a/pkg/controllers/securitypolicy/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"runtime"
 	"time"
@@ -128,7 +129,27 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				updateFail(r, &ctx, obj, &err)
 				return ResultNormal, nil
 			}
-			log.Error(err, "operate failed, would retry exponentially", "securitypolicy", req.NamespacedName)
+			// check if invalid license
+			apiErr, _ := nsxutil.DumpAPIError(err)
+			if apiErr != nil {
+				invalidLicense := false
+				errorMessage := ""
+				for _, apiErrItem := range apiErr.RelatedErrors {
+					if *apiErrItem.ErrorCode == nsxutil.InvalidLicenseErrorCode {
+						invalidLicense = true
+						errorMessage = *apiErrItem.ErrorMessage
+					}
+				}
+				if *apiErr.ErrorCode == nsxutil.InvalidLicenseErrorCode {
+					invalidLicense = true
+					errorMessage = *apiErr.ErrorMessage
+				}
+				if invalidLicense {
+					log.Error(err, "Invalid license, nsx-operator will restart", "error message", errorMessage)
+					os.Exit(1)
+				}
+			}
+			log.Error(err, "create or update failed, would retry exponentially", "securitypolicy", req.NamespacedName)
 			updateFail(r, &ctx, obj, &err)
 			return ResultRequeue, err
 		}

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 const (
@@ -180,4 +181,32 @@ func (client *Client) NSXCheckVersion(feature int) bool {
 	}
 	client.NSXVerChecker.featureSupported[feature] = true
 	return true
+}
+
+// ValidateLicense validates NSX license. init is used to indicate whether nsx-operator is init or not
+// if not init, nsx-operator will check if license has been updated.
+// once license updated, operator will restart
+// if FeatureContainer license is false, operatore will restart
+func (client *Client) ValidateLicense(init bool) error {
+	log.Info("Checking NSX license")
+	oldContainerLicense := util.IsLicensed(util.FeatureContainer)
+	oldDfwLicense := util.IsLicensed(util.FeatureDFW)
+	err := client.NSXChecker.cluster.FetchLicense()
+	if err != nil {
+		return err
+	}
+	if !util.IsLicensed(util.FeatureContainer) {
+		err = errors.New("NSX license check failed")
+		log.Error(err, "container license is not supported")
+		return err
+	}
+	if !init {
+		newContainerLicense := util.IsLicensed(util.FeatureContainer)
+		newDfwLicense := util.IsLicensed(util.FeatureDFW)
+		if newContainerLicense != oldContainerLicense || newDfwLicense != oldDfwLicense {
+			log.Info("license updated, reset", "container license new value", newContainerLicense, "DFW license new value", newDfwLicense, "container license old value", oldContainerLicense, "DFW license old value", oldDfwLicense)
+			return errors.New("license updated")
+		}
+	}
+	return nil
 }

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 var (
@@ -77,6 +78,10 @@ func InitializeSecurityPolicy(service common.Service) (*SecurityPolicyService, e
 }
 
 func (service *SecurityPolicyService) CreateOrUpdateSecurityPolicy(obj *v1alpha1.SecurityPolicy) error {
+	if !nsxutil.IsLicensed(nsxutil.FeatureDFW) {
+		log.Info("no DFW license, skip creating SecurityPolicy.")
+		return nsxutil.RestrictionError{Desc: "no DFW license"}
+	}
 	nsxSecurityPolicy, nsxGroups, err := service.buildSecurityPolicy(obj)
 	if err != nil {
 		log.Error(err, "failed to build SecurityPolicy")

--- a/pkg/nsx/util/errors.go
+++ b/pkg/nsx/util/errors.go
@@ -7,6 +7,10 @@ import (
 	"fmt"
 )
 
+const (
+	InvalidLicenseErrorCode = 505
+)
+
 type NsxError interface {
 	setDetail(detail *ErrorDetail)
 	Error() string

--- a/pkg/nsx/util/license.go
+++ b/pkg/nsx/util/license.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"sync"
+)
+
+const (
+	FeatureContainer        = "CONTAINER"
+	FeatureDFW              = "DFW"
+	LicenseContainerNetwork = "CONTAINER_NETWORKING"
+	LicenseDFW              = "DFW"
+	LicenseContainer        = "CONTAINER"
+)
+
+var (
+	licenseMutex        sync.Mutex
+	licenseMap          = map[string]bool{}
+	Features_to_check   = []string{}
+	Feature_license_map = map[string][]string{FeatureContainer: {LicenseContainerNetwork,
+		LicenseContainer},
+		FeatureDFW: {LicenseDFW}}
+)
+
+func init() {
+	for k := range Feature_license_map {
+		Features_to_check = append(Features_to_check, k)
+		licenseMap[k] = false
+	}
+}
+
+type NsxLicense struct {
+	Results []struct {
+		FeatureName string `json:"feature_name"`
+		IsLicensed  bool   `json:"is_licensed"`
+	} `json:"results"`
+	ResultCount int `json:"result_count"`
+}
+
+func IsLicensed(feature string) bool {
+	licenseMutex.Lock()
+	defer licenseMutex.Unlock()
+	return licenseMap[feature]
+}
+
+func UpdateLicense(feature string, isLicensed bool) {
+	licenseMutex.Lock()
+	licenseMap[feature] = isLicensed
+	licenseMutex.Unlock()
+}
+
+func searchLicense(licenses *NsxLicense, licenseNames []string) bool {
+	license := false
+	for _, licenseName := range licenseNames {
+		for _, feature := range licenses.Results {
+			if feature.FeatureName == licenseName {
+				return feature.IsLicensed
+			}
+		}
+	}
+	return license
+}
+
+func UpdateFeatureLicense(licenses *NsxLicense) {
+	for _, feature := range Features_to_check {
+		licenseNames := Feature_license_map[feature]
+		license := searchLicense(licenses, licenseNames)
+		UpdateLicense(feature, license)
+		log.V(1).Info("update license", "feature", feature, "license", license)
+	}
+}

--- a/pkg/nsx/util/license_test.go
+++ b/pkg/nsx/util/license_test.go
@@ -1,0 +1,132 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLicensed(t *testing.T) {
+	licenseMap[FeatureContainer] = true
+	assert.True(t, IsLicensed(FeatureContainer))
+
+	licenseMap[FeatureDFW] = false
+	assert.False(t, IsLicensed(FeatureDFW))
+}
+
+func TestUpdateLicense(t *testing.T) {
+	UpdateLicense(FeatureDFW, true)
+	assert.True(t, licenseMap[FeatureDFW])
+
+	UpdateLicense(FeatureDFW, false)
+	assert.False(t, licenseMap[FeatureDFW])
+}
+
+func TestSearchLicense(t *testing.T) {
+	licenses := &NsxLicense{
+		Results: []struct {
+			FeatureName string `json:"feature_name"`
+			IsLicensed  bool   `json:"is_licensed"`
+		}{
+			{
+				FeatureName: LicenseContainer,
+				IsLicensed:  true,
+			},
+			{
+				FeatureName: LicenseDFW,
+				IsLicensed:  false,
+			},
+		},
+	}
+
+	// Search for license that exists
+	assert.True(t, searchLicense(licenses, Feature_license_map[FeatureContainer]))
+
+	// Search for license that does not exist
+	assert.False(t, searchLicense(licenses, []string{"IDFW"}))
+
+	// Search with empty results
+	licenses.Results = []struct {
+		FeatureName string `json:"feature_name"`
+		IsLicensed  bool   `json:"is_licensed"`
+	}{}
+	assert.False(t, searchLicense(licenses, Feature_license_map[FeatureContainer]))
+
+	licenses = &NsxLicense{
+		Results: []struct {
+			FeatureName string `json:"feature_name"`
+			IsLicensed  bool   `json:"is_licensed"`
+		}{
+			{
+				FeatureName: LicenseContainerNetwork,
+				IsLicensed:  true,
+			},
+			{
+				FeatureName: LicenseDFW,
+				IsLicensed:  false,
+			},
+			{
+				FeatureName: LicenseContainer,
+				IsLicensed:  false,
+			},
+		},
+	}
+	assert.True(t, searchLicense(licenses, Feature_license_map[FeatureContainer]))
+
+	licenses = &NsxLicense{
+		Results: []struct {
+			FeatureName string `json:"feature_name"`
+			IsLicensed  bool   `json:"is_licensed"`
+		}{
+			{
+				FeatureName: LicenseContainerNetwork,
+				IsLicensed:  false,
+			},
+
+			{
+				FeatureName: LicenseContainer,
+				IsLicensed:  true,
+			},
+		},
+	}
+	assert.False(t, searchLicense(licenses, Feature_license_map[FeatureContainer]))
+}
+
+func TestUpdateFeatureLicense(t *testing.T) {
+
+	// Normal case
+	licenses := &NsxLicense{
+		Results: []struct {
+			FeatureName string `json:"feature_name"`
+			IsLicensed  bool   `json:"is_licensed"`
+		}{
+			{FeatureName: LicenseDFW, IsLicensed: true},
+			{FeatureName: LicenseContainer, IsLicensed: true},
+		},
+	}
+
+	UpdateFeatureLicense(licenses)
+	assert.True(t, IsLicensed(FeatureDFW))
+	assert.True(t, IsLicensed(FeatureContainer))
+
+	// Empty license list
+	licenses.Results = nil
+	UpdateFeatureLicense(licenses)
+	assert.False(t, IsLicensed(FeatureDFW))
+	assert.False(t, IsLicensed(FeatureContainer))
+
+	licenses = &NsxLicense{
+		Results: []struct {
+			FeatureName string `json:"feature_name"`
+			IsLicensed  bool   `json:"is_licensed"`
+		}{
+			{FeatureName: LicenseDFW, IsLicensed: false},
+			{FeatureName: LicenseContainerNetwork, IsLicensed: false},
+			{FeatureName: LicenseContainer, IsLicensed: true},
+		},
+	}
+
+	UpdateFeatureLicense(licenses)
+	assert.False(t, IsLicensed(FeatureDFW))
+	assert.False(t, IsLicensed(FeatureContainer))
+}

--- a/pkg/third_party/retry/retry_test.go
+++ b/pkg/third_party/retry/retry_test.go
@@ -159,8 +159,8 @@ func TestMaxDelay(t *testing.T) {
 	)
 	dur := time.Since(start)
 	assert.Error(t, err)
-	assert.True(t, dur > 170*time.Millisecond, "5 times with maximum delay retry is longer than 170ms")
-	assert.True(t, dur < 200*time.Millisecond, "5 times with maximum delay retry is shorter than 200ms")
+	assert.Greater(t, dur, 120*time.Millisecond, "5 times with maximum delay retry is greater than 120ms")
+	assert.Less(t, dur, 250*time.Millisecond, "5 times with maximum delay retry is less than 250ms")
 }
 
 func TestBackOffDelay(t *testing.T) {


### PR DESCRIPTION
While init, it will check the license from nsxt side. If CONTAINER license is disable, it will reboot. If DFW license is disable, security policy will be only response for DELETE operation. It will run a routine to check license periodically. If there is no DFW license, it will check license more frequently

SecurityPolicy controller will check if error is invalid license error.

Test Done:
no CONTAINER license
1. if no CONTAINER license, nsx-operator should reset CONTAINER license enable, DFW disable
1. nsx-operator could bootup
2. security policy failed to create or update
3. security policy could be deleted CONTAINER license enable, DFW enable -> CONTAINER/DFW disable
1. nsx-operator restart due to DFW changed no DFW license, but nsx-operator try to create security policy
1. nsx-operator restart due to invalid license error