### PR TITLE
Add K8s CR name and uuid into NSX resource ID

### DIFF
--- a/pkg/controllers/staticroute/staticroute_controller.go
+++ b/pkg/controllers/staticroute/staticroute_controller.go
@@ -113,7 +113,7 @@ func (r *StaticRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if controllerutil.ContainsFinalizer(obj, commonservice.StaticRouteFinalizerName) {
 			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, common.MetricResTypeStaticRoute)
 			// TODO, update the value from 'default' to actual value， get OrgID, ProjectID, VPCID depending on obj.Namespace from vpc store
-			if err := r.Service.DeleteStaticRoute(string(obj.UID)); err != nil {
+			if err := r.Service.DeleteStaticRoute(obj); err != nil {
 				log.Error(err, "delete failed, would retry exponentially", "staticroute", req.NamespacedName)
 				deleteFail(r, &ctx, obj, &err)
 				return ResultRequeue, err

--- a/pkg/controllers/staticroute/staticroute_controller_test.go
+++ b/pkg/controllers/staticroute/staticroute_controller_test.go
@@ -205,7 +205,7 @@ func TestStaticRouteReconciler_Reconcile(t *testing.T) {
 		return nil
 	})
 
-	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, uid string) error {
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, obj *v1alpha1.StaticRoute) error {
 		assert.FailNow(t, "should not be called")
 		return nil
 	})
@@ -223,7 +223,7 @@ func TestStaticRouteReconciler_Reconcile(t *testing.T) {
 		v1sp.Finalizers = []string{common.StaticRouteFinalizerName}
 		return nil
 	})
-	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, uid string) error {
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, obj *v1alpha1.StaticRoute) error {
 		return nil
 	})
 	_, ret = r.Reconcile(ctx, req)
@@ -238,7 +238,7 @@ func TestStaticRouteReconciler_Reconcile(t *testing.T) {
 		v1sp.Finalizers = []string{common.StaticRouteFinalizerName}
 		return nil
 	})
-	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, uid string) error {
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, obj *v1alpha1.StaticRoute) error {
 		return errors.New("delete failed")
 	})
 
@@ -333,7 +333,7 @@ func TestStaticRouteReconciler_GarbageCollector(t *testing.T) {
 		a = append(a, model.StaticRoutes{Id: &id, Tags: tag2})
 		return a
 	})
-	patch.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, uid string) error {
+	patch.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, obj *v1alpha1.StaticRoute) error {
 		assert.FailNow(t, "should not be called")
 		return nil
 	})
@@ -351,7 +351,7 @@ func TestStaticRouteReconciler_GarbageCollector(t *testing.T) {
 	patch.ApplyMethod(reflect.TypeOf(service), "ListStaticRoute", func(_ *staticroute.StaticRouteService) []model.StaticRoutes {
 		return []model.StaticRoutes{}
 	})
-	patch.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, uid string) error {
+	patch.ApplyMethod(reflect.TypeOf(service), "DeleteStaticRoute", func(_ *staticroute.StaticRouteService, obj *v1alpha1.StaticRoute) error {
 		assert.FailNow(t, "should not be called")
 		return nil
 	})

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -199,7 +199,7 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		})
 	err = errors.New("DeleteSubnetPort failed")
 	patchesDeleteSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPort,
-		func(s *subnetport.SubnetPortService, uid types.UID) error {
+		func(s *subnetport.SubnetPortService, uid string) error {
 			return err
 		})
 	defer patchesDeleteSubnetPort.Reset()
@@ -229,7 +229,7 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 	err = errors.New("Update failed")
 	k8sClient.EXPECT().Update(ctx, gomock.Any()).Return(err)
 	patchesDeleteSubnetPort = gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPort,
-		func(s *subnetport.SubnetPortService, uid types.UID) error {
+		func(s *subnetport.SubnetPortService, uid string) error {
 			return nil
 		})
 	defer patchesDeleteSubnetPort.Reset()
@@ -248,7 +248,7 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		})
 	k8sClient.EXPECT().Update(ctx, gomock.Any()).Return(nil)
 	patchesDeleteSubnetPort = gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPort,
-		func(s *subnetport.SubnetPortService, uid types.UID) error {
+		func(s *subnetport.SubnetPortService, uid string) error {
 			return nil
 		})
 	defer patchesDeleteSubnetPort.Reset()
@@ -265,7 +265,7 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			return nil
 		})
 	patchesDeleteSubnetPort = gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPort,
