### PR TITLE
Use fixed value to set number of reconciles for NetworkPolicy controller

### DIFF
--- a/pkg/controllers/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controllers/networkpolicy/networkpolicy_controller.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"runtime"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -130,7 +129,7 @@ func (r *NetworkPolicyReconciler) setupWithManager(mgr ctrl.Manager) error {
 		For(&networkingv1.NetworkPolicy{}).
 		WithOptions(
 			controller.Options{
-				MaxConcurrentReconciles: runtime.NumCPU(),
+				MaxConcurrentReconciles: common.NumReconcile(),
 			}).
 		Complete(r)
 }


### PR DESCRIPTION
Refer to:
https://github.com/vmware-tanzu/nsx-operator/pull/515 to use fixed value to set number of reconciles for NetworkPolicy controller as well.