### PR TITLE
Support the DHCP on subnet/subnetset and the specific CIDR on subnet

### DIFF
--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -92,7 +92,11 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return common.ResultRequeue, err
 		}
 		contextID := *node.Id
-		nsxSubnetPortState, err := r.SubnetPortService.CreateOrUpdateSubnetPort(pod, nsxSubnetPath, contextID, &pod.ObjectMeta.Labels)
+		nsxSubnet, err := r.SubnetService.GetSubnetByPath(nsxSubnetPath)
+		if err != nil {
+			return common.ResultRequeue, err
+		}
+		nsxSubnetPortState, err := r.SubnetPortService.CreateOrUpdateSubnetPort(pod, nsxSubnet, contextID, &pod.ObjectMeta.Labels)
 		if err != nil {
 			log.Error(err, "failed to create or update NSX subnet port, would retry exponentially", "pod.Name", req.NamespacedName, "pod.UID", pod.UID)
 			updateFail(r, &ctx, pod, &err)

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -20,7 +20,8 @@ type VPCServiceProvider interface {
 }
 
 type SubnetServiceProvider interface {
-	GetSubnetByKey(key string) *model.VpcSubnet
+	GetSubnetByKey(key string) (*model.VpcSubnet, error)
+	GetSubnetByPath(path string) (*model.VpcSubnet, error)
 	GetSubnetsByIndex(key, value string) []*model.VpcSubnet
 	CreateOrUpdateSubnet(obj client.Object, vpcInfo VPCResourceInfo, tags []model.Tag) (string, error)
 	GenerateSubnetNSTags(obj client.Object, nsUID string) []model.Tag

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -275,8 +276,22 @@ func (service *SubnetService) UpdateSubnetSetStatus(obj *v1alpha1.SubnetSet) err
 	return nil
 }
 
-func (service *SubnetService) GetSubnetByKey(key string) *model.VpcSubnet {
-	return service.SubnetStore.GetByKey(key)
+func (service *SubnetService) GetSubnetByKey(key string) (*model.VpcSubnet, error) {
+	nsxSubnet := service.SubnetStore.GetByKey(key)
+	if nsxSubnet == nil {
+		return nil, errors.New("NSX subnet not found in store")
+	}
+	return nsxSubnet, nil
+}
+
+func (service *SubnetService) GetSubnetByPath(path string) (*model.VpcSubnet, error) {
+	pathSlice := strings.Split(path, "/")
+	if len(pathSlice) == 0 {
+		return nil, fmt.Errorf("invalid path '%s' while getting subnet", path)
+	}
+	key := pathSlice[len(pathSlice)-1]
+	nsxSubnet, err := service.GetSubnetByKey(key)
+	return nsxSubnet, err
 }
 
 func (service *SubnetService) ListSubnetID() sets.Set[string] {

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -1,0 +1,122 @@
+package subnetport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+func TestBuildSubnetPort(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	service := &SubnetPortService{
+		Service: common.Service{
+			Client:    k8sClient,
+			NSXClient: &nsx.Client{},
+			NSXConfig: &config.NSXOperatorConfig{
+				NsxConfig: &config.NsxConfig{
+					EnforcementPoint: "vmc-enforcementpoint",
+				},
+				CoeConfig: &config.CoeConfig{
+					Cluster: "fake_cluster",
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+	namespace := &corev1.Namespace{}
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), namespace).Return(nil).Do(
+		func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+			return nil
+		})
+
+	tests := []struct {
+		name          string
+		obj           interface{}
+		nsxSubnet     *model.VpcSubnet
+		contextID     string
+		labelTags     *map[string]string
+		expectedPort  *model.VpcSubnetPort
+		expectedError error
+	}{
+		{
+			name: "01",
+			obj: &v1alpha1.SubnetPort{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1alpha1",
+					Kind:       "SubnetPort",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
+					Name:      "fake_subnetport",
+					Namespace: "fake_ns",
+				},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				DhcpConfig: &model.VpcSubnetDhcpConfig{
+					EnableDhcp: common.Bool(true),
+				},
+				Path: common.String("fake_path"),
+			},
+			contextID: "fake_context_id",
+			labelTags: nil,
+			expectedPort: &model.VpcSubnetPort{
+				DisplayName: common.String("port-fake_subnetport"),
+				Id:          common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+				Tags: []model.Tag{
+					{
+						Scope: common.String("nsx-op/cluster"),
+						Tag:   common.String("fake_cluster"),
+					},
+					{
+						Scope: common.String("nsx-op/version"),
+						Tag:   common.String("1.0.0"),
+					},
+					{
+						Scope: common.String("nsx-op/vm_namespace"),
+						Tag:   common.String("fake_ns"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_name"),
+						Tag:   common.String("fake_subnetport"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_uid"),
+						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+					},
+				},
+				Path:       common.String("fake_path/ports/2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+				ParentPath: common.String("fake_path"),
+				Attachment: &model.PortAttachment{
+					AllocateAddresses: common.String("DHCP"),
+					Type_:             common.String("STATIC"),
+					Id:                common.String("32636365-6333-4239-ad37-3534362d3466"),
+					TrafficTag:        common.Int64(0),
+				},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedPort, err := service.buildSubnetPort(tt.obj, tt.nsxSubnet, tt.contextID, tt.labelTags)
+			assert.Equal(t, tt.expectedPort, observedPort)
+			assert.Equal(t, common.CompareResource(SubnetPortToComparable(tt.expectedPort), SubnetPortToComparable(observedPort)), false)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+
+}

--- a/test/e2e/manifest/testSubnet/subnetport-in-dhcp-subnetset.yaml
+++ b/test/e2e/manifest/testSubnet/subnetport-in-dhcp-subnetset.yaml
@@ -1,0 +1,7 @@
+apiVersion: nsx.vmware.com/v1alpha1
+kind: SubnetPort
+metadata:
+  name: port-in-dhcp-subnetset
+  namespace: subnet-e2e
+spec:
+  subnetSet: user-pod-subnetset-dhcp

--- a/test/e2e/manifest/testSubnet/subnetport-in-static-subnetset.yaml
+++ b/test/e2e/manifest/testSubnet/subnetport-in-static-subnetset.yaml
@@ -1,7 +1,7 @@
 apiVersion: nsx.vmware.com/v1alpha1
 kind: SubnetPort
 metadata:
-  name: port-2
+  name: port-in-static-subnetset
   namespace: subnet-e2e
 spec:
-  subnetSet: user-pod-subnetset
+  subnetSet: user-pod-subnetset-static

--- a/test/e2e/manifest/testSubnet/subnetset-dhcp.yaml
+++ b/test/e2e/manifest/testSubnet/subnetset-dhcp.yaml
@@ -1,9 +1,8 @@
 apiVersion: nsx.vmware.com/v1alpha1
 kind: SubnetSet
 metadata:
-  name: user-pod-subnetset
+  name: user-pod-subnetset-dhcp
   namespace: subnet-e2e
 spec:
-  advancedConfig:
-    staticIPAllocation:
-      enable: true
+  DHCPConfig:
+    enableDHCP: true

--- a/test/e2e/manifest/testSubnet/subnetset-static.yaml
+++ b/test/e2e/manifest/testSubnet/subnetset-static.yaml
@@ -1,0 +1,9 @@
+apiVersion: nsx.vmware.com/v1alpha1
+kind: SubnetSet
+metadata:
+  name: user-pod-subnetset-static
+  namespace: subnet-e2e
+spec:
+  advancedConfig:
+    staticIPAllocation:
+      enable: true


### PR DESCRIPTION
Testings done:
```
Case 1. create DHCP subnet CR without specific CIDR and create the subnetport CR,
        then check the CRs status
Case 2. create DHCP subnet CR with specific CIDR and create the subnetport CR,
        then check the CRs status
Case 3. create static IPAM subnet CR without specific CIDR and create the subnetport CR,
        then check the CRs status
Case 4. create static IPAM subnet CR with specific CIDR and create the subnetport CR,
        then check the CRs status
```