### PR TITLE
Fix NetworkInfo gc issue

### DIFF
--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
@@ -17,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
-
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
@@ -56,7 +56,7 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			controllerutil.AddFinalizer(obj, commonservice.NetworkInfoFinalizerName)
 			if err := r.Client.Update(ctx, obj); err != nil {
 				log.Error(err, "add finalizer", "NetworkInfo", req.NamespacedName)
-				updateFail(r, &ctx, obj, &err, r.Client)
+				updateFail(r, &ctx, obj, &err, r.Client, nil)
 				return common.ResultRequeue, err
 			}
 			log.V(1).Info("added finalizer on NetworkInfo CR", "NetworkInfo", req.NamespacedName)
@@ -64,8 +64,8 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 		createdVpc, nc, err := r.Service.CreateOrUpdateVPC(obj)
 		if err != nil {
-			log.Error(err, "operate failed, would retry exponentially", "VPC", req.NamespacedName)
-			updateFail(r, &ctx, obj, &err, r.Client)
+			log.Error(err, "create vpc failed, would retry exponentially", "VPC", req.NamespacedName)
+			updateFail(r, &ctx, obj, &err, r.Client, nil)
 			return common.ResultRequeueAfter10sec, err
 		}
 
@@ -77,8 +77,15 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if !isShared {
 			err = r.Service.CreateOrUpdateAVIRule(createdVpc, obj.Namespace)
 			if err != nil {
-				log.Error(err, "operate failed, would retry exponentially", "NetworkInfo", req.NamespacedName)
-				updateFail(r, &ctx, obj, &err, r.Client)
+				state := &v1alpha1.VPCState{
+					Name:                    *createdVpc.DisplayName,
+					VPCPath:                 *createdVpc.Path,
+					DefaultSNATIP:           "",
+					LoadBalancerIPAddresses: "",
+					PrivateIPv4CIDRs:        nc.PrivateIPv4CIDRs,
+				}
+				log.Error(err, "update avi rule failed, would retry exponentially", "NetworkInfo", req.NamespacedName)
+				updateFail(r, &ctx, obj, &err, r.Client, state)
 				return common.ResultRequeueAfter10sec, err
 			}
 		}
@@ -90,6 +97,14 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			snatIP, err = r.Service.GetDefaultSNATIP(*createdVpc)
 			if err != nil {
 				log.Error(err, "failed to read default SNAT ip from VPC", "VPC", createdVpc.Id)
+				state := &v1alpha1.VPCState{
+					Name:                    *createdVpc.DisplayName,
+					VPCPath:                 *createdVpc.Path,
+					DefaultSNATIP:           "",
+					LoadBalancerIPAddresses: "",
+					PrivateIPv4CIDRs:        nc.PrivateIPv4CIDRs,
+				}
+				updateFail(r, &ctx, obj, &err, r.Client, state)
 				return common.ResultRequeueAfter10sec, err
 			}
 		}
@@ -101,11 +116,26 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			path, cidr, err = r.Service.GetAVISubnetInfo(*createdVpc)
 			if err != nil {
 				log.Error(err, "failed to read lb subnet path and cidr", "VPC", createdVpc.Id)
+				state := &v1alpha1.VPCState{
+					Name:                    *createdVpc.DisplayName,
+					VPCPath:                 *createdVpc.Path,
+					DefaultSNATIP:           snatIP,
+					LoadBalancerIPAddresses: "",
+					PrivateIPv4CIDRs:        nc.PrivateIPv4CIDRs,
+				}
+				updateFail(r, &ctx, obj, &err, r.Client, state)
 				return common.ResultRequeueAfter10sec, err
 			}
 		}
 
