### PR TITLE
E2e test should not delete customize_networkconfig

### DIFF
--- a/test/e2e/nsx_networkinfo_test.go
+++ b/test/e2e/nsx_networkinfo_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	NetworkInfoCRType     = "networkinfoes"
+	NetworkInfoCRType     = "networkinfos"
 	NSCRType              = "namespaces"
 	PrivateIPBlockNSXType = "IpAddressBlock"
 
@@ -68,7 +68,6 @@ func TestCustomizedNetworkInfo(t *testing.T) {
 	_ = applyYAML(nsPath, "")
 
 	defer deleteYAML(nsPath, "")
-	defer deleteYAML(ncPath, "")
 
 	ns := "customized-ns"
 


### PR DESCRIPTION
In e2e test, vpcnetworkconfig should not be deleted when test finishes.
Networkinfo's plural is networkinfos, not networkinfoes.