### PR TITLE
Fix webhook cert issue in HA mode

### DIFF
--- a/cmd/webhookcert/main.go
+++ b/cmd/webhookcert/main.go
@@ -16,8 +16,11 @@ import (
 	"path"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
@@ -27,6 +30,8 @@ import (
 var (
 	log                            = logger.Log
 	validatingWebhookConfiguration = "nsx-operator-validating-webhook-configuration"
+	namespace                      = "vmware-system-nsx"
+	certName                       = "nsx-operator-webhook-cert"
 )
 
 func main() {
@@ -37,14 +42,14 @@ func main() {
 }
 
 // WriteFile writes data in the file at the given path
-func writeFile(filepath string, cert *bytes.Buffer) error {
+func writeFile(filepath string, cert []byte) error {
 	f, err := os.Create(filepath)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
-	_, err = f.Write(cert.Bytes())
+	_, err = f.Write(cert)
 	if err != nil {
 		return err
 	}
@@ -142,28 +147,61 @@ func generateWebhookCerts() error {
 		Bytes: x509.MarshalPKCS1PrivateKey(serverKey),
 	})
 
+	kubeClient := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())
+	certSecret := &corev1.Secret{
+		TypeMeta: v1.TypeMeta{},
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: namespace,
+			Name:      certName,
+		},
+		Data: map[string][]byte{
+			"tls.key": serverKeyPEM.Bytes(),
+			"tls.crt": serverCertPEM.Bytes(),
+		},
+	}
+	if err := retry.OnError(retry.DefaultRetry, func(err error) bool {
+		return err != nil
+	}, func() error {
+		if _, err := kubeClient.CoreV1().Secrets(namespace).Create(context.TODO(), certSecret, v1.CreateOptions{}); err != nil {
+			if errors.IsAlreadyExists(err) {
+				// In HA mode, there are multiple nsx-operator instances trying to create webhook certificates, this
+				// guarantees that only one instance can create webhook certificates.
+				log.Info("Secret already existed, skip creating", "name", certName)
+				certSecret, err = kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), certName, v1.GetOptions{})
+				if err != nil {
+					return err
+				}
+			} else {
+				log.Error(err, "Failed to create secret", "name", certName)
+				return err
+			}
+		} else {
+			if err = updateWebhookConfig(kubeClient, caPEM); err != nil {
+				log.Error(err, "Failed to update webhook configuration", "name", validatingWebhookConfiguration)
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
 	if err = os.MkdirAll(config.WebhookCertDir, 0755); err != nil {
 		log.Error(err, "Failed to create directory", "Dir", config.WebhookCertDir)
 		return err
 	}
-	if err = writeFile(path.Join(config.WebhookCertDir, "tls.crt"), serverCertPEM); err != nil {
+	if err = writeFile(path.Join(config.WebhookCertDir, "tls.crt"), certSecret.Data["tls.crt"]); err != nil {
 		log.Error(err, "Failed to write tls cert", "Path", path.Join(config.WebhookCertDir, "tls.crt"))
 		return err
 	}
 
-	if err = writeFile(path.Join(config.WebhookCertDir, "tls.key"), serverKeyPEM); err != nil {
+	if err = writeFile(path.Join(config.WebhookCertDir, "tls.key"), certSecret.Data["tls.key"]); err != nil {
 		log.Error(err, "Failed to write tls cert", "Path", path.Join(config.WebhookCertDir, "tls.key"))
-		return err
-	}
-	if err = updateWebhookConfig(caPEM); err != nil {
 		return err
 	}
 	return nil
 }
 
-func updateWebhookConfig(caCert *bytes.Buffer) error {
-	config := ctrl.GetConfigOrDie()
-	kubeClient := kubernetes.NewForConfigOrDie(config)
+func updateWebhookConfig(kubeClient *kubernetes.Clientset, caCert *bytes.Buffer) error {
 	webhookCfg, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.TODO(), validatingWebhookConfiguration, v1.GetOptions{})
 	if err != nil {
 		return err


### PR DESCRIPTION
When nsx-operator is deployed with HA mode, each instances will try to generate webhook certificates and update webhook configuration. This will cause that each instance is using different certs and the webhook can't work. So use secret to store webhook certs instead. Each instance will try to create cert secret and k8s api-server could guarantee that only one will succeed.

Tests:
1. Depeloy nsx-operator with mutli replicas, check the webhook server work as expected.