### PR TITLE
Log NSX API errors with NSXApiError utility function

### DIFF
--- a/pkg/nsx/services/ippool/ippool.go
+++ b/pkg/nsx/services/ippool/ippool.go
@@ -137,9 +137,11 @@ func (service *IPPoolService) Apply(nsxIPPool *model.IpAddressPool, nsxIPSubnets
 		} else {
 			err = service.NSXClient.ProjectInfraClient.Patch(VPCInfo[0].OrgID, VPCInfo[0].ProjectID, *infraIPPool,
 				&EnforceRevisionCheckParam)
+			err = util.NSXApiError(err)
 		}
 	} else if IPPoolType == common.IPPoolTypePublic {
 		err = service.NSXClient.InfraClient.Patch(*infraIPPool, &EnforceRevisionCheckParam)
+		err = util.NSXApiError(err)
 	} else {
 		err = util.NoEffectiveOption{Desc: "not valid IPPool type"}
 	}
@@ -233,6 +235,7 @@ func (service *IPPoolService) acquireCidr(obj *v1alpha2.IPPool, subnetRequest *v
 		return "", err
 	}
 	m, err := service.NSXClient.RealizedEntitiesClient.List(VPCInfo[0].OrgID, VPCInfo[0].ProjectID, intentPath, nil)
+	err = util.NSXApiError(err)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/nsx/services/node/node.go
+++ b/pkg/nsx/services/node/node.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 var (
@@ -82,6 +83,7 @@ func (service *NodeService) SyncNodeStore(nodeName string, deleted bool) error {
 		// node.NodeStore.Apply(updatedNode)
 	}
 	nodeResults, err := service.NSXClient.HostTransPortNodesClient.List("default", "default", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	err = nsxutil.NSXApiError(err)
 	if err != nil {
 		return fmt.Errorf("failed to list HostTransportNodes: %s", err)
 	}

--- a/pkg/nsx/services/nsxserviceaccount/cluster.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
@@ -191,6 +192,7 @@ func (s *NSXServiceAccountService) RestoreRealizedNSXServiceAccount(ctx context.
 		return fmt.Errorf("PI/CCP doesn't match")
 	}
 	_, err := s.NSXClient.ClusterControlPlanesClient.Get(siteId, enforcementpointId, normalizedClusterName)
+	err = nsxutil.NSXApiError(err)
 	if err == nil {
 		return fmt.Errorf("CCP store is not synchronized")
 	}
@@ -240,6 +242,7 @@ func (s *NSXServiceAccountService) createPIAndCCP(normalizedClusterName string, 
 			CertificatePem: &cert,
 			Tags:           common.ConvertTagsToMPTags(s.buildBasicTags(obj)),
 		})
+		err = nsxutil.NSXApiError(err)
 		if err != nil {
 			return "", err
 		}
@@ -260,6 +263,7 @@ func (s *NSXServiceAccountService) createPIAndCCP(normalizedClusterName string, 
 			NodeId:       existingClusterId,
 			Tags:         s.buildBasicTags(obj),
 		})
+		err = nsxutil.NSXApiError(err)
 		if err != nil {
 			return "", err
 		}
