### PR TITLE
[NSXServiceAccount] Fix store issues +1

### DIFF
--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
@@ -559,7 +559,7 @@ func TestNSXServiceAccountReconciler_GarbageCollector(t *testing.T) {
 				name2 := "name2"
 				clusterName2 := "cl1-ns2-name2"
 				uid2 := "00000000-0000-0000-0000-000000000002"
-				assert.NoError(t, r.Service.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{
+				assert.NoError(t, r.Service.PrincipalIdentityStore.Add(&mpmodel.PrincipalIdentity{
 					Name: &clusterName2,
 					Tags: []mpmodel.Tag{{
 						Scope: &tagScopeNamespace,
@@ -813,7 +813,7 @@ func TestNSXServiceAccountReconciler_garbageCollector(t *testing.T) {
 				name2 := "name2"
 				clusterName2 := "cl1-ns2-name2"
 				uid2 := "00000000-0000-0000-0000-000000000002"
-				assert.NoError(t, r.Service.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{
+				assert.NoError(t, r.Service.PrincipalIdentityStore.Add(&mpmodel.PrincipalIdentity{
 					Name: &clusterName2,
 					Tags: []mpmodel.Tag{{
 						Scope: &tagScopeNamespace,
@@ -830,7 +830,7 @@ func TestNSXServiceAccountReconciler_garbageCollector(t *testing.T) {
 				name3 := "name3"
 				clusterName3 := "cl1-ns3-name3"
 				uid3 := "00000000-0000-0000-0000-000000000003"
-				assert.NoError(t, r.Service.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{
+				assert.NoError(t, r.Service.PrincipalIdentityStore.Add(&mpmodel.PrincipalIdentity{
 					Name: &clusterName3,
 					Tags: []mpmodel.Tag{{
 						Scope: &tagScopeNamespace,
@@ -847,7 +847,7 @@ func TestNSXServiceAccountReconciler_garbageCollector(t *testing.T) {
 				name4 := "name4"
 				clusterName4 := "cl1-ns4-name4"
 				uid4 := "00000000-0000-0000-0000-000000000004"
-				assert.NoError(t, r.Service.ClusterControlPlaneStore.Add(model.ClusterControlPlane{
+				assert.NoError(t, r.Service.ClusterControlPlaneStore.Add(&model.ClusterControlPlane{
 					Id: &clusterName4,
 					Tags: []model.Tag{{
 						Scope: &tagScopeNamespace,

--- a/pkg/nsx/services/common/store.go
+++ b/pkg/nsx/services/common/store.go
@@ -212,6 +212,8 @@ func (service *Service) InitializeCommonStore(wg *sync.WaitGroup, fatalErrors ch
 		pathUnescape, _ := url.PathUnescape("path%3A")
 		queryParam += " AND " + pathUnescape + path
 	}
-	queryParam += " AND marked_for_delete:false"
+	if store.IsPolicyAPI() {
+		queryParam += " AND marked_for_delete:false"
+	}
 	service.PopulateResourcetoStore(wg, fatalErrors, resourceTypeValue, queryParam, store, nil)
 }

--- a/pkg/nsx/services/nsxserviceaccount/cluster.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster.go
@@ -246,7 +246,7 @@ func (s *NSXServiceAccountService) createPIAndCCP(normalizedClusterName string, 
 		if err != nil {
 			return "", err
 		}
-		s.PrincipalIdentityStore.Add(pi)
+		s.PrincipalIdentityStore.Add(&pi)
 	} else if !hasPI != (piObj == nil) {
 		return "", fmt.Errorf("old PI exists")
 	}
@@ -267,7 +267,7 @@ func (s *NSXServiceAccountService) createPIAndCCP(normalizedClusterName string, 
 		if err != nil {
 			return "", err
 		}
-		s.ClusterControlPlaneStore.Add(ccp)
+		s.ClusterControlPlaneStore.Add(&ccp)
 		clusterId = *ccp.NodeId
 	} else if !hasCCP != (ccpObj == nil) {
 		return "", fmt.Errorf("old CCP exists")
@@ -340,12 +340,12 @@ func (s *NSXServiceAccountService) DeleteNSXServiceAccount(ctx context.Context, 
 			log.Error(err, "failed to delete", "ClusterControlPlane", normalizedClusterName)
 			return err
 		}
-		s.ClusterControlPlaneStore.Delete(model.ClusterControlPlane{Id: &normalizedClusterName})
+		s.ClusterControlPlaneStore.Delete(&model.ClusterControlPlane{Id: &normalizedClusterName})
 	}
 
 	// delete PI
 	if piobj := s.PrincipalIdentityStore.GetByKey(normalizedClusterName); isDeletePI && (piobj != nil) {
-		pi := piobj.(mpmodel.PrincipalIdentity)
+		pi := piobj.(*mpmodel.PrincipalIdentity)
 		if err := s.NSXClient.PrincipalIdentitiesClient.Delete(*pi.Id); err != nil {
 			err = nsxutil.NSXApiError(err)
 			log.Error(err, "failed to delete", "PrincipalIdentity", *pi.Name)
@@ -437,17 +437,18 @@ func (s *NSXServiceAccountService) updatePIAndCCPCert(normalizedClusterName, uid
 	}
 
 	// update ClusterControlPlane cert
-	ccp := ccpObj.(model.ClusterControlPlane)
+	ccp := ccpObj.(*model.ClusterControlPlane)
 	ccp.Certificate = &cert
-	if ccp, err := s.NSXClient.ClusterControlPlanesClient.Update(siteId, enforcementpointId, normalizedClusterName, ccp); err != nil {
+	if ccp2, err := s.NSXClient.ClusterControlPlanesClient.Update(siteId, enforcementpointId, normalizedClusterName, *ccp); err != nil {
 		err = nsxutil.NSXApiError(err)
 		return err
 	} else {
+		ccp = &ccp2
 		s.ClusterControlPlaneStore.Add(ccp)
 	}
 
 	// update PI cert
-	pi := piObj.(mpmodel.PrincipalIdentity)
+	pi := piObj.(*mpmodel.PrincipalIdentity)
 	oldCertId := ""
 	if pi.CertificateId != nil {
 		oldCertId = *pi.CertificateId
@@ -460,13 +461,14 @@ func (s *NSXServiceAccountService) updatePIAndCCPCert(normalizedClusterName, uid
 		err = nsxutil.NSXApiError(err)
 		return err
 	}
-	if pi, err = s.NSXClient.PrincipalIdentitiesClient.Updatecertificate(mpmodel.UpdatePrincipalIdentityCertificateRequest{
+	if pi2, err := s.NSXClient.PrincipalIdentitiesClient.Updatecertificate(mpmodel.UpdatePrincipalIdentityCertificateRequest{
 		CertificateId:       certList.Results[0].Id,
 		PrincipalIdentityId: pi.Id,
 	}); err != nil {
 		err = nsxutil.NSXApiError(err)
 		return err
 	} else {
+		pi = &pi2
 		s.PrincipalIdentityStore.Add(pi)
 	}
 	if oldCertId != "" {
@@ -495,7 +497,7 @@ func (s *NSXServiceAccountService) GetNSXServiceAccountNameByUID(uid string) (na
 		return
 	}
 	for _, obj := range objs {
-		pi := obj.(mpmodel.PrincipalIdentity)
+		pi := obj.(*mpmodel.PrincipalIdentity)
 		for _, tag := range pi.Tags {
 			switch *tag.Scope {
 			case common.TagScopeNamespace:
@@ -514,7 +516,7 @@ func (s *NSXServiceAccountService) GetNSXServiceAccountNameByUID(uid string) (na
 		return
 	}
 	for _, obj := range objs {
-		ccp := obj.(model.ClusterControlPlane)
+		ccp := obj.(*model.ClusterControlPlane)
 		for _, tag := range ccp.Tags {
 			if tag.Scope != nil {
 				switch *tag.Scope {

--- a/pkg/nsx/services/nsxserviceaccount/cluster_test.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster_test.go
@@ -551,7 +551,7 @@ func TestNSXServiceAccountService_RestoreRealizedNSXServiceAccount(t *testing.T)
 				vpcPath := "/orgs/default/projects/k8scl-one:test/vpcs/vpc1"
 				piId := "Id1"
 				uid := "00000000-0000-0000-0000-000000000001"
-				s.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{
+				s.PrincipalIdentityStore.Add(&mpmodel.PrincipalIdentity{
 					IsProtected: &isProtectedTrue,
 					Name:        &normalizedClusterName,
 					NodeId:      &normalizedClusterName,
@@ -583,7 +583,7 @@ func TestNSXServiceAccountService_RestoreRealizedNSXServiceAccount(t *testing.T)
 					}},
 				})
 				nodeId := "clusterId1"
-				s.ClusterControlPlaneStore.Add(model.ClusterControlPlane{
+				s.ClusterControlPlaneStore.Add(&model.ClusterControlPlane{
 					Id:           &normalizedClusterName,
 					NodeId:       &nodeId,
 					Revision:     &revision1,
@@ -637,7 +637,7 @@ func TestNSXServiceAccountService_RestoreRealizedNSXServiceAccount(t *testing.T)
 				vpcPath := "/orgs/default/projects/k8scl-one:test/vpcs/vpc1"
 				piId := "Id1"
 				uid := "00000000-0000-0000-0000-000000000001"
-				s.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{
+				s.PrincipalIdentityStore.Add(&mpmodel.PrincipalIdentity{
 					IsProtected: &isProtectedTrue,
 					Name:        &normalizedClusterName,
 					NodeId:      &normalizedClusterName,
@@ -1130,8 +1130,8 @@ func TestNSXServiceAccountService_ValidateAndUpdateRealizedNSXServiceAccount(t *
 					Scope: &uidScope,
 					Tag:   &uidTag,
 				}}}
-				assert.NoError(t, s.ClusterControlPlaneStore.Add(ccp))
-				assert.NoError(t, s.PrincipalIdentityStore.Add(pi))
+				assert.NoError(t, s.ClusterControlPlaneStore.Add(&ccp))
+				assert.NoError(t, s.PrincipalIdentityStore.Add(&pi))
 
 				patches := gomonkey.ApplyMethodSeq(s.NSXClient, "NSXCheckVersion", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{true},
@@ -1245,8 +1245,8 @@ func TestNSXServiceAccountService_DeleteNSXServiceAccount(t *testing.T) {
 				normalizedClusterName := "k8scl-one_test-ns1-name1"
 				piId := "piId1"
 				certId := "certId1"
-				assert.NoError(t, s.ClusterControlPlaneStore.Add(model.ClusterControlPlane{Id: &normalizedClusterName}))
-				assert.NoError(t, s.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{Name: &normalizedClusterName, Id: &piId, CertificateId: &certId}))
+				assert.NoError(t, s.ClusterControlPlaneStore.Add(&model.ClusterControlPlane{Id: &normalizedClusterName}))
+				assert.NoError(t, s.PrincipalIdentityStore.Add(&mpmodel.PrincipalIdentity{Name: &normalizedClusterName, Id: &piId, CertificateId: &certId}))
 				assert.NoError(t, s.Client.Create(ctx, &v1alpha1.NSXServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "name1",
@@ -1285,8 +1285,8 @@ func TestNSXServiceAccountService_DeleteNSXServiceAccount(t *testing.T) {
 				normalizedClusterName := "k8scl-one_test-ns1-name1"
 				piId := "piId1"
 				certId := "certId1"
-				assert.NoError(t, s.ClusterControlPlaneStore.Add(model.ClusterControlPlane{Id: &normalizedClusterName}))
-				assert.NoError(t, s.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{Name: &normalizedClusterName, Id: &piId, CertificateId: &certId, Tags: []mpmodel.Tag{{
+				assert.NoError(t, s.ClusterControlPlaneStore.Add(&model.ClusterControlPlane{Id: &normalizedClusterName}))
+				assert.NoError(t, s.PrincipalIdentityStore.Add(&mpmodel.PrincipalIdentity{Name: &normalizedClusterName, Id: &piId, CertificateId: &certId, Tags: []mpmodel.Tag{{
 					Scope: &uidScope,
 					Tag:   &uidTag,
 				}}}))
@@ -1357,7 +1357,7 @@ func TestNSXServiceAccountService_ListNSXServiceAccountRealization(t *testing.T)
 				piName := piKey
 				piId := piKey + "-id"
 				crUID := piKey + "-uid"
-				assert.NoError(t, s.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{
+				assert.NoError(t, s.PrincipalIdentityStore.Add(&mpmodel.PrincipalIdentity{
 					Id:   &piId,
 					Name: &piName,
 					Tags: []mpmodel.Tag{{
@@ -1369,7 +1369,7 @@ func TestNSXServiceAccountService_ListNSXServiceAccountRealization(t *testing.T)
 			for _, ccpKey := range tt.ccpKeys {
 				ccpId := ccpKey
 				crUID := ccpKey + "-uid"
-				assert.NoError(t, s.ClusterControlPlaneStore.Add(model.ClusterControlPlane{
+				assert.NoError(t, s.ClusterControlPlaneStore.Add(&model.ClusterControlPlane{
 					Id: &ccpId,
 					Tags: []model.Tag{{
 						Scope: &tagScopeNSXServiceAccountCRUID,
@@ -1448,7 +1448,7 @@ func TestNSXServiceAccountService_GetNSXServiceAccountNameByUID(t *testing.T) {
 				piName := piKey.Namespace + "-" + piKey.Name
 				piId := piName + "-id"
 				crUID := piName + "-uid"
-				assert.NoError(t, s.PrincipalIdentityStore.Add(mpmodel.PrincipalIdentity{
+				assert.NoError(t, s.PrincipalIdentityStore.Add(&mpmodel.PrincipalIdentity{
 					Id:   &piId,
 					Name: &piName,
 					Tags: []mpmodel.Tag{{
@@ -1466,7 +1466,7 @@ func TestNSXServiceAccountService_GetNSXServiceAccountNameByUID(t *testing.T) {
 			for _, ccpKey := range tt.ccpKeys {
 				ccpId := ccpKey.Namespace + "-" + ccpKey.Name
 				crUID := ccpId + "-uid"
-				assert.NoError(t, s.ClusterControlPlaneStore.Add(model.ClusterControlPlane{
+				assert.NoError(t, s.ClusterControlPlaneStore.Add(&model.ClusterControlPlane{
 					Id: &ccpId,
 					Tags: []model.Tag{{
 						Scope: &tagScopeNamespace,

--- a/pkg/nsx/services/nsxserviceaccount/store_test.go
+++ b/pkg/nsx/services/nsxserviceaccount/store_test.go
@@ -27,8 +27,8 @@ func Test_indexFunc(t *testing.T) {
 		want    []string
 		wantErr bool
 	}{
-		{"1", args{obj: ccp}, []string{"11111"}, false},
-		{"2", args{obj: pi}, []string{"11111"}, false},
+		{"1", args{obj: &ccp}, []string{"11111"}, false},
+		{"2", args{obj: &pi}, []string{"11111"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -49,6 +49,7 @@ func Test_keyFunc(t *testing.T) {
 	ccp := model.ClusterControlPlane{Id: &Id}
 	pi := mpmodel.PrincipalIdentity{Name: &Id}
 	o := model.UserInfo{}
+	var o2 *model.UserInfo
 	type args struct {
 		obj interface{}
 	}
@@ -58,9 +59,11 @@ func Test_keyFunc(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"1", args{obj: ccp}, Id, false},
-		{"2", args{obj: pi}, Id, false},
+		{"1", args{obj: &ccp}, Id, false},
+		{"2", args{obj: &pi}, Id, false},
 		{"0", args{obj: o}, "", true},
+		{"typednil", args{obj: o2}, "", true},
+		{"nil", args{obj: nil}, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Use pointer for PrincipalIdentityStore and ClusterControlPlane store to match initialization
Remove " AND marked_for_delete:false" for MP resource query