-		updateSuccess(r, &ctx, obj, r.Client, *createdVpc.DisplayName, *createdVpc.Path, snatIP, path, cidr, nc.PrivateIPv4CIDRs, nc.Name)
+		state := &v1alpha1.VPCState{
+			Name:                    *createdVpc.DisplayName,
+			VPCPath:                 *createdVpc.Path,
+			DefaultSNATIP:           snatIP,
+			LoadBalancerIPAddresses: cidr,
+			PrivateIPv4CIDRs:        nc.PrivateIPv4CIDRs,
+		}
+		updateSuccess(r, &ctx, obj, r.Client, state, nc.Name, path)
 	} else {
 		if controllerutil.ContainsFinalizer(obj, commonservice.NetworkInfoFinalizerName) {
 			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, common.MetricResTypeNetworkInfo)
@@ -179,8 +209,11 @@ func (r *NetworkInfoReconciler) Start(mgr ctrl.Manager) error {
 	return nil
 }
 
-// GarbageCollector collect vpc which has been removed from networkInfo crd.
-// cancel is used to break the loop during UT
+// GarbageCollector logic for nsx-vpc is that:
+// 1. list all current existing namespace in kubernetes
+// 2. list all the nsx-vpc in vpcStore
+// 3. loop all the nsx-vpc to get its namespace, check if the namespace still exist
+// 4. if ns do not exist anymore, delete the nsx-vpc resource
 func (r *NetworkInfoReconciler) GarbageCollector(cancel chan bool, timeout time.Duration) {
 	ctx := context.Background()
 	log.Info("VPC garbage collector started")
@@ -190,31 +223,35 @@ func (r *NetworkInfoReconciler) GarbageCollector(cancel chan bool, timeout time.
 			return
 		case <-time.After(timeout):
 		}
+		// read all nsx-vpc from vpc store
 		nsxVPCList := r.Service.ListVPC()
 		if len(nsxVPCList) == 0 {
 			continue
 		}
 
-		networkInfoList := &v1alpha1.NetworkInfoList{}
-		err := r.Client.List(ctx, networkInfoList)
+		// read all namespaces from k8s
+		namespaces := &corev1.NamespaceList{}
+		err := r.Client.List(ctx, namespaces)
 		if err != nil {
-			log.Error(err, "failed to list NetworkInfo CR")
+			log.Error(err, "failed to list k8s namespaces")
 			continue
 		}
 
-		crdNetworkInfoVPCStateSet := sets.NewString()
-		for _, networkInfo := range networkInfoList.Items {
-			for _, vpcState := range networkInfo.VPCs {
-				crdNetworkInfoVPCStateSet.Insert(vpcState.VPCPath)
-			}
+		nsSet := sets.NewString()
+		for _, ns := range namespaces.Items {
+			nsSet.Insert(ns.Namespace)
 		}
 
 		for _, elem := range nsxVPCList {
-			if crdNetworkInfoVPCStateSet.Has(*elem.Path) {
+			// for go lint Implicit memory aliasing in for loop
+			// this limitation is fixed after golang 1.22, should remove the temp var after upgrading to 1.22
+			tempElem := elem
+			nsxVPCNamespace := getNamespaceFromNSXVPC(&tempElem)
+			if nsSet.Has(nsxVPCNamespace) {
 				continue
 			}
 
-			log.V(1).Info("GC collected nsx VPC object", "ID", elem.Id)
+			log.V(1).Info("GC collected nsx VPC object", "ID", elem.Id, "Namespace", nsxVPCNamespace)
 			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, common.MetricResTypeNetworkInfo)
 			err = r.Service.DeleteVPC(*elem.Path)
 			if err != nil {

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -563,8 +563,6 @@ func (s *VPCService) CreateOrUpdateVPC(obj *v1alpha1.NetworkInfo) (*model.Vpc, *
 	if err != nil {
 		log.Error(err, "failed to create VPC", "Project", nc.NsxtProject, "Namespace", obj.Namespace)
 		// TODO: this seems to be a nsx bug, in some case, even if nsx returns failed but the object is still created.
-		// in this condition, we still need to read the object and update it into store, or else operator will create multiple
-		// vpcs for this namespace.
 		log.Info("try to read VPC although VPC creation failed", "VPC", *createdVpc.Id)
 		failedVpc, rErr := s.NSXClient.VPCClient.Get(nc.Org, nc.NsxtProject, *createdVpc.Id)
 		if rErr != nil {
@@ -572,10 +570,8 @@ func (s *VPCService) CreateOrUpdateVPC(obj *v1alpha1.NetworkInfo) (*model.Vpc, *
 			log.Info("confirmed VPC is not created", "VPC", createdVpc.Id)
 			return nil, nil, err
 		} else {
-			// vpc created anyway, update store, and in this scenario, we condsider creating successfully
-			log.Info("read VPCs from NSX after creation failed, still update VPC store", "VPC", *createdVpc.Id)
-			s.VpcStore.Add(&failedVpc)
-			return &failedVpc, &nc, nil
+			// vpc created anyway, in this case, we consider this vpc is created successfully and continue realize process
+			log.Info("vpc created although nsx return error, continue to check realization", "VPC", *failedVpc.Id)
 		}
 	}
 


### PR DESCRIPTION
1. refactor update NetworkInfo CRD logic
2. do not insert vpc into store if we hit nsx issue that vpc is created but nsx api return error
3. in networkinfo gc logic, only compare if the nsx-vpc's namespace still exist.