### PR TITLE
Workaround for DATA RACE

### DIFF
--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -49,7 +49,7 @@ var FeaturesName = [AllFeatures]string{"VPC", "SECURITY_POLICY", "NSX_SERVICE_AC
 
 type Client struct {
 	NsxConfig     *config.NSXOperatorConfig
-	RestConnector *client.RestConnector
+	RestConnector client.Connector
 	Cluster       *Cluster
 
 	QueryClient    search.QueryClient
@@ -116,7 +116,7 @@ func (ck *NSXHealthChecker) CheckNSXHealth(req *http.Request) error {
 	}
 }
 
-func restConnector(c *Cluster) *client.RestConnector {
+func restConnector(c *Cluster) client.Connector {
 	connector, _ := c.NewRestConnector()
 	return connector
 }

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -162,10 +162,11 @@ func (cluster *Cluster) CreateServerUrl(host string, scheme string) string {
 
 // NewRestConnector creates a RestConnector used for SDK client.
 // HeaderConfig is used to use http header for request, it could be ignored if no extra header needed.
-func (cluster *Cluster) NewRestConnector() (*policyclient.RestConnector, *HeaderConfig) {
+func (cluster *Cluster) NewRestConnector() (policyclient.Connector, *HeaderConfig) {
 	nsxtUrl := cluster.CreateServerUrl(cluster.endpoints[0].Host(), cluster.endpoints[0].Scheme())
-	connector := policyclient.NewRestConnector(nsxtUrl, *cluster.client)
+	connector := policyclient.NewConnector(nsxtUrl, policyclient.UsingRest(nil), policyclient.WithHttpClient(cluster.client))
 	header := CreateHeaderConfig(false, false, cluster.config.AllowOverwriteHeader)
+	connector.NewExecutionContext()
 	return connector, header
 }
 


### PR DESCRIPTION
There is data race while running cleanup
The root cause is that lazy creation without lock
1. switch to use NewConnector instead of NewRestConnector
2. call connector.NewExecutionContext to avoid lazy creation

Test Done:
1. use go run -race cmd_clean/main.go to run and check if there is DATA RACE
2. no data race reported