### PR TITLE
Fix CVE-2023-45288

### DIFF
--- a/build/image/photon/Dockerfile
+++ b/build/image/photon/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5 as golang-build
+FROM golang:1.21.9 as golang-build
 
 WORKDIR /source
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/nsx-operator
 
-go 1.21
+go 1.21.9
 
 replace (
 	github.com/vmware-tanzu/nsx-operator/pkg/apis => ./pkg/apis


### PR DESCRIPTION
If uses 'go 1.21' in go.mod, the golang version is 1.21.5. NSX Operator uses sigs.k8s.io/controller-runtime/pkg/metrics/server which uses the net/http, the HTTP/2 is enable by default.

Upgrade golang to 1.21.9 to include the fix

Test Done:
1.#nsx-operator-1 % go version
go: downloading go1.21.9 (darwin/amd64)
go version go1.21.9 darwin/amd64

Issue: #3376772