### PR TITLE
Specify the release branches the triggering workflow must run on in order to trigger related workflow

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,9 +2,13 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - main
+    - 'v[0-9].[0-9]+.[0-9]+'
   pull_request:
-    branches: [ main ]
+    branches:
+    - main
+    - 'v[0-9].[0-9]+.[0-9]+'
 
 jobs:
   build:


### PR DESCRIPTION
Specify the release branches the triggering workflow must run on in order to trigger related workflow

ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

    Signed-off-by: Wenqi Qiu <wenqiq@vmware.com>
