### PR TITLE
Fix the issue that VM cannot get DHCP IP

### DIFF
--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -88,12 +88,14 @@ func (service *SubnetService) buildDHCPConfig(enableDHCP bool, poolSize int64) *
 	// otherwise Subnet will use DhcpConfig inherited from VPC.
 	dhcpConfig := &model.VpcSubnetDhcpConfig{
 		EnableDhcp: Bool(enableDHCP),
-		StaticPoolConfig: &model.StaticPoolConfig{
+	}
+	if !enableDHCP {
+		dhcpConfig.StaticPoolConfig = &model.StaticPoolConfig{
 			// Number of IPs to be reserved in static ip pool.
 			// By default, if dhcp is enabled then static ipv4 pool size will be zero and all available IPs will be
 			// reserved in local dhcp pool. Maximum allowed value is 'subnet size - 4'.
 			Ipv4PoolSize: Int64(poolSize),
-		},
+		}
 	}
 	return dhcpConfig
 }


### PR DESCRIPTION
In DHCP subnet, the static ip pool size should be zero.

Testing done:

1. Patch the fix in a live testbed and ceate a DHCP subnet
2. Create a VM under the DHCP subnet and check the VM can get the DHCP IP:
>     # kubectl get vm -n yiyi-ns  -o wide test-vm-dhcp-cloudinit-jammy-fixed
>     NAME                                 POWER-STATE   CLASS               IMAGE                   PRIMARY-IP4    AGE
>     test-vm-dhcp-cloudinit-jammy-fixed   PoweredOn     best-effort-small   vmi-d8b7c860a0eab5c84   172.26.1.131   5m47s