### PR TITLE
Get path info from store while deleting staticroute

### DIFF
--- a/pkg/controllers/staticroute/staticroute_controller.go
+++ b/pkg/controllers/staticroute/staticroute_controller.go
@@ -113,7 +113,7 @@ func (r *StaticRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if controllerutil.ContainsFinalizer(obj, commonservice.StaticRouteFinalizerName) {
 			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, common.MetricResTypeStaticRoute)
 			// TODO, update the value from 'default' to actual value， get OrgID, ProjectID, VPCID depending on obj.Namespace from vpc store
-			if err := r.Service.DeleteStaticRoute(req.Namespace, string(obj.UID)); err != nil {
+			if err := r.Service.DeleteStaticRoute(string(obj.UID)); err != nil {
 				log.Error(err, "delete failed, would retry exponentially", "staticroute", req.NamespacedName)
 				deleteFail(r, &ctx, obj, &err)
 				return ResultRequeue, err

--- a/pkg/controllers/staticroute/staticroute_controller_test.go
+++ b/pkg/controllers/staticroute/staticroute_controller_test.go
@@ -205,7 +205,7 @@ func TestStaticRouteReconciler_Reconcile(t *testing.T) {
 		return nil
 	})
 
-	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, namespace string, uid string) error {
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, uid string) error {
 		assert.FailNow(t, "should not be called")
 		return nil
 	})
@@ -223,7 +223,7 @@ func TestStaticRouteReconciler_Reconcile(t *testing.T) {
 		v1sp.Finalizers = []string{common.StaticRouteFinalizerName}
 		return nil
 	})
-	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, namespace string, uid string) error {
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, uid string) error {
 		return nil
 	})
 	_, ret = r.Reconcile(ctx, req)
@@ -238,7 +238,7 @@ func TestStaticRouteReconciler_Reconcile(t *testing.T) {
 		v1sp.Finalizers = []string{common.StaticRouteFinalizerName}
 		return nil
 	})
-	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, namespace string, uid string) error {
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, uid string) error {
 		return errors.New("delete failed")
 	})
 
@@ -333,7 +333,7 @@ func TestStaticRouteReconciler_GarbageCollector(t *testing.T) {
 		a = append(a, model.StaticRoutes{Id: &id, Tags: tag2})
 		return a
 	})
-	patch.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, namespace string, uid string) error {
+	patch.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, uid string) error {
 		assert.FailNow(t, "should not be called")
 		return nil
 	})
@@ -351,7 +351,7 @@ func TestStaticRouteReconciler_GarbageCollector(t *testing.T) {
 	patch.ApplyMethod(reflect.TypeOf(service), "ListStaticRoute", func(_ *staticroute.StaticRouteService) []model.StaticRoutes {
 		return []model.StaticRoutes{}
 	})
-	patch.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, namespace string, uid string) error {
+	patch.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, uid string) error {
 		assert.FailNow(t, "should not be called")
 		return nil
 	})

--- a/pkg/nsx/services/staticroute/staticroute.go
+++ b/pkg/nsx/services/staticroute/staticroute.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
 type StaticRouteService struct {
@@ -134,12 +135,17 @@ func (service *StaticRouteService) GetUID(staticroute *model.StaticRoutes) *stri
 
 }
 
-func (service *StaticRouteService) DeleteStaticRoute(namespace string, uid string) error {
-	vpc := service.VPCService.ListVPCInfo(namespace)
-	if len(vpc) == 0 {
+func (service *StaticRouteService) DeleteStaticRoute(uid string) error {
+	id := String(util.GenerateID(uid, "sr", "", ""))
+	staticroute := service.StaticRouteStore.GetByKey(*id)
+	if staticroute == nil {
 		return nil
 	}
-	return service.DeleteStaticRouteByPath(vpc[0].OrgID, vpc[0].ProjectID, vpc[0].ID, uid)
+	vpcResourceInfo, err := common.ParseVPCResourcePath(*staticroute.Path)
+	if err != nil {
+		return err
+	}
+	return service.DeleteStaticRouteByPath(vpcResourceInfo.OrgID, vpcResourceInfo.ProjectID, vpcResourceInfo.ID, *id)
 }
 
 func (service *StaticRouteService) ListStaticRoute() []*model.StaticRoutes {

--- a/pkg/nsx/services/staticroute/staticroute_test.go
+++ b/pkg/nsx/services/staticroute/staticroute_test.go
@@ -128,25 +128,21 @@ func TestStaticRouteService_DeleteStaticRoute(t *testing.T) {
 		t.Error(err)
 	}
 
-	id := "vpc-1"
-	sr1 := &model.StaticRoutes{Id: &id}
+	uid := "uid-123"
+	id := "sr_uid-123"
+	path := "/orgs/default/projects/project-1/vpcs/vpc-1"
+	sr1 := &model.StaticRoutes{Id: &id, Path: &path}
 
 	returnservice.StaticRouteStore.Add(sr1)
 
-	patches := gomonkey.ApplyMethod(reflect.TypeOf(returnservice.VPCService), "ListVPCInfo", func(_ common.VPCServiceProvider, ns string) []common.VPCResourceInfo {
-		id := "vpc-1"
-		return []common.VPCResourceInfo{{OrgID: "default", ProjectID: "project-1", VPCID: "vpc-1", ID: id}}
-	})
-
 	// no record found
 	mockStaticRouteclient.EXPECT().Delete(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Times(0)
-	err = returnservice.DeleteStaticRoute("123", "vpc1")
+	err = returnservice.DeleteStaticRoute(id)
 	assert.Equal(t, err, nil)
-	defer patches.Reset()
 
 	// delete record
 	mockStaticRouteclient.EXPECT().Delete("default", "project-1", "vpc-1", id).Return(nil).Times(1)
-	err = returnservice.DeleteStaticRoute("123", id)
+	err = returnservice.DeleteStaticRoute(uid)
 	assert.Equal(t, err, nil)
 	srs := returnservice.StaticRouteStore.List()
 	assert.Equal(t, len(srs), 0)


### PR DESCRIPTION
In previous version, controller tried to get org/project/vpc info from vpc service. But vpc service may delete vpc before staticroute.

Read org/project/vpc from staticroute path