### PR TITLE
Normalize tag scope length for SecurityPolicy matchlabel key

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -16,7 +16,8 @@ import (
 
 const (
 	HashLength                         int    = 8
-	MaxTagLength                       int    = 256
+	MaxTagScopeLength                  int    = 128
+	MaxTagValueLength                  int    = 256
 	MaxIdLength                        int    = 255
 	MaxNameLength                      int    = 255
 	MaxSubnetNameLength                int    = 80
@@ -117,9 +118,11 @@ const (
 	SharePrefix                         = "share"
 )
 
-var TagValueVersion = []string{ValueMajorVersion, ValueMinorVersion, ValuePatchVersion}
-var TagValueScopeSecurityPolicyName = TagScopeSecurityPolicyCRName
-var TagValueScopeSecurityPolicyUID = TagScopeSecurityPolicyCRUID
+var (
+	TagValueVersion                 = []string{ValueMajorVersion, ValueMinorVersion, ValuePatchVersion}
+	TagValueScopeSecurityPolicyName = TagScopeSecurityPolicyCRName
+	TagValueScopeSecurityPolicyUID  = TagScopeSecurityPolicyCRUID
+)
 
 var (
 	ResourceType                    = "resource_type"

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -68,16 +68,16 @@ func NormalizeLabels(matchLabels *map[string]string) *map[string]string {
 }
 
 func NormalizeLabelKey(key string) string {
-	if len(key) <= common.MaxTagLength {
+	if len(key) <= common.MaxTagScopeLength {
 		return key
 	}
 	splitted := strings.Split(key, "/")
 	key = splitted[len(splitted)-1]
-	return NormalizeName(key)
+	return normalizeNamebyLimit(key, common.MaxTagScopeLength)
 }
 
 func NormalizeName(name string) string {
-	return normalizeNamebyLimit(name, common.MaxTagLength)
+	return normalizeNamebyLimit(name, common.MaxTagValueLength)
 }
 
 func normalizeNamebyLimit(name string, limit int) string {

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -30,15 +30,15 @@ func TestNormalizeName(t *testing.T) {
 }
 
 func TestNormalizeLabelKey(t *testing.T) {
-	shortKey := strings.Repeat("a", 256)
+	shortKey := strings.Repeat("a", 128)
 	assert.Equal(t, NormalizeLabelKey(shortKey), shortKey)
-	longKey := strings.Repeat("a", 257) + "/def"
+	longKey := strings.Repeat("a", 129) + "/def"
 	assert.Equal(t, NormalizeLabelKey(longKey), "def")
 }
 
 func TestNormalizeLabels(t *testing.T) {
-	shortKey := strings.Repeat("a", 256)
-	longKey := strings.Repeat("a", 257) + "/def"
+	shortKey := strings.Repeat("a", 128)
+	longKey := strings.Repeat("a", 129) + "/def"
 	longValue := strings.Repeat("v", 257)
 	tests := []struct {
 		name           string


### PR DESCRIPTION
In NSX, the length of scope field in a tag based condition cannot exceed 128 chars. This patch is to normalize matchlabel key length to limit the length of tag scope to 128 chars when converting matchlabel to the NSX tags.