### PR TITLE
Remove logger global setting for cleanup

### DIFF
--- a/pkg/clean/clean_dlb.go
+++ b/pkg/clean/clean_dlb.go
@@ -10,6 +10,8 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
+
+	"github.com/go-logr/logr"
 )
 
 type (
@@ -63,7 +65,7 @@ func httpQueryDLBResources(cluster *nsx.Cluster, cf *config.NSXOperatorConfig, r
 	return resourcePath, nil
 }
 
-func CleanDLB(ctx context.Context, cluster *nsx.Cluster, cf *config.NSXOperatorConfig) error {
+func CleanDLB(ctx context.Context, cluster *nsx.Cluster, cf *config.NSXOperatorConfig, log *logr.Logger) error {
 	log.Info("Deleting DLB resources started")
 
 	resources := []string{"Group", "LBVirtualServer", "LBService", "LBPool", "LBCookiePersistenceProfile"}

--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	log  = logger.Log
+	log  = &logger.Log
 	lock = &sync.Mutex{}
 )
 

--- a/pkg/controllers/ippool/ippool_controller.go
+++ b/pkg/controllers/ippool/ippool_controller.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	log           = logger.Log
+	log           = &logger.Log
 	resultNormal  = common.ResultNormal
 	resultRequeue = common.ResultRequeue
 	MetricResType = common.MetricResTypeIPPool

--- a/pkg/controllers/namespace/namespace_controller.go
+++ b/pkg/controllers/namespace/namespace_controller.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	AnnotationNamespaceVPCError = " nsx.vmware.com/vpc_error"
-	log                         = logger.Log
+	log                         = &logger.Log
 )
 
 // NamespaceReconciler process namespace create/delete event

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	log           = logger.Log
+	log           = &logger.Log
 	MetricResType = common.MetricResTypeNetworkInfo
 )
 

--- a/pkg/controllers/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controllers/networkpolicy/networkpolicy_controller.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	log                     = logger.Log
+	log                     = &logger.Log
 	ResultNormal            = common.ResultNormal
 	ResultRequeue           = common.ResultRequeue
 	ResultRequeueAfter5mins = common.ResultRequeueAfter5mins

--- a/pkg/controllers/node/node_controller.go
+++ b/pkg/controllers/node/node_controller.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	log               = logger.Log
+	log               = &logger.Log
 	MetricResTypeNode = common.MetricResTypeNode
 )
 

--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
@@ -33,7 +33,7 @@ import (
 )
 
 var (
-	log                     = logger.Log
+	log                     = &logger.Log
 	ResultNormal            = common.ResultNormal
 	ResultRequeue           = common.ResultRequeue
 	ResultRequeueAfter5mins = common.ResultRequeueAfter5mins

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	log              = logger.Log
+	log              = &logger.Log
 	MetricResTypePod = common.MetricResTypePod
 )
 

--- a/pkg/controllers/securitypolicy/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller.go
@@ -40,7 +40,7 @@ import (
 )
 
 var (
-	log                     = logger.Log
+	log                     = &logger.Log
 	ResultNormal            = common.ResultNormal
 	ResultRequeue           = common.ResultRequeue
 	ResultRequeueAfter5mins = common.ResultRequeueAfter5mins

--- a/pkg/controllers/service/service_lb_controller.go
+++ b/pkg/controllers/service/service_lb_controller.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	log           = logger.Log
+	log           = &logger.Log
 	ResultNormal  = common.ResultNormal
 	ResultRequeue = common.ResultRequeue
 	MetricResType = common.MetricResTypeServiceLb

--- a/pkg/controllers/staticroute/staticroute_controller.go
+++ b/pkg/controllers/staticroute/staticroute_controller.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	log                     = logger.Log
+	log                     = &logger.Log
 	ResultNormal            = common.ResultNormal
 	ResultRequeue           = common.ResultRequeue
 	ResultRequeueAfter5mins = common.ResultRequeueAfter5mins

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	log                     = logger.Log
+	log                     = &logger.Log
 	ResultNormal            = common.ResultNormal
 	ResultRequeue           = common.ResultRequeue
 	ResultRequeueAfter5mins = common.ResultRequeueAfter5mins

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	log                     = logger.Log
+	log                     = &logger.Log
 	MetricResTypeSubnetPort = common.MetricResTypeSubnetPort
 )
 

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	log                     = logger.Log
+	log                     = &logger.Log
 	ResultNormal            = common.ResultNormal
 	ResultRequeue           = common.ResultRequeue
 	ResultRequeueAfter5mins = common.ResultRequeueAfter5mins

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -27,6 +27,10 @@ func init() {
 	Log = logf.Log.WithName("nsx-operator")
 }
 
