### PR TITLE
Fix the node not found issue when creating subnet port

### DIFF
--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -91,7 +91,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			log.Error(err, "failed to get node ID for pod", "pod.Name", req.NamespacedName, "pod.UID", pod.UID, "node", pod.Spec.NodeName)
 			return common.ResultRequeue, err
 		}
-		contextID := *node.Id
+		contextID := *node.UniqueId
 		nsxSubnet, err := r.SubnetService.GetSubnetByPath(nsxSubnetPath)
 		if err != nil {
 			return common.ResultRequeue, err
@@ -143,7 +143,7 @@ func (r *PodReconciler) GetNodeByName(nodeName string) (*model.HostTransportNode
 	if len(nodes) > 1 {
 		var nodeIDs []string
 		for _, node := range nodes {
-			nodeIDs = append(nodeIDs, *node.Id)
+			nodeIDs = append(nodeIDs, *node.UniqueId)
 		}
 		return nil, fmt.Errorf("multiple node IDs found for node %s: %v", nodeName, nodeIDs)
 	}

--- a/pkg/nsx/services/node/node.go
+++ b/pkg/nsx/services/node/node.go
@@ -74,7 +74,7 @@ func (service *NodeService) SyncNodeStore(nodeName string, deleted bool) error {
 	}
 	// TODO: confirm whether we need to resync the node info from NSX
 	if len(nodes) == 1 {
-		log.Info("node alreay cached", "node.Fqdn", nodes[0].NodeDeploymentInfo.Fqdn, "node.Id", *nodes[0].Id)
+		log.Info("node alreay cached", "node.Fqdn", nodes[0].NodeDeploymentInfo.Fqdn, "node.UniqueId", *nodes[0].UniqueId)
 		// updatedNode, err := service.NSXClient.HostTransPortNodesClient.Get("default", "default", nodes[0].Id)
 		// if err != nil {
 		// 	return fmt.Errorf("failed to get HostTransPortNode for node %s: %s", nodeName, err)

--- a/pkg/nsx/services/node/store.go
+++ b/pkg/nsx/services/node/store.go
@@ -56,7 +56,7 @@ func (nodeStore *NodeStore) GetByIndex(key string, value string) []*model.HostTr
 func keyFunc(obj interface{}) (string, error) {
 	switch v := obj.(type) {
 	case *model.HostTransportNode:
-		return *v.Id, nil
+		return *v.UniqueId, nil
 	default:
 		return "", errors.New("keyFunc doesn't support unknown type")
 	}

--- a/pkg/nsx/services/node/store_test.go
+++ b/pkg/nsx/services/node/store_test.go
@@ -13,7 +13,7 @@ import (
 
 func Test_KeyFunc(t *testing.T) {
 	id := "test_id"
-	node := model.HostTransportNode{Id: &id}
+	node := model.HostTransportNode{UniqueId: &id}
 	t.Run("1", func(t *testing.T) {
 		got, _ := keyFunc(&node)
 		if got != "test_id" {
@@ -34,7 +34,7 @@ func TestSubnetStore_Apply(t *testing.T) {
 	}
 	nodeStore := &NodeStore{ResourceStore: resourceStore}
 	fakeNode := model.HostTransportNode{
-		Id: common.String("node_id"),
+		UniqueId: common.String("node_id"),
 		NodeDeploymentInfo: &model.FabricHostNode{
 			Fqdn: common.String("node_name"),
 		},


### PR DESCRIPTION
We found a case in the new NSX build that the node.Id may not match the node.UniqueId and node.RealizationId. That broke our previous assumption in https://github.com/vmware-tanzu/nsx-operator/pull/297#discussion_r1311316157,
i.e. I thought the node's id/realization_id/unique_id are the same.

For example, the output of the NSX API:

```
{
  ...
  "id" : "192-163-255-xxx-162bba4a-4945-4906-9e4a-ef128398e555host-18",
  "display_name" : "192.163.255.28",
  ...
  "unique_id" : "0bd18d0d-33f6-4034-b95f-9fcb0874b846",
  "realization_id" : "0bd18d0d-33f6-4034-b95f-9fcb0874b846",
  ...
}
```

So this patch will change to use the UniqueId as the node's key to
avoid the following error reported by NSX:

`SegmentPort with ... does not belong to this node, returning.`

Tesing done:
Patched the fix on the problematic testbed, then the pending pod can
become running and the NSX operator log indicates that the subnet
port was created.