### PR TITLE
Add init container for generating webhook cert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ test: manifests generate fmt vet envtest .coverage ## Run tests .
 build: generate fmt vet ## Build manager binary.
 	@mkdir -p $(BINDIR)
 	GOOS=linux go build -o $(BINDIR)/manager $(GOFLAGS) -ldflags '$(LDFLAGS)' cmd/main.go
+	GOOS=linux go build -o $(BINDIR)/webhookcert $(GOFLAGS) -ldflags '$(LDFLAGS)' cmd/webhookcert/main.go
 
 .PHONY: build-clean
 build-clean: generate fmt vet ## Build clean binary.

--- a/build/image/photon/Dockerfile
+++ b/build/image/photon/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /source
 
 COPY . /source
 RUN CGO_ENABLED=0 go build -o manager cmd/main.go
+RUN CGO_ENABLED=0 go build -o webhookcert cmd/webhookcert/main.go
 RUN CGO_ENABLED=0 go build -o clean cmd_clean/main.go
 
 FROM photon
@@ -12,6 +13,7 @@ RUN tdnf -y install shadow && \
     useradd -s /bin/bash nsx-operator
 
 COPY --from=golang-build /source/manager /usr/local/bin/
+COPY --from=golang-build /source/webhookcert /usr/local/bin/
 COPY --from=golang-build /source/clean /usr/local/bin/
 
 USER nsx-operator

--- a/build/yaml/webhook/manifests.yaml
+++ b/build/yaml/webhook/manifests.yaml
@@ -3,9 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
-  name: validating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: vmware-system-nsx/nsx-operator-webhook-cert
+  name: nsx-operator-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/cmd/webhookcert/main.go
+++ b/cmd/webhookcert/main.go
@@ -1,0 +1,186 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path"
+	"time"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+)
+
+var (
+	log                            = logger.Log
+	validatingWebhookConfiguration = "nsx-operator-validating-webhook-configuration"
+)
+
+func main() {
+	log.Info("Generating webhook certificates...")
+	if err := generateWebhookCerts(); err != nil {
+		panic(err)
+	}
+}
+
+// WriteFile writes data in the file at the given path
+func writeFile(filepath string, cert *bytes.Buffer) error {
+	f, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write(cert.Bytes())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func generateWebhookCerts() error {
+	var caPEM, serverCertPEM, serverKeyPEM *bytes.Buffer
+	// CA config
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return err
+	}
+	ca := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"broadcom.com"},
+			CommonName:   "webhook",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	// CA private key
+	caKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		log.Error(err, "Failed to generate private key")
+		return err
+	}
+
+	// Self-signed CA certificate
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caKey.PublicKey, caKey)
+	if err != nil {
+		log.Error(err, "Failed to generate CA")
+		return err
+	}
+
+	// PEM encode CA cert
+	caPEM = new(bytes.Buffer)
+	pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+
+	dnsNames := []string{"subnetset", "subnetset.vmware-system-nsx", "subnetset.vmware-system-nsx.svc"}
+	commonName := "subnetset.vmware-system-nsx.svc"
+
+	serialNumber, err = rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return err
+	}
+	// server cert config
+	cert := &x509.Certificate{
+		DNSNames:     dnsNames,
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   commonName,
+			Organization: []string{"broadcom.com"},
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(1, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	// server private key
+	serverKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		log.Error(err, "Failed to generate server key")
+		return err
+	}
+
+	// sign the server cert
+	serverCertBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &serverKey.PublicKey, caKey)
+	if err != nil {
+		log.Error(err, "Failed to sign server certificate")
+		return err
+	}
+
+	// PEM encode the  server cert and key
+	serverCertPEM = new(bytes.Buffer)
+	pem.Encode(serverCertPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: serverCertBytes,
+	})
+
+	serverKeyPEM = new(bytes.Buffer)
+	pem.Encode(serverKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(serverKey),
+	})
+
+	if err = os.MkdirAll(config.WebhookCertDir, 0755); err != nil {
+		log.Error(err, "Failed to create directory", "Dir", config.WebhookCertDir)
+		return err
+	}
+	if err = writeFile(path.Join(config.WebhookCertDir, "tls.crt"), serverCertPEM); err != nil {
+		log.Error(err, "Failed to write tls cert", "Path", path.Join(config.WebhookCertDir, "tls.crt"))
+		return err
+	}
+
+	if err = writeFile(path.Join(config.WebhookCertDir, "tls.key"), serverKeyPEM); err != nil {
+		log.Error(err, "Failed to write tls cert", "Path", path.Join(config.WebhookCertDir, "tls.key"))
+		return err
+	}
+	if err = updateWebhookConfig(caPEM); err != nil {
+		return err
+	}
+	return nil
+}
+
+func updateWebhookConfig(caCert *bytes.Buffer) error {
+	config := ctrl.GetConfigOrDie()
+	kubeClient := kubernetes.NewForConfigOrDie(config)
+	webhookCfg, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.TODO(), validatingWebhookConfiguration, v1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	updated := false
+	for idx, webhook := range webhookCfg.Webhooks {
+		if bytes.Equal(webhook.ClientConfig.CABundle, caCert.Bytes()) {
+			continue
+		}
+		updated = true
+		webhook.ClientConfig.CABundle = caCert.Bytes()
+		webhookCfg.Webhooks[idx] = webhook
+	}
+	if updated {
+		if _, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(context.TODO(), webhookCfg, v1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,16 +25,15 @@ const (
 	// LicenseInterval is the timeout for checking license status
 	LicenseInterval = 86400
 	// LicenseIntervalForDFW is the timeout for checking license status while no DFW license enabled
-	LicenseIntervalForDFW  = 1800
-	defaultWebhookPort     = 9981
-	defaultWebhookCertPath = "/tmp/k8s-webhook-server/serving-certs"
+	LicenseIntervalForDFW = 1800
+	defaultWebhookPort    = 9981
+	WebhookCertDir        = "/tmp/k8s-webhook-server/serving-certs"
 )
 
 var (
 	LogLevel               int
 	ProbeAddr, MetricsAddr string
 	WebhookServerPort      int
-	WebhookCertDir         string
 	configFilePath         = ""
 	configLog              *zap.SugaredLogger
 	tokenProvider          auth.TokenProvider
@@ -153,7 +152,6 @@ func AddFlags() {
 	flag.StringVar(&MetricsAddr, "metrics-bind-address", ":8093", "The address the metrics endpoint binds to.")
 	flag.IntVar(&LogLevel, "log-level", 0, "Use zap-core log system.")
 	flag.IntVar(&WebhookServerPort, "webhook-server-port", defaultWebhookPort, "Port number to expose the controller webhook server")
-	flag.StringVar(&WebhookCertDir, "webhook-cert-dir", defaultWebhookCertPath, "Directory for certificate for webhook server")
 	flag.Parse()
 }
 


### PR DESCRIPTION
Cert-manager may be not ready when deploying nsx-operator, which make
that nsx-operator can't leverage cert-manager to issuing webhook certs.
Instead, add an init container to generate self-signed certificates and
inject CA into webhook configurations.

Test done:
1. Check webhook server certificate generated by init container.
2. Check CA is injected into webhook configurations.
3. Check webhook server running up.