### PR TITLE
Refactor startup process in HA mode

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	crdv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/crd.nsx.vmware.com/v1alpha1"
@@ -30,7 +31,6 @@ import (
 	networkinfocontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/networkinfo"
 	networkpolicycontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/networkpolicy"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/node"
-	nsxserviceaccountcontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/nsxserviceaccount"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/pod"
 	securitypolicycontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/securitypolicy"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/service"
@@ -38,17 +38,20 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/subnet"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/subnetport"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/subnetset"
+	nodeservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/node"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/staticroute"
+	subnetservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnet"
+	subnetportservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
+
+	commonctl "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	nsxserviceaccountcontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/nsxserviceaccount"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	ipaddressallocationservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/ipaddressallocation"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/ippool"
-	nodeservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/node"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/nsxserviceaccount"
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/staticroute"
-	subnetservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnet"
-	subnetportservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
@@ -109,6 +112,7 @@ func StartNSXServiceAccountController(mgr ctrl.Manager, commonService common.Ser
 		log.Error(err, "failed to create controller", "controller", "NSXServiceAccount")
 		os.Exit(1)
 	}
+	go commonctl.GenericGarbageCollector(make(chan bool), common.GCInterval, nsxServiceAccountReconcile.CollectGarbage)
 }
 
 func StartIPPoolController(mgr ctrl.Manager, ipPoolService *ippool.IPPoolService, vpcService common.VPCServiceProvider) {
@@ -124,6 +128,7 @@ func StartIPPoolController(mgr ctrl.Manager, ipPoolService *ippool.IPPoolService
 		log.Error(err, "failed to create controller", "controller", "IPPool")
 		os.Exit(1)
 	}
+	go commonctl.GenericGarbageCollector(make(chan bool), common.GCInterval, ippoolReconcile.CollectGarbage)
 }
 
 func StartNetworkInfoController(mgr ctrl.Manager, vpcService *vpc.VPCService) {
@@ -137,6 +142,7 @@ func StartNetworkInfoController(mgr ctrl.Manager, vpcService *vpc.VPCService) {
 		log.Error(err, "failed to create networkinfo controller", "controller", "NetworkInfo")
 		os.Exit(1)
 	}
+	go commonctl.GenericGarbageCollector(make(chan bool), common.GCInterval, networkInfoReconciler.CollectGarbage)
 }
 
 func StartNamespaceController(mgr ctrl.Manager, cf *config.NSXOperatorConfig, vpcService common.VPCServiceProvider) {
@@ -168,28 +174,7 @@ func StartIPAddressAllocationController(mgr ctrl.Manager, ipAddressAllocationSer
 	}
 }
 
-func main() {
-	log.Info("starting NSX Operator")
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                  scheme,
-		HealthProbeBindAddress:  config.ProbeAddr,
-		Metrics:                 metricsserver.Options{BindAddress: config.MetricsAddr},
-		LeaderElection:          cf.HAEnabled(),
-		LeaderElectionNamespace: nsxOperatorNamespace,
-		LeaderElectionID:        "nsx-operator",
-	})
-	if err != nil {
-		log.Error(err, "failed to init manager")
-		os.Exit(1)
-	}
-
-	// nsxClient is used to interact with NSX API.
-	nsxClient := nsx.GetClient(cf)
-	if nsxClient == nil {
-		log.Error(err, "failed to get nsx client")
-		os.Exit(1)
-	}
-
+func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 	//  Embed the common commonService to sub-services.
 	commonService := common.Service{
 		Client:    mgr.GetClient(),
@@ -209,6 +194,7 @@ func main() {
 		}
 		log.Info("VPC mode is enabled")
 
+		var err error
 		vpcService, err = vpc.InitializeVPC(commonService)
 		if err != nil {
 			log.Error(err, "failed to initialize vpc commonService", "controller", "VPC")
@@ -273,6 +259,43 @@ func main() {
 	// Start the NSXServiceAccount controller.
 	if cf.EnableAntreaNSXInterworking {
 		StartNSXServiceAccountController(mgr, commonService)
+	}
+
+}
+
+func electMaster(mgr manager.Manager, nsxClient *nsx.Client) {
+	log.Info("I'm trying to be elected as master")
+	<-mgr.Elected()
+	log.Info("I'm the master now")
+	startServiceController(mgr, nsxClient)
+}
+
+func main() {
+	log.Info("starting NSX Operator")
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                  scheme,
+		HealthProbeBindAddress:  config.ProbeAddr,
+		Metrics:                 metricsserver.Options{BindAddress: config.MetricsAddr},
+		LeaderElection:          cf.HAEnabled(),
+		LeaderElectionNamespace: nsxOperatorNamespace,
+		LeaderElectionID:        "nsx-operator",
+	})
+	if err != nil {
+		log.Error(err, "failed to init manager")
+		os.Exit(1)
+	}
+
+	// nsxClient is used to interact with NSX API.
+	nsxClient := nsx.GetClient(cf)
+	if nsxClient == nil {
+		log.Error(nil, "failed to get nsx client")
+		os.Exit(1)
+	}
+
+	if cf.HAEnabled() {
+		go electMaster(mgr, nsxClient)
+	} else {
+		startServiceController(mgr, nsxClient)
 	}
 
 	if metrics.AreMetricsExposed(cf) {

--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -157,7 +157,3 @@ func GenericGarbageCollector(cancel chan bool, timeout time.Duration, f func(ctx
 		}
 	}
 }
-
-func GcOnce(gc GarbageCollector, once *sync.Once) {
-	once.Do(func() { go GenericGarbageCollector(make(chan bool), servicecommon.GCInterval, gc.CollectGarbage) })
-}

--- a/pkg/controllers/ippool/ippool_controller.go
+++ b/pkg/controllers/ippool/ippool_controller.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"sync"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -39,7 +38,6 @@ var (
 	resultNormal  = common.ResultNormal
 	resultRequeue = common.ResultRequeue
 	MetricResType = common.MetricResTypeIPPool
-	once          sync.Once
 )
 
 // IPPoolReconciler reconciles a IPPool object
@@ -115,9 +113,6 @@ func (r *IPPoolReconciler) setReadyStatusTrue(ctx *context.Context, ippool *v1al
 }
 
 func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// Use once.Do to ensure gc is called only once
-	common.GcOnce(r, &once)
-
 	obj := &v1alpha2.IPPool{}
 	log.Info("reconciling ippool CR", "ippool", req.NamespacedName)
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerSyncTotal, MetricResType)

