### PR TITLE
Unify SecurityPolicy/Networkpolicy deletion process with GC and cleanup

### DIFF
--- a/pkg/controllers/securitypolicy/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller.go
@@ -167,7 +167,7 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	} else {
 		if controllerutil.ContainsFinalizer(obj, servicecommon.SecurityPolicyFinalizerName) {
 			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, MetricResType)
-			if err := r.Service.DeleteSecurityPolicy(obj, false, servicecommon.ResourceTypeSecurityPolicy); err != nil {
+			if err := r.Service.DeleteSecurityPolicy(obj.UID, false, servicecommon.ResourceTypeSecurityPolicy); err != nil {
 				log.Error(err, "deletion failed, would retry exponentially", "securitypolicy", req.NamespacedName)
 				deleteFail(r, &ctx, obj, &err)
 				return ResultRequeue, err

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -1,7 +1,6 @@
 package securitypolicy
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -32,18 +31,18 @@ func TestBuildSecurityPolicy(t *testing.T) {
 		},
 	)
 
-	podSelectorRule0IDPort000 := fmt.Sprintf("%s_%d_%d", service.buildRuleID(&spWithPodSelector, &spWithPodSelector.Spec.Rules[0], 0, common.ResourceTypeSecurityPolicy), 0, 0)
-	podSelectorRule1IDPort000 := fmt.Sprintf("%s_%d_%d", service.buildRuleID(&spWithPodSelector, &spWithPodSelector.Spec.Rules[1], 1, common.ResourceTypeSecurityPolicy), 0, 0)
-	vmSelectorRule0IDPort000 := fmt.Sprintf("%s_%d_%d", service.buildRuleID(&spWithVMSelector, &spWithVMSelector.Spec.Rules[0], 0, common.ResourceTypeSecurityPolicy), 0, 0)
-	vmSelectorRule1IDPort000 := fmt.Sprintf("%s_%d_%d", service.buildRuleID(&spWithVMSelector, &spWithVMSelector.Spec.Rules[1], 1, common.ResourceTypeSecurityPolicy), 0, 0)
-	vmSelectorRule2IDPort000 := fmt.Sprintf("%s_%d_%d", service.buildRuleID(&spWithVMSelector, &spWithVMSelector.Spec.Rules[2], 2, common.ResourceTypeSecurityPolicy), 0, 0)
+	podSelectorRule0IDPort000 := service.buildExpandedRuleId(service.buildRuleID(&spWithPodSelector, &spWithPodSelector.Spec.Rules[0], 0, common.ResourceTypeSecurityPolicy), 0, 0)
+	podSelectorRule1IDPort000 := service.buildExpandedRuleId(service.buildRuleID(&spWithPodSelector, &spWithPodSelector.Spec.Rules[1], 1, common.ResourceTypeSecurityPolicy), 0, 0)
+	vmSelectorRule0IDPort000 := service.buildExpandedRuleId(service.buildRuleID(&spWithVMSelector, &spWithVMSelector.Spec.Rules[0], 0, common.ResourceTypeSecurityPolicy), 0, 0)
+	vmSelectorRule1IDPort000 := service.buildExpandedRuleId(service.buildRuleID(&spWithVMSelector, &spWithVMSelector.Spec.Rules[1], 1, common.ResourceTypeSecurityPolicy), 0, 0)
+	vmSelectorRule2IDPort000 := service.buildExpandedRuleId(service.buildRuleID(&spWithVMSelector, &spWithVMSelector.Spec.Rules[2], 2, common.ResourceTypeSecurityPolicy), 0, 0)
 
-	podSelectorRule0Name00, _ := service.buildRuleDisplayName(&spWithPodSelector, &spWithPodSelector.Spec.Rules[0], 0, -1, false, common.ResourceTypeSecurityPolicy)
-	podSelectorRule1Name00, _ := service.buildRuleDisplayName(&spWithPodSelector, &spWithPodSelector.Spec.Rules[1], 0, -1, false, common.ResourceTypeSecurityPolicy)
+	podSelectorRule0Name00, _ := service.buildRuleDisplayName(&spWithPodSelector.Spec.Rules[0], 0, -1, false, common.ResourceTypeSecurityPolicy)
+	podSelectorRule1Name00, _ := service.buildRuleDisplayName(&spWithPodSelector.Spec.Rules[1], 0, -1, false, common.ResourceTypeSecurityPolicy)
 
-	vmSelectorRule0Name00, _ := service.buildRuleDisplayName(&spWithVMSelector, &spWithVMSelector.Spec.Rules[0], 0, -1, false, common.ResourceTypeSecurityPolicy)
-	vmSelectorRule1Name00, _ := service.buildRuleDisplayName(&spWithVMSelector, &spWithVMSelector.Spec.Rules[1], 0, -1, false, common.ResourceTypeSecurityPolicy)
-	vmSelectorRule2Name00, _ := service.buildRuleDisplayName(&spWithVMSelector, &spWithVMSelector.Spec.Rules[2], 0, -1, false, common.ResourceTypeSecurityPolicy)
+	vmSelectorRule0Name00, _ := service.buildRuleDisplayName(&spWithVMSelector.Spec.Rules[0], 0, -1, false, common.ResourceTypeSecurityPolicy)
+	vmSelectorRule1Name00, _ := service.buildRuleDisplayName(&spWithVMSelector.Spec.Rules[1], 0, -1, false, common.ResourceTypeSecurityPolicy)
+	vmSelectorRule2Name00, _ := service.buildRuleDisplayName(&spWithVMSelector.Spec.Rules[2], 0, -1, false, common.ResourceTypeSecurityPolicy)
 
 	tests := []struct {
 		name           string
@@ -801,7 +800,7 @@ func TestBuildRuleDisplayName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			observedDisplayName, observedError := service.buildRuleDisplayName(tt.inputSecurityPolicy, tt.inputRule, tt.portIdx, -1, false, tt.createdFor)
+			observedDisplayName, observedError := service.buildRuleDisplayName(tt.inputRule, tt.portIdx, -1, false, tt.createdFor)
 			assert.Equal(t, tt.expectedRuleDisplayName, observedDisplayName)
 			assert.Equal(t, nil, observedError)
 		})

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -85,44 +85,7 @@ func InitializeSecurityPolicy(service common.Service, vpcService common.VPCServi
 	}
 	indexScope := common.TagValueScopeSecurityPolicyUID
 
-	securityPolicyService.securityPolicyStore = &SecurityPolicyStore{ResourceStore: common.ResourceStore{
-		Indexer: cache.NewIndexer(
-			keyFunc, cache.Indexers{
-				indexScope:                      indexBySecurityPolicyUID,
-				common.TagScopeNetworkPolicyUID: indexByNetworkPolicyUID,
-			}),
-		BindingType: model.SecurityPolicyBindingType(),
-	}}
-	securityPolicyService.groupStore = &GroupStore{ResourceStore: common.ResourceStore{
-		Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
-			indexScope:                      indexBySecurityPolicyUID,
-			common.TagScopeNetworkPolicyUID: indexByNetworkPolicyUID,
-			common.TagScopeRuleID:           indexGroupFunc,
-		}),
-		BindingType: model.GroupBindingType(),
-	}}
-	securityPolicyService.ruleStore = &RuleStore{ResourceStore: common.ResourceStore{
-		Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
-			indexScope:                      indexBySecurityPolicyUID,
-			common.TagScopeNetworkPolicyUID: indexByNetworkPolicyUID,
-		}),
-		BindingType: model.RuleBindingType(),
-	}}
-
-	securityPolicyService.projectGroupStore = &GroupStore{ResourceStore: common.ResourceStore{
-		Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
-			indexScope:                      indexBySecurityPolicyUID,
-			common.TagScopeNetworkPolicyUID: indexByNetworkPolicyUID,
-		}),
-		BindingType: model.GroupBindingType(),
-	}}
-	securityPolicyService.shareStore = &ShareStore{ResourceStore: common.ResourceStore{
-		Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
-			indexScope:                      indexBySecurityPolicyUID,
-			common.TagScopeNetworkPolicyUID: indexByNetworkPolicyUID,
-		}),
-		BindingType: model.ShareBindingType(),
-	}}
+	securityPolicyService.setUpStore(indexScope)
 	securityPolicyService.vpcService = vpcService
 
 	projectGroupShareTag := []model.Tag{
@@ -164,6 +127,47 @@ func InitializeSecurityPolicy(service common.Service, vpcService common.VPCServi
 	return securityPolicyService, nil
 }
 
+func (s *SecurityPolicyService) setUpStore(indexScope string) {
+	s.securityPolicyStore = &SecurityPolicyStore{ResourceStore: common.ResourceStore{
+		Indexer: cache.NewIndexer(
+			keyFunc, cache.Indexers{
+				indexScope:                      indexBySecurityPolicyUID,
+				common.TagScopeNetworkPolicyUID: indexByNetworkPolicyUID,
+			}),
+		BindingType: model.SecurityPolicyBindingType(),
+	}}
+	s.groupStore = &GroupStore{ResourceStore: common.ResourceStore{
+		Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
+			indexScope:                      indexBySecurityPolicyUID,
+			common.TagScopeNetworkPolicyUID: indexByNetworkPolicyUID,
+			common.TagScopeRuleID:           indexGroupFunc,
+		}),
+		BindingType: model.GroupBindingType(),
+	}}
+	s.ruleStore = &RuleStore{ResourceStore: common.ResourceStore{
+		Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
+			indexScope:                      indexBySecurityPolicyUID,
+			common.TagScopeNetworkPolicyUID: indexByNetworkPolicyUID,
+		}),
+		BindingType: model.RuleBindingType(),
+	}}
+
+	s.projectGroupStore = &GroupStore{ResourceStore: common.ResourceStore{
+		Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
+			indexScope:                      indexBySecurityPolicyUID,
+			common.TagScopeNetworkPolicyUID: indexByNetworkPolicyUID,
+		}),
+		BindingType: model.GroupBindingType(),
+	}}
+	s.shareStore = &ShareStore{ResourceStore: common.ResourceStore{
+		Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
+			indexScope:                      indexBySecurityPolicyUID,
+			common.TagScopeNetworkPolicyUID: indexByNetworkPolicyUID,
+		}),
+		BindingType: model.ShareBindingType(),
+	}}
+}
+
 func (service *SecurityPolicyService) CreateOrUpdateSecurityPolicy(obj interface{}) error {
 	if !nsxutil.IsLicensed(nsxutil.FeatureDFW) {
 		log.Info("no DFW license, skip creating SecurityPolicy.")
@@ -177,13 +181,18 @@ func (service *SecurityPolicyService) CreateOrUpdateSecurityPolicy(obj interface
 			return err
 		}
 		for _, internalSecurityPolicy := range internalSecurityPolicies {
-			err = service.createOrUpdateSecurityPolicy(internalSecurityPolicy, common.ResourceTypeNetworkPolicy)
+			err = service.createOrUpdateVPCSecurityPolicy(internalSecurityPolicy, common.ResourceTypeNetworkPolicy)
 			if err != nil {
 				return err
 			}
 		}
 	case *v1alpha1.SecurityPolicy:
-		err = service.createOrUpdateSecurityPolicy(obj.(*v1alpha1.SecurityPolicy), common.ResourceTypeSecurityPolicy)
+		if isVpcEnabled(service) {
+			err = service.createOrUpdateVPCSecurityPolicy(obj.(*v1alpha1.SecurityPolicy), common.ResourceTypeSecurityPolicy)
+		} else {
+			// For T1 network SecurityPolicy create/update
+			err = service.createOrUpdateSecurityPolicy(obj.(*v1alpha1.SecurityPolicy), common.ResourceTypeSecurityPolicy)
+		}
 	}
 	return err
 }
