### PR TITLE
Chang LabelLbIngressIpMode label value

### DIFF
--- a/pkg/controllers/service/service_lb_controller.go
+++ b/pkg/controllers/service/service_lb_controller.go
@@ -69,7 +69,7 @@ func (r *ServiceLbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *ServiceLbReconciler) setServiceLbStatus(ctx *context.Context, lbService *v1.Service) {
 	ipMode := v1.LoadBalancerIPModeProxy
 	statusUpdated := false
-	// If tanzu.vmware.com/ingress-ip-mode label with values proxy or vip,
+	// If nsx.vmware.com/ingress-ip-mode label with values proxy or vip,
 	// the LoadBalancer serivice ipMode status would be set to whatever the label is set to,
 	// Otherwise, it's set to Proxy by default when unset or other invalid values.
 	if labelIpMode, ok := lbService.Labels[servicecommon.LabelLbIngressIpMode]; ok {

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -59,7 +59,7 @@ const (
 	LabelDefaultSubnetSet              string = "nsxoperator.vmware.com/default-subnetset-for"
 	LabelDefaultVMSubnetSet            string = "VirtualMachine"
 	LabelDefaultPodSubnetSet           string = "Pod"
-	LabelLbIngressIpMode               string = "tanzu.vmware.com/ingress-ip-mode"
+	LabelLbIngressIpMode               string = "nsx.vmware.com/ingress-ip-mode"
 	LabelLbIngressIpModeVipValue       string = "vip"
 	LabelLbIngressIpModeProxyValue     string = "proxy"
 	DefaultPodSubnetSet                string = "pod-default"


### PR DESCRIPTION
This patch is to change LabelLbIngressIpMode label from  tanzu.vmware.com/ingress-ip-mode to nsx.vmware.com/ingress-ip-mode