### PR TITLE
Replace shared vpc namespace annotation(#578)

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -73,7 +73,7 @@ const (
 	TagValueGroupDestination           string = "destination"
 	TagValueGroupAvi                   string = "avi"
 	AnnotationVPCNetworkConfig         string = "nsx.vmware.com/vpc_network_config"
-	AnnotationVPCName                  string = "nsx.vmware.com/vpc_name"
+	AnnotationSharedVPCNamespace       string = "nsx.vmware.com/shared_vpc_namespace"
 	AnnotationDefaultNetworkConfig     string = "nsx.vmware.com/default"
 	AnnotationAttachmentRef            string = "nsx.vmware.com/attachment_ref"
 	AnnotationPodMAC                   string = "nsx.vmware.com/mac"

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -382,16 +382,11 @@ func (s *VPCService) getSharedVPCNamespaceFromNS(ns string) (string, error) {
 		return "", nil
 	}
 
-	// If no annotation nsx.vmware.com/vpc_name on ns, this is not a shared vpc
-	ncName, exist := annos[common.AnnotationVPCName]
+	// If no annotation nsx.vmware.com/shared_vpc_namespace on ns, this is not a shared vpc
+	shared_ns, exist := annos[common.AnnotationSharedVPCNamespace]
 	if !exist {
 		return "", nil
 	}
-
-	// Retrieve the shared vpc namespace from annotation
-	// The format should be namespace/vpc_name, e.g. kube-system/infra-vpc
-	shared_ns := strings.Split(ncName, "/")[0]
-
 	return shared_ns, nil
 }
 

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -135,7 +135,7 @@ func TestGetSharedVPCNamespaceFromNS(t *testing.T) {
 		expected string
 	}{
 		{"1", "test-ns-1", map[string]string{"nsx.vmware.com/vpc_network_config": "default"}, ""},
-		{"2", "test-ns-2", map[string]string{"nsx.vmware.com/vpc_network_config": "infra", "nsx.vmware.com/vpc_name": "kube-system/fake_vpc"}, "kube-system"},
+		{"2", "test-ns-2", map[string]string{"nsx.vmware.com/vpc_network_config": "infra", "nsx.vmware.com/shared_vpc_namespace": "kube-system"}, "kube-system"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -20,12 +20,13 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/client/clientset/versioned"
+
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/test/e2e/providers"
 )
 
 const (
-	defaultTimeout         = 100 * time.Second
+	defaultTimeout         = 200 * time.Second
 	verifyNoneExistTimeout = 15 * time.Second
 	crdVersion             = "v1alpha1"
 )

--- a/test/e2e/manifest/testSubnet/shared_ns.yaml
+++ b/test/e2e/manifest/testSubnet/shared_ns.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    nsx.vmware.com/vpc_name: target-ns/target-ns-vpc
+    nsx.vmware.com/shared_vpc_namespace: target-ns
   name: target-ns
 
 ---
@@ -11,5 +11,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    nsx.vmware.com/vpc_name: target-ns/target-ns-vpc
+    nsx.vmware.com/shared_vpc_namespace: target-ns
   name: subnet-e2e-shared


### PR DESCRIPTION
Previously, "nsx.vmware.com/vpc_name: <namespace name>:<vpc name>" annotation represents the namespace share vpc from other namespace, as we removed VPC CRD,
 we can change this annotation to "nsx.vmware.com/shared-vpc-namespace: <shared vpc namespace>".
Signed-off-by: Xie Zheng <xizheng@vmware.com>