### PR TITLE
Add back caller to log

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -65,7 +65,8 @@ func ZapLogger(cfDebug bool, cfLogLevel int) logr.Logger {
 		zapcore.AddSync(zapcore.Lock(os.Stdout)),
 		zapcore.Level(-1*logLevel),
 	)
-	zapLogger := zap.New(core)
+	zapLogger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1))
+
 	defer zapLogger.Sync()
 
 	return zapr.NewLogger(zapLogger)


### PR DESCRIPTION
Add back, print caller filename and line number in log. It was removed by commit 9921fe33708bb6277459246782b2365886f7280f