--- a/pkg/controllers/ippool/ippool_controller_test.go
+++ b/pkg/controllers/ippool/ippool_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -113,11 +112,6 @@ func TestIPPoolReconciler_Reconcile(t *testing.T) {
 	}
 	ctx := context.Background()
 	req := controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "dummy", Name: "dummy"}}
-
-	// common.GcOnce do nothing
-	var once sync.Once
-	pat := gomonkey.ApplyMethod(reflect.TypeOf(&once), "Do", func(_ *sync.Once, _ func()) {})
-	defer pat.Reset()
 
 	// not found
 	errNotFound := errors.New("not found")

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -5,7 +5,6 @@ package networkinfo
 
 import (
 	"context"
-	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
@@ -29,7 +28,6 @@ import (
 var (
 	log           = &logger.Log
 	MetricResType = common.MetricResTypeNetworkInfo
-	once          sync.Once
 )
 
 // NetworkInfoReconciler NetworkInfoReconcile reconciles a NetworkInfo object
@@ -42,9 +40,6 @@ type NetworkInfoReconciler struct {
 }
 
 func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// Use once.Do to ensure gc is called only once
-	common.GcOnce(r, &once)
-
 	obj := &v1alpha1.NetworkInfo{}
 	log.Info("reconciling NetworkInfo CR", "NetworkInfo", req.NamespacedName)
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerSyncTotal, common.MetricResTypeNetworkInfo)

--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,7 +39,6 @@ var (
 	MetricResType           = common.MetricResTypeNSXServiceAccount
 	count                   = uint16(0)
 	ca                      []byte
-	once                    sync.Once
 )
 
 // NSXServiceAccountReconciler reconciles a NSXServiceAccount object.
@@ -68,9 +66,6 @@ type NSXServiceAccountReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
 func (r *NSXServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// Use once.Do to ensure gc is called only once
-	common.GcOnce(r, &once)
-
 	obj := &nsxvmwarecomv1alpha1.NSXServiceAccount{}
 	log.Info("reconciling CR", "nsxserviceaccount", req.NamespacedName)
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerSyncTotal, MetricResType)

--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
@@ -513,9 +512,6 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 				patches := tt.prepareFunc(t, r, ctx)
 				defer patches.Reset()
 			}
-			var once sync.Once
-			patches2 := gomonkey.ApplyMethod(reflect.TypeOf(&once), "Do", func(_ *sync.Once, _ func()) {})
-			defer patches2.Reset()
 
 			got, err := r.Reconcile(ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {

--- a/pkg/controllers/securitypolicy/securitypolicy_controller_test.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
@@ -190,11 +189,6 @@ func TestSecurityPolicyReconciler_Reconcile(t *testing.T) {
 	}
 	ctx := context.Background()
 	req := controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "dummy", Name: "dummy"}}
-
-	// common.GcOnce do nothing
-	var once sync.Once
-	pat := gomonkey.ApplyMethod(reflect.TypeOf(&once), "Do", func(_ *sync.Once, _ func()) {})
-	defer pat.Reset()
 
 	// not found
 	errNotFound := errors.New("not found")

--- a/pkg/controllers/staticroute/staticroute_controller_test.go
+++ b/pkg/controllers/staticroute/staticroute_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"reflect"
-	"sync"
 	"testing"
 
 	gomonkey "github.com/agiledragon/gomonkey/v2"
