### PR TITLE
Support envoy while retrive JWT

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -265,7 +265,11 @@ func (operatorConfig *NSXOperatorConfig) createTokenProvider() error {
 	}
 
 	if err := operatorConfig.VCConfig.validate(); err == nil {
-		tokenProvider, _ = jwt.NewTokenProvider(operatorConfig.VCEndPoint, operatorConfig.HttpsPort, operatorConfig.SsoDomain, operatorConfig.VCUser, operatorConfig.VCPassword, vcCaCert, operatorConfig.Insecure)
+		if operatorConfig.EnvoyPort != 0 {
+			tokenProvider, _ = jwt.NewTokenProvider(operatorConfig.EnvoyHost, operatorConfig.EnvoyPort, operatorConfig.SsoDomain, operatorConfig.VCUser, operatorConfig.VCPassword, vcCaCert, operatorConfig.Insecure, "http")
+		} else {
+			tokenProvider, _ = jwt.NewTokenProvider(operatorConfig.VCEndPoint, operatorConfig.HttpsPort, operatorConfig.SsoDomain, operatorConfig.VCUser, operatorConfig.VCPassword, vcCaCert, operatorConfig.Insecure, "https")
+		}
 	}
 	return nil
 }

--- a/pkg/nsx/auth/jwt/JWTtokenprovider.go
+++ b/pkg/nsx/auth/jwt/JWTtokenprovider.go
@@ -32,9 +32,9 @@ func (provider *JWTTokenProvider) HeaderValue(token string) string {
 	return "Bearer " + token
 }
 
