### PR TITLE
Add support for VPC mixed mode

### DIFF
--- a/build/yaml/webhook/manifests.yaml
+++ b/build/yaml/webhook/manifests.yaml
@@ -30,3 +30,36 @@ webhooks:
     resources:
     - subnetsets
   sideEffects: None
+- admissionReviewVersions:
+    - v1
+  clientConfig:
+    service:
+      name: subnetset
+      namespace: vmware-system-nsx
+      path: /validate-vpc-enablement
+  failurePolicy: Fail
+  name: vpcnetwork.validating.nsx.vmware.com
+  rules:
+    - apiGroups:
+        - nsx.vmware.com
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+      resources:
+        - networkinfos
+        - nsxserviceaccount
+        - securitypolicies
+        - staticroutes
+        - subnetports
+        - subnets
+        - subnetsets
+    - apiGroups:
+        - nsx.vmware.com
+      apiVersions:
+        - v1alpha2
+      operations:
+        - CREATE
+      resources:
+        - ippools
+  sideEffects: None

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha2"
@@ -35,6 +36,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/subnet"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/subnetport"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/subnetset"
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/vpcnetwork"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
@@ -133,12 +135,13 @@ func StartNetworkInfoController(mgr ctrl.Manager, vpcService *vpc.VPCService) {
 	}
 }
 