@@ -175,11 +174,6 @@ func TestStaticRouteReconciler_Reconcile(t *testing.T) {
 	}
 	ctx := context.Background()
 	req := controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "dummy", Name: "dummy"}}
-
-	// common.GcOnce do nothing
-	var once sync.Once
-	pat := gomonkey.ApplyMethod(reflect.TypeOf(&once), "Do", func(_ *sync.Once, _ func()) {})
-	defer pat.Reset()
 
 	// not found
 	errNotFound := errors.New("not found")

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sync"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	v1 "k8s.io/api/core/v1"
@@ -38,7 +37,6 @@ var (
 	ResultRequeueAfter5mins = common.ResultRequeueAfter5mins
 	ResultRequeueAfter10sec = common.ResultRequeueAfter10sec
 	MetricResTypeSubnet     = common.MetricResTypeSubnet
-	once                    sync.Once
 )
 
 // SubnetReconciler reconciles a SubnetSet object
@@ -52,9 +50,6 @@ type SubnetReconciler struct {
 }
 
 func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// Use once.Do to ensure gc is called only once
-	common.GcOnce(r, &once)
-
 	obj := &v1alpha1.Subnet{}
 	log.Info("reconciling subnet CR", "subnet", req.NamespacedName)
 	metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerSyncTotal, MetricResTypeSubnet)
@@ -305,6 +300,7 @@ func StartSubnetController(mgr ctrl.Manager, subnetService *subnet.SubnetService
 		log.Error(err, "failed to create controller", "controller", "Subnet")
 		return err
 	}
+	go common.GenericGarbageCollector(make(chan bool), servicecommon.GCInterval, subnetReconciler.CollectGarbage)
 	return nil
 }
 

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -3,8 +3,6 @@ package subnetport
 import (
 	"context"
 	"errors"
-	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -78,11 +76,6 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			return nsxSubnet, nil
 		})
 	defer patchesGetSubnetByPath.Reset()
-
-	// common.GcOnce do nothing
-	var once sync.Once
-	pat := gomonkey.ApplyMethod(reflect.TypeOf(&once), "Do", func(_ *sync.Once, _ func()) {})
-	defer pat.Reset()
 
 	// not found
 	errNotFound := errors.New("not found")

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sync"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	v1 "k8s.io/api/core/v1"
@@ -36,7 +35,6 @@ var (
 	ResultRequeue           = common.ResultRequeue
 	ResultRequeueAfter5mins = common.ResultRequeueAfter5mins
 	MetricResTypeSubnetSet  = common.MetricResTypeSubnetSet
-	once                    sync.Once
 )
 
 // SubnetSetReconciler reconciles a SubnetSet object
@@ -50,9 +48,6 @@ type SubnetSetReconciler struct {
 }
 
 func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// Use once.Do to ensure gc is called only once
-	common.GcOnce(r, &once)
-
 	obj := &v1alpha1.SubnetSet{}
 	log.Info("reconciling subnetset CR", "subnetset", req.NamespacedName)
 	metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerSyncTotal, MetricResTypeSubnetSet)

--- a/test/e2e/nsx_subnet_test.go
+++ b/test/e2e/nsx_subnet_test.go
@@ -27,7 +27,7 @@ const (
 	VPCNetworkConfigCRName = "default"
 	// SubnetDeletionTimeout requires a bigger value than defaultTimeout, it's because that it takes some time for NSX to
 	// recycle allocated IP addresses and NSX VPCSubnet won't be deleted until all IP addresses have been recycled.
-	SubnetDeletionTimeout = 300 * time.Second
+	SubnetDeletionTimeout = 600 * time.Second
 )
 
 func verifySubnetSetCR(subnetSet string) bool {


### PR DESCRIPTION
If switch on HA mode, the state of the master is the normal process, the standby is waiting for the lease lock
Standby
<img width="1907" alt="image" src="https://github.com/user-attachments/assets/aab47a0c-38eb-486f-a1bc-8484b33697bd">
Also, move service initialization after entering master mode.
<img width="1894" alt="image" src="https://github.com/user-attachments/assets/22d891f4-7b40-4fd5-9fd0-f9dd2c9ed1d5">
The garbage collector only runs in master
<img width="1571" alt="image" src="https://github.com/user-attachments/assets/3ee31e03-7f76-4a67-8eac-9e93b1182f6c">

Now kill master pod, the standby acquires the lock and run
<img width="1883" alt="image" src="https://github.com/user-attachments/assets/84c30ccd-9540-4bc8-a5d8-f89ae4a5c265">
Garbage collector also run in it
<img width="1759" alt="image" src="https://github.com/user-attachments/assets/0f15f62d-6906-456e-bc90-8e7c0ca90403">

The new standby is waiting
<img width="1752" alt="image" src="https://github.com/user-attachments/assets/fd8d4e6d-c1e7-4213-85f6-04e07715f6b6">

This patch doesn't affect non-HA mode.