### PR TITLE
Add lock for vpc networkconfig storage

### DIFF
--- a/pkg/controllers/namespace/namespace_controller_test.go
+++ b/pkg/controllers/namespace/namespace_controller_test.go
@@ -43,8 +43,12 @@ func createNameSpaceReconciler() *NamespaceReconciler {
 				},
 			},
 		},
-		VPCNetworkConfigMap:   map[string]common.VPCNetworkConfigInfo{},
-		VPCNSNetworkConfigMap: map[string]string{},
+		VPCNetworkConfigStore: vpc.VPCNetworkInfoStore{
+			VPCNetworkConfigMap: map[string]common.VPCNetworkConfigInfo{},
+		},
+		VPCNSNetworkConfigStore: vpc.VPCNsNetworkConfigStore{
+			VPCNSNetworkConfigMap: map[string]string{},
+		},
 	}
 
 	return &NamespaceReconciler{

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -75,9 +75,13 @@ func createService(t *testing.T) (*VPCService, *gomock.Controller, *mocks.MockVp
 				},
 			},
 		},
-		VpcStore:              vpcStore,
-		VPCNetworkConfigMap:   map[string]common.VPCNetworkConfigInfo{},
-		VPCNSNetworkConfigMap: map[string]string{},
+		VpcStore: vpcStore,
+		VPCNetworkConfigStore: VPCNetworkInfoStore{
+			VPCNetworkConfigMap: map[string]common.VPCNetworkConfigInfo{},
+		},
+		VPCNSNetworkConfigStore: VPCNsNetworkConfigStore{
+			VPCNSNetworkConfigMap: map[string]string{},
+		},
 	}
 	return service, mockCtrl, mockVpcclient
 }
@@ -181,9 +185,13 @@ func TestGetVPCsByNamespace(t *testing.T) {
 	}
 	vpcStore := &VPCStore{ResourceStore: resourceStore}
 	service := &VPCService{
-		Service:               common.Service{NSXClient: nil},
-		VPCNetworkConfigMap:   map[string]common.VPCNetworkConfigInfo{},
-		VPCNSNetworkConfigMap: map[string]string{},
+		Service: common.Service{NSXClient: nil},
+		VPCNetworkConfigStore: VPCNetworkInfoStore{
+			VPCNetworkConfigMap: map[string]common.VPCNetworkConfigInfo{},
+		},
+		VPCNSNetworkConfigStore: VPCNsNetworkConfigStore{
+			VPCNSNetworkConfigMap: map[string]string{},
+		},
 	}
 	service.VpcStore = vpcStore
 	type args struct {
@@ -415,9 +423,13 @@ func TestCreateOrUpdateAVIRule(t *testing.T) {
 	spStore := &AviSecurityPolicyStore{ResourceStore: resourceStore2}
 
 	service := &VPCService{
-		Service:               common.Service{NSXClient: nil},
-		VPCNetworkConfigMap:   map[string]common.VPCNetworkConfigInfo{},
-		VPCNSNetworkConfigMap: map[string]string{},
+		Service: common.Service{NSXClient: nil},
+		VPCNetworkConfigStore: VPCNetworkInfoStore{
+			VPCNetworkConfigMap: map[string]common.VPCNetworkConfigInfo{},
+		},
+		VPCNSNetworkConfigStore: VPCNsNetworkConfigStore{
+			VPCNSNetworkConfigMap: map[string]string{},
+		},
 	}
 
 	service.RuleStore = ruleStore


### PR DESCRIPTION
Add locker for VPC network config storage map object to avoid concurrent modification