-func StartNamespaceController(mgr ctrl.Manager, cf *config.NSXOperatorConfig, vpcService common.VPCServiceProvider) {
+func StartNamespaceController(mgr ctrl.Manager, cf *config.NSXOperatorConfig, vpcService common.VPCServiceProvider, networkProvider vpcnetwork.VPCNetworkProvider) {
 	nsReconciler := &namespacecontroller.NamespaceReconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
-		NSXConfig:  cf,
-		VPCService: vpcService,
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		NSXConfig:       cf,
+		VPCService:      vpcService,
+		NetworkProvider: networkProvider,
 	}
 
 	if err := nsReconciler.Start(mgr); err != nil {
@@ -149,14 +152,26 @@ func StartNamespaceController(mgr ctrl.Manager, cf *config.NSXOperatorConfig, vp
 
 func main() {
 	log.Info("starting NSX Operator")
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgrOptions := ctrl.Options{
 		Scheme:                  scheme,
 		HealthProbeBindAddress:  config.ProbeAddr,
 		Metrics:                 metricsserver.Options{BindAddress: config.MetricsAddr},
 		LeaderElection:          cf.HAEnabled(),
 		LeaderElectionNamespace: nsxOperatorNamespace,
 		LeaderElectionID:        "nsx-operator",
-	})
+	}
+
+	enableWebhook := true
+	if _, err := os.Stat(config.WebhookCertDir); errors.Is(err, os.ErrNotExist) {
+		log.Error(err, "server cert not found, disabling webhook server", "cert", config.WebhookCertDir)
+		enableWebhook = false
+	} else {
+		mgrOptions.WebhookServer = webhook.NewServer(webhook.Options{
+			Port:    config.WebhookServerPort,
+			CertDir: config.WebhookCertDir,
+		})
+	}
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOptions)
 	if err != nil {
 		log.Error(err, "failed to init manager")
 		os.Exit(1)
@@ -181,6 +196,10 @@ func main() {
 	var vpcService *vpc.VPCService
 
 	if cf.CoeConfig.EnableVPCNetwork {
+		if !enableWebhook {
+			log.Error(nil, "Webhook cert is not provided, can't filter out the CRs in a non-VPC namespace")
+			os.Exit(1)
+		}
 		// Check NSX version for VPC networking mode
 		if !commonService.NSXClient.NSXCheckVersion(nsx.VPC) {
 			log.Error(nil, "VPC mode cannot be enabled if NSX version is lower than 4.1.1")
@@ -218,16 +237,15 @@ func main() {
 			os.Exit(1)
 		}
 		// Start controllers which only supports VPC
+		var vpcNetworkProvider vpcnetwork.VPCNetworkProvider
+		if cf.CoeConfig.EnableVPCMixedMode {
+			vpcNetworkProvider = vpcnetwork.StartNetworkController(mgr)
+		}
 		StartNetworkInfoController(mgr, vpcService)
-		StartNamespaceController(mgr, cf, vpcService)
+		StartNamespaceController(mgr, cf, vpcService, vpcNetworkProvider)
 		// Start subnet/subnetset controller.
 		if err := subnet.StartSubnetController(mgr, subnetService, subnetPortService, vpcService); err != nil {
 			os.Exit(1)
-		}
-		enableWebhook := true
-		if _, err := os.Stat(config.WebhookCertDir); errors.Is(err, os.ErrNotExist) {
-			log.Error(err, "server cert not found, disabling webhook server", "cert", config.WebhookCertDir)
-			enableWebhook = false
 		}
 		if err := subnetset.StartSubnetSetController(mgr, subnetService, subnetPortService, vpcService, enableWebhook); err != nil {
 			os.Exit(1)
@@ -236,10 +254,10 @@ func main() {
 		node.StartNodeController(mgr, nodeService)
 		staticroutecontroller.StartStaticRouteController(mgr, staticRouteService)
 		subnetport.StartSubnetPortController(mgr, subnetPortService, subnetService, vpcService)
-		pod.StartPodController(mgr, subnetPortService, subnetService, vpcService, nodeService)
+		pod.StartPodController(mgr, subnetPortService, subnetService, vpcService, nodeService, vpcNetworkProvider)
 		StartIPPoolController(mgr, ipPoolService, vpcService)
-		networkpolicycontroller.StartNetworkPolicyController(mgr, commonService, vpcService)
-		service.StartServiceLbController(mgr, commonService)
+		networkpolicycontroller.StartNetworkPolicyController(mgr, commonService, vpcService, vpcNetworkProvider)
+		service.StartServiceLbController(mgr, commonService, vpcNetworkProvider)
 	}
 	// Start controllers which can run in non-VPC mode
 	securitypolicycontroller.StartSecurityPolicyController(mgr, commonService, vpcService)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace (
 	github.com/vmware-tanzu/nsx-operator/pkg/apis => ./pkg/apis
 	github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1 => ./pkg/apis/v1alpha1
 	github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha2 => ./pkg/apis/v1alpha2
-        github.com/vmware-tanzu/nsx-operator/pkg/client => ./pkg/client
+	github.com/vmware-tanzu/nsx-operator/pkg/client => ./pkg/client
 )
 
 require (
@@ -14,6 +14,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/deckarep/golang-set v1.8.0
 	github.com/go-logr/logr v1.3.0
+	github.com/go-logr/zapr v1.2.4
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
@@ -23,6 +24,7 @@ require (
 	github.com/prometheus/client_golang v1.16.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.4
+	github.com/vmware-tanzu/net-operator-api v0.0.0-20240529180459-ccac5a20bda1
 	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240305035435-c992c623aad3
 	github.com/vmware-tanzu/nsx-operator/pkg/client v0.0.0-20240102061654-537b080e159f
 	github.com/vmware-tanzu/vm-operator/api v1.8.2
@@ -53,7 +55,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gibson042/canonicaljson-go v1.0.3 // indirect
-	github.com/go-logr/zapr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/vmware-tanzu/nsx-operator/pkg/client v0.0.0-20240102061654-537b080e159f h1:EV4eiUQr3QpUGfTtqdVph0+bmE+3cj0aNJpd9n2qTdo=
-github.com/vmware-tanzu/nsx-operator/pkg/client v0.0.0-20240102061654-537b080e159f/go.mod h1:dzob8tUzpAREQPtbbjQs4b1UyQDR37B2TiIdg8WJSRM=
+github.com/vmware-tanzu/net-operator-api v0.0.0-20240529180459-ccac5a20bda1 h1:r8RuSJnLEStOdGTfaZeOjH4rvRB4Gm/N1+qtU16VrI0=
+github.com/vmware-tanzu/net-operator-api v0.0.0-20240529180459-ccac5a20bda1/go.mod h1:w6QJGm3crIA16ZIz1FVQXD2NVeJhOgGXxW05RbVTSTo=
 github.com/vmware-tanzu/vm-operator/api v1.8.2 h1:7cZHVusqAmAMFWvsiU7X5xontxdjasknI/sVfe0p0Z4=
 github.com/vmware-tanzu/vm-operator/api v1.8.2/go.mod h1:vauVboD3sQxP+pb28TnI9wfrj+0nH2zSEc9Q7AzWJ54=
 github.com/vmware/govmomi v0.27.4 h1:5kY8TAkhB20lsjzrjE073eRb8+HixBI29PVMG5lxq6I=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,8 +94,9 @@ type DefaultConfig struct {
 }
 
 type CoeConfig struct {
-	Cluster          string `ini:"cluster"`
-	EnableVPCNetwork bool   `ini:"enable_vpc_network"`
+	Cluster            string `ini:"cluster"`
+	EnableVPCNetwork   bool   `ini:"enable_vpc_network"`
+	EnableVPCMixedMode bool   `ini:"enable_vpc_mixed_mode"`
 }
 
 type NsxConfig struct {
@@ -237,6 +238,10 @@ func (operatorConfig *NSXOperatorConfig) validate() error {
 	}
 	if err := operatorConfig.NsxConfig.validate(operatorConfig.CoeConfig.EnableVPCNetwork); err != nil {
 		return err
+	}
+	if operatorConfig.CoeConfig.EnableVPCMixedMode && !operatorConfig.CoeConfig.EnableVPCNetwork {
+		configLog.Error("VPC mixed mode is enabled but VPC is not enabled")
+		return errors.New("VPC mixed mode can't be enabled without VPC network enablement")
 	}
 	// TODO, verify if user&pwd, cert, jwt has any of them provided
 	return nil

--- a/pkg/controllers/namespace/namespace_controller_test.go
+++ b/pkg/controllers/namespace/namespace_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	vpcnetworktesting "github.com/vmware-tanzu/nsx-operator/pkg/controllers/vpcnetwork/testing"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
@@ -40,9 +41,10 @@ func createNameSpaceReconciler() *NamespaceReconciler {
 	}
 
 	return &NamespaceReconciler{
-		Client:     fake.NewClientBuilder().Build(),
-		Scheme:     fake.NewClientBuilder().Build().Scheme(),
-		VPCService: service,
+		Client:          fake.NewClientBuilder().Build(),
+		Scheme:          fake.NewClientBuilder().Build().Scheme(),
+		VPCService:      service,
+		NetworkProvider: &vpcnetworktesting.FakeVPCNetworkProvider{},
 	}
 }
 

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
-	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
@@ -329,13 +328,7 @@ func (r *SubnetSetReconciler) Start(mgr ctrl.Manager, enableWebhook bool) error 
 		return err
 	}
 	if enableWebhook {
-		hookServer := webhook.NewServer(webhook.Options{
-			Port:    config.WebhookServerPort,
-			CertDir: config.WebhookCertDir,
-		})
-		if err := mgr.Add(hookServer); err != nil {
-			return err
-		}
+		hookServer := mgr.GetWebhookServer()
 		hookServer.Register("/validate-nsx-vmware-com-v1alpha1-subnetset",
 			&webhook.Admission{
 				Handler: &SubnetSetValidator{

--- a/pkg/controllers/vpcnetwork/interfaces.go
+++ b/pkg/controllers/vpcnetwork/interfaces.go
@@ -1,0 +1,17 @@
+/* Copyright © 2024 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package vpcnetwork
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type ReconcileFunc func(ctx context.Context, req ctrl.Request) (ctrl.Result, error)
+
+type VPCNetworkProvider interface {
+	IsVPCEnabledOnNamespace(ns string) (bool, error)
+	ReconcileWithVPCFilters(resource string, ctx context.Context, req ctrl.Request, innerFunc ReconcileFunc) (ctrl.Result, error)
+}

--- a/pkg/controllers/vpcnetwork/network_controller.go
+++ b/pkg/controllers/vpcnetwork/network_controller.go
@@ -1,0 +1,186 @@
+/* Copyright © 2024 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package vpcnetwork
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
+)
+
+var (
+	log           = logger.Log
+	resultNormal  = common.ResultNormal
+	resultRequeue = common.ResultRequeue
+
+	systemNetworkNamespaces sets.Set[string]
+)
+
+const (
+	defaultNetworkLabelKey   = "is-default-network"
+	defaultNetworkLabelValue = "true"
+	vpcNetworkValidationPath = "/validate-vpc-enablement"
+)
+
+// NetworkReconciler reconciles a WCP Network object
+type NetworkReconciler struct {
+	Client client.Client
+	Scheme *apimachineryruntime.Scheme
+}
+
+func (r *NetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Log the Network create/update event.
+	log.Info("reconciling network CR", "network", req.NamespacedName)
+
+	ns := req.Namespace
+	if systemNetworkNamespaces.Has(ns) {
+		log.Info("Default Network CR in system Namespaces is updated to VPC type", "req", req.NamespacedName)
+		return resultNormal, nil
+	}
+
+	// Find the system Network Namespace when creating Network CRs
+	nsObj := &v1.Namespace{}
+	err := r.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: ns}, nsObj)
+	// This shall not happen, adding the below logic for security purpose.
+	if err != nil {
+		log.Error(err, "failed to check Namespace CR", "namespace", ns)
+		return resultRequeue, client.IgnoreNotFound(err)
+	}
+	isSystem, _ := util.IsVPCSystemNamespace(r.Client, ns, nsObj)
+	if isSystem {
+		systemNetworkNamespaces.Insert(ns)
+		if systemNetworkNamespaces.Len() == 1 {
+			log.Info("Default Network in system Namespaces is created", "req", req.NamespacedName)
+		} else {
+			// In theory, this shall not happen, adding log here for security.
+			log.Error(nil, "Multiple default Networks are found in system NSs", "namespaces", systemNetworkNamespaces.Len())
+		}
+	}
+	return resultNormal, nil
+}
+
+func (r *NetworkReconciler) IsVPCEnabledOnNamespace(ns string) (bool, error) {
+	nsObj := &v1.Namespace{}
+	err := r.Client.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: ns}, nsObj)
+	if err != nil {
+		log.Error(err, "failed to check Namespace CR", "namespace", ns)
+		return false, err
+	}
+	isSystem, _ := util.IsVPCSystemNamespace(r.Client, ns, nsObj)
+	if isSystem {
+		if systemNetworkNamespaces.Len() == 0 {
+			return false, fmt.Errorf("no shared VPC namespace found with system Namespace %s", ns)
+		}
+		ns = systemNetworkNamespaces.UnsortedList()[0]
+	}
+	netList := &v1alpha1.NetworkList{}
+	matchingLabels := client.MatchingLabels{defaultNetworkLabelKey: defaultNetworkLabelValue}
+	err = r.Client.List(context.Background(), netList, client.InNamespace(ns), matchingLabels)
+	if err != nil {
+		log.Error(err, "failed to list default Network in Namespace", "namespace", ns)
+		return false, err
+	}
+	if len(netList.Items) == 0 {
+		return false, fmt.Errorf("no default network found in Namespace %s", ns)
+	}
+	network := netList.Items[0]
+	return network.Spec.Type == v1alpha1.NetworkTypeNSXTVPC, nil
+}
+
+func (r *NetworkReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Register validation webhook to check VPC is enabled or not when creating CRs in a Namespace.
+	webhookServer := mgr.GetWebhookServer()
+	webhookServer.Register(vpcNetworkValidationPath,
+		&webhook.Admission{
+			Handler: r,
+		})
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.Network{}).
+		WithEventFilter(predicate.Funcs{
+			CreateFunc: func(createEvent event.CreateEvent) bool {
+				// Filter the resources only labeled with "is-default-network = true"
+				return isDefaultNetwork(createEvent.Object)
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				return false
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				// Ignore the deletion event.
+				return false
+			},
+		}).
+		WithOptions(
+			controller.Options{
+				MaxConcurrentReconciles: common.NumReconcile(),
+			}).
+		Complete(r)
+}
+
+func newNetworkController(mgr ctrl.Manager) *NetworkReconciler {
+	systemNetworkNamespaces = sets.New[string]()
+	return &NetworkReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+}
+
+func StartNetworkController(mgr ctrl.Manager) VPCNetworkProvider {
+	networkReconcile := newNetworkController(mgr)
+	err := networkReconcile.SetupWithManager(mgr)
+	if err != nil {
+		log.Error(err, "failed to create controller", "controller", "Network")
+		os.Exit(1)
+	}
+	return networkReconcile
+}
+
+// isDefaultNetwork returns true only if the provided network is labeled with "is-default-network=true".
+func isDefaultNetwork(network client.Object) bool {
+	labels := network.GetLabels()
+	networkLabelValue, found := labels[defaultNetworkLabelKey]
+	if !found {
+		return false
+	}
+	return strings.EqualFold(networkLabelValue, defaultNetworkLabelValue)
+}
+
+func predictNetworkUpdateEvent(e event.UpdateEvent, log logr.Logger) bool {
+	oldObj := e.ObjectOld.(*v1alpha1.Network)
+	newObj := e.ObjectNew.(*v1alpha1.Network)
+	if !isDefaultNetwork(newObj) {
+		return false
+	}
+	if oldObj.Spec.Type == newObj.Spec.Type {
+		return false
+	}
+	if newObj.Spec.Type != v1alpha1.NetworkTypeNSXTVPC {
+		log.Info("DefaultNetwork has updated its type to non-VPC, ignore", "namespace",
+			newObj.Namespace, "name", newObj.Name, "oldType", oldObj.Spec.Type, "newType", newObj.Spec.Type)
+		return false
+	}
+	if !systemNetworkNamespaces.Has(newObj.Namespace) {
+		log.Info("Ignore the event to update network type as VPC in a non-system Namespaces", "namespace", newObj.Namespace)
+		return false
+	}
+	log.Info("receive network update to VPC event", "name", oldObj.Name, "namespace", oldObj.Name)
+	return true
+}

--- a/pkg/controllers/vpcnetwork/network_handler.go
+++ b/pkg/controllers/vpcnetwork/network_handler.go
@@ -1,0 +1,106 @@
+/* Copyright © 2024 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package vpcnetwork
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
+)
+
+type EnqueueRequestForNetwork struct {
+	Client client.Client
+	Lister func(namespace string) ([]types.NamespacedName, error)
+}
+
+func (e *EnqueueRequestForNetwork) Create(_ context.Context, _ event.CreateEvent, _ workqueue.RateLimitingInterface) {
+	log.V(1).Info("namespace create event, do nothing")
+}
+
+func (e *EnqueueRequestForNetwork) Delete(_ context.Context, _ event.DeleteEvent, _ workqueue.RateLimitingInterface) {
+	log.V(1).Info("namespace delete event, do nothing")
+}
+
+func (e *EnqueueRequestForNetwork) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.RateLimitingInterface) {
+	log.V(1).Info("namespace generic event, do nothing")
+}
+
+func (e *EnqueueRequestForNetwork) Update(ctx context.Context, updateEvent event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	network := updateEvent.ObjectNew.(*v1alpha1.Network)
+	netNS := network.Namespace
+	objs := make([]types.NamespacedName, 0)
+	listCRsInNS := func(ns string) error {
+		crs, err := e.Lister(ns)
+		if err != nil {
+			log.Error(err, "Failed to list CRs in the Namespace", "namespace", network.Namespace)
+			return err
+		}
+		objs = append(objs, crs...)
+		return nil
+	}
+
+	// List existing CRs in a non-system and add into the queue
+	if !systemNetworkNamespaces.Has(netNS) {
+		if err := listCRsInNS(network.Namespace); err != nil {
+			return
+		}
+	} else {
+		// List CRs in all system Namespaces and all into the queue.
+		namespaceList := &v1.NamespaceList{}
+		err := e.Client.List(ctx, namespaceList)
+		if err != nil {
+			log.Error(err, "failed to list Namespaces after system network is updated to VPC", "namespace", network.Namespace)
+			return
+		}
+		for i := range namespaceList.Items {
+			ns := namespaceList.Items[i]
+			if isSystem, _ := util.IsVPCSystemNamespace(e.Client, ns.Name, &ns); isSystem {
+				if err = listCRsInNS(ns.Name); err != nil {
+					return
+				}
+			}
+		}
+	}
+
+	for _, namespacedname := range objs {
+		q.Add(reconcile.Request{NamespacedName: namespacedname})
+	}
+}
+
+var PredicateFuncsByNetwork = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return false
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return predictNetworkUpdateEvent(e, log.V(1))
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+}
+
+func (r *NetworkReconciler) ReconcileWithVPCFilters(resource string, ctx context.Context, req ctrl.Request, innerFunc ReconcileFunc) (ctrl.Result, error) {
+	vpcEnabled, err := r.IsVPCEnabledOnNamespace(req.Namespace)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("failed to check VPC enablement when processing %s", resource), "namespace", req.Namespace, "name", req.Name)
+		return common.ResultRequeue, err
+	}
+	if !vpcEnabled {
+		log.V(2).Info(fmt.Sprintf("VPC is not enabled, ignore %s in the Namespace", resource), "namespace", req.Namespace)
+		return common.ResultNormal, nil
+	}
+	return innerFunc(ctx, req)
+}

--- a/pkg/controllers/vpcnetwork/network_test.go
+++ b/pkg/controllers/vpcnetwork/network_test.go
@@ -1,0 +1,712 @@
+/* Copyright © 2024 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package vpcnetwork
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
+	svccommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+var (
+	systemNS = "kube-system"
+)
+
+func TestPredictNetworkUpdateEvent(t *testing.T) {
+	oldDNS := []string{"1.1.1.1"}
+	newDNS := []string{"1.1.1.1", "1.1.1.2"}
+	nonSystemNS := "ns1"
+	systemNetworkNamespaces = sets.New[string](systemNS)
+
+	for _, tc := range []struct {
+		name      string
+		oldNet    *v1alpha1.Network
+		newNet    *v1alpha1.Network
+		expResult bool
+	}{
+		{
+			name:      "Update event on non-default Network",
+			oldNet:    createNetwork("non-default", systemNS, v1alpha1.NetworkTypeNSXT, nil, oldDNS),
+			newNet:    createNetwork("non-default", systemNS, v1alpha1.NetworkTypeNSXTVPC, nil, newDNS),
+			expResult: false,
+		},
+		{
+			name:      "Update default VDS Network with no change on network type",
+			oldNet:    createVDSDefaultNetwork("default", systemNS, oldDNS),
+			newNet:    createVDSDefaultNetwork("default", systemNS, newDNS),
+			expResult: false,
+		},
+		{
+			name:      "Update default VPC Network with no change on network type",
+			oldNet:    createVPCDefaultNetwork("default", nonSystemNS, oldDNS),
+			newNet:    createVPCDefaultNetwork("default", nonSystemNS, newDNS),
+			expResult: false,
+		},
+		{
+			name:      "Update default Network to non-VPC type",
+			oldNet:    createVDSDefaultNetwork("default", nonSystemNS, oldDNS),
+			newNet:    createDefaultNetwork("default", nonSystemNS, v1alpha1.NetworkTypeNSXT, newDNS),
+			expResult: false,
+		},
+		{
+			name:      "Update default Network in a non-system Namespace",
+			oldNet:    createVDSDefaultNetwork("default", nonSystemNS, oldDNS),
+			newNet:    createVPCDefaultNetwork("default", nonSystemNS, oldDNS),
+			expResult: false,
+		},
+		{
+			name:      "Update default Network to VPC in system Namespaces",
+			oldNet:    createVDSDefaultNetwork("default", systemNS, oldDNS),
+			newNet:    createVPCDefaultNetwork("default", systemNS, oldDNS),
+			expResult: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Network create event is ignored.
+			createResult := PredicateFuncsByNetwork.Create(event.CreateEvent{
+				Object: tc.oldNet,
+			})
+			assert.False(t, createResult)
+			// Network update event is processed.
+			updateEvent := event.UpdateEvent{
+				ObjectOld: tc.oldNet,
+				ObjectNew: tc.newNet,
+			}
+			updateResult := PredicateFuncsByNetwork.Update(updateEvent)
+			assert.Equal(t, tc.expResult, updateResult)
+			// Network delete event is ignored.
+			deleteResult := PredicateFuncsByNetwork.Delete(event.DeleteEvent{
+				Object: tc.newNet,
+			})
+			assert.False(t, deleteResult)
+		})
+	}
+}
+
+func TestIsDefaultNetwork(t *testing.T) {
+	//systemNetworkNamespaces = sets.New[string]()
+	for _, tc := range []struct {
+		name      string
+		network   *v1alpha1.Network
+		expResult bool
+	}{
+		{
+			name:      "Network without any labels",
+			network:   createNetwork("net1", "ns1", v1alpha1.NetworkTypeNSXTVPC, nil, nil),
+			expResult: false,
+		},
+		{
+			name:      "Network without default label key",
+			network:   createNetwork("net2", "ns1", v1alpha1.NetworkTypeNSXTVPC, map[string]string{"invalid-key": "true"}, nil),
+			expResult: false,
+		},
+		{
+			name:      "Network with default label key and value false",
+			network:   createNetwork("net3", "ns1", v1alpha1.NetworkTypeNSXTVPC, map[string]string{defaultNetworkLabelKey: "false"}, nil),
+			expResult: false,
+		},
+		{
+			name:      "Network with default label key and value true",
+			network:   createNetwork("net4", "ns1", v1alpha1.NetworkTypeNSXTVPC, map[string]string{defaultNetworkLabelKey: defaultNetworkLabelValue}, nil),
+			expResult: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actResult := isDefaultNetwork(tc.network)
+			assert.Equal(t, tc.expResult, actResult)
+		})
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	reconciler := &NetworkReconciler{Client: k8sClient}
+	systemNetworkNamespaces = sets.New[string]()
+
+	ctx := context.Background()
+	systemReq := types.NamespacedName{
+		Namespace: systemNS,
+		Name:      "default-net1",
+	}
+	nonSystemReq1 := types.NamespacedName{
+		Namespace: "ns1",
+		Name:      "default",
+	}
+	nonSystemReq2 := types.NamespacedName{
+		Namespace: "ns2",
+		Name:      "default",
+	}
+
+	for _, tc := range []struct {
+		name          string
+		existingNSs   map[string]bool
+		request       ctrl.Request
+		mockFunc      func()
+		expErr        string
+		expResult     ctrl.Result
+		addToSystemNS bool
+	}{
+		{
+			name:    "Error when fetching Network's Namespace ",
+			request: ctrl.Request{NamespacedName: systemReq},
+			mockFunc: func() {
+				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("failure to get Namespace"))
+			},
+			expErr:    "failure to get Namespace",
+			expResult: resultRequeue,
+		},
+		{
+			name:    "Network's Namespace is annotated with VPC system false",
+			request: ctrl.Request{NamespacedName: nonSystemReq1},
+			mockFunc: func() {
+				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+					func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+						copyNamespace(obj, createWorkloadNamespace(nonSystemReq1.Namespace))
+						return nil
+					},
+				)
+			},
+			expResult:     resultNormal,
+			addToSystemNS: false,
+		},
+		{
+			name:    "Network's Namespace has no system annotation key",
+			request: ctrl.Request{NamespacedName: nonSystemReq2},
+			mockFunc: func() {
+				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+					func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+						copyNamespace(obj, createWorkloadNamespace(nonSystemReq2.Namespace))
+						return nil
+					},
+				)
+			},
+			expResult:     resultNormal,
+			addToSystemNS: false,
+		},
+		{
+			name:    "Network is in system Namespace",
+			request: ctrl.Request{NamespacedName: systemReq},
+			mockFunc: func() {
+				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+					func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+						copyNamespace(obj, createSystemNamespace(systemReq.Namespace))
+						return nil
+					},
+				)
+			},
+			expResult:     resultNormal,
+			addToSystemNS: true,
+		},
+		{
+			name:          "Update Network type in system Namespace without read Namespace",
+			request:       ctrl.Request{NamespacedName: systemReq},
+			expResult:     resultNormal,
+			addToSystemNS: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.mockFunc != nil {
+				tc.mockFunc()
+			}
+			result, err := reconciler.Reconcile(ctx, tc.request)
+			if tc.expErr != "" {
+				assert.EqualError(t, err, tc.expErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expResult, result)
+			if tc.addToSystemNS {
+				assert.Contains(t, systemNetworkNamespaces, tc.request.Namespace)
+			} else {
+				assert.NotContains(t, systemNetworkNamespaces, tc.request.Namespace)
+			}
+		})
+	}
+}
+
+func TestIsVPCEnabledOnNamespace(t *testing.T) {
+	defer func() {
+		systemNetworkNamespaces = nil
+	}()
+
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	reconciler := &NetworkReconciler{Client: k8sClient}
+	netNSForSystem := "kube-system"
+	defaultNetworkInSystem := createVPCDefaultNetwork("default", netNSForSystem, nil)
+	systemNetworkNamespaces = sets.New[string](netNSForSystem)
+
+	for _, tc := range []struct {
+		name       string
+		ns         string
+		listNs     string
+		netListErr error
+		isSystemNS bool
+		nsGetErr   error
+		listNets   []v1alpha1.Network
+		expErr     string
+		expResult  bool
+	}{
+		{
+			name:      "Error when checking system Namespaces",
+			ns:        "ns0",
+			nsGetErr:  fmt.Errorf("failed to list Namespaces"),
+			expErr:    "failed to list Namespaces",
+			expResult: false,
+		},
+		{
+			name:       "Error when listing Network CRs",
+			ns:         "ns1",
+			listNs:     "ns1",
+			netListErr: fmt.Errorf("failed to list Networks in Namespace"),
+			expErr:     "failed to list Networks in Namespace",
+			expResult:  false,
+		},
+		{
+			name:      "No default network exists in Namespace",
+			ns:        "ns2",
+			listNs:    "ns2",
+			listNets:  []v1alpha1.Network{},
+			expErr:    "no default network found in Namespace ns2",
+			expResult: false,
+		},
+		{
+			name:   "Default network type is VDS in Namespace ns3",
+			ns:     "ns3",
+			listNs: "ns3",
+			listNets: []v1alpha1.Network{
+				*createVDSDefaultNetwork("default-ns3", "ns3", nil),
+			},
+			expResult: false,
+		},
+		{
+			name:   "Default network type is VPC in Namespace ns4",
+			ns:     "ns4",
+			listNs: "ns4",
+			listNets: []v1alpha1.Network{
+				*createVPCDefaultNetwork("default-ns4", "ns4", nil),
+			},
+			expResult: true,
+		},
+		{
+			name:       "Default system network type is VPC",
+			ns:         netNSForSystem,
+			isSystemNS: true,
+			listNs:     netNSForSystem,
+			listNets:   []v1alpha1.Network{*defaultNetworkInSystem},
+			expResult:  true,
+		},
+		{
+			name:       "Check VPC from a different system Namespace",
+			ns:         "system",
+			isSystemNS: true,
+			listNs:     netNSForSystem,
+			listNets:   []v1alpha1.Network{*defaultNetworkInSystem},
+			expResult:  true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.nsGetErr != nil {
+				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.nsGetErr)
+			} else {
+				var namespace *corev1.Namespace
+				if tc.isSystemNS {
+					namespace = createSystemNamespace(tc.ns)
+				} else {
+					namespace = createWorkloadNamespace(tc.ns)
+				}
+				k8sClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Namespace: tc.ns, Name: tc.ns}, &corev1.Namespace{}).Return(nil).Do(
+					func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+						copyNamespace(obj, namespace)
+						return nil
+					},
+				)
+				matchingLabels := client.MatchingLabels{defaultNetworkLabelKey: defaultNetworkLabelValue}
+				listOptions := []client.ListOption{
+					client.InNamespace(tc.listNs), matchingLabels,
+				}
+				k8sClient.EXPECT().List(gomock.Any(), &v1alpha1.NetworkList{}, listOptions).Return(tc.netListErr).Do(
+					func(_ context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+						netList := obj.(*v1alpha1.NetworkList)
+						netList.Items = tc.listNets
+						return tc.netListErr
+					},
+				)
+			}
+
+			result, err := reconciler.IsVPCEnabledOnNamespace(tc.ns)
+			if tc.expErr != "" {
+				assert.EqualError(t, err, tc.expErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expResult, result)
+		})
+	}
+}
+
+func TestReconcileWithVPCFilters(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	reconciler := &NetworkReconciler{Client: k8sClient}
+	ctx := context.Background()
+	var innerHandledRequest types.NamespacedName
+	innerHandled := false
+
+	innerfunc := func(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+		innerHandled = true
+		innerHandledRequest = req.NamespacedName
+		return resultNormal, nil
+	}
+	for _, tc := range []struct {
+		name            string
+		request         ctrl.Request
+		listErr         error
+		listNets        []v1alpha1.Network
+		expErr          string
+		expResult       ctrl.Result
+		expInnerHandled bool
+	}{
+		{
+			name:      "Error when listing Network CRs",
+			listErr:   fmt.Errorf("failed to list Networks in Namespace"),
+			expErr:    "failed to list Networks in Namespace",
+			expResult: common.ResultRequeue,
+		},
+		{
+			name:    "Default network type is VDS",
+			request: ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "pod1"}},
+			listNets: []v1alpha1.Network{
+				{ObjectMeta: v1.ObjectMeta{
+					Namespace: "ns1",
+					Name:      "default",
+					Labels:    map[string]string{defaultNetworkLabelKey: defaultNetworkLabelValue}},
+					Spec: v1alpha1.NetworkSpec{
+						Type: v1alpha1.NetworkTypeVDS,
+					}},
+			},
+			expResult:       common.ResultNormal,
+			expInnerHandled: false,
+		},
+		{
+			name:    "Default network type is VPC",
+			request: ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns2", Name: "pod2"}},
+			listNets: []v1alpha1.Network{
+				{ObjectMeta: v1.ObjectMeta{
+					Namespace: "ns2",
+					Name:      "default",
+					Labels:    map[string]string{defaultNetworkLabelKey: defaultNetworkLabelValue}},
+					Spec: v1alpha1.NetworkSpec{
+						Type: v1alpha1.NetworkTypeNSXTVPC,
+					}},
+			},
+			expResult:       common.ResultNormal,
+			expInnerHandled: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			innerHandled = false
+			k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(
+				func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+					copyNamespace(obj, createWorkloadNamespace(tc.request.Namespace))
+					return nil
+				},
+			)
+			k8sClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.listErr).Do(
+				func(_ context.Context, obj client.ObjectList, options ...client.ListOption) error {
+					netList := obj.(*v1alpha1.NetworkList)
+					netList.Items = tc.listNets
+					return tc.listErr
+				},
+			)
+
+			result, err := reconciler.ReconcileWithVPCFilters("test", ctx, tc.request, innerfunc)
+			if tc.expErr != "" {
+				assert.EqualError(t, err, tc.expErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expResult, result)
+			assert.Equal(t, tc.expInnerHandled, innerHandled)
+			if tc.expInnerHandled {
+				assert.Equal(t, tc.request.NamespacedName, innerHandledRequest)
+			}
+		})
+	}
+}
+
+func TestEnqueueRequestForNetwork(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	nsAdd, nsUpdate, nsDelete, nsGeneric := "add", "update", "delete", "unknown"
+	systemNS1 := "system"
+	systemNetworkNamespaces = sets.New[string](systemNS)
+
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	enquedItems := make([]types.NamespacedName, 0)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	// Start a goroutine to get items from the queue.
+	go func() {
+		defer wg.Done()
+		for {
+			obj, _ := queue.Get()
+			item := obj.(reconcile.Request)
+			if item.Namespace == "stop" {
+				return
+			}
+			enquedItems = append(enquedItems, item.NamespacedName)
+			queue.Forget(obj)
+			queue.Done(obj)
+		}
+	}()
+
+	ctx := context.Background()
+	lister := fakeLister{items: []types.NamespacedName{
+		{Namespace: nsAdd, Name: "obj11"},
+		{Namespace: nsUpdate, Name: "obj21"},
+		{Namespace: nsUpdate, Name: "obj22"},
+		{Namespace: nsDelete, Name: "obj31"},
+		{Namespace: nsGeneric, Name: "obj41"},
+		{Namespace: systemNS, Name: "obj-system"},
+		{Namespace: systemNS1, Name: "obj-system1"},
+	}}
+
+	enqueueRequest := EnqueueRequestForNetwork{Client: k8sClient, Lister: lister.list}
+	// Call create event
+	netInAdd := createVPCDefaultNetwork("net1", nsAdd, nil)
+	enqueueRequest.Create(ctx, event.CreateEvent{Object: netInAdd}, queue)
+	// Call update event
+	netInUpdateOld := createVDSDefaultNetwork("net1", nsUpdate, nil)
+	netInUpdateNew := createVPCDefaultNetwork("net1", nsUpdate, nil)
+	enqueueRequest.Update(ctx, event.UpdateEvent{ObjectOld: netInUpdateOld, ObjectNew: netInUpdateNew}, queue)
+	// Call delete event
+	netInDelete := createVPCDefaultNetwork("net1", nsDelete, nil)
+	enqueueRequest.Delete(ctx, event.DeleteEvent{Object: netInDelete}, queue)
+	// Call generic event
+	netInGeneric := createVPCDefaultNetwork("net1", nsGeneric, nil)
+	enqueueRequest.Generic(ctx, event.GenericEvent{Object: netInGeneric}, queue)
+
+	// Call network update event in system NS
+	systemNetUpdateOld := createVDSDefaultNetwork("net1", systemNS, nil)
+	systemNetUpdateNew := createVPCDefaultNetwork("net1", systemNS, nil)
+	k8sClient.EXPECT().List(gomock.Any(), &corev1.NamespaceList{}).Return(nil).Do(
+		func(_ context.Context, obj client.ObjectList, options ...client.ListOption) error {
+			nsList := obj.(*corev1.NamespaceList)
+			nsList.Items = []corev1.Namespace{
+				*createSystemNamespace(systemNS),
+				*createSystemNamespace(systemNS1),
+				*createWorkloadNamespace(nsAdd),
+				*createWorkloadNamespace(nsUpdate),
+				*createWorkloadNamespace(nsDelete),
+				*createWorkloadNamespace(nsGeneric),
+			}
+			return nil
+		},
+	)
+	enqueueRequest.Update(ctx, event.UpdateEvent{ObjectOld: systemNetUpdateOld, ObjectNew: systemNetUpdateNew}, queue)
+	// Send stop event
+	queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "stop"}})
+
+	wg.Wait()
+	// Validate only update events are enqueue.
+	assert.Equal(t, 4, len(enquedItems))
+	assert.Contains(t, enquedItems, types.NamespacedName{Namespace: nsUpdate, Name: "obj21"})
+	assert.Contains(t, enquedItems, types.NamespacedName{Namespace: nsUpdate, Name: "obj22"})
+	assert.Contains(t, enquedItems, types.NamespacedName{Namespace: systemNS, Name: "obj-system"})
+	assert.Contains(t, enquedItems, types.NamespacedName{Namespace: systemNS1, Name: "obj-system1"})
+	queue.ShutDown()
+}
+
+func TestWebhookHandle(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	reconciler := &NetworkReconciler{Client: k8sClient}
+
+	vpcWlNS := "ns1"
+	vdsWlNS := "ns2"
+	vpcNetwork := createVPCDefaultNetwork("net1", vpcWlNS, nil)
+	vdsNetwork := createVDSDefaultNetwork("net2", vdsWlNS, nil)
+	networks := map[string][]v1alpha1.Network{
+		vpcWlNS: {*vpcNetwork},
+		vdsWlNS: {*vdsNetwork},
+	}
+	allowedResp := admission.Allowed("")
+	disallowedResp := admission.Errored(http.StatusBadRequest, fmt.Errorf("VPC is not enabled in Namespace %s", vdsWlNS))
+	systemNetworkNamespaces = sets.New[string]()
+
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name              string
+		validatedResource bool
+		requestKinds      []string
+		requestNS         string
+		isSystemNS        bool
+		listNetInNS       bool
+		req               admission.Request
+		expResponse       admission.Response
+	}{
+		{
+			name:              "Allow creating Pod in VPC NSs",
+			validatedResource: false,
+			requestKinds:      []string{"Pod"},
+			requestNS:         vpcWlNS,
+			listNetInNS:       true,
+			expResponse:       allowedResp,
+		},
+		{
+			name:              "Allow creating Pod in non-VPC NSs",
+			validatedResource: false,
+			requestKinds:      []string{"Pod"},
+			requestNS:         vdsWlNS,
+			listNetInNS:       true,
+			expResponse:       allowedResp,
+		},
+		{
+			name:              "Allow creating resources in VPC NSs",
+			validatedResource: true,
+			requestKinds:      []string{"IPPool", "NetworkInfo", "NSXServiceAccount", "SecurityPolicy", "StaticRoute", "SubnetPort", "Subnet", "SubnetSet"},
+			requestNS:         vpcWlNS,
+			listNetInNS:       true,
+			expResponse:       allowedResp,
+		},
+		{
+			name:              "Disallow creating resources in non-VPC NSs",
+			validatedResource: true,
+			requestKinds:      []string{"IPPool", "NetworkInfo", "NSXServiceAccount", "SecurityPolicy", "StaticRoute", "SubnetPort", "Subnet", "SubnetSet"},
+			requestNS:         vdsWlNS,
+			listNetInNS:       true,
+			expResponse:       disallowedResp,
+		}, {
+			name:              "Error when listing resources in a system NS with no Networks",
+			validatedResource: true,
+			isSystemNS:        true,
+			requestKinds:      []string{"IPPool"},
+			requestNS:         "kube-system",
+			listNetInNS:       false,
+			expResponse: admission.Errored(http.StatusBadRequest,
+				fmt.Errorf("unable to check the default network type in Namespace kube-system: no shared VPC namespace found with system Namespace kube-system")),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.validatedResource {
+				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(
+					func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+						if tc.isSystemNS {
+							copyNamespace(obj, createSystemNamespace(tc.requestNS))
+						} else {
+							copyNamespace(obj, createWorkloadNamespace(tc.requestNS))
+						}
+						return nil
+					},
+				).Times(len(tc.requestKinds))
+				if tc.listNetInNS {
+					k8sClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(
+						func(_ context.Context, obj client.ObjectList, options ...client.ListOption) error {
+							netList := obj.(*v1alpha1.NetworkList)
+							netList.Items = networks[tc.requestNS]
+							return nil
+						},
+					).Times(len(tc.requestKinds))
+				}
+			}
+			for _, kind := range tc.requestKinds {
+				req := admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{Kind: v1.GroupVersionKind{Kind: kind}, Namespace: tc.requestNS},
+				}
+				response := reconciler.Handle(ctx, req)
+				assert.Equal(t, tc.expResponse, response)
+			}
+		})
+	}
+}
+
+type fakeLister struct {
+	items []types.NamespacedName
+	err   error
+}
+
+func (l *fakeLister) list(ns string) ([]types.NamespacedName, error) {
+	results := make([]types.NamespacedName, 0)
+	for _, item := range l.items {
+		if item.Namespace == ns {
+			results = append(results, item)
+		}
+	}
+	return results, l.err
+}
+
+func createVPCDefaultNetwork(name, ns string, dns []string) *v1alpha1.Network {
+	return createDefaultNetwork(name, ns, v1alpha1.NetworkTypeNSXTVPC, dns)
+}
+
+func createVDSDefaultNetwork(name, ns string, dns []string) *v1alpha1.Network {
+	return createDefaultNetwork(name, ns, v1alpha1.NetworkTypeVDS, dns)
+}
+
+func createDefaultNetwork(name, ns string, networkType v1alpha1.NetworkType, dns []string) *v1alpha1.Network {
+	return createNetwork(name, ns, networkType, map[string]string{defaultNetworkLabelKey: defaultNetworkLabelValue}, dns)
+}
+
+func createNetwork(name, ns string, networkType v1alpha1.NetworkType, labels map[string]string, dns []string) *v1alpha1.Network {
+	return &v1alpha1.Network{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+			Labels:    labels,
+		},
+		Spec: v1alpha1.NetworkSpec{
+			Type: networkType,
+			DNS:  dns,
+		},
+	}
+}
+
+func copyNamespace(obj client.Object, namespace *corev1.Namespace) {
+	nsObj := obj.(*corev1.Namespace)
+	nsObj.Namespace = namespace.Namespace
+	nsObj.Name = namespace.Name
+	nsObj.Annotations = namespace.Annotations
+	nsObj.Labels = namespace.Labels
+}
+
+func createSystemNamespace(name string) *corev1.Namespace {
+	return createNamespace(name, map[string]string{})
+}
+
+func createWorkloadNamespace(name string) *corev1.Namespace {
+	return createNamespace(name, map[string]string{svccommon.LabelWorkloadNamespace: "true"})
+}
+
+func createNamespace(name string, labels map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}

--- a/pkg/controllers/vpcnetwork/network_webhook.go
+++ b/pkg/controllers/vpcnetwork/network_webhook.go
@@ -1,0 +1,48 @@
+/* Copyright © 2024 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package vpcnetwork
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func (r *NetworkReconciler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	objKind := req.Kind.Kind
+	switch objKind {
+	case "IPPool":
+		fallthrough
+	case "NetworkInfo":
+		fallthrough
+	case "NSXServiceAccount":
+		fallthrough
+	case "SecurityPolicy":
+		fallthrough
+	case "StaticRoute":
+		fallthrough
+	case "SubnetPort":
+		fallthrough
+	case "Subnet":
+		fallthrough
+	case "SubnetSet":
+		ns := req.Namespace
+		enabled, err := r.IsVPCEnabledOnNamespace(ns)
+		if err != nil {
+			log.Error(err, "failed to check if VPC is enabled when validating CR creation", "Namespace", ns, objKind, req.Namespace+"/"+req.Name)
+			returnedErr := fmt.Errorf("unable to check the default network type in Namespace %s: %v", ns, err)
+			return admission.Errored(http.StatusBadRequest, returnedErr)
+		}
+		if !enabled {
+			log.Info("VPC is not enabled in Namespace, reject CR", "Namespace", ns, objKind, req.Namespace+"/"+req.Name)
+			return admission.Errored(http.StatusBadRequest, fmt.Errorf("VPC is not enabled in Namespace %s", ns))
+		}
+		return admission.Allowed("")
+	default:
+		log.Info("Unsupported kind in the validation, allow by default", "kind", objKind)
+		return admission.Allowed("")
+	}
+}

--- a/pkg/controllers/vpcnetwork/testing/network_testing.go
+++ b/pkg/controllers/vpcnetwork/testing/network_testing.go
@@ -1,0 +1,26 @@
+/*
+Copyright © 2024 VMware, Inc. All Rights Reserved.
+
+	SPDX-License-Identifier: Apache-2.0
+*/
+package testing
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/vpcnetwork"
+)
+
+// FakeVPCNetworkProvider is maintained for test only
+type FakeVPCNetworkProvider struct {
+}
+
+func (p *FakeVPCNetworkProvider) IsVPCEnabledOnNamespace(ns string) (bool, error) {
+	return true, nil
+}
+
+func (p *FakeVPCNetworkProvider) ReconcileWithVPCFilters(resource string, ctx context.Context, req ctrl.Request, innerFunc vpcnetwork.ReconcileFunc) (ctrl.Result, error) {
+	return innerFunc(ctx, req)
+}

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -78,6 +78,7 @@ const (
 	AnnotationAttachmentRef            string = "nsx.vmware.com/attachment_ref"
 	AnnotationPodMAC                   string = "nsx.vmware.com/mac"
 	AnnotationPodAttachment            string = "nsx.vmware.com/attachment"
+	LabelWorkloadNamespace             string = "vmware.com/for-user-workloads"
 	TagScopePodName                    string = "nsx-op/pod_name"
 	TagScopePodUID                     string = "nsx-op/pod_uid"
 	ValueMajorVersion                  string = "1"

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -147,6 +147,19 @@ func IsSystemNamespace(c client.Client, ns string, obj *v1.Namespace) (bool, err
 	return false, nil
 }
 
+func IsVPCSystemNamespace(c client.Client, ns string, obj *v1.Namespace) (bool, error) {
+	nsObj := &v1.Namespace{}
+	if obj != nil {
+		nsObj = obj
+	} else if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: ns}, nsObj); err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+	if wlNSLabelVal, ok := nsObj.Labels[common.LabelWorkloadNamespace]; ok && strings.ToLower(wlNSLabelVal) == "true" {
+		return false, nil
+	}
+	return true, nil
+}
+
 // CheckPodHasNamedPort checks if the pod has a named port, it filters the pod events
 // we don't want give concern.
 func CheckPodHasNamedPort(pod v1.Pod, reason string) bool {


### PR DESCRIPTION
1. Add controller for CR Network to maintain the default Network resource in system Namespaces.
2. Add watch in Pod/Namepsace/Service/NetworkPolicy controller to requeue resources when Network type is switch to VPC.
3. Add precheck on if the default Network type is VPC or not in resource create events.
4. Add webhook in NCP owned resource creations to check if the default Network type is VPC or not in a Namespace.