-		func(s *subnetport.SubnetPortService, uid types.UID) error {
+		func(s *subnetport.SubnetPortService, uid string) error {
 			assert.FailNow(t, "should not be called")
 			return nil
 		})
@@ -294,7 +294,7 @@ func TestSubnetPortReconciler_GarbageCollector(t *testing.T) {
 		})
 	defer patchesListNSXSubnetPortIDForCR.Reset()
 	patchesDeleteSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPort,
-		func(s *subnetport.SubnetPortService, uid types.UID) error {
+		func(s *subnetport.SubnetPortService, uid string) error {
 			return nil
 		})
 	defer patchesDeleteSubnetPort.Reset()
@@ -311,6 +311,7 @@ func TestSubnetPortReconciler_GarbageCollector(t *testing.T) {
 		a.Items = append(a.Items, v1alpha1.SubnetPort{})
 		a.Items[0].ObjectMeta = metav1.ObjectMeta{}
 		a.Items[0].UID = "1234"
+		a.Items[0].Name = "subnetPort1"
 		return nil
 	})
 	r.CollectGarbage(context.Background())

--- a/pkg/nsx/services/ipaddressallocation/builder.go
+++ b/pkg/nsx/services/ipaddressallocation/builder.go
@@ -37,11 +37,11 @@ func (service *IPAddressAllocationService) BuildIPAddressAllocation(IPAddressAll
 }
 
 func (service *IPAddressAllocationService) buildIPAddressAllocationID(IPAddressAllocation *v1alpha1.IPAddressAllocation) string {
-	return util.GenerateID(string(IPAddressAllocation.UID), IPADDRESSALLOCATIONPREFIX, "", "")
+	return util.GenerateIDByObject(IPAddressAllocation)
 }
 
 func (service *IPAddressAllocationService) buildIPAddressAllocationName(IPAddressAllocation *v1alpha1.IPAddressAllocation) string {
-	return util.GenerateDisplayName(IPAddressAllocation.ObjectMeta.Name, IPADDRESSALLOCATIONPREFIX, "", "", service.NSXConfig.Cluster)
+	return util.GenerateTruncName(common.MaxNameLength, IPAddressAllocation.ObjectMeta.Name, "", "", "", service.NSXConfig.Cluster)
 }
 
 func (service *IPAddressAllocationService) buildIPAddressAllocationTags(IPAddressAllocation *v1alpha1.IPAddressAllocation) []model.Tag {

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -1079,9 +1079,9 @@ func TestGetFinalSecurityPolicyResouce(t *testing.T) {
 				spObj:      &spWithPodSelector,
 			},
 			expectedPolicy: &model.SecurityPolicy{
-				DisplayName:    &spName,
-				Id:             &spID,
-				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/sp_uidA_scope"},
+				DisplayName:    common.String("spA"),
+				Id:             common.String("spA-uidA"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA-uidA_scope"},
 				SequenceNumber: &seq0,
 				Rules:          []model.Rule{},
 				Tags:           basicTags,

--- a/pkg/nsx/services/staticroute/builder.go
+++ b/pkg/nsx/services/staticroute/builder.go
@@ -42,8 +42,8 @@ func (service *StaticRouteService) buildStaticRoute(obj *v1alpha1.StaticRoute) (
 		nexthop.IpAddress = &obj.Spec.NextHops[index].IPAddress
 		sr.NextHops = append(sr.NextHops, nexthop)
 	}
-	sr.Id = String(util.GenerateID(string(obj.UID), "sr", "", ""))
-	sr.DisplayName = String(util.GenerateTruncName(common.MaxNameLength, obj.Name, "sr", "", "", ""))
+	sr.Id = String(util.GenerateIDByObject(obj))
+	sr.DisplayName = String(util.GenerateTruncName(common.MaxNameLength, obj.Name, "", "", "", ""))
 	sr.Tags = service.buildBasicTags(obj)
 	return sr, nil
 }

--- a/pkg/nsx/services/staticroute/builder_test.go
+++ b/pkg/nsx/services/staticroute/builder_test.go
@@ -33,6 +33,7 @@ func TestBuildStaticRoute(t *testing.T) {
 	obj.Spec.NextHops = []v1alpha1.NextHop{{IPAddress: ip1}, {IPAddress: ip2}}
 	obj.ObjectMeta.Name = "teststaticroute"
 	obj.ObjectMeta.Namespace = "qe"
+	obj.ObjectMeta.UID = "uuid1"
 	service := &StaticRouteService{}
 	service.NSXConfig = &config.NSXOperatorConfig{}
 	service.NSXConfig.CoeConfig = &config.CoeConfig{}
@@ -40,4 +41,8 @@ func TestBuildStaticRoute(t *testing.T) {
 	staticroutes, err := service.buildStaticRoute(obj)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(staticroutes.NextHops), 2)
+	expName := "teststaticroute"
+	assert.Equal(t, expName, *staticroutes.DisplayName)
+	expId := "teststaticroute-uuid1"
+	assert.Equal(t, expId, *staticroutes.Id)
 }

--- a/pkg/nsx/services/staticroute/staticroute.go
+++ b/pkg/nsx/services/staticroute/staticroute.go
@@ -104,9 +104,9 @@ func (service *StaticRouteService) patch(orgId string, projectId string, vpcId s
 	return nil
 }
 
-func (service *StaticRouteService) DeleteStaticRouteByPath(orgId string, projectId string, vpcId string, uid string) error {
+func (service *StaticRouteService) DeleteStaticRouteByPath(orgId string, projectId string, vpcId string, id string) error {
 	staticRouteClient := service.NSXClient.StaticRouteClient
-	staticroute := service.StaticRouteStore.GetByKey(uid)
+	staticroute := service.StaticRouteStore.GetByKey(id)
 	if staticroute == nil {
 		return nil
 	}
@@ -135,9 +135,9 @@ func (service *StaticRouteService) GetUID(staticroute *model.StaticRoutes) *stri
 
 }
 
-func (service *StaticRouteService) DeleteStaticRoute(uid string) error {
-	id := String(util.GenerateID(uid, "sr", "", ""))
-	staticroute := service.StaticRouteStore.GetByKey(*id)
+func (service *StaticRouteService) DeleteStaticRoute(obj *v1alpha1.StaticRoute) error {
+	id := util.GenerateIDByObject(obj)
+	staticroute := service.StaticRouteStore.GetByKey(id)
 	if staticroute == nil {
 		return nil
 	}
@@ -145,7 +145,7 @@ func (service *StaticRouteService) DeleteStaticRoute(uid string) error {
 	if err != nil {
 		return err
 	}
-	return service.DeleteStaticRouteByPath(vpcResourceInfo.OrgID, vpcResourceInfo.ProjectID, vpcResourceInfo.ID, *id)
+	return service.DeleteStaticRouteByPath(vpcResourceInfo.OrgID, vpcResourceInfo.ProjectID, vpcResourceInfo.ID, id)
 }
 
 func (service *StaticRouteService) ListStaticRoute() []*model.StaticRoutes {

--- a/pkg/nsx/services/staticroute/staticroute_test.go
+++ b/pkg/nsx/services/staticroute/staticroute_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
@@ -128,21 +129,26 @@ func TestStaticRouteService_DeleteStaticRoute(t *testing.T) {
 		t.Error(err)
 	}
 
-	uid := "uid-123"
-	id := "sr_uid-123"
+	srObj := &v1alpha1.StaticRoute{
+		ObjectMeta: v1.ObjectMeta{
+			UID:  "uid-123",
+			Name: "sr",
+		},
+	}
+	id := "sr-uid-123"
 	path := "/orgs/default/projects/project-1/vpcs/vpc-1"
 	sr1 := &model.StaticRoutes{Id: &id, Path: &path}
 
-	returnservice.StaticRouteStore.Add(sr1)
-
 	// no record found
 	mockStaticRouteclient.EXPECT().Delete(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Times(0)
-	err = returnservice.DeleteStaticRoute(id)
+	err = returnservice.DeleteStaticRoute(srObj)
 	assert.Equal(t, err, nil)
+
+	returnservice.StaticRouteStore.Add(sr1)
 
 	// delete record
 	mockStaticRouteclient.EXPECT().Delete("default", "project-1", "vpc-1", id).Return(nil).Times(1)
-	err = returnservice.DeleteStaticRoute(uid)
+	err = returnservice.DeleteStaticRoute(srObj)
 	assert.Equal(t, err, nil)
 	srs := returnservice.StaticRouteStore.List()
 	assert.Equal(t, len(srs), 0)

--- a/pkg/nsx/services/subnet/builder_test.go
+++ b/pkg/nsx/services/subnet/builder_test.go
@@ -1,0 +1,62 @@
+package subnet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/crd.nsx.vmware.com/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+func TestBuildSubnetName(t *testing.T) {
+	svc := &SubnetService{
+		Service: common.Service{
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{
+					Cluster: "cluster1",
+				},
+			},
+		},
+	}
+	subnet := &v1alpha1.Subnet{
+		ObjectMeta: v1.ObjectMeta{
+			UID:  "uuid1",
+			Name: "subnet1",
+		},
+	}
+	name := svc.buildSubnetName(subnet)
+	expName := "subnet1-uuid1"
+	assert.Equal(t, expName, name)
+	id := svc.BuildSubnetID(subnet)
+	expId := "subnet1-uuid1"
+	assert.Equal(t, expId, id)
+}
+
+func TestBuildSubnetSetName(t *testing.T) {
+	svc := &SubnetService{
+		Service: common.Service{
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{
+					Cluster: "b720ee2c-5788-4680-9796-0f93db33d8a9",
+				},
+			},
+		},
+	}
+	subnetset := &v1alpha1.SubnetSet{
+		ObjectMeta: v1.ObjectMeta{
+			UID:  "28e85c0b-21e4-4cab-b1c3-597639dfe752",
+			Name: "pod-default",
+		},
+	}
+	index := "0c5d588b"
+	name := svc.buildSubnetSetName(subnetset, index)
+	expName := "pod-default-28e85c0b-21e4-4cab-b1c3-597639dfe752-0c5d588b"
+	assert.Equal(t, expName, name)
+	assert.True(t, len(name) <= 80)
+	id := svc.buildSubnetSetID(subnetset, index)
+	expId := "pod-default-28e85c0b-21e4-4cab-b1c3-597639dfe752_0c5d588b"
+	assert.Equal(t, expId, id)
+}

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -40,7 +40,7 @@ func TestBuildSubnetPort(t *testing.T) {
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), namespace).Return(nil).Do(
 		func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 			return nil
-		})
+		}).AnyTimes()
 
 	tests := []struct {
 		name          string
@@ -73,8 +73,8 @@ func TestBuildSubnetPort(t *testing.T) {
 			contextID: "fake_context_id",
 			labelTags: nil,
 			expectedPort: &model.VpcSubnetPort{
-				DisplayName: common.String("port-fake_subnetport"),
-				Id:          common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+				DisplayName: common.String("fake_subnetport"),
+				Id:          common.String("fake_subnetport-2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
 				Tags: []model.Tag{
 					{
 						Scope: common.String("nsx-op/cluster"),
@@ -97,13 +97,72 @@ func TestBuildSubnetPort(t *testing.T) {
 						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
 					},
 				},
-				Path:       common.String("fake_path/ports/2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+				Path:       common.String("fake_path/ports/fake_subnetport-2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
 				ParentPath: common.String("fake_path"),
 				Attachment: &model.PortAttachment{
 					AllocateAddresses: common.String("DHCP"),
 					Type_:             common.String("STATIC"),
-					Id:                common.String("32636365-6333-4239-ad37-3534362d3466"),
+					Id:                common.String("66616b65-5f73-4562-ae65-74706f72742d"),
 					TrafficTag:        common.Int64(0),
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "02",
+			obj: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "c5db1800-ce4c-11de-a935-8105ba7ace78",
+					Name:      "fake_pod",
+					Namespace: "fake_ns",
+				},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				DhcpConfig: &model.VpcSubnetDhcpConfig{
+					EnableDhcp: common.Bool(true),
+				},
+				Path: common.String("fake_path"),
+			},
+			contextID: "fake_context_id",
+			labelTags: nil,
+			expectedPort: &model.VpcSubnetPort{
+				DisplayName: common.String("fake_pod"),
+				Id:          common.String("fake_pod-c5db1800-ce4c-11de-a935-8105ba7ace78"),
+				Tags: []model.Tag{
+					{
+						Scope: common.String("nsx-op/cluster"),
+						Tag:   common.String("fake_cluster"),
+					},
+					{
+						Scope: common.String("nsx-op/version"),
+						Tag:   common.String("1.0.0"),
+					},
+					{
+						Scope: common.String("nsx-op/namespace"),
+						Tag:   common.String("fake_ns"),
+					},
+					{
+						Scope: common.String("nsx-op/pod_name"),
+						Tag:   common.String("fake_pod"),
+					},
+					{
+						Scope: common.String("nsx-op/pod_uid"),
+						Tag:   common.String("c5db1800-ce4c-11de-a935-8105ba7ace78"),
+					},
+				},
+				Path:       common.String("fake_path/ports/fake_pod-c5db1800-ce4c-11de-a935-8105ba7ace78"),
+				ParentPath: common.String("fake_path"),
+				Attachment: &model.PortAttachment{
+					AllocateAddresses: common.String("DHCP"),
+					Type_:             common.String("STATIC"),
+					Id:                common.String("66616b65-5f70-4f64-ad63-356462313830"),
+					TrafficTag:        common.Int64(0),
+					AppId:             common.String("c5db1800-ce4c-11de-a935-8105ba7ace78"),
+					ContextId:         common.String("fake_context_id"),
 				},
 			},
 			expectedError: nil,

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -1,0 +1,117 @@
+package subnetport
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+func TestListNSXSubnetPortIDForCR(t *testing.T) {
+	subnetPortService := createSubnetPortService()
+	crName := "fake_subnetport"
+	crUUID := "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"
+	subnetPortByCR := &model.VpcSubnetPort{
+		DisplayName: common.String(crName),
+		Id:          common.String(fmt.Sprintf("%s-%s", crName, crUUID)),
+		Tags: []model.Tag{
+			{
+				Scope: common.String("nsx-op/cluster"),
+				Tag:   common.String("fake_cluster"),
+			},
+			{
+				Scope: common.String("nsx-op/version"),
+				Tag:   common.String("1.0.0"),
+			},
+			{
+				Scope: common.String("nsx-op/vm_namespace"),
+				Tag:   common.String("fake_ns"),
+			},
+			{
+				Scope: common.String("nsx-op/subnetport_name"),
+				Tag:   common.String(crName),
+			},
+			{
+				Scope: common.String("nsx-op/subnetport_uid"),
+				Tag:   common.String(crUUID),
+			},
+		},
+		Path:       common.String("/orgs/default/projects/default/vpcs/vpc1/subnets/subnet1/ports/ports/fake_subnetport-2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+		ParentPath: common.String("/orgs/default/projects/default/vpcs/vpc1/subnets/subnet1"),
+		Attachment: &model.PortAttachment{
+			AllocateAddresses: common.String("DHCP"),
+			Type_:             common.String("STATIC"),
+			Id:                common.String("66616b65-5f73-4562-ae65-74706f72742d"),
+			TrafficTag:        common.Int64(0),
+		},
+	}
+	subnetPortService.SubnetPortStore.Add(subnetPortByCR)
+	subnetPortIDs := subnetPortService.ListNSXSubnetPortIDForCR()
+	assert.Equal(t, 1, len(subnetPortIDs))
+	assert.Equal(t, *subnetPortByCR.Id, subnetPortIDs.UnsortedList()[0])
+}
+
+func TestListNSXSubnetPortIDForPod(t *testing.T) {
+	subnetPortService := createSubnetPortService()
+	podName := "fake_pod"
+	podUUID := "c5db1800-ce4c-11de-a935-8105ba7ace78"
+	subnetPortByPod := &model.VpcSubnetPort{
+		DisplayName: common.String(podName),
+		Id:          common.String(fmt.Sprintf("fake_pod-%s", podUUID)),
+		Tags: []model.Tag{
+			{
+				Scope: common.String("nsx-op/cluster"),
+				Tag:   common.String("fake_cluster"),
+			},
+			{
+				Scope: common.String("nsx-op/version"),
+				Tag:   common.String("1.0.0"),
+			},
+			{
+				Scope: common.String("nsx-op/namespace"),
+				Tag:   common.String("fake_ns"),
+			},
+			{
+				Scope: common.String("nsx-op/pod_name"),
+				Tag:   common.String(podName),
+			},
+			{
+				Scope: common.String("nsx-op/pod_uid"),
+				Tag:   common.String(podUUID),
+			},
+		},
+		Path:       common.String("/orgs/default/projects/default/vpcs/vpc1/subnets/subnet1/ports/fake_pod-c5db1800-ce4c-11de-a935-8105ba7ace78"),
+		ParentPath: common.String("/orgs/default/projects/default/vpcs/vpc1/subnets/subnet1"),
+		Attachment: &model.PortAttachment{
+			AllocateAddresses: common.String("DHCP"),
+			Type_:             common.String("STATIC"),
+			Id:                common.String("66616b65-5f70-4f64-ad63-356462313830"),
+			TrafficTag:        common.Int64(0),
+			AppId:             common.String(podUUID),
+			ContextId:         common.String("fake_context_id"),
+		},
+	}
+	subnetPortService.SubnetPortStore.Add(subnetPortByPod)
+	subnetPortIDs := subnetPortService.ListNSXSubnetPortIDForPod()
+	assert.Equal(t, 1, len(subnetPortIDs))
+	assert.Equal(t, *subnetPortByPod.Id, subnetPortIDs.UnsortedList()[0])
+}
+
+func createSubnetPortService() *SubnetPortService {
+	return &SubnetPortService{
+		SubnetPortStore: &SubnetPortStore{ResourceStore: common.ResourceStore{
+			Indexer: cache.NewIndexer(
+				keyFunc,
+				cache.Indexers{
+					common.TagScopeSubnetPortCRUID: subnetPortIndexByCRUID,
+					common.TagScopePodUID:          subnetPortIndexByPodUID,
+					common.IndexKeySubnetID:        subnetPortIndexBySubnetID,
+				}),
+			BindingType: model.VpcSubnetPortBindingType(),
+		}},
+	}
+}

--- a/pkg/nsx/services/vpc/builder_test.go
+++ b/pkg/nsx/services/vpc/builder_test.go
@@ -33,7 +33,7 @@ func Test_buildNSXLBS(t *testing.T) {
 			name: "1",
 			args: args{
 				obj: &v1alpha1.NetworkInfo{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "ns1", UID: "netinfouid1"},
 					VPCs:       nil,
 				},
 				nsObj: &v1.Namespace{
@@ -45,8 +45,8 @@ func Test_buildNSXLBS(t *testing.T) {
 				relaxScaleValidation: nil,
 			},
 			want: &model.LBService{
-				Id:          common.String("nsuid1"),
-				DisplayName: common.String("vpc-cluster1--ns1"),
+				Id:          common.String("ns1-netinfouid1"),
+				DisplayName: common.String("ns1-netinfouid1"),
 				Tags: []model.Tag{
 					{
 						Scope: common.String(common.TagScopeCluster),
@@ -74,6 +74,112 @@ func Test_buildNSXLBS(t *testing.T) {
 				return
 			}
 			assert.Equalf(t, tt.want, got, "buildNSXLBS(%v, %v, %v, %v, %v, %v)", tt.args.obj, tt.args.nsObj, tt.args.cluster, tt.args.lbsSize, tt.args.vpcPath, tt.args.relaxScaleValidation)
+		})
+	}
+}
+
+func TestBuildNSXVPC(t *testing.T) {
+	nc := common.VPCNetworkConfigInfo{
+		ExternalIPv4Blocks: []string{"10.10.0.0/16"},
+		PrivateIPv4CIDRs:   []string{"192.168.1.0/24"},
+		DefaultGatewayPath: "gw1",
+		ShortID:            "short1",
+		EdgeClusterPath:    "edge1",
+	}
+	netInfoObj := &v1alpha1.NetworkInfo{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "ns1", UID: "netinfouid1"},
+		VPCs:       nil,
+	}
+	nsObj := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ns1", UID: "nsuid1"},
+	}
+	clusterStr := "cluster1"
+
+	for _, tc := range []struct {
+		name        string
+		existingVPC *model.Vpc
+		pathMap     map[string]string
+		useAVILB    bool
+		expVPC      *model.Vpc
+	}{
+		{
+			name: "existing VPC not change",
+			existingVPC: &model.Vpc{
+				ExternalIpv4Blocks: []string{"10.10.0.0/16"},
+				PrivateIpv4Blocks:  []string{"192.168.1.0/24"},
+			},
+			useAVILB: true,
+		},
+		{
+			name: "existing VPC changes private IPv4 blocks",
+			existingVPC: &model.Vpc{
+				ExternalIpv4Blocks: []string{"10.10.0.0/16"},
+				PrivateIpv4Blocks:  []string{},
+			},
+			pathMap:  map[string]string{"vpc1": "192.168.3.0/24"},
+			useAVILB: false,
+			expVPC: &model.Vpc{
+				ExternalIpv4Blocks: []string{"10.10.0.0/16"},
+				PrivateIpv4Blocks:  []string{"192.168.3.0/24"},
+				ShortId:            common.String("short1"),
+			},
+		},
+		{
+			name:     "create new VPC with AVI load balancer enabled",
+			pathMap:  map[string]string{"vpc1": "192.168.3.0/24"},
+			useAVILB: true,
+			expVPC: &model.Vpc{
+				Id:                 common.String("ns1-netinfouid1"),
+				DisplayName:        common.String("ns1-netinfouid1"),
+				DefaultGatewayPath: common.String("gw1"),
+				SiteInfos: []model.SiteInfo{
+					{
+						EdgeClusterPaths: []string{"edge1"},
+					},
+				},
+				LoadBalancerVpcEndpoint: &model.LoadBalancerVPCEndpoint{Enabled: common.Bool(true)},
+				ExternalIpv4Blocks:      []string{"10.10.0.0/16"},
+				PrivateIpv4Blocks:       []string{"192.168.3.0/24"},
+				IpAddressType:           common.String("IPV4"),
+				ShortId:                 common.String("short1"),
+				Tags: []model.Tag{
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("cluster1")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("ns1")},
+					{Scope: common.String("nsx-op/namespace_uid"), Tag: common.String("nsuid1")},
+				},
+			},
+		},
+		{
+			name:     "create new VPC with AVI load balancer disabled",
+			pathMap:  map[string]string{"vpc1": "192.168.3.0/24"},
+			useAVILB: false,
+			expVPC: &model.Vpc{
+				Id:                 common.String("ns1-netinfouid1"),
+				DisplayName:        common.String("ns1-netinfouid1"),
+				DefaultGatewayPath: common.String("gw1"),
+				SiteInfos: []model.SiteInfo{
+					{
+						EdgeClusterPaths: []string{"edge1"},
+					},
+				},
+				ExternalIpv4Blocks: []string{"10.10.0.0/16"},
+				PrivateIpv4Blocks:  []string{"192.168.3.0/24"},
+				IpAddressType:      common.String("IPV4"),
+				ShortId:            common.String("short1"),
+				Tags: []model.Tag{
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("cluster1")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("ns1")},
+					{Scope: common.String("nsx-op/namespace_uid"), Tag: common.String("nsuid1")},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildNSXVPC(netInfoObj, nsObj, nc, clusterStr, tc.pathMap, tc.existingVPC, tc.useAVILB)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expVPC, got)
 		})
 	}
 }

--- a/test/e2e/nsx_security_policy_test.go
+++ b/test/e2e/nsx_security_policy_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -241,7 +240,6 @@ func TestSecurityPolicyNamedPortWithoutPod(t *testing.T) {
 	nsClient := "client"
 	nsWeb := "web"
 	securityPolicyCRName := "named-port-policy-without-pod"
-	securityPolicyNSXDisplayName := fmt.Sprintf("sp-%s-%s", nsWeb, securityPolicyCRName)
 	webA := "web"
 	labelWeb := "tcp-deployment"
 	ruleName0 := "all-ingress-isolation"
@@ -266,7 +264,7 @@ func TestSecurityPolicyNamedPortWithoutPod(t *testing.T) {
 	assertNil(t, err, "Error when waiting for Security Policy %s", securityPolicyCRName)
 
 	// Check NSX resource existing
-	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyNSXDisplayName, true)
+	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeSecurityPolicy, securityPolicyCRName, true)
 	assertNil(t, err)
 	err = testData.waitForResourceExistOrNot(nsWeb, common.ResourceTypeRule, ruleName0, true)
 	assertNil(t, err)


### PR DESCRIPTION
A pre-created VPC is possibly shared in mutiple K8s Namespaces even K8s
clusters, which required the corresponding NSX resources created in the same VPC
must use unique id.

To avoid NSX resources created by the K8s CRs in different Namespaces use the
same ID and to improve the readability of the reource ID, this change uses the
format ${cr_name}-${cr_uuid} to generate the NSX resource ID. For the scenario
that one K8s CR is translated to multiple NSX resources, e.g., Groups, a suffix
is added in the ID field to ensure it is unique. In the meanwhile, the prefix
which represents the resource type is removed from both the NSX resource id and
display_name.

Another change is for the VpcSubnet Id generated by SubnetSet CR. The index is
changed from a uuid to the hash of a uuid and its length is 8.

For the NSX resource's display_name, the corresponding CR's name is used to
improve its readability. The exceptions include Subnet and VPC (NSX LBs is also
changed), which uses format ${cr_name}-${cr_uuid}. This is because vCenter
create folders for subnet and VPC using its display_name, we use a UUID as a
suffix in the display_names field to ensure it is unique.
    
These NSX resources created because of K8s CRs are impacted in this change.
- Subnet and Subnetset
- SubnetPort
- SecurityPolicy and NetworkPolicy
- StaticRoute
- Group
- IPAllocation
    
Test Done:
Unit test is added.
e2e test
      - K8s CR: subnet/subnetset
      - K8s CR: staticroute
      - K8s CR: securitypolicy and networkpolicy (including Groups and Rule)     
      - K8s CR: subnetport

```
---------- kubectl get subnets ----------
NAME      Namespace        UID
subnet1   vpc2-namespace   d578ef4b-e1d2-471b-88f7-f6885077efae
********** NSX API: get VpcSubnet, tag: nsx-op/subnet_name: subnet1 **********
{
  "id": "subnet1-d578ef4b-e1d2-471b-88f7-f6885077efae",
  "display_name": "3d7b2c3f-1b87-454f-9f38-5bdebd9d8214-subnet1"
}
---------- kubectl get staticroutes ----------
NAME     Namespace        UID
test-2   vpc2-namespace   50fd5059-55bf-4016-8c05-a195693644e0
********** NSX API: get StaticRoutes, tag: nsx-op/static_route_name: test-2 **********
{
  "id": "test-2-50fd5059-55bf-4016-8c05-a195693644e0",
  "display_name": "test-2-50fd5059-55bf-4016-8c05-a195693644e0"
}
---------- kubectl get securitypolicy ingress-policy-1 ----------
NAME               Namespace        UID
ingress-policy-1   vpc2-namespace   0774edad-74bd-4fc2-8560-f1175fe40dfb
********** NSX API: get SecurityPolicy, tag: nsx-op/security_policy_name: ingress-policy-1 **********
{
  "id": "ingress-policy-1-0774edad-74bd-4fc2-8560-f1175fe40dfb",
  "display_name": "ingress-policy-1"
}
********** NSX API: get Group, tag: nsx-op/security_policy_name: ingress-policy-1 **********
{
  "id": "ingress-policy-1-0774edad-74bd-4fc2-8560-f1175fe40dfb_scope",
  "display_name": "vpc2-namespace-ingress-policy-1-scope"
}
{
  "id": "ingress-policy-1-0774edad-74bd-4fc2-8560-f1175fe40dfb_0_src",
  "display_name": "ingress-policy-1-0-src"
}
********** NSX API: get Rule, tag: nsx-op/security_policy_name: ingress-policy-1 **********
{
  "id": "ingress-policy-1-0774edad-74bd-4fc2-8560-f1175fe40dfb_0_a8c1e289467c571eeed9c3bbdbbb451a9946965c_0_0",
  "display_name": "TCP.8000-ingress-allow"
}
---------- kubectl get networkpolicy test-network-policy ----------
NAME                  Namespace        UID
test-network-policy   vpc2-namespace   ccd46d0b-0301-446e-8efd-ba0ff909f771
********** NSX API: get SecurityPolicy, tag: nsx-op/network_policy_name: ingress-policy-1 **********
{
  "id": "test-network-policy-allow-ccd46d0b-0301-446e-8efd-ba0ff909f771_allow",
  "display_name": "test-network-policy-allow"
}
********** NSX API: get Group, tag: nsx-op/network_policy_name: test-network-policy-allow **********
{
  "id": "test-network-policy-allow-ccd46d0b-0301-446e-8efd-ba0ff909f771_allow_scope",
  "display_name": "vpc2-namespace-test-network-policy-allow-scope"
}
{
  "id": "test-network-policy-allow-ccd46d0b-0301-446e-8efd-ba0ff909f771_allow_0_dst",
  "display_name": "test-network-policy-allow-0-dst"
}
********** NSX API: get Rule, tag: nsx-op/network_policy_name: test-network-policy-allow **********
{
  "id": "test-network-policy-allow-ccd46d0b-0301-446e-8efd-ba0ff909f771_allow_0_707c3a6b759b426540d1c7c218dc9782a74685b6_0_0",
  "display_name": "TCP.5978-egress-allow"
}
---------- kubectl get ipallocations ----------
NAME                     Namespace        UID
guestcluster-workers-a   vpc2-namespace   f95fd988-7ed4-4a5e-aab1-e69a9f39ba11
********** NSX API: get VpcIpAddressAllocation under vpc2-namespace **********
{
  "id": "guestcluster-workers-a-f95fd988-7ed4-4a5e-aab1-e69a9f39ba11",
  "display_name": "3d7b2c3f-1b87-454f-9f38-5bdebd9d8214-guestcluster-workers-a"
}
```
