### PR TITLE
Format subnetset types filed and fix subnet types typo(CP#617)

### DIFF
--- a/build/yaml/crd/nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/nsx.vmware.com_subnets.yaml
@@ -128,7 +128,7 @@ spec:
                 items:
                   type: string
                 type: array
-              networkAddreses:
+              networkAddresses:
                 items:
                   type: string
                 type: array

--- a/pkg/apis/nsx.vmware.com/v1alpha1/subnet_types.go
+++ b/pkg/apis/nsx.vmware.com/v1alpha1/subnet_types.go
@@ -31,7 +31,7 @@ type SubnetSpec struct {
 // SubnetStatus defines the observed state of Subnet.
 type SubnetStatus struct {
 	NSXResourcePath     string      `json:"nsxResourcePath,omitempty"`
-	NetworkAddresses    []string    `json:"networkAddreses,omitempty"`
+	NetworkAddresses    []string    `json:"networkAddresses,omitempty"`
 	GatewayAddresses    []string    `json:"gatewayAddresses,omitempty"`
 	DHCPServerAddresses []string    `json:"DHCPServerAddresses,omitempty"`
 	Conditions          []Condition `json:"conditions,omitempty"`

--- a/pkg/apis/nsx.vmware.com/v1alpha1/subnetset_types.go
+++ b/pkg/apis/nsx.vmware.com/v1alpha1/subnetset_types.go
@@ -24,7 +24,7 @@ type SubnetSetSpec struct {
 
 // SubnetInfo defines the observed state of a single Subnet of a SubnetSet.
 type SubnetInfo struct {
-	NSXResourcePath   string   `json:"nsxResourcePath,omitempty"`
+	NSXResourcePath     string   `json:"nsxResourcePath,omitempty"`
 	NetworkAddresses    []string `json:"networkAddresses,omitempty"`
 	GatewayAddresses    []string `json:"gatewayAddresses,omitempty"`
 	DHCPServerAddresses []string `json:"DHCPServerAddresses,omitempty"`

--- a/pkg/apis/v1alpha1/subnet_types.go
+++ b/pkg/apis/v1alpha1/subnet_types.go
@@ -31,7 +31,7 @@ type SubnetSpec struct {
 // SubnetStatus defines the observed state of Subnet.
 type SubnetStatus struct {
 	NSXResourcePath     string      `json:"nsxResourcePath,omitempty"`
-	NetworkAddresses    []string    `json:"networkAddreses,omitempty"`
+	NetworkAddresses    []string    `json:"networkAddresses,omitempty"`
 	GatewayAddresses    []string    `json:"gatewayAddresses,omitempty"`
 	DHCPServerAddresses []string    `json:"DHCPServerAddresses,omitempty"`
 	Conditions          []Condition `json:"conditions,omitempty"`

--- a/pkg/apis/v1alpha1/subnetset_types.go
+++ b/pkg/apis/v1alpha1/subnetset_types.go
@@ -24,7 +24,7 @@ type SubnetSetSpec struct {
 
 // SubnetInfo defines the observed state of a single Subnet of a SubnetSet.
 type SubnetInfo struct {
-	NSXResourcePath   string   `json:"nsxResourcePath,omitempty"`
+	NSXResourcePath     string   `json:"nsxResourcePath,omitempty"`
 	NetworkAddresses    []string `json:"networkAddresses,omitempty"`
 	GatewayAddresses    []string `json:"gatewayAddresses,omitempty"`
 	DHCPServerAddresses []string `json:"DHCPServerAddresses,omitempty"`


### PR DESCRIPTION
1.Format subnetset types files to align struct var fields 
2.Fix subnet type networkaddresses filed name typo

CP:https://github.com/vmware-tanzu/nsx-operator/pull/617