### PR TITLE
Refactor ZapLogger

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,14 +1,14 @@
 package logger
 
 import (
-	"flag"
+	"os"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	zapcr "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 const logTmFmtWithMS = "2006-01-02 15:04:05.000"
@@ -42,6 +42,7 @@ func getLogLevel(cfDebug bool, cfLogLevel int) int {
 }
 
 func ZapLogger(cfDebug bool, cfLogLevel int) logr.Logger {
+	logLevel := getLogLevel(cfDebug, cfLogLevel)
 	encoderConf := zapcore.EncoderConfig{
 		CallerKey:      "caller_line",
 		LevelKey:       "level_name",
@@ -55,24 +56,13 @@ func ZapLogger(cfDebug bool, cfLogLevel int) logr.Logger {
 		EncodeDuration: zapcore.SecondsDurationEncoder,
 		EncodeName:     zapcore.FullNameEncoder,
 	}
+	core := zapcore.NewCore(
+		zapcore.NewConsoleEncoder(encoderConf),
+		zapcore.AddSync(zapcore.Lock(os.Stdout)),
+		zapcore.Level(-1*logLevel),
+	)
+	zapLogger := zap.New(core)
+	defer zapLogger.Sync()
 
-	opts := zapcr.Options{
-		Development:     true,
-		Level:           zap.NewAtomicLevelAt(zap.InfoLevel),
-		Encoder:         zapcore.NewConsoleEncoder(encoderConf),
-		StacktraceLevel: zap.FatalLevel,
-	}
-	opts.BindFlags(flag.CommandLine)
-
-	// In level.go of zapcore, higher levels are more important.
-	// However, in logr.go, a higher verbosity level means a log message is less important.
-	// So we need to reverse the order of the levels.
-	logLevel := getLogLevel(cfDebug, cfLogLevel)
-	opts.Level = zapcore.Level(-1 * logLevel)
-	opts.ZapOpts = append(opts.ZapOpts, zap.AddCaller(), zap.AddCallerSkip(0))
-	if logLevel > 0 {
-		opts.StacktraceLevel = zap.ErrorLevel
-	}
-
-	return zapcr.New(zapcr.UseFlagOptions(&opts))
+	return zapr.NewLogger(zapLogger)
 }


### PR DESCRIPTION
Previous ZapLogger used global function opts.BindFlags which make it
1. could be called only once
2. may conflict with other module

Refactor it not to use BindFlags

Test Done:
1. call ZapLogger twice in the test program to check if it's panic or not