### PR TITLE
Cleanup subnetport created by Avi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 .DS_Store
 go.work
 go.work.sum
+.golangci-bin


### PR DESCRIPTION
Avi controller will create subnetport on avi subnet of VPC, when there are stale subnetports left behind, it will fail to cleanup VPC complaining "IpAddressSubnet cannot be deleted as IP from subnet range is being used.", we hereby initialize avi resource store and it will be only used when cleanup avi resources, the cleanup process will follow up cleanup subnetport created by nsx-operator, then it will succeed to cleanup vpc even though there is avi subnet.