@@ -380,12 +389,13 @@ func (service *SecurityPolicyService) getStores() (*SecurityPolicyStore, *RuleSt
 	return service.securityPolicyStore, service.ruleStore, service.groupStore, service.projectGroupStore, service.shareStore
 }
 
-func (service *SecurityPolicyService) createOrUpdateSecurityPolicy(obj *v1alpha1.SecurityPolicy, createdFor string) error {
-	securityPolicyStore, ruleStore, groupStore, projectGroupStore, shareStore := service.getStores()
+func (service *SecurityPolicyService) getFinalSecurityPolicyResource(obj *v1alpha1.SecurityPolicy, createdFor string) (*model.SecurityPolicy, []model.Group, *[]ProjectShare, bool, error) {
+	securityPolicyStore, ruleStore, groupStore, _, _ := service.getStores()
+
 	nsxSecurityPolicy, nsxGroups, projectShares, err := service.buildSecurityPolicy(obj, createdFor)
 	if err != nil {
-		log.Error(err, "failed to build SecurityPolicy")
-		return err
+		log.Error(err, "failed to build SecurityPolicy from CR", "ID", obj.UID)
+		return nil, nil, nil, false, err
 	}
 
 	if len(nsxSecurityPolicy.Scope) == 0 {
@@ -395,25 +405,12 @@ func (service *SecurityPolicyService) createOrUpdateSecurityPolicy(obj *v1alpha1
 	if createdFor == common.ResourceTypeNetworkPolicy {
 		indexScope = common.TagScopeNetworkPolicyUID
 	}
-	existingSecurityPolicy := securityPolicyStore.GetByKey(*nsxSecurityPolicy.Id)
-	existingRules := ruleStore.GetByIndex(indexScope, string(obj.UID))
-	existingGroups := groupStore.GetByIndex(indexScope, string(obj.UID))
 
+	existingSecurityPolicy := securityPolicyStore.GetByKey(*nsxSecurityPolicy.Id)
 	isChanged := true
 	if existingSecurityPolicy != nil {
 		isChanged = common.CompareResource(SecurityPolicyPtrToComparable(existingSecurityPolicy), SecurityPolicyPtrToComparable(nsxSecurityPolicy))
 	}
-
-	changed, stale := common.CompareResources(RulesPtrToComparable(existingRules), RulesToComparable(nsxSecurityPolicy.Rules))
-	changedRules, staleRules := ComparableToRules(changed), ComparableToRules(stale)
-	changed, stale = common.CompareResources(GroupsPtrToComparable(existingGroups), GroupsToComparable(*nsxGroups))
-	changedGroups, staleGroups := ComparableToGroups(changed), ComparableToGroups(stale)
-
-	if !isChanged && len(changedRules) == 0 && len(staleRules) == 0 && len(changedGroups) == 0 && len(staleGroups) == 0 {
-		log.Info("securityPolicy, rules and groups are not changed, skip updating them", "nsxSecurityPolicy.Id", nsxSecurityPolicy.Id)
-		return nil
-	}
-
 	var finalSecurityPolicy *model.SecurityPolicy
 	if isChanged {
 		finalSecurityPolicy = nsxSecurityPolicy
@@ -421,122 +418,55 @@ func (service *SecurityPolicyService) createOrUpdateSecurityPolicy(obj *v1alpha1
 		finalSecurityPolicy = existingSecurityPolicy
 	}
 
-	finalRules := make([]model.Rule, 0)
-	for i := len(staleRules) - 1; i >= 0; i-- { // Don't use range, it would copy the element
-		staleRules[i].MarkedForDelete = &MarkedForDelete // nsx clients need this field to delete the rules
-	}
-	finalRules = append(finalRules, staleRules...)
-	finalRules = append(finalRules, changedRules...)
+	existingRules := ruleStore.GetByIndex(indexScope, string(obj.UID))
+	finalRules := service.updateRules(existingRules, nsxSecurityPolicy.Rules)
 	finalSecurityPolicy.Rules = finalRules
 
-	finalGroups := make([]model.Group, 0)
-	for i := len(staleGroups) - 1; i >= 0; i-- { // Don't use range, it would copy the element
-		staleGroups[i].MarkedForDelete = &MarkedForDelete // nsx clients need this field to delete the group
-	}
-	finalGroups = append(finalGroups, staleGroups...)
-	finalGroups = append(finalGroups, changedGroups...)
-
-	// WrapHighLevelSecurityPolicy will modify the input security policy, so we need to make a copy for the following store update.
-	finalSecurityPolicyCopy := *finalSecurityPolicy
-	finalSecurityPolicyCopy.Rules = finalRules
+	existingGroups := groupStore.GetByIndex(indexScope, string(obj.UID))
+	finalGroups := service.updateGroups(existingGroups, *nsxGroups)
 
 	if isVpcEnabled(service) {
-		vpcInfo, err := service.getVpcInfo(obj.ObjectMeta.Namespace)
-		if err != nil {
-			return err
-		}
-
-		finalProjectGroups := make([]model.Group, 0)
-		finalProjectShares := make([]model.Share, 0)
-		nsxProjectGroups := make([]model.Group, 0)
-		nsxProjectShares := make([]model.Share, 0)
-		for i := len(*projectShares) - 1; i >= 0; i-- {
-			nsxProjectGroups = append(nsxProjectGroups, *((*projectShares)[i].shareGroup))
-			nsxProjectShares = append(nsxProjectShares, *((*projectShares)[i].share))
-		}
-
-		// Create/Update nsx project shares and nsx project level groups
-		existingNsxProjectGroups := projectGroupStore.GetByIndex(indexScope, string(obj.UID))
-		changed, stale := common.CompareResources(GroupsPtrToComparable(existingNsxProjectGroups), GroupsToComparable(nsxProjectGroups))
-		changedProjectGroups, staleProjectGroups := ComparableToGroups(changed), ComparableToGroups(stale)
-		if len(changedProjectGroups) == 0 && len(staleProjectGroups) == 0 {
-			log.Info("project groups are not changed, skip updating them")
-		}
-		for i := len(staleProjectGroups) - 1; i >= 0; i-- {
-			staleProjectGroups[i].MarkedForDelete = &MarkedForDelete
-		}
-		finalProjectGroups = append(finalProjectGroups, staleProjectGroups...)
-		finalProjectGroups = append(finalProjectGroups, changedProjectGroups...)
-
-		existingNsxProjectShares := shareStore.GetByIndex(indexScope, string(obj.UID))
-		changed, stale = common.CompareResources(SharesPtrToComparable(existingNsxProjectShares), SharesToComparable(nsxProjectShares))
-		changedProjectShares, staleProjectShares := ComparableToShares(changed), ComparableToShares(stale)
-		if len(changedProjectShares) == 0 && len(staleProjectShares) == 0 {
-			log.Info("project shares are not changed, skip updating them")
-		}
-		for i := len(staleProjectShares) - 1; i >= 0; i-- {
-			staleProjectShares[i].MarkedForDelete = &MarkedForDelete
-		}
-		finalProjectShares = append(finalProjectShares, staleProjectShares...)
-		finalProjectShares = append(finalProjectShares, changedProjectShares...)
-
-		// 1.Wrap project groups and shares into project child infra.
-		var projectInfra []*data.StructValue
-		if len(finalProjectGroups) != 0 || len(finalProjectShares) != 0 {
-			projectInfra, err = service.wrapHierarchyProjectResources(finalProjectShares, finalProjectGroups)
-			if err != nil {
-				log.Error(err, "failed to wrap project groups and shares")
-				return err
-			}
-		}
-
-		// 2.Wrap SecurityPolicy, groups, rules under VPC level together with project groups and shares into one hierarchy resource tree.
-		orgRoot, err := service.WrapHierarchyVpcSecurityPolicy(finalSecurityPolicy, finalGroups, projectInfra, vpcInfo)
-		if err != nil {
-			log.Error(err, "failed to wrap SecurityPolicy in VPC")
-			return err
-		}
-
-		// 3.Create/update SecurityPolicy together with groups, rules under VPC level and project groups, shares.
-		err = service.NSXClient.OrgRootClient.Patch(*orgRoot, &EnforceRevisionCheckParam)
-		err = nsxutil.NSXApiError(err)
-		if err != nil {
-			log.Error(err, "failed to create or update SecurityPolicy in VPC")
-			return err
-		}
-
-		if len(finalProjectGroups) != 0 {
-			err = projectGroupStore.Apply(&finalProjectGroups)
-			if err != nil {
-				log.Error(err, "failed to apply store", "nsxProjectGroups", finalProjectGroups)
-				return err
-			}
-		}
-
-		if len(finalProjectShares) != 0 {
-			err = shareStore.Apply(&finalProjectShares)
-			if err != nil {
-				log.Error(err, "failed to apply store", "nsxProjectShares", finalProjectShares)
-				return err
-			}
-		}
+		return finalSecurityPolicy, finalGroups, projectShares, isChanged, nil
 	} else {
-		infraSecurityPolicy, err := service.WrapHierarchySecurityPolicy(finalSecurityPolicy, finalGroups)
-		if err != nil {
-			log.Error(err, "failed to wrap SecurityPolicy")
-			return err
-		}
-		err = service.NSXClient.InfraClient.Patch(*infraSecurityPolicy, &EnforceRevisionCheckParam)
-		err = nsxutil.NSXApiError(err)
-		if err != nil {
-			log.Error(err, "failed to create or update SecurityPolicy")
-			return err
-		}
+		return finalSecurityPolicy, finalGroups, nil, isChanged, nil
 	}
+}
+
+func (service *SecurityPolicyService) createOrUpdateSecurityPolicy(obj *v1alpha1.SecurityPolicy, createdFor string) error {
+	finalSecurityPolicy, finalGroups, _, isChanged, err := service.getFinalSecurityPolicyResource(obj, createdFor)
 	if err != nil {
+		log.Error(err, "failed to get FinalSecurityPolicy from CR", "ID", obj.UID)
 		return err
 	}
 
+	// WrapHighLevelSecurityPolicy will modify the input security policy, so we need to make a copy for the following store update.
+	finalSecurityPolicyCopy := *finalSecurityPolicy
+
+	if !isChanged && len(finalSecurityPolicy.Rules) == 0 && len(finalGroups) == 0 {
+		log.Info("securityPolicy, rules, groups are not changed, skip updating them", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
+		return nil
+	}
+
+	infraSecurityPolicy, err := service.WrapHierarchySecurityPolicy(finalSecurityPolicy, finalGroups)
+	if err != nil {
+		log.Error(err, "failed to wrap SecurityPolicy", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
+		return err
+	}
+	err = service.NSXClient.InfraClient.Patch(*infraSecurityPolicy, &EnforceRevisionCheckParam)
+	err = nsxutil.NSXApiError(err)
+	if err != nil {
+		log.Error(err, "failed to create or update SecurityPolicy", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
+		return err
+	}
+	// Get SecurityPolicy from NSX after HAPI call as NSX renders several fields like `path`/`parent_path`.
+	finalSecurityPolicyCopy, err = service.NSXClient.SecurityClient.Get(getDomain(service), *finalSecurityPolicy.Id)
+	err = nsxutil.NSXApiError(err)
+	if err != nil {
+		log.Error(err, "failed to get SecurityPolicy", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
+		return err
+	}
+
+	securityPolicyStore, ruleStore, groupStore, _, _ := service.getStores()
 	// The steps below know how to deal with NSX resources, if there is MarkedForDelete, then delete it from store,
 	// otherwise add or update it to store.
 	if isChanged {
@@ -546,229 +476,201 @@ func (service *SecurityPolicyService) createOrUpdateSecurityPolicy(obj *v1alpha1
 			return err
 		}
 	}
-	if !(len(changedRules) == 0 && len(staleRules) == 0) {
-		err = ruleStore.Apply(&finalSecurityPolicyCopy)
+	err = ruleStore.Apply(&finalSecurityPolicyCopy)
+	if err != nil {
+		log.Error(err, "failed to apply store", "nsxRules", finalSecurityPolicyCopy.Rules)
+		return err
+	}
+	err = groupStore.Apply(&finalGroups)
+	if err != nil {
+		log.Error(err, "failed to apply store", "nsxGroups", finalGroups)
+		return err
+	}
+	log.Info("successfully created or updated NSX SecurityPolicy", "nsxSecurityPolicy", finalSecurityPolicyCopy)
+	return nil
+}
+
+func (service *SecurityPolicyService) createOrUpdateVPCSecurityPolicy(obj *v1alpha1.SecurityPolicy, createdFor string) error {
+	vpcInfo, err := service.getVpcInfo(obj.ObjectMeta.Namespace)
+	if err != nil {
+		return err
+	}
+
+	finalSecurityPolicy, finalGroups, projectShares, isChanged, err := service.getFinalSecurityPolicyResource(obj, createdFor)
+	if err != nil {
+		log.Error(err, "failed to get FinalSecurityPolicy from CR", "ID", obj.UID)
+		return err
+	}
+
+	securityPolicyStore, ruleStore, groupStore, projectGroupStore, shareStore := service.getStores()
+	indexScope := common.TagValueScopeSecurityPolicyUID
+	if createdFor == common.ResourceTypeNetworkPolicy {
+		indexScope = common.TagScopeNetworkPolicyUID
+	}
+
+	// WrapHierarchyVpcSecurityPolicy will modify the input security policy, so we need to make a copy for the following store update.
+	finalSecurityPolicyCopy := *finalSecurityPolicy
+
+	nsxProjectGroups := make([]model.Group, 0)
+	nsxProjectShares := make([]model.Share, 0)
+	for i := len(*projectShares) - 1; i >= 0; i-- {
+		nsxProjectGroups = append(nsxProjectGroups, *((*projectShares)[i].shareGroup))
+		nsxProjectShares = append(nsxProjectShares, *((*projectShares)[i].share))
+	}
+
+	// Create/Update nsx project shares and nsx project level groups
+	existingNsxProjectGroups := projectGroupStore.GetByIndex(indexScope, string(obj.UID))
+	finalProjectGroups := service.updateGroups(existingNsxProjectGroups, nsxProjectGroups)
+
+	existingNsxProjectShares := shareStore.GetByIndex(indexScope, string(obj.UID))
+	finalProjectShares := service.updateShares(existingNsxProjectShares, nsxProjectShares)
+
+	if !isChanged && len(finalSecurityPolicy.Rules) == 0 && len(finalGroups) == 0 && len(finalProjectGroups) == 0 && len(finalProjectShares) == 0 {
+		log.Info("securityPolicy, rules, groups and shares are not changed, skip updating them", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
+		return nil
+	}
+
+	// TODO: Simplify resource wrap and patch for both create/delete.
+	// 1.Wrap project groups and shares into project child infra.
+	var projectInfra []*data.StructValue
+	if len(finalProjectGroups) != 0 || len(finalProjectShares) != 0 {
+		projectInfra, err = service.wrapHierarchyProjectResources(finalProjectShares, finalProjectGroups)
 		if err != nil {
-			log.Error(err, "failed to apply store", "nsxRules", finalSecurityPolicyCopy.Rules)
+			log.Error(err, "failed to wrap project groups and shares", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
 			return err
 		}
 	}
-	if !(len(changedGroups) == 0 && len(staleGroups) == 0) {
-		err = groupStore.Apply(&finalGroups)
+
+	// 2.Wrap SecurityPolicy, groups, rules under VPC level together with project groups and shares into one hierarchy resource tree.
+	orgRoot, err := service.WrapHierarchyVpcSecurityPolicy(&finalSecurityPolicyCopy, finalGroups, projectInfra, vpcInfo)
+	if err != nil {
+		log.Error(err, "failed to wrap SecurityPolicy in VPC", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
+		return err
+	}
+
+	// 3.Create/update SecurityPolicy together with groups, rules under VPC level and project groups, shares.
+	err = service.NSXClient.OrgRootClient.Patch(*orgRoot, &EnforceRevisionCheckParam)
+	err = nsxutil.NSXApiError(err)
+	if err != nil {
+		log.Error(err, "failed to create or update SecurityPolicy in VPC", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
+		return err
+	}
+
+	// Get SecurityPolicy from NSX after HAPI call as NSX renders several fields like `path`/`parent_path`.
+	finalSecurityPolicyCopy, err = service.NSXClient.VPCSecurityClient.Get(vpcInfo.OrgID, vpcInfo.ProjectID, vpcInfo.VPCID, *finalSecurityPolicyCopy.Id)
+	err = nsxutil.NSXApiError(err)
+	if err != nil {
+		log.Error(err, "failed to get SecurityPolicy in VPC", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
+		return err
+	}
+
+	// TODO: Simplify resource store update for both create/delete.
+	// The steps below know how to deal with NSX resources, if there is MarkedForDelete, then delete it from store,
+	// otherwise add or update it to store.
+	if isChanged {
+		err = securityPolicyStore.Apply(&finalSecurityPolicyCopy)
 		if err != nil {
-			log.Error(err, "failed to apply store", "nsxGroups", finalGroups)
+			log.Error(err, "failed to apply store", "securityPolicy", finalSecurityPolicyCopy)
 			return err
 		}
 	}
-	log.Info("successfully created or updated nsx SecurityPolicy", "nsxSecurityPolicy", finalSecurityPolicyCopy)
+
+	err = ruleStore.Apply(&finalSecurityPolicyCopy)
+	if err != nil {
+		log.Error(err, "failed to apply store", "nsxRules", finalSecurityPolicyCopy.Rules)
+		return err
+	}
+	err = groupStore.Apply(&finalGroups)
+	if err != nil {
+		log.Error(err, "failed to apply store", "nsxGroups", finalGroups)
+		return err
+	}
+	err = projectGroupStore.Apply(&finalProjectGroups)
+	if err != nil {
+		log.Error(err, "failed to apply store", "nsxProjectGroups", finalProjectGroups)
+		return err
+	}
+	err = shareStore.Apply(&finalProjectShares)
+	if err != nil {
+		log.Error(err, "failed to apply store", "nsxProjectShares", finalProjectShares)
+		return err
+	}
+
+	log.Info("successfully created or updated NSX SecurityPolicy in VPC", "nsxSecurityPolicy", finalSecurityPolicyCopy)
 	return nil
 }
 
 func (service *SecurityPolicyService) DeleteSecurityPolicy(obj interface{}, isVpcCleanup bool, createdFor string) error {
 	var err error
-	switch obj.(type) {
+	switch sp := obj.(type) {
 	case *networkingv1.NetworkPolicy:
-		internalSecurityPolicies, err := service.convertNetworkPolicyToInternalSecurityPolicies(obj.(*networkingv1.NetworkPolicy))
-		if err != nil {
-			return err
+		CRPolicySet := sets.New[string]()
+		CRPolicySet.Insert(service.BuildNetworkPolicyAllowPolicyID(string(sp.UID)))
+		CRPolicySet.Insert(service.BuildNetworkPolicyIsolationPolicyID(string(sp.UID)))
+		for elem := range CRPolicySet {
+			err = service.deleteVPCSecurityPolicy(types.UID(elem), createdFor)
 		}
-		for _, internalSecurityPolicy := range internalSecurityPolicies {
-			err = service.deleteSecurityPolicy(internalSecurityPolicy, isVpcCleanup, createdFor)
-			if err != nil {
-				return err
-			}
-		}
-	case *v1alpha1.SecurityPolicy:
-		err = service.deleteSecurityPolicy(obj, isVpcCleanup, createdFor)
 	case types.UID:
-		err = service.deleteSecurityPolicy(obj, isVpcCleanup, createdFor)
+		if isVpcEnabled(service) || isVpcCleanup {
+			err = service.deleteVPCSecurityPolicy(sp, createdFor)
+		} else {
+			// For T1 network SecurityPolicy deletion
+			err = service.deleteSecurityPolicy(sp)
+		}
 	}
 	return err
 }
 
-func (service *SecurityPolicyService) deleteSecurityPolicy(obj interface{}, isVpcCleanup bool, createdFor string) error {
+func (service *SecurityPolicyService) deleteSecurityPolicy(sp types.UID) error {
 	var nsxSecurityPolicy *model.SecurityPolicy
-	var spNameSpace string
 	var err error
 	g := make([]model.Group, 0)
 	nsxGroups := &g
 	r := make([]model.Rule, 0)
 	nsxRules := &r
-	var projectShares *[]ProjectShare
-	nsxProjectShares := make([]model.Share, 0)
-	nsxProjectGroups := make([]model.Group, 0)
-	securityPolicyStore, ruleStore, groupStore, projectGroupStore, shareStore := service.getStores()
-	switch sp := obj.(type) {
-	// This case is for normal SecurityPolicy deletion process, which means that SecurityPolicy
-	// has corresponding nsx SecurityPolicy object
-	case *v1alpha1.SecurityPolicy:
-		nsxSecurityPolicy, nsxGroups, projectShares, err = service.buildSecurityPolicy(sp, createdFor)
-		spNameSpace = sp.ObjectMeta.Namespace
-		if err != nil {
-			log.Error(err, "failed to build nsx SecurityPolicy in deleting")
-			return err
-		}
+	securityPolicyStore, ruleStore, groupStore, _, _ := service.getStores()
 
-		// Collect project share and project level groups that need to be removed from nsx
-		// project share and project groups only needed in VPC network.
-		for i := len(*projectShares) - 1; i >= 0; i-- {
-			nsxProjectGroups = append(nsxProjectGroups, *(*projectShares)[i].shareGroup)
-			nsxProjectShares = append(nsxProjectShares, *(*projectShares)[i].share)
-		}
-
-	// This case is for SecurityPolicy GC or cleanup process, which means that SecurityPolicy
-	// doesn't exist in K8s any more but still has corresponding nsx SecurityPolicy object.
-	// Hence, we use SecurityPolicy's UID here from store instead of K8s SecurityPolicy object
-	case types.UID:
-		indexScope := common.TagValueScopeSecurityPolicyUID
-		if createdFor == common.ResourceTypeNetworkPolicy {
-			indexScope = common.TagScopeNetworkPolicyUID
-		}
-		existingSecurityPolices := securityPolicyStore.GetByIndex(indexScope, string(sp))
-		if len(existingSecurityPolices) == 0 {
-			log.Info("NSX security policy is not found in store, skip deleting it", "nsxSecurityPolicyUID", sp, "createdFor", createdFor)
-			return nil
-		}
-		nsxSecurityPolicy = existingSecurityPolices[0]
-		// Get namespace of nsx SecurityPolicy from tags since there is no K8s SecurityPolicy object
-		for i := len(nsxSecurityPolicy.Tags) - 1; i >= 0; i-- {
-			if *(nsxSecurityPolicy.Tags[i].Scope) == common.TagScopeNamespace {
-				spNameSpace = *(nsxSecurityPolicy.Tags[i].Tag)
-				log.V(1).Info("get namespace with SecurityPolicy index", "namespace", spNameSpace, "securityPolicyUID", string(sp))
-				break
-			}
-		}
-
-		existingGroups := groupStore.GetByIndex(indexScope, string(sp))
-		if len(existingGroups) == 0 {
-			log.Info("did not get groups with SecurityPolicy index", "securityPolicyUID", string(sp))
-		}
-		for _, group := range existingGroups {
-			*nsxGroups = append(*nsxGroups, *group)
-		}
-
-		// In GC or Cleanup process, there is no nsx rules in the security policy retrieved from securityPolicy store
-		// the rules associated the deleting security policy can only be gotten from rule store.
-		existingRules := ruleStore.GetByIndex(indexScope, string(sp))
-		if len(existingRules) == 0 {
-			log.Info("did not get rules with SecurityPolicy index", "securityPolicyUID", string(sp))
-		}
-		for _, rule := range existingRules {
-			*nsxRules = append(*nsxRules, *rule)
-		}
-		nsxSecurityPolicy.Rules = *nsxRules
-
-		if isVpcEnabled(service) || isVpcCleanup {
-			existingNsxProjectGroups := projectGroupStore.GetByIndex(indexScope, string(sp))
-			if len(existingNsxProjectGroups) == 0 {
-				log.Info("did not get project groups with SecurityPolicy index", "securityPolicyUID", string(sp))
-			}
-			for _, projectGroup := range existingNsxProjectGroups {
-				nsxProjectGroups = append(nsxProjectGroups, *projectGroup)
-			}
-			existingNsxProjectShares := shareStore.GetByIndex(indexScope, string(sp))
-			if len(existingNsxProjectShares) == 0 {
-				log.Info("did not get project shares with SecurityPolicy index", "securityPolicyUID", string(sp))
-			}
-			for _, nsxShare := range existingNsxProjectShares {
-				nsxProjectShares = append(nsxProjectShares, *nsxShare)
-			}
-		}
+	// For normal SecurityPolicy deletion process, which means that SecurityPolicy has corresponding nsx SecurityPolicy object
+	// And for SecurityPolicy GC or cleanup process, which means that SecurityPolicy doesn't exist in K8s any more
+	// but still has corresponding nsx SecurityPolicy object.
+	// We use SecurityPolicy's UID from store to get NSX SecurityPolicy object
+	indexScope := common.TagValueScopeSecurityPolicyUID
+	existingSecurityPolices := securityPolicyStore.GetByIndex(indexScope, string(sp))
+	if len(existingSecurityPolices) == 0 {
+		log.Info("NSX security policy is not found in store, skip deleting it", "nsxSecurityPolicyUID", sp)
+		return nil
+	}
+	nsxSecurityPolicy = existingSecurityPolices[0]
+	if nsxSecurityPolicy.Path == nil {
+		err = errors.New("nsxSecurityPolicy path is empty")
+		log.Error(err, "failed to delete SecurityPolicy", "nsxSecurityPolicyUID", sp)
+		return err
 	}
 
 	nsxSecurityPolicy.MarkedForDelete = &MarkedForDelete
-	for i := len(*nsxGroups) - 1; i >= 0; i-- { // Don't use range, it would copy the element
-		(*nsxGroups)[i].MarkedForDelete = &MarkedForDelete
-	}
-	for i := len(nsxSecurityPolicy.Rules) - 1; i >= 0; i-- { // Don't use range, it would copy the element
-		nsxSecurityPolicy.Rules[i].MarkedForDelete = &MarkedForDelete
-	}
+
+	// There is no nsx groups/rules in the security policy retrieved from securityPolicy store.
+	// The groups/rules associated the deleting security policy can only be gotten from group/rule store.
+	existingGroups := groupStore.GetByIndex(indexScope, string(sp))
+	service.markDeleteGroups(existingGroups, nsxGroups, sp)
+
+	existingRules := ruleStore.GetByIndex(indexScope, string(sp))
+	service.markDeleteRules(existingRules, nsxRules, sp)
+	nsxSecurityPolicy.Rules = *nsxRules
 
 	// WrapHighLevelSecurityPolicy will modify the input security policy, so we need to make a copy for the following store update.
 	finalSecurityPolicyCopy := *nsxSecurityPolicy
 	finalSecurityPolicyCopy.Rules = nsxSecurityPolicy.Rules
 
-	if isVpcEnabled(service) || isVpcCleanup {
-		var vpcInfo *common.VPCResourceInfo
-		if isVpcCleanup == false {
-			vpcInfo, err = service.getVpcInfo(spNameSpace)
-			if err != nil {
-				return err
-			}
-		} else {
-			// In cleanup process, vpcInfo should be listed directly from security policy store to avoid calling VPC service.
-			// Get orgId, projectId, vpcId from security policy path "/orgs/<orgId>/projects/<projectId>/vpcs/<vpcId>/security-policies/<spId>"
-			if nsxSecurityPolicy.Path == nil {
-				err = errors.New("nsxSecurityPolicy path is empty")
-				log.Error(err, "failed to delete SecurityPolicy in VPC")
-				return err
-			}
-
-			vpcInfo = new(common.VPCResourceInfo)
-			vpcInfo.OrgID, vpcInfo.ProjectID, vpcInfo.VPCID, _ = nsxutil.ParseVPCPath(*(nsxSecurityPolicy.Path))
-		}
-
-		for i := len(nsxProjectGroups) - 1; i >= 0; i-- {
-			nsxProjectGroups[i].MarkedForDelete = &MarkedForDelete
-		}
-		for i := len(nsxProjectShares) - 1; i >= 0; i-- {
-			nsxProjectShares[i].MarkedForDelete = &MarkedForDelete
-		}
-
-		// 1.Wrap project groups and shares into project child infra.
-		var projectInfra []*data.StructValue
-		if len(nsxProjectShares) != 0 || len(nsxProjectGroups) != 0 {
-			projectInfra, err = service.wrapHierarchyProjectResources(nsxProjectShares, nsxProjectGroups)
-			if err != nil {
-				log.Error(err, "failed to wrap project groups and shares")
-				return err
-			}
-		}
-
-		// 2.Wrap SecurityPolicy, groups, rules under VPC level together with project groups and shares into one hierarchy resource tree.
-		orgRoot, err := service.WrapHierarchyVpcSecurityPolicy(nsxSecurityPolicy, *nsxGroups, projectInfra, vpcInfo)
-		if err != nil {
-			log.Error(err, "failed to wrap SecurityPolicy in VPC")
-			return err
-		}
-
-		// 3.Create/update SecurityPolicy together with groups, rules under VPC level and project groups, shares.
-		err = service.NSXClient.OrgRootClient.Patch(*orgRoot, &EnforceRevisionCheckParam)
-		err = nsxutil.NSXApiError(err)
-		if err != nil {
-			log.Error(err, "failed to delete SecurityPolicy in VPC")
-			return err
-		}
-
-		if len(nsxProjectGroups) != 0 {
-			err = projectGroupStore.Apply(&nsxProjectGroups)
-			if err != nil {
-				log.Error(err, "failed to apply store", "nsxProjectGroups", nsxProjectGroups)
-				return err
-			}
-		}
-
-		if len(nsxProjectShares) != 0 {
-			err = shareStore.Apply(&nsxProjectShares)
-			if err != nil {
-				log.Error(err, "failed to apply store", "nsxProjectShares", nsxProjectShares)
-				return err
-			}
-		}
-	} else {
-		infraSecurityPolicy, err := service.WrapHierarchySecurityPolicy(nsxSecurityPolicy, *nsxGroups)
-		if err != nil {
-			log.Error(err, "failed to wrap SecurityPolicy")
-			return err
-		}
-		err = service.NSXClient.InfraClient.Patch(*infraSecurityPolicy, &EnforceRevisionCheckParam)
-		err = nsxutil.NSXApiError(err)
-		if err != nil {
-			log.Error(err, "failed to delete SecurityPolicy")
-			return err
-		}
-	}
+	infraSecurityPolicy, err := service.WrapHierarchySecurityPolicy(nsxSecurityPolicy, *nsxGroups)
 	if err != nil {
+		log.Error(err, "failed to wrap SecurityPolicy", "nsxSecurityPolicyId", nsxSecurityPolicy.Id)
+		return err
+	}
+	err = service.NSXClient.InfraClient.Patch(*infraSecurityPolicy, &EnforceRevisionCheckParam)
+	err = nsxutil.NSXApiError(err)
+	if err != nil {
+		log.Error(err, "failed to delete SecurityPolicy", "nsxSecurityPolicyId", nsxSecurityPolicy.Id)
 		return err
 	}
 
@@ -788,7 +690,120 @@ func (service *SecurityPolicyService) deleteSecurityPolicy(obj interface{}, isVp
 		return err
 	}
 
-	log.Info("successfully deleted nsx SecurityPolicy", "nsxSecurityPolicy", finalSecurityPolicyCopy)
+	log.Info("successfully deleted NSX SecurityPolicy", "nsxSecurityPolicy", finalSecurityPolicyCopy)
+	return nil
+}
+
+func (service *SecurityPolicyService) deleteVPCSecurityPolicy(sp types.UID, createdFor string) error {
+	var nsxSecurityPolicy *model.SecurityPolicy
+	var err error
+	g := make([]model.Group, 0)
+	nsxGroups := &g
+	r := make([]model.Rule, 0)
+	nsxRules := &r
+	g1 := make([]model.Group, 0)
+	s := make([]model.Share, 0)
+	nsxProjectGroups := &g1
+	nsxProjectShares := &s
+	securityPolicyStore, ruleStore, groupStore, projectGroupStore, shareStore := service.getStores()
+
+	// For normal SecurityPolicy deletion process, which means that SecurityPolicy has corresponding nsx SecurityPolicy object
+	// And for SecurityPolicy GC or cleanup process, which means that SecurityPolicy doesn't exist in K8s any more
+	// but still has corresponding nsx SecurityPolicy object.
+	// We use SecurityPolicy's UID from store to get NSX SecurityPolicy object
+	indexScope := common.TagValueScopeSecurityPolicyUID
+	if createdFor == common.ResourceTypeNetworkPolicy {
+		indexScope = common.TagScopeNetworkPolicyUID
+	}
+	existingSecurityPolices := securityPolicyStore.GetByIndex(indexScope, string(sp))
+	if len(existingSecurityPolices) == 0 {
+		log.Info("NSX security policy is not found in store, skip deleting it", "nsxSecurityPolicyUID", sp, "createdFor", createdFor)
+		return nil
+	}
+	nsxSecurityPolicy = existingSecurityPolices[0]
+
+	// vpcInfo should be listed directly from security policy store to avoid calling VPC service.
+	// Get orgId, projectId, vpcId from security policy path "/orgs/<orgId>/projects/<projectId>/vpcs/<vpcId>/security-policies/<spId>"
+	if nsxSecurityPolicy.Path == nil {
+		err = errors.New("nsxSecurityPolicy path is empty")
+		log.Error(err, "failed to delete SecurityPolicy in VPC", "nsxSecurityPolicyUID", sp)
+		return err
+	}
+	vpcInfo, _ := common.ParseVPCResourcePath(*(nsxSecurityPolicy.Path))
+
+	nsxSecurityPolicy.MarkedForDelete = &MarkedForDelete
+
+	// There is no nsx groups/rules in the security policy retrieved from securityPolicy store.
+	// The groups/rules associated the deleting security policy can only be gotten from group/rule store.
+	existingGroups := groupStore.GetByIndex(indexScope, string(sp))
+	service.markDeleteGroups(existingGroups, nsxGroups, sp)
+
+	existingRules := ruleStore.GetByIndex(indexScope, string(sp))
+	service.markDeleteRules(existingRules, nsxRules, sp)
+	nsxSecurityPolicy.Rules = *nsxRules
+
+	existingNsxProjectGroups := projectGroupStore.GetByIndex(indexScope, string(sp))
+	service.markDeleteGroups(existingNsxProjectGroups, nsxProjectGroups, sp)
+
+	existingNsxProjectShares := shareStore.GetByIndex(indexScope, string(sp))
+	service.markDeleteShares(existingNsxProjectShares, nsxProjectShares, sp)
+
+	// WrapHierarchyVpcSecurityPolicy will modify the input security policy, so we need to make a copy for the following store update.
+	finalSecurityPolicyCopy := *nsxSecurityPolicy
+	finalSecurityPolicyCopy.Rules = nsxSecurityPolicy.Rules
+
+	// 1.Wrap project groups and shares into project child infra.
+	var projectInfra []*data.StructValue
+	if len(*nsxProjectShares) != 0 || len(*nsxProjectGroups) != 0 {
+		projectInfra, err = service.wrapHierarchyProjectResources(*nsxProjectShares, *nsxProjectGroups)
+		if err != nil {
+			log.Error(err, "failed to wrap project groups and shares", "nsxSecurityPolicyId", nsxSecurityPolicy.Id)
+			return err
+		}
+	}
+
+	// 2.Wrap SecurityPolicy, groups, rules under VPC level together with project groups and shares into one hierarchy resource tree.
+	orgRoot, err := service.WrapHierarchyVpcSecurityPolicy(nsxSecurityPolicy, *nsxGroups, projectInfra, &vpcInfo)
+	if err != nil {
+		log.Error(err, "failed to wrap SecurityPolicy in VPC", "nsxSecurityPolicyId", nsxSecurityPolicy.Id)
+		return err
+	}
+
+	// 3.Create/update SecurityPolicy together with groups, rules under VPC level and project groups, shares.
+	err = service.NSXClient.OrgRootClient.Patch(*orgRoot, &EnforceRevisionCheckParam)
+	err = nsxutil.NSXApiError(err)
+	if err != nil {
+		log.Error(err, "failed to delete SecurityPolicy in VPC", "nsxSecurityPolicyId", nsxSecurityPolicy.Id)
+		return err
+	}
+
+	err = securityPolicyStore.Apply(&finalSecurityPolicyCopy)
+	if err != nil {
+		log.Error(err, "failed to apply store", "securityPolicy", finalSecurityPolicyCopy)
+		return err
+	}
+	err = ruleStore.Apply(&finalSecurityPolicyCopy)
+	if err != nil {
+		log.Error(err, "failed to apply store", "nsxRules", finalSecurityPolicyCopy.Rules)
+		return err
+	}
+	err = groupStore.Apply(nsxGroups)
+	if err != nil {
+		log.Error(err, "failed to apply store", "nsxGroups", nsxGroups)
+		return err
+	}
+	err = projectGroupStore.Apply(nsxProjectGroups)
+	if err != nil {
+		log.Error(err, "failed to apply store", "nsxProjectGroups", nsxProjectGroups)
+		return err
+	}
+	err = shareStore.Apply(nsxProjectShares)
+	if err != nil {
+		log.Error(err, "failed to apply store", "nsxProjectShares", nsxProjectShares)
+		return err
+	}
+
+	log.Info("successfully deleted NSX SecurityPolicy in VPC", "nsxSecurityPolicy", finalSecurityPolicyCopy)
 	return nil
 }
 
@@ -880,6 +895,81 @@ func (service *SecurityPolicyService) Cleanup(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (service *SecurityPolicyService) updateRules(existingRules []*model.Rule, expectedRules []model.Rule) []model.Rule {
+	changed, stale := common.CompareResources(RulesPtrToComparable(existingRules), RulesToComparable(expectedRules))
+	changedRules, staleRules := ComparableToRules(changed), ComparableToRules(stale)
+	finalRules := make([]model.Rule, 0)
+	for i := len(staleRules) - 1; i >= 0; i-- { // Don't use range, it would copy the element
+		staleRules[i].MarkedForDelete = &MarkedForDelete // nsx clients need this field to delete the rules
+	}
+	finalRules = append(finalRules, staleRules...)
+	finalRules = append(finalRules, changedRules...)
+	return finalRules
+}
+
+func (service *SecurityPolicyService) updateGroups(existingGroups []*model.Group, expectedGroups []model.Group) []model.Group {
+	changed, stale := common.CompareResources(GroupsPtrToComparable(existingGroups), GroupsToComparable(expectedGroups))
+	changedGroups, staleGroups := ComparableToGroups(changed), ComparableToGroups(stale)
+	finalGroups := make([]model.Group, 0)
+	for i := len(staleGroups) - 1; i >= 0; i-- {
+		staleGroups[i].MarkedForDelete = &MarkedForDelete
+	}
+	finalGroups = append(finalGroups, staleGroups...)
+	finalGroups = append(finalGroups, changedGroups...)
+	return finalGroups
+}
+
+func (service *SecurityPolicyService) updateShares(existingShares []*model.Share, expectedShares []model.Share) []model.Share {
+	changed, stale := common.CompareResources(SharesPtrToComparable(existingShares), SharesToComparable(expectedShares))
+	changedShares, staleShares := ComparableToShares(changed), ComparableToShares(stale)
+	for i := len(staleShares) - 1; i >= 0; i-- {
+		staleShares[i].MarkedForDelete = &MarkedForDelete
+	}
+	finalShares := make([]model.Share, 0)
+	finalShares = append(finalShares, staleShares...)
+	finalShares = append(finalShares, changedShares...)
+	return finalShares
+}
+
+func (service *SecurityPolicyService) markDeleteGroups(existingGroups []*model.Group, deleteGroups *[]model.Group, sp types.UID) {
+	if len(existingGroups) == 0 {
+		log.Info("did not get groups with SecurityPolicy index", "securityPolicyUID", string(sp))
+		return
+	}
+	for _, group := range existingGroups {
+		*deleteGroups = append(*deleteGroups, *group)
+	}
+	for i := len(*deleteGroups) - 1; i >= 0; i-- {
+		(*deleteGroups)[i].MarkedForDelete = &MarkedForDelete
+	}
+}
+
+func (service *SecurityPolicyService) markDeleteRules(existingRules []*model.Rule, deleteRules *[]model.Rule, sp types.UID) {
+	if len(existingRules) == 0 {
+		log.Info("did not get rules with SecurityPolicy index", "securityPolicyUID", string(sp))
+		return
+	}
+	for _, rule := range existingRules {
+		*deleteRules = append(*deleteRules, *rule)
+	}
+	for i := len(*deleteRules) - 1; i >= 0; i-- {
+		(*deleteRules)[i].MarkedForDelete = &MarkedForDelete
+	}
+}
+
+func (service *SecurityPolicyService) markDeleteShares(existingShares []*model.Share, deleteShares *[]model.Share, sp types.UID) {
+	if len(existingShares) == 0 {
+		log.Info("did not get shares with SecurityPolicy index", "securityPolicyUID", string(sp))
+		return
+	}
+	for _, share := range existingShares {
+		*deleteShares = append(*deleteShares, *share)
+	}
+	for i := len(*deleteShares) - 1; i >= 0; i-- {
+		(*deleteShares)[i].MarkedForDelete = &MarkedForDelete
+	}
 }
 
 func (s *SecurityPolicyService) getVpcInfo(spNameSpace string) (*common.VPCResourceInfo, error) {

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -4,13 +4,17 @@
 package securitypolicy
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -363,6 +367,795 @@ func TestListSecurityPolicyID(t *testing.T) {
 			got := service.ListSecurityPolicyID()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("SecurityPolicyService.ListSecurityPolicyID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListUpdateRules(t *testing.T) {
+	r1 := model.Rule{
+		DisplayName:       String("nsxrule1"),
+		Id:                String("nsxrule_1"),
+		DestinationGroups: []string{"ANY"},
+		Direction:         &nsxDirectionIn,
+		Scope:             []string{"/infra/domains/k8scl-one/groups/sp_uidA_0_scope"},
+		SequenceNumber:    &seq0,
+		Services:          []string{"ANY"},
+		SourceGroups:      []string{"/infra/domains/k8scl-one/groups/sp_uidA_0_src"},
+		Action:            &nsxActionAllow,
+	}
+
+	tests := []struct {
+		name          string
+		existingRules []*model.Rule
+		expectedRules []model.Rule
+		finalRulesLen int
+	}{
+		{
+			name: "test-rule-nochange",
+			existingRules: []*model.Rule{
+				&r1,
+			},
+			expectedRules: []model.Rule{
+				{
+					DisplayName:       String("nsxrule1"),
+					Id:                String("nsxrule_1"),
+					DestinationGroups: []string{"ANY"},
+					Direction:         &nsxDirectionIn,
+					Scope:             []string{"/infra/domains/k8scl-one/groups/sp_uidA_0_scope"},
+					SequenceNumber:    &seq0,
+					Services:          []string{"ANY"},
+					SourceGroups:      []string{"/infra/domains/k8scl-one/groups/sp_uidA_0_src"},
+					Action:            &nsxActionAllow,
+				},
+			},
+			finalRulesLen: 0,
+		},
+		{
+			name: "test-rule-change",
+			existingRules: []*model.Rule{
+				&r1,
+			},
+			expectedRules: []model.Rule{
+				{
+					DisplayName:       String("nsxrule1"),
+					Id:                String("nsxrule_1"),
+					DestinationGroups: []string{"ANY"},
+					Direction:         &nsxDirectionIn,
+					Scope:             []string{"/infra/domains/k8scl-one/groups/sp_uidA_1_scope"},
+					SequenceNumber:    &seq0,
+					Services:          []string{"ANY"},
+					SourceGroups:      []string{"/infra/domains/k8scl-one/groups/sp_uidA_0_src"},
+					Action:            &nsxActionAllow,
+				},
+			},
+			finalRulesLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			finalRules := service.updateRules(tt.existingRules, tt.expectedRules)
+			assert.Equal(t, tt.finalRulesLen, len(finalRules))
+		})
+	}
+}
+
+func TestListUpdateGroups(t *testing.T) {
+	mId, mTag, mTag2, mScope := "11111", "11111", "22222", "nsx-op/security_policy_cr_uid"
+	markDelete := true
+
+	g1 := model.Group{
+		Id:              &mId,
+		Tags:            []model.Tag{{Tag: &mTag, Scope: &mScope}},
+		MarkedForDelete: &markDelete,
+	}
+
+	tests := []struct {
+		name           string
+		existingGroups []*model.Group
+		expectedGroups []model.Group
+		finalGroupsLen int
+	}{
+		{
+			name: "test-group-nochange",
+			existingGroups: []*model.Group{
+				&g1,
+			},
+			expectedGroups: []model.Group{
+				{
+					Id:              &mId,
+					Tags:            []model.Tag{{Tag: &mTag, Scope: &mScope}},
+					MarkedForDelete: &markDelete,
+				},
+			},
+			finalGroupsLen: 0,
+		},
+		{
+			name: "test-group-change",
+			existingGroups: []*model.Group{
+				&g1,
+			},
+			expectedGroups: []model.Group{
+				{
+					Id:              String("nsxgroup"),
+					Tags:            []model.Tag{{Tag: &mTag, Scope: &mScope}},
+					MarkedForDelete: &markDelete,
+				},
+			},
+			finalGroupsLen: 2,
+		},
+		{
+			name: "test-group-change1",
+			existingGroups: []*model.Group{
+				&g1,
+			},
+			expectedGroups: []model.Group{
+				{
+					Id:              &mId,
+					Tags:            []model.Tag{{Tag: &mTag2, Scope: &mScope}},
+					MarkedForDelete: &markDelete,
+				},
+			},
+			finalGroupsLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			finalGroups := service.updateGroups(tt.existingGroups, tt.expectedGroups)
+			assert.Equal(t, tt.finalGroupsLen, len(finalGroups))
+		})
+	}
+}
+
+func TestListUpdateShares(t *testing.T) {
+	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_cr_uid"
+
+	s1 := model.Share{
+		Id:         &mId,
+		Tags:       []model.Tag{{Tag: &mTag, Scope: &mScope}},
+		SharedWith: []string{"/org/default/project/default/vpc/vpc1"},
+	}
+
+	tests := []struct {
+		name           string
+		existingShares []*model.Share
+		expectedShares []model.Share
+		finalSharesLen int
+	}{
+		{
+			name: "test-share-nochange",
+			existingShares: []*model.Share{
+				&s1,
+			},
+			expectedShares: []model.Share{
+				{
+					Id:         &mId,
+					Tags:       []model.Tag{{Tag: &mTag, Scope: &mScope}},
+					SharedWith: []string{"/org/default/project/default/vpc/vpc1"},
+				},
+			},
+			finalSharesLen: 0,
+		},
+		{
+			name: "test-share-change",
+			existingShares: []*model.Share{
+				&s1,
+			},
+			expectedShares: []model.Share{
+				{
+					Id:         String("nsxshare"),
+					Tags:       []model.Tag{{Tag: &mTag, Scope: &mScope}},
+					SharedWith: []string{"/org/default/project/default/vpc/vpc1"},
+				},
+			},
+			finalSharesLen: 2,
+		},
+		{
+			name: "test-sahre-change1",
+			existingShares: []*model.Share{
+				&s1,
+			},
+			expectedShares: []model.Share{
+				{
+					Id:         &mId,
+					Tags:       []model.Tag{{Tag: &mTag, Scope: &mScope}},
+					SharedWith: []string{"/org/default/project/default/vpc/vpc2"},
+				},
+			},
+			finalSharesLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			finalShares := service.updateShares(tt.existingShares, tt.expectedShares)
+			assert.Equal(t, tt.finalSharesLen, len(finalShares))
+		})
+	}
+}
+
+func TestListMarkDeleteRules(t *testing.T) {
+	var sp types.UID
+	sp = "sp_test"
+	markNoDelete := false
+
+	r := make([]model.Rule, 0)
+	r1 := model.Rule{
+		DisplayName:       String("nsxrule1"),
+		Id:                String("nsxrule_1"),
+		DestinationGroups: []string{"ANY"},
+		Direction:         &nsxDirectionIn,
+		Scope:             []string{"/infra/domains/k8scl-one/groups/sp_uidA_0_scope"},
+		SequenceNumber:    &seq0,
+		Services:          []string{"ANY"},
+		SourceGroups:      []string{"/infra/domains/k8scl-one/groups/sp_uidA_0_src"},
+		Action:            &nsxActionAllow,
+		MarkedForDelete:   &markNoDelete,
+	}
+
+	tests := []struct {
+		name          string
+		existingRules []*model.Rule
+		deleteRules   *[]model.Rule
+	}{
+		{
+			name: "test-rule-delete",
+			existingRules: []*model.Rule{
+				&r1,
+			},
+			deleteRules: &r,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service.markDeleteRules(tt.existingRules, tt.deleteRules, sp)
+			for i := len(*tt.deleteRules) - 1; i >= 0; i-- {
+				assert.Equal(t, MarkedForDelete, *((*tt.deleteRules)[i].MarkedForDelete))
+			}
+		})
+	}
+}
+
+func TestListMarkDeleteGroups(t *testing.T) {
+	var sp types.UID
+	sp = "sp_test"
+	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_cr_uid"
+	markNoDelete := false
+
+	g := make([]model.Group, 0)
+	g1 := model.Group{
+		Id:              &mId,
+		Tags:            []model.Tag{{Tag: &mTag, Scope: &mScope}},
+		MarkedForDelete: &markNoDelete,
+	}
+
+	tests := []struct {
+		name           string
+		existingGroups []*model.Group
+		deleteGroups   *[]model.Group
+	}{
+		{
+			name: "test-group-delete",
+			existingGroups: []*model.Group{
+				&g1,
+			},
+			deleteGroups: &g,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service.markDeleteGroups(tt.existingGroups, tt.deleteGroups, sp)
+			for i := len(*tt.deleteGroups) - 1; i >= 0; i-- {
+				assert.Equal(t, MarkedForDelete, *((*tt.deleteGroups)[i].MarkedForDelete))
+			}
+		})
+	}
+}
+
+func TestListMarkDeleteShares(t *testing.T) {
+	var sp types.UID
+	sp = "sp_test"
+	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_cr_uid"
+	markNoDelete := false
+
+	s := make([]model.Share, 0)
+	s1 := model.Share{
+		Id:              &mId,
+		Tags:            []model.Tag{{Tag: &mTag, Scope: &mScope}},
+		SharedWith:      []string{"/org/default/project/default/vpc/vpc1"},
+		MarkedForDelete: &markNoDelete,
+	}
+
+	tests := []struct {
+		name           string
+		existingShares []*model.Share
+		deleteShares   *[]model.Share
+	}{
+		{
+			name: "test-share-nochange",
+			existingShares: []*model.Share{
+				&s1,
+			},
+			deleteShares: &s,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service.markDeleteShares(tt.existingShares, tt.deleteShares, sp)
+			for i := len(*tt.deleteShares) - 1; i >= 0; i-- {
+				assert.Equal(t, MarkedForDelete, *((*tt.deleteShares)[i].MarkedForDelete))
+			}
+		})
+	}
+}
+
+func TestDleleteVPCSecurityPolicy(t *testing.T) {
+	vpcPath := "/orgs/default/projects/projectQuality/vpcs/vpc1"
+
+	type args struct {
+		uid        types.UID
+		createdFor string
+	}
+	tests := []struct {
+		name                         string
+		prepareFunc                  func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		args                         args
+		inputPolicy                  *model.SecurityPolicy
+		wantErr                      bool
+		wantSecurityPolicyStoreCount int
+		wantRuleStoreCount           int
+		wantGroupStoreCount          int
+		wantProjectGroupStoreCount   int
+		wantProjectShareStoreCount   int
+	}{
+		{
+			name: "successDeleteVPCSecurityPolicy",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				mGId := "sp_uidA_0_scope"
+				mTag, mScope := tagValuePolicyCRUID, tagScopeSecurityPolicyCRUID
+				g := make([]model.Group, 0)
+				g1 := &g
+				scopeGroup := model.Group{
+					Id:   &mGId,
+					Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+				}
+				*g1 = append(*g1, scopeGroup)
+				assert.NoError(t, s.groupStore.Apply(g1))
+
+				mProjGId := "sp_uidA_1_src"
+				g = make([]model.Group, 0)
+				g2 := &g
+				projectGroup := model.Group{
+					Id:   &mProjGId,
+					Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+				}
+				*g2 = append(*g2, projectGroup)
+				assert.NoError(t, s.projectGroupStore.Apply(g2))
+
+				mSId := "share-projectQuality-group-sp_uidA_1_src"
+				sh := make([]model.Share, 0)
+				s1 := &sh
+				projectShare := model.Share{
+					Id:         &mSId,
+					Tags:       []model.Tag{{Tag: &mTag, Scope: &mScope}},
+					SharedWith: []string{"/org/default/project/projectQuality/vpcs/vpc1"},
+				}
+				*s1 = append(*s1, projectShare)
+				assert.NoError(t, s.shareStore.Apply(s1))
+
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				uid:        types.UID(tagValuePolicyCRUID),
+			},
+			inputPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             &tagValuePolicyCRUID,
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/sp_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules: []model.Rule{
+					{
+						DisplayName:       &ruleNameWithPodSelector00,
+						Id:                &ruleID0,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"ANY"},
+						Action:            &nsxActionAllow,
+						Tags:              basicTags,
+					},
+					{
+						DisplayName:       &ruleNameWithNsSelector00,
+						Id:                &ruleID1,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq1,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/sp_uidA_1_src"},
+						Action:            &nsxActionAllow,
+						Tags:              basicTags,
+					},
+				},
+				Tags: basicTags,
+				Path: &vpcPath,
+			},
+			wantErr:                      false,
+			wantSecurityPolicyStoreCount: 0,
+			wantRuleStoreCount:           0,
+			wantGroupStoreCount:          0,
+			wantProjectGroupStoreCount:   0,
+			wantProjectShareStoreCount:   0,
+		},
+		{
+			name: "errorDeleteVPCSecurityPolicy",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				mGId := "sp_uidA_0_scope"
+				mTag, mScope := tagValuePolicyCRUID, tagScopeSecurityPolicyCRUID
+				g := make([]model.Group, 0)
+				g1 := &g
+				scopeGroup := model.Group{
+					Id:   &mGId,
+					Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+				}
+				*g1 = append(*g1, scopeGroup)
+				assert.NoError(t, s.groupStore.Apply(g1))
+
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{fmt.Errorf("mock error")},
+					Times:  1,
+				}})
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				uid:        types.UID(tagValuePolicyCRUID),
+			},
+			inputPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             &tagValuePolicyCRUID,
+				Scope:          []string{"/orgs/default/projects/default/vpcs/vpc1/groups/sp_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules: []model.Rule{
+					{
+						DisplayName:       &ruleNameWithPodSelector00,
+						Id:                &ruleID0,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"ANY"},
+						Action:            &nsxActionAllow,
+						Tags:              basicTags,
+					},
+				},
+				Tags: basicTags,
+				Path: &vpcPath,
+			},
+			wantErr:                      true,
+			wantSecurityPolicyStoreCount: 1,
+			wantRuleStoreCount:           1,
+			wantGroupStoreCount:          1,
+			wantProjectGroupStoreCount:   0,
+			wantProjectShareStoreCount:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeService := fakeSecurityPolicyService()
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			assert.NoError(t, fakeService.securityPolicyStore.Apply(tt.inputPolicy))
+			assert.NoError(t, fakeService.ruleStore.Apply(tt.inputPolicy))
+
+			patches := tt.prepareFunc(t, fakeService)
+			defer patches.Reset()
+
+			if err := fakeService.deleteVPCSecurityPolicy(tt.args.uid, tt.args.createdFor); (err != nil) != tt.wantErr {
+				t.Errorf("deleteVPCSecurityPolicy error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.wantSecurityPolicyStoreCount, len(fakeService.securityPolicyStore.ListKeys()))
+			assert.Equal(t, tt.wantRuleStoreCount, len(fakeService.ruleStore.ListKeys()))
+			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectGroupStoreCount, len(fakeService.projectGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.shareStore.ListKeys()))
+		})
+	}
+}
+
+func TestCreateOrUpdateSecurityPolicy(t *testing.T) {
+	VPCInfo := make([]common.VPCResourceInfo, 1)
+	VPCInfo[0].OrgID = "default"
+	VPCInfo[0].ProjectID = "projectQuality"
+	VPCInfo[0].VPCID = "vpc1"
+
+	fakeService := fakeSecurityPolicyService()
+	fakeService.NSXConfig.EnableVPCNetwork = true
+	mockVPCService := common.MockVPCServiceProvider{}
+	fakeService.vpcService = &mockVPCService
+
+	podSelectorRule0IDPort000 := fakeService.buildExpandedRuleId(fakeService.buildRuleID(&spWithPodSelector, &spWithPodSelector.Spec.Rules[0], 0, common.ResourceTypeSecurityPolicy), 0, 0)
+	podSelectorRule1IDPort000 := fakeService.buildExpandedRuleId(fakeService.buildRuleID(&spWithPodSelector, &spWithPodSelector.Spec.Rules[1], 1, common.ResourceTypeSecurityPolicy), 0, 0)
+
+	podSelectorRule0Name00, _ := fakeService.buildRuleDisplayName(&spWithPodSelector.Spec.Rules[0], 0, -1, false, common.ResourceTypeSecurityPolicy)
+	podSelectorRule1Name00, _ := fakeService.buildRuleDisplayName(&spWithPodSelector.Spec.Rules[1], 0, -1, false, common.ResourceTypeSecurityPolicy)
+
+	type args struct {
+		spObj      *v1alpha1.SecurityPolicy
+		createdFor string
+	}
+	tests := []struct {
+		name                         string
+		prepareFunc                  func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		args                         args
+		expectedPolicy               *model.SecurityPolicy
+		wantErr                      bool
+		wantSecurityPolicyStoreCount int
+		wantRuleStoreCount           int
+		wantGroupStoreCount          int
+		wantProjectGroupStoreCount   int
+		wantProjectShareStoreCount   int
+	}{
+		{
+			name: "successCreateUpdateVPCSecurityPolicy",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVpcInfo",
+					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
+						return &VPCInfo[0], nil
+					})
+
+				patches.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+
+				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+					func(s *SecurityPolicyService, ns string) types.UID {
+						return types.UID(tagValueNSUID)
+					})
+
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				spObj:      &spWithPodSelector,
+			},
+			expectedPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             &spID,
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/sp_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules: []model.Rule{
+					{
+						DisplayName:       &podSelectorRule0Name00,
+						Id:                &podSelectorRule0IDPort000,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxDirectionIn,
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/sp_uidA_0_scope"},
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/sp_uidA_0_src"},
+						Action:            &nsxActionAllow,
+						Tags:              basicTags,
+					},
+					{
+						DisplayName:       &podSelectorRule1Name00,
+						Id:                &podSelectorRule1IDPort000,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq1,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/sp_uidA_1_src"},
+						Action:            &nsxActionAllow,
+						Tags:              basicTags,
+					},
+				},
+				Tags: basicTags,
+			},
+			wantErr:                      false,
+			wantSecurityPolicyStoreCount: 1,
+			wantRuleStoreCount:           2,
+			wantGroupStoreCount:          2,
+			wantProjectGroupStoreCount:   2,
+			wantProjectShareStoreCount:   2,
+		},
+		{
+			name: "errorCreateUpdateVPCSecurityPolicy",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVpcInfo",
+					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
+						return &VPCInfo[0], nil
+					})
+
+				patches.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{fmt.Errorf("mock error")},
+					Times:  1,
+				}})
+
+				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+					func(s *SecurityPolicyService, ns string) types.UID {
+						return types.UID(tagValueNSUID)
+					})
+
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				spObj:      &spWithPodSelector,
+			},
+			expectedPolicy:               &model.SecurityPolicy{},
+			wantErr:                      true,
+			wantSecurityPolicyStoreCount: 0,
+			wantRuleStoreCount:           0,
+			wantGroupStoreCount:          0,
+			wantProjectGroupStoreCount:   0,
+			wantProjectShareStoreCount:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			patches := tt.prepareFunc(t, fakeService)
+			patches.ApplyMethodSeq(fakeService.NSXClient.VPCSecurityClient, "Get", []gomonkey.OutputCell{{
+				Values: gomonkey.Params{*(tt.expectedPolicy), nil},
+				Times:  1,
+			}})
+			defer patches.Reset()
+
+			if err := fakeService.createOrUpdateVPCSecurityPolicy(tt.args.spObj, tt.args.createdFor); (err != nil) != tt.wantErr {
+				t.Errorf("createOrUpdateVPCSecurityPolicy error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.Equal(t, tt.wantSecurityPolicyStoreCount, len(fakeService.securityPolicyStore.ListKeys()))
+			assert.Equal(t, tt.wantRuleStoreCount, len(fakeService.ruleStore.ListKeys()))
+			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectGroupStoreCount, len(fakeService.projectGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.shareStore.ListKeys()))
+		})
+	}
+}
+
+func TestGetFinalSecurityPolicyResouce(t *testing.T) {
+	VPCInfo := make([]common.VPCResourceInfo, 1)
+	VPCInfo[0].OrgID = "default"
+	VPCInfo[0].ProjectID = "projectQuality"
+	VPCInfo[0].VPCID = "vpc1"
+
+	fakeService := fakeSecurityPolicyService()
+	mockVPCService := common.MockVPCServiceProvider{}
+	fakeService.vpcService = &mockVPCService
+
+	type args struct {
+		spObj      *v1alpha1.SecurityPolicy
+		createdFor string
+	}
+	tests := []struct {
+		name                       string
+		prepareFunc                func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		args                       args
+		expectedPolicy             *model.SecurityPolicy
+		wantErr                    bool
+		wantSecurityPolicyChanged  bool
+		wantRuleStoreCount         int
+		wantGroupStoreCount        int
+		wantProjectGroupStoreCount int
+	}{
+		{
+			name: "getFinalSecurityPolicyResouceForVPCMode",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				s.NSXConfig.EnableVPCNetwork = true
+
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVpcInfo",
+					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
+						return &VPCInfo[0], nil
+					})
+
+				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+					func(s *SecurityPolicyService, ns string) types.UID {
+						return types.UID(tagValueNSUID)
+					})
+
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				spObj:      &spWithPodSelector,
+			},
+			expectedPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             &spID,
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/sp_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules:          []model.Rule{},
+				Tags:           basicTags,
+			},
+			wantErr:                    false,
+			wantSecurityPolicyChanged:  true,
+			wantRuleStoreCount:         2,
+			wantGroupStoreCount:        2,
+			wantProjectGroupStoreCount: 2,
+		},
+		{
+			name: "getFinalSecurityPolicyResouceForT1",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				s.NSXConfig.EnableVPCNetwork = false
+
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVpcInfo",
+					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
+						return &VPCInfo[0], nil
+					})
+
+				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+					func(s *SecurityPolicyService, ns string) types.UID {
+						return types.UID(tagValueNSUID)
+					})
+
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				spObj:      &spWithPodSelector,
+			},
+			expectedPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             &spID,
+				Scope:          []string{"/infra/domains/k8scl-one:test/groups/sp_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules:          []model.Rule{},
+				Tags:           basicTags,
+			},
+			wantErr:                    false,
+			wantSecurityPolicyChanged:  true,
+			wantRuleStoreCount:         2,
+			wantGroupStoreCount:        4,
+			wantProjectGroupStoreCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			patches := tt.prepareFunc(t, fakeService)
+			defer patches.Reset()
+
+			var finalSecurityPolicy *model.SecurityPolicy
+			var finalGroups []model.Group
+			var projectShares *[]ProjectShare
+			var isChanged bool
+			var err error
+
+			if finalSecurityPolicy, finalGroups, projectShares, isChanged, err = fakeService.getFinalSecurityPolicyResource(tt.args.spObj, tt.args.createdFor); (err != nil) != tt.wantErr {
+				t.Errorf("getFinalSecurityPolicyResouce error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.Equal(t, *tt.expectedPolicy.Id, *finalSecurityPolicy.Id)
+			assert.Equal(t, tt.expectedPolicy.Scope[0], finalSecurityPolicy.Scope[0])
+			assert.Equal(t, true, isChanged)
+			assert.Equal(t, tt.wantGroupStoreCount, len(finalGroups))
+			assert.Equal(t, tt.wantRuleStoreCount, len(finalSecurityPolicy.Rules))
+
+			if fakeService.NSXConfig.EnableVPCNetwork {
+				assert.Equal(t, tt.wantProjectGroupStoreCount, len(*projectShares))
+			} else {
+				assert.Equal(t, (*[]ProjectShare)(nil), projectShares)
 			}
 		})
 	}


### PR DESCRIPTION
In certain cases, SecurityPolicy or Networkpolicy deletion will fail because there is no VPC info found if VPC has been deleted before SP deletion.

Hence, this patch is to
1. Save NSX SecurityPolicy path after HAPI call into the store. This saved SecurityPolicy path will be used for deletion, GC or Cleanup to get VPC info.
2. Refactor SecurityPolicy creation/update and deletion process.
3. Unify SecurityPolicy normal deletion process with GC and cleanup,
which means it uses SecurityPolicy and NetworkPolicy UID to get NSX SecurityPolicy
from the store to avoid the rebuilding process. Because the rebuilding process also needs to
get VPC by VPC service, this step might fail.

The test done:
1. Create SecurityPolicy and Networkpolicy in VPC mode, and delete them successfully.
2. Create SecurityPolicy  in T1 mode, and delete them successfully.
3. Create SecurityPolicy and Networkpolicy in VPC mode, and delete them from K8s firstly, and do GC to see
created NSX SecurityPolicies are deleted by GC.
4. Create SecurityPolicy in T1 mode, and delete them from K8s firstly, and do GC to see
created NSX SecurityPolicies are deleted by GC.