### PR TITLE
Fix the issue when there's no pod without the specific named port

### DIFF
--- a/pkg/controllers/securitypolicy/pod_handler.go
+++ b/pkg/controllers/securitypolicy/pod_handler.go
@@ -102,8 +102,9 @@ var PredicateFuncsPod = predicate.Funcs{
 		oldObj := e.ObjectOld.(*v1.Pod)
 		newObj := e.ObjectNew.(*v1.Pod)
 		log.V(1).Info("receive pod update event", "namespace", oldObj.Namespace, "name", oldObj.Name)
-		if reflect.DeepEqual(oldObj.ObjectMeta.Labels, newObj.ObjectMeta.Labels) {
-			log.V(1).Info("label of pod is not changed, ignore it", "name", oldObj.Name)
+		// The NSX operator should handle the case when the pod phase is changed from Pending to Running.
+		if reflect.DeepEqual(oldObj.ObjectMeta.Labels, newObj.ObjectMeta.Labels) && oldObj.Status.Phase == newObj.Status.Phase {
+			log.V(1).Info("pod label and phase are not changed, ignore it", "name", oldObj.Name)
 			return false
 		}
 		if util.CheckPodHasNamedPort(*newObj, "update") {

--- a/test/e2e/manifest/testSecurityPolicy/named-port-without-pod.yaml
+++ b/test/e2e/manifest/testSecurityPolicy/named-port-without-pod.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-deployment
+  namespace: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      role: web
+  template:
+    metadata:
+      labels:
+        deployment: tcp-deployment
+        role: web
+    spec:
+      hostname: web-deployment
+      containers:
+        - name: web
+          image: "harbor-repo.vmware.com/dockerhub-proxy-cache/humanux/http_https_echo:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+              name: web-port
+          resources:
+            requests: # make sure that the pod cannot be running
+              cpu: "10000m"
+              memory: "10000Gi"
+---
+apiVersion: nsx.vmware.com/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: named-port-policy-without-pod
+  namespace: web
+spec:
+  priority: 10
+  appliedTo:
+    - podSelector:
+        matchLabels:
+          role: web
+  rules:
+    - direction: in
+      action: allow
+      ports:
+        - protocol: TCP
+          port: web-port
+    - direction: in
+      action: drop
+    - direction: out
+      action: drop


### PR DESCRIPTION
About the named port feature, when there's not any pod with the specific
port in the policy (e.g. the pod not running, or even there's not any pod),
the NSX operator will reports the error and the reconcile will fail.
It's not expected and the policy's deletion is also blocked by the same cause.

This patch is to fix this issue: the security policy will still be created
even though its named port doesn't match any pod.

Testings done:
```
A. 1. create the security policy CR without any pod matching its named port
   2. check the NSX security policy can be created
   3. create the pod matching the named port and wait until it's running
   4. confirmed that the new rule is created in the existing NSX security policy
B. 1. create the pod with named port but keep it in pending phase
   2. create the security policy CR
   3. check the NSX security policy can be created
   4. make the pod be running
   5. confirmed that the new rule is created in the existing NSX security policy
C. 1. create the security policy CR without any pod matching its named port
   2. delete the security policy CR
   3. confirmed that the NSX security policy can be removed
```