@@ -332,6 +336,7 @@ func (s *NSXServiceAccountService) DeleteNSXServiceAccount(ctx context.Context, 
 	if isDeleteCCP {
 		cascade := true
 		if err := s.NSXClient.ClusterControlPlanesClient.Delete(siteId, enforcementpointId, normalizedClusterName, &cascade); err != nil {
+			err = nsxutil.NSXApiError(err)
 			log.Error(err, "failed to delete", "ClusterControlPlane", normalizedClusterName)
 			return err
 		}
@@ -342,11 +347,13 @@ func (s *NSXServiceAccountService) DeleteNSXServiceAccount(ctx context.Context, 
 	if piobj := s.PrincipalIdentityStore.GetByKey(normalizedClusterName); isDeletePI && (piobj != nil) {
 		pi := piobj.(mpmodel.PrincipalIdentity)
 		if err := s.NSXClient.PrincipalIdentitiesClient.Delete(*pi.Id); err != nil {
+			err = nsxutil.NSXApiError(err)
 			log.Error(err, "failed to delete", "PrincipalIdentity", *pi.Name)
 			return err
 		}
 		if pi.CertificateId != nil && *pi.CertificateId != "" {
 			if err := s.NSXClient.CertificatesClient.Delete(*pi.CertificateId); err != nil {
+				err = nsxutil.NSXApiError(err)
 				log.Error(err, "failed to delete", "PrincipalIdentity", *pi.Name, "Certificate", *pi.CertificateId)
 				return err
 			}
@@ -433,6 +440,7 @@ func (s *NSXServiceAccountService) updatePIAndCCPCert(normalizedClusterName, uid
 	ccp := ccpObj.(model.ClusterControlPlane)
 	ccp.Certificate = &cert
 	if ccp, err := s.NSXClient.ClusterControlPlanesClient.Update(siteId, enforcementpointId, normalizedClusterName, ccp); err != nil {
+		err = nsxutil.NSXApiError(err)
 		return err
 	} else {
 		s.ClusterControlPlaneStore.Add(ccp)
@@ -449,18 +457,21 @@ func (s *NSXServiceAccountService) updatePIAndCCPCert(normalizedClusterName, uid
 		PemEncoded:  &cert,
 	})
 	if err != nil {
+		err = nsxutil.NSXApiError(err)
 		return err
 	}
 	if pi, err = s.NSXClient.PrincipalIdentitiesClient.Updatecertificate(mpmodel.UpdatePrincipalIdentityCertificateRequest{
 		CertificateId:       certList.Results[0].Id,
 		PrincipalIdentityId: pi.Id,
 	}); err != nil {
+		err = nsxutil.NSXApiError(err)
 		return err
 	} else {
 		s.PrincipalIdentityStore.Add(pi)
 	}
 	if oldCertId != "" {
 		if err := s.NSXClient.CertificatesClient.Delete(oldCertId); err != nil {
+			err = nsxutil.NSXApiError(err)
 			log.Error(err, "failed to delete", "PrincipalIdentity", *pi.Name, "Old Certificate", *pi.CertificateId)
 		}
 	}

--- a/pkg/nsx/services/realizestate/realize_state.go
+++ b/pkg/nsx/services/realizestate/realize_state.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 type RealizeStateService struct {
@@ -43,6 +44,7 @@ func (service *RealizeStateService) CheckRealizeState(backoff wait.Backoff, inte
 		return !IsRealizeStateError(err)
 	}, func() error {
 		results, err := service.NSXClient.RealizedEntitiesClient.List(vpcInfo.OrgID, vpcInfo.ProjectID, intentPath, nil)
+		err = nsxutil.NSXApiError(err)
 		if err != nil {
 			return err
 		}

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -499,6 +499,7 @@ func (service *SecurityPolicyService) createOrUpdateSecurityPolicy(obj *v1alpha1
 
 		// 3.Create/update SecurityPolicy together with groups, rules under VPC level and project groups, shares.
 		err = service.NSXClient.OrgRootClient.Patch(*orgRoot, &EnforceRevisionCheckParam)
+		err = nsxutil.NSXApiError(err)
 		if err != nil {
 			log.Error(err, "failed to create or update SecurityPolicy in VPC")
 			return err
@@ -526,6 +527,7 @@ func (service *SecurityPolicyService) createOrUpdateSecurityPolicy(obj *v1alpha1
 			return err
 		}
 		err = service.NSXClient.InfraClient.Patch(*infraSecurityPolicy, &EnforceRevisionCheckParam)
+		err = nsxutil.NSXApiError(err)
 		if err != nil {
 			log.Error(err, "failed to create or update SecurityPolicy")
 			return err
@@ -732,6 +734,7 @@ func (service *SecurityPolicyService) deleteSecurityPolicy(obj interface{}, isVp
 
 		// 3.Create/update SecurityPolicy together with groups, rules under VPC level and project groups, shares.
 		err = service.NSXClient.OrgRootClient.Patch(*orgRoot, &EnforceRevisionCheckParam)
+		err = nsxutil.NSXApiError(err)
 		if err != nil {
 			log.Error(err, "failed to delete SecurityPolicy in VPC")
 			return err
@@ -759,6 +762,7 @@ func (service *SecurityPolicyService) deleteSecurityPolicy(obj interface{}, isVp
 			return err
 		}
 		err = service.NSXClient.InfraClient.Patch(*infraSecurityPolicy, &EnforceRevisionCheckParam)
+		err = nsxutil.NSXApiError(err)
 		if err != nil {
 			log.Error(err, "failed to delete SecurityPolicy")
 			return err
@@ -805,8 +809,10 @@ func (service *SecurityPolicyService) createOrUpdateGroups(obj *v1alpha1.Securit
 			vpcId := (*vpcInfo).VPCID
 
 			err = service.NSXClient.VpcGroupClient.Patch(orgId, projectId, vpcId, *group.Id, *group)
+			err = nsxutil.NSXApiError(err)
 		} else {
 			err = service.NSXClient.GroupClient.Patch(getDomain(service), *group.Id, *group)
+			err = nsxutil.NSXApiError(err)
 		}
 	}
 

--- a/pkg/nsx/services/staticroute/staticroute.go
+++ b/pkg/nsx/services/staticroute/staticroute.go
@@ -83,6 +83,7 @@ func (service *StaticRouteService) CreateOrUpdateStaticRoute(namespace string, o
 		return err
 	}
 	staticRoute, err := service.NSXClient.StaticRouteClient.Get(vpc[0].OrgID, vpc[0].ProjectID, vpc[0].ID, *nsxStaticRoute.Id)
+	err = nsxutil.NSXApiError(err)
 	if err != nil {
 		return err
 	}
@@ -95,6 +96,7 @@ func (service *StaticRouteService) CreateOrUpdateStaticRoute(namespace string, o
 
 func (service *StaticRouteService) patch(orgId string, projectId string, vpcId string, st *model.StaticRoutes) error {
 	err := service.NSXClient.StaticRouteClient.Patch(orgId, projectId, vpcId, *st.Id, *st)
+	err = nsxutil.NSXApiError(err)
 	if err != nil {
 		return err
 	}
@@ -109,6 +111,7 @@ func (service *StaticRouteService) DeleteStaticRouteByPath(orgId string, project
 	}
 
 	if err := staticRouteClient.Delete(orgId, projectId, vpcId, *staticroute.Id); err != nil {
+		err = nsxutil.NSXApiError(err)
 		return err
 	}
 	if err := service.StaticRouteStore.Delete(staticroute); err != nil {

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -111,10 +111,12 @@ func (service *SubnetService) createOrUpdateSubnet(obj client.Object, nsxSubnet 
 		return "", err
 	}
 	if err = service.NSXClient.OrgRootClient.Patch(*orgRoot, &EnforceRevisionCheckParam); err != nil {
+		err = nsxutil.NSXApiError(err)
 		return "", err
 	}
 	// Get Subnet from NSX after patch operation as NSX renders several fields like `path`/`parent_path`.
 	if *nsxSubnet, err = service.NSXClient.SubnetsClient.Get(vpcInfo.OrgID, vpcInfo.ProjectID, vpcInfo.VPCID, *nsxSubnet.Id); err != nil {
+		err = nsxutil.NSXApiError(err)
 		return "", err
 	}
 	realizeService := realizestate.InitializeRealizeState(service.Service)
@@ -151,6 +153,7 @@ func (service *SubnetService) DeleteSubnet(nsxSubnet model.VpcSubnet) error {
 		return err
 	}
 	if err = service.NSXClient.OrgRootClient.Patch(*orgRoot, &EnforceRevisionCheckParam); err != nil {
+		err = nsxutil.NSXApiError(err)
 		// Subnets that are not deleted successfully will finally be deleted by GC.
 		log.Error(err, "failed to delete Subnet", "ID", *nsxSubnet.Id)
 		return err
@@ -198,12 +201,14 @@ func (service *SubnetService) IsOrphanSubnet(subnet model.VpcSubnet, subnetsetID
 func (service *SubnetService) DeleteIPAllocation(orgID, projectID, vpcID, subnetID string) error {
 	ipAllocations, err := service.NSXClient.IPAllocationClient.List(orgID, projectID, vpcID, subnetID, ipPoolID,
 		nil, nil, nil, nil, nil, nil)
+	err = nsxutil.NSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to get ip-allocations", "Subnet", subnetID)
 		return err
 	}
 	for _, alloc := range ipAllocations.Results {
 		if err = service.NSXClient.IPAllocationClient.Delete(orgID, projectID, vpcID, subnetID, ipPoolID, *alloc.Id); err != nil {
+			err = nsxutil.NSXApiError(err)
 			log.Error(err, "failed to delete ip-allocation", "Subnet", subnetID, "ip-alloc", *alloc.Id)
 			return err
 		}
@@ -218,6 +223,7 @@ func (service *SubnetService) GetSubnetStatus(subnet *model.VpcSubnet) ([]model.
 		return nil, err
 	}
 	statusList, err := service.NSXClient.SubnetStatusClient.List(param.OrgID, param.ProjectID, param.VPCID, *subnet.Id)
+	err = nsxutil.NSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to get subnet status")
 		return nil, err
@@ -236,6 +242,7 @@ func (service *SubnetService) getIPPoolUsage(nsxSubnet *model.VpcSubnet) (*model
 		return nil, err
 	}
 	ipPool, err := service.NSXClient.IPPoolClient.Get(param.OrgID, param.ProjectID, param.VPCID, *nsxSubnet.Id, ipPoolID)
+	err = nsxutil.NSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to get ip-pool", "Subnet", *nsxSubnet.Id)
 		return nil, err

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -103,6 +103,7 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 			return nil, err
 		}
 		err = service.NSXClient.PortClient.Patch(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, *nsxSubnetPort.Id, *nsxSubnetPort)
+		err = nsxutil.NSXApiError(err)
 		if err != nil {
 			log.Error(err, "failed to create or update subnet port", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)
 			return nil, err
@@ -188,6 +189,7 @@ func (service *SubnetPortService) GetSubnetPortState(obj interface{}, nsxSubnetP
 	}
 	nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID := nsxutil.ParseVPCPath(nsxSubnetPath)
 	nsxSubnetPortState, err := service.NSXClient.PortStateClient.Get(nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID, string(uid), nil, nil)
+	err = nsxutil.NSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to get subnet port state", "nsxSubnetPortID", uid, "nsxSubnetPath", nsxSubnetPath)
 		return nil, err
@@ -203,6 +205,7 @@ func (service *SubnetPortService) DeleteSubnetPort(uid types.UID) error {
 	}
 	nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID := nsxutil.ParseVPCPath(*nsxSubnetPort.Path)
 	err := service.NSXClient.PortClient.Delete(nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID, string(uid))
+	err = nsxutil.NSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to delete subnetport", "nsxSubnetPort.Path", *nsxSubnetPort.Path)
 		return err
@@ -234,6 +237,7 @@ func (service *SubnetPortService) GetGatewayPrefixForSubnetPort(obj *v1alpha1.Su
 	}
 	// TODO: if the port is not the first on the same subnet, try to get the info from existing realized subnetport CR to avoid query NSX API again.
 	statusList, err := service.NSXClient.SubnetStatusClient.List(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID)
+	err = nsxutil.NSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to get subnet status")
 		return "", -1, err

--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -311,6 +311,63 @@ func DumpHttpRequest(request *http.Request) {
 	log.V(2).Info("http request", "url", request.URL, "body", string(body), "head", request.Header)
 }
 
+// NSXApiError processes an error and returns a formatted NSX API error message if applicable.
+// If the processed API error is nil, return the original error
+func NSXApiError(err error) error {
+	if err == nil {
+		return err
+	}
+	apierror, _ := DumpAPIError(err)
+	if apierror == nil {
+		return err
+	}
+	return fmt.Errorf("nsx error code: %d, message: %s, details: %s, related error: %s",
+		safeInt(apierror.ErrorCode), safeString(apierror.ErrorMessage), safeString(apierror.Details),
+		relatedErrorsToString(apierror.RelatedErrors))
+}
+
+func relatedErrorToString(err *model.RelatedApiError) string {
+	if err == nil {
+		return "nil"
+	}
+
+	return fmt.Sprintf(
+		"{Details: %s, ErrorCode: %d,  ErrorMessage: %s, ModuleName: %s}",
+		safeString(err.Details),
+		safeInt(err.ErrorCode),
+		safeString(err.ErrorMessage),
+		safeString(err.ModuleName),
+	)
+}
+
+func relatedErrorsToString(errors []model.RelatedApiError) string {
+	if errors == nil {
+		return "nil"
+	}
+
+	var errorStrings []string
+	for i := 0; i < len(errors); i++ {
+		currentErr := errors[i]
+		errorStrings = append(errorStrings, relatedErrorToString(&currentErr))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(errorStrings, ", "))
+}
+
+func safeString(ptr *string) string {
+	if ptr == nil {
+		return ""
+	}
+	return *ptr
+}
+
+func safeInt(ptr *int64) int64 {
+	if ptr == nil {
+		return 0
+	}
+	return *ptr
+}
+
 // if ApiError is nil, check ErrorTypeEnum, such as ServiceUnavailable
 // if both return value are nil, the error is not on the list
 // there is no httpstatus, ApiError does't include it


### PR DESCRIPTION
Previously, the log
`nsx-system nsx-ncp-d7d769f8b-dm7b6 nsx-operator 2024-06-20 08:31:55.547	ERROR	failed to create VPC	{"Project": "nsx_operator_e2e_test", "Namespace": "kube-system", "error": "com.vmware.vapi.std.errors.invalid_request"}`
`invalid_request` is not readable to users, we try to parse it to nsx api error or return the original if
failed to parse.
The new log `nsx-system nsx-ncp-9dcc89f7f-dfmfr nsx-operator 2024-06-25 14:37:51.098	ERROR	controller/controller.go:329	Reconciler error	{"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "Pod": {"name":"coredns-76f75df574-8tm29","namespace":"kube-system"}, "namespace": "kube-system", "name": "coredns-76f75df574-8tm29", "reconcileID": "088ba077-f9c3-446b-bd9a-a6d0a9d59dc7", "error": "nsx error code: 500157, message: Error while creating objects of type:VpcSubnet, details: , related error: [{Details: , ErrorCode: 600,  ErrorMessage: The requested object : /orgs/default/projects/nsx_operator_e2e_test/vpcs/96139faf-71b6-4200-9336-2bf5c38e3a9c could not be found. Object identifiers are case sensitive., ModuleName: common-services}]"}` is more friendly to user.


 Signed-off-by: Xie Zheng <xizheng@vmware.com>