### PR TITLE
Change NetworkInfo CR plural

### DIFF
--- a/build/yaml/crd/nsx.vmware.com_networkinfos.yaml
+++ b/build/yaml/crd/nsx.vmware.com_networkinfos.yaml
@@ -5,13 +5,13 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
-  name: networkinfoes.nsx.vmware.com
+  name: networkinfos.nsx.vmware.com
 spec:
   group: nsx.vmware.com
   names:
     kind: NetworkInfo
     listKind: NetworkInfoList
-    plural: networkinfoes
+    plural: networkinfos
     singular: networkinfo
   scope: Namespaced
   versions:

--- a/pkg/apis/nsx.vmware.com/v1alpha1/networkinfo_types.go
+++ b/pkg/apis/nsx.vmware.com/v1alpha1/networkinfo_types.go
@@ -12,6 +12,7 @@ import (
 //+kubebuilder:storageversion
 
 // NetworkInfo is used to report the network information for a namespace.
+// +kubebuilder:resource:path=networkinfos
 type NetworkInfo struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/v1alpha1/networkinfo_types.go
+++ b/pkg/apis/v1alpha1/networkinfo_types.go
@@ -12,6 +12,7 @@ import (
 //+kubebuilder:storageversion
 
 // NetworkInfo is used to report the network information for a namespace.
+// +kubebuilder:resource:path=networkinfos
 type NetworkInfo struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
For kubernetes client-go, the generated networkinfo plural is networkinfos. Change NetworkInfo CRD to use networkinfos as plural instead of networkinfoes.