-func NewTokenProvider(vcEndpoint string, port int, ssoDomain, user, password string, caCert []byte, insecure bool) (auth.TokenProvider, error) {
+func NewTokenProvider(vcEndpoint string, port int, ssoDomain, user, password string, caCert []byte, insecure bool, scheme string) (auth.TokenProvider, error) {
 	// not load username/password, not create vapi session, defer them to cache.refreshJWT
-	tesClient, err := NewTESClient(vcEndpoint, port, ssoDomain, user, password, caCert, insecure)
+	tesClient, err := NewTESClient(vcEndpoint, port, ssoDomain, user, password, caCert, insecure, scheme)
 	if err != nil {
 		log.Error(err, "failed to create tes client")
 		return nil, err

--- a/pkg/nsx/auth/jwt/JWTtokenprovider_test.go
+++ b/pkg/nsx/auth/jwt/JWTtokenprovider_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestJWTTokenprovider_NewTokenProvider(t *testing.T) {
-	_, err := NewTokenProvider("127.0.0.1", 443, "vsphere.local", "", "", []byte{}, false)
+	_, err := NewTokenProvider("127.0.0.1", 443, "vsphere.local", "", "", []byte{}, false, "https")
 	_, ok := err.(*url.Error)
 	assert.Equal(t, ok, false)
 

--- a/pkg/nsx/auth/jwt/tesclient.go
+++ b/pkg/nsx/auth/jwt/tesclient.go
@@ -29,8 +29,8 @@ type TESClient struct {
 }
 
 // NewTESClient creates a TESClient object.
-func NewTESClient(hostname string, port int, ssoDomain string, username, password string, caCertPem []byte, insecureSkipVerify bool) (*TESClient, error) {
-	client, err := NewVCClient(hostname, port, ssoDomain, username, password, caCertPem, insecureSkipVerify)
+func NewTESClient(hostname string, port int, ssoDomain string, username, password string, caCertPem []byte, insecureSkipVerify bool, scheme string) (*TESClient, error) {
+	client, err := NewVCClient(hostname, port, ssoDomain, username, password, caCertPem, insecureSkipVerify, scheme)
 	if err != nil {
 		log.Error(err, "new TESClient failed")
 		return nil, err

--- a/pkg/nsx/auth/jwt/testclient_test.go
+++ b/pkg/nsx/auth/jwt/testclient_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestTESClient_NewTESClient(t *testing.T) {
-	_, err := NewTESClient("10.0.0.1", 433, "vsphere.local", "admin", "admin", []byte{}, true)
+	_, err := NewTESClient("10.0.0.1", 433, "vsphere.local", "admin", "admin", []byte{}, true, "https")
 	assert.Equal(t, err, nil)
 }
 

--- a/pkg/nsx/auth/jwt/vcclient.go
+++ b/pkg/nsx/auth/jwt/vcclient.go
@@ -62,9 +62,9 @@ func createHttpClient(insecureSkipVerify bool, caCertPem []byte) *http.Client {
 }
 
 // NewVCClient creates a new logged in VC client with vapi session.
-func NewVCClient(hostname string, port int, ssoDomain string, userName, password string, caCertPem []byte, insecureSkipVerify bool) (*VCClient, error) {
+func NewVCClient(hostname string, port int, ssoDomain string, userName, password string, caCertPem []byte, insecureSkipVerify bool, scheme string) (*VCClient, error) {
 	httpClient := createHttpClient(insecureSkipVerify, caCertPem)
-	baseurl := fmt.Sprintf("https://%s:%d/rest", hostname, port)
+	baseurl := fmt.Sprintf("%s://%s:%d/rest", scheme, hostname, port)
 	vcurl, _ := url.Parse(baseurl)
 
 	vcurl.User = url.UserPassword(userName, password)
@@ -193,7 +193,7 @@ func (vcClient *VCClient) getorCreateSTSClient() (*sts.Client, error) {
 		return stsClient, nil
 	}
 
-	vimSdkURL := fmt.Sprintf("https://%s/sdk", vcClient.url.Host)
+	vimSdkURL := fmt.Sprintf("%s://%s/sdk", vcClient.url.Scheme, vcClient.url.Host)
 	vimClient, err := vcClient.createVimClient(context.Background(), vimSdkURL)
 	if err != nil {
 		return nil, err
@@ -204,7 +204,7 @@ func (vcClient *VCClient) getorCreateSTSClient() (*sts.Client, error) {
 }
 
 func (vcClient *VCClient) createSCClient(vimClient *vim25.Client) *soap.Client {
-	url := fmt.Sprintf("https://%s/sts/STSService/%s", vcClient.url.Host, vcClient.ssoDomain)
+	url := fmt.Sprintf("%s://%s/sts/STSService/%s", vcClient.url.Scheme, vcClient.url.Host, vcClient.ssoDomain)
 	return vimClient.Client.NewServiceClient(url, "oasis:names:tc:SAML:2.0:assertion")
 }
 

--- a/pkg/nsx/auth/jwt/vcclient_test.go
+++ b/pkg/nsx/auth/jwt/vcclient_test.go
@@ -61,7 +61,7 @@ func TestVCClient_NewVCClient(t *testing.T) {
 		singer := &sts.Signer{}
 		return singer, nil
 	})
-	vcClient, err := NewVCClient(host, port, ssoDomain, userName, password, nil, true)
+	vcClient, err := NewVCClient(host, port, ssoDomain, userName, password, nil, true, "https")
 	assert.Equal(t, err, nil)
 	assert.NotEqual(t, vcClient, nil)
 
@@ -70,7 +70,7 @@ func TestVCClient_NewVCClient(t *testing.T) {
 
 	// bad session data
 	offset += 1
-	_, err = NewVCClient(host, port, ssoDomain, userName, password, nil, true)
+	_, err = NewVCClient(host, port, ssoDomain, userName, password, nil, true, "https")
 	assert.Equal(t, err, nil)
 
 }
@@ -101,7 +101,7 @@ func TestVCClient_getorRenewVAPISession(t *testing.T) {
 	userName := "admin"
 	password := "admin"
 	ssoDomain := "vsphere.local"
-	vcClient, err := NewVCClient(host, port, ssoDomain, userName, password, nil, true)
+	vcClient, err := NewVCClient(host, port, ssoDomain, userName, password, nil, true, "https")
 	assert.Equal(t, err, nil)
 	assert.NotEqual(t, vcClient, nil)
 
@@ -126,12 +126,12 @@ func TestVCClient_reloadUsernamePass(t *testing.T) {
 	password := "admin"
 	ssoDomain := "vsphere.local"
 	// reload == false
-	vcClient, _ := NewVCClient(host, port, ssoDomain, userName, password, nil, true)
+	vcClient, _ := NewVCClient(host, port, ssoDomain, userName, password, nil, true, "https")
 	err := vcClient.reloadUsernamePass()
 	assert.Nil(t, err)
 
 	// reload == true
-	vcClient, _ = NewVCClient(host, port, ssoDomain, "", "", nil, true)
+	vcClient, _ = NewVCClient(host, port, ssoDomain, "", "", nil, true, "https")
 	err = vcClient.reloadUsernamePass()
 	assert.NotNil(t, err)
 


### PR DESCRIPTION
While using wcp user to run cleanup, all the traffic will be redict to envoy.

Test Done:
Runing it in the VC, JWT token could be retrieved: root@sc2-10-186-129-223 [ ~ ]# ./clean -cluster=domain-c10:5ade3f1c-6d56-4692-bf5a-297b7fd22fad -mgr-ip=10.186.139.171:443 -vc-endpoint=sc2-10-186-129-223.eng.vmware.com -vc-sso-domain="vsphere.local" -vc-https-port=443 -vc-user="wcp-cluster-user-14fb27a8-9bc6-4648-97b0-3843d796eac9-00af62e2-190c-4aa1-9449-48a422d782a9@vsphere.local" -vc-passwd='#UN)RPL%]5{gm|SJXaN`' -log-level=1 -thumbprint=16C4D138AD196B63E878CD6823FBDA55A1DD57:CD  -envoyhost=localhost -nsx-user=admin -nsx-passwd=T7-QapFewLZa  -envoyport=1080

2024-04-26 08:07:30.953 DEBUG   jwt/vcclient.go:158     creating Holder of Key signer
2024-04-26 08:07:30.953 DEBUG   jwt/vcclient.go:212     creating vmomi client
2024-04-26 08:07:31.073 DEBUG   jwt/vcclient.go:274     generating certificate  {"user": "wcp-cluster-user-14fb27a8-9bc6-4648-97b0-3843d796eac9-00af62e2-190c-4aa1-9449-48a422d782a9@vsphere.local", "notBefore": "2024-04-26 08:01:31.073", "notAfter": "2024-04-26 09:07:31.073"}
2024-04-26 08:07:31.107 INFO    jwt/vcclient.go:85      creating new vapi session for vcClient
2024-04-26 08:07:31.220 DEBUG   jwt/tesclient.go:61     sending saml token to TES for JWT
2024-04-26 08:07:31.373 DEBUG   jwt/vcclient.go:236     HTTP request    {"request": "http://localhost:1080/rest//vcenter/tokenservice/token-exchange", "response status": 200}
2024-04-26 08:07:31.373 DEBUG   jwt/tesclient.go:78     exchanged JWT