+func InitLog(log *logr.Logger) {
+	Log = *log
+}
+
 // If debug set in configmap, set log level to 1.
 // If loglevel set in command line and greater than debug log level, set it to command line level.
 func getLogLevel(cfDebug bool, cfLogLevel int) int {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,7 +24,7 @@ const (
 	ScrapeTimeout                   = 30
 )
 
-var log = logger.Log
+var log = &logger.Log
 
 var (
 	NSXOperatorHealthStats = prometheus.NewGauge(

--- a/pkg/nsx/auth/jwt/JWTtokenprovider.go
+++ b/pkg/nsx/auth/jwt/JWTtokenprovider.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	log = logger.Log
+	log = &logger.Log
 )
 
 type JWTTokenProvider struct {

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -63,7 +63,7 @@ type NsxVersion struct {
 var (
 	jarCache   = NewJar()
 	nsxVersion = &NsxVersion{}
-	log        = logger.Log
+	log        = &logger.Log
 )
 
 // NewCluster creates a cluster based on nsx Config.

--- a/pkg/nsx/ratelimiter/ratelimiter.go
+++ b/pkg/nsx/ratelimiter/ratelimiter.go
@@ -16,7 +16,7 @@ import (
 // APIReduceRateCodes is http status code set which will trigger rate limiter adjust.
 var (
 	APIReduceRateCodes = [2]int{429, 503}
-	log                = logger.Log
+	log                = &logger.Log
 )
 
 const (

--- a/pkg/nsx/services/common/compare.go
+++ b/pkg/nsx/services/common/compare.go
@@ -7,7 +7,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 )
 
-var log = logger.Log
+var log = &logger.Log
 
 type Comparable interface {
 	Key() string

--- a/pkg/nsx/services/ippool/ippool.go
+++ b/pkg/nsx/services/ippool/ippool.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	log                           = logger.Log
+	log                           = &logger.Log
 	MarkedForDelete               = true
 	EnforceRevisionCheckParam     = false
 	ResourceTypeIPPool            = common.ResourceTypeIPPool

--- a/pkg/nsx/services/node/node.go
+++ b/pkg/nsx/services/node/node.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	log              = logger.Log
+	log              = &logger.Log
 	ResourceTypeNode = servicecommon.ResourceTypeNode
 	MarkedForDelete  = true
 )

--- a/pkg/nsx/services/nsxserviceaccount/cluster.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster.go
@@ -43,7 +43,7 @@ const (
 )
 
 var (
-	log = logger.Log
+	log = &logger.Log
 
 	isProtectedTrue = true
 	vpcRole         = "ccp_internal_operator"

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	log                        = logger.Log
+	log                        = &logger.Log
 	MarkedForDelete            = true
 	EnforceRevisionCheckParam  = false
 	ResourceTypeSecurityPolicy = common.ResourceTypeSecurityPolicy

--- a/pkg/nsx/services/staticroute/staticroute.go
+++ b/pkg/nsx/services/staticroute/staticroute.go
@@ -23,7 +23,7 @@ type StaticRouteService struct {
 }
 
 var (
-	log                     = logger.Log
+	log                     = &logger.Log
 	resourceTypeStaticRoute = "StaticRoutes"
 	String                  = common.String
 )

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	log                       = logger.Log
+	log                       = &logger.Log
 	MarkedForDelete           = true
 	EnforceRevisionCheckParam = false
 	ResourceTypeSubnet        = common.ResourceTypeSubnet

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	log                    = logger.Log
+	log                    = &logger.Log
 	ResourceTypeSubnetPort = servicecommon.ResourceTypeSubnetPort
 	MarkedForDelete        = true
 )

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	log             = logger.Log
+	log             = &logger.Log
 	ctx             = context.Background()
 	ResourceTypeVPC = common.ResourceTypeVpc
 	NewConverter    = common.NewConverter

--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -31,7 +31,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 )
 
-var log = logger.Log
+var log = &logger.Log
 
 // ErrorDetail is error detail which info extracted from http.Response.Body.
 type ErrorDetail struct {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -56,7 +56,7 @@ func init() {
 	}
 }
 
-var log = logger.Log
+var log = &logger.Log
 
 func NormalizeLabels(matchLabels *map[string]string) *map[string]string {
 	newLabels := make(map[string]string)


### PR DESCRIPTION
 Using separate instance for each cleanup instance
    
    Cleanup should support multiple instances which each should have its
    own logger instance.
    Remove glogal SetLogger calling for cleanup, but nsx-operator still have it
    Using logger.InitLog to create initialize log
    
    Test Done:
    1. run cleanup, check if log output is normal
    2. run manager, check if log output is normal

        