### PR TITLE
Remove duplicated securitypolicies from networkpolicy conversion

### DIFF
--- a/pkg/controllers/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controllers/networkpolicy/networkpolicy_controller.go
@@ -58,12 +58,12 @@ func deleteFail(r *NetworkPolicyReconciler, c *context.Context, o *networkingv1.
 }
 
 func updateSuccess(r *NetworkPolicyReconciler, c *context.Context, o *networkingv1.NetworkPolicy) {
-	r.Recorder.Event(o, v1.EventTypeNormal, common.ReasonSuccessfulUpdate, "NetworkPolicy CR has been successfully updated")
+	r.Recorder.Event(o, v1.EventTypeNormal, common.ReasonSuccessfulUpdate, "NetworkPolicy has been successfully updated")
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateSuccessTotal, MetricResType)
 }
 
 func deleteSuccess(r *NetworkPolicyReconciler, _ *context.Context, o *networkingv1.NetworkPolicy) {
-	r.Recorder.Event(o, v1.EventTypeNormal, common.ReasonSuccessfulDelete, "NetworkPolicy CR has been successfully deleted")
+	r.Recorder.Event(o, v1.EventTypeNormal, common.ReasonSuccessfulDelete, "NetworkPolicy has been successfully deleted")
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteSuccessTotal, MetricResType)
 }
 

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -258,7 +258,6 @@ func (service *SecurityPolicyService) convertNetworkPolicyToInternalSecurityPoli
 			spAllow.Spec.Rules = append(spAllow.Spec.Rules, *rule)
 		}
 	}
-	securityPolicies = append(securityPolicies, spAllow, spIsolation)
 
 	if len(networkPolicy.Spec.Egress) > 0 {
 		spIsolation.Spec.Rules = append(spIsolation.Spec.Rules, v1alpha1.SecurityPolicyRule{


### PR DESCRIPTION
This patch is to remove duplicated securitypolicies generation when networkpolicy is converted to securitypolicies this is because the allow section securitypolicy and isolation securitypolicy have been appended to the final generated securitypolicy list by twice.

Also, this patch to refine networkpolicy event recorder message.

Testing done:
1. Create Networkpolicy with ingress or egress or both.
2. Verify API call and log to see there is no more duplicated securitypolicies after networkpolicy conversion