### PR TITLE
Add support for PrincipalIdentity

### DIFF
--- a/pkg/nsx/services/common/store.go
+++ b/pkg/nsx/services/common/store.go
@@ -51,6 +51,9 @@ func (resourceStore *ResourceStore) TransResourceToStore(entity *data.StructValu
 		}
 	}
 	objAddr := nsxutil.CasttoPointer(obj)
+	if objAddr == nil {
+		return fmt.Errorf("failed to cast to pointer")
+	}
 	err2 := resourceStore.Add(objAddr)
 	if err2 != nil {
 		return err2

--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -26,6 +26,7 @@ import (
 	apierrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
@@ -490,6 +491,8 @@ func FindTag(tags []model.Tag, tagScope string) string {
 
 func CasttoPointer(obj interface{}) interface{} {
 	switch v := obj.(type) {
+	case mpmodel.PrincipalIdentity:
+		return &v
 	case model.Rule:
 		return &v
 	case model.StaticRoutes:
@@ -521,6 +524,8 @@ func CasttoPointer(obj interface{}) interface{} {
 	case model.IpAddressBlock:
 		return &v
 	default:
+		objType := reflect.TypeOf(obj)
+		log.Info("Unsupported type", "objType", objType)
 		return nil
 	}
 }

--- a/pkg/nsx/util/utils_test.go
+++ b/pkg/nsx/util/utils_test.go
@@ -15,10 +15,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
 func TestHttpErrortoNSXError(t *testing.T) {
@@ -509,4 +512,37 @@ Hce3uM6Xn8sAglod/r+0onZ09yoiH2Qj5EY50wUIOPtey2ilhuhwoo/M7Nt/yomF
 
 	header = CertPemBytesToHeader("/tmp/test.pem")
 	assert.Equal(t, "", header)
+}
+
+func TestCasttoPointer(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  interface{}
+		want interface{}
+	}{
+		{
+			name: "PrincipalIdentity",
+			obj:  mpmodel.PrincipalIdentity{},
+			want: &mpmodel.PrincipalIdentity{},
+		},
+		{
+			name: "Rule",
+			obj:  model.Rule{},
+			want: &model.Rule{},
+		},
+		// Add more test cases for other types
+		{
+			name: "UnsupportedType",
+			obj:  model.Tag{},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CasttoPointer(tt.obj); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CasttoPointer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Add support for PrincipalIdentity.
Log unsupported type.
Return error if CasttoPointer result is nil