### PR TITLE
Fix bug, could delete subnetset when there are still stale subnetport…

### DIFF
--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -105,9 +105,16 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	} else {
 		if controllerutil.ContainsFinalizer(obj, servicecommon.SubnetSetFinalizerName) {
 			metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteTotal, MetricResTypeSubnetSet)
-			if err := r.DeleteSubnetForSubnetSet(*obj, false); err != nil {
+			hasStaleSubnetPorts, err := r.DeleteSubnetForSubnetSet(*obj, false)
+			if err != nil {
 				log.Error(err, "deletion failed, would retry exponentially", "subnetset", req.NamespacedName)
 				deleteFail(r, ctx, obj, "")
+				return ResultRequeue, err
+			}
+			if hasStaleSubnetPorts {
+				err := fmt.Errorf("stale subnet ports found while deleting subnetset %v", req.NamespacedName)
+				log.Error(err, "deletion failed, delete all the subnetports first", "subnetset", req.NamespacedName)
+				updateFail(r, ctx, obj, err.Error())
 				return ResultRequeue, err
 			}
 			controllerutil.RemoveFinalizer(obj, servicecommon.SubnetSetFinalizerName)
@@ -254,7 +261,7 @@ func (r *SubnetSetReconciler) CollectGarbage(ctx context.Context) {
 
 	subnetSetIDs := sets.New[string]()
 	for _, subnetSet := range subnetSetList.Items {
-		if err := r.DeleteSubnetForSubnetSet(subnetSet, true); err != nil {
+		if _, err := r.DeleteSubnetForSubnetSet(subnetSet, true); err != nil {
 			metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteFailTotal, MetricResTypeSubnetSet)
 		} else {
 			metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteSuccessTotal, MetricResTypeSubnetSet)
@@ -273,12 +280,14 @@ func (r *SubnetSetReconciler) CollectGarbage(ctx context.Context) {
 	}
 }
 
-func (r *SubnetSetReconciler) DeleteSubnetForSubnetSet(obj v1alpha1.SubnetSet, updataStatus bool) error {
+func (r *SubnetSetReconciler) DeleteSubnetForSubnetSet(obj v1alpha1.SubnetSet, updataStatus bool) (bool, error) {
 	nsxSubnets := r.SubnetService.SubnetStore.GetByIndex(servicecommon.TagScopeSubnetSetCRUID, string(obj.GetUID()))
 	hitError := false
+	hasStaleSubnetPorts := false
 	for _, subnet := range nsxSubnets {
 		portNums := len(r.SubnetPortService.GetPortsOfSubnet(*subnet.Id))
 		if portNums > 0 {
+			hasStaleSubnetPorts = true
 			continue
 		}
 		if err := r.SubnetService.DeleteSubnet(*subnet); err != nil {
@@ -289,13 +298,13 @@ func (r *SubnetSetReconciler) DeleteSubnetForSubnetSet(obj v1alpha1.SubnetSet, u
 	}
 	if updataStatus {
 		if err := r.SubnetService.UpdateSubnetSetStatus(&obj); err != nil {
-			return err
+			return hasStaleSubnetPorts, err
 		}
 	}
 	if hitError {
-		return errors.New("error occurs when deleting subnet")
+		return hasStaleSubnetPorts, errors.New("error occurs when deleting subnet")
 	}
-	return nil
+	return hasStaleSubnetPorts, nil
 }
 
 func StartSubnetSetController(mgr ctrl.Manager, subnetService *subnet.SubnetService,


### PR DESCRIPTION
When there are stale subnetports in one subnet of subnetset, we should not allow deleting it.
Tests done:

```
apiVersion: nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: pod-59
  namespace: zx-test-2
spec:
  subnetSet: pod-default
```

create subnetport and delete pod-default, it will fail reporting

```
2024-07-15 03:30:04.994	INFO	subnetset/subnetset_controller.go:57	reconciling subnetset CR	{"subnetset": {"name":"pod-default","namespace":"zx-test-2"}}
2024-07-15 03:30:04.994	ERROR	subnetset/subnetset_controller.go:122	deletion failed, delete all the subnetports first	{"subnetset": {"name":"pod-default","namespace":"zx-test-2"}, "error": "stale subnet ports found while deleting subnetset zx-test-2/pod-default"}
2024-07-15 03:30:05.034	INFO	subnetset/subnetset_controller.go:204	updated SubnetSet	{"Name": "pod-default", "Namespace": "zx-test-2", "New Conditions": [{"type":"Ready","status":"False","lastTransitionTime":"2024-07-15T03:30:04Z","reason":"SubnetNotReady","message":"stale subnet ports found while deleting subnetset zx-test-2/pod-default"}]}
2024-07-15 03:30:05.034	DEBUG	recorder/recorder.go:104	stale subnet ports found while deleting subnetset zx-test-2/pod-default	{"type": "Warning", "object": {"kind":"SubnetSet","namespace":"zx-test-2","name":"pod-default","uid":"779fb1b6-50c5-49cf-b870-04e6ea6f13c7","apiVersion":"nsx.vmware.com/v1alpha1","resourceVersion":"1897779"}, "reason": "FailUpdate"}
```

delete vm-default will succeed since it has no port attached in it.