### PR TITLE
Fix nil panic when an unexpected NSX response is received

### DIFF
--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -97,7 +97,7 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		snatIP, path, cidr := "", "", ""
 		// currently, auto snat is not exposed, and use default value True
 		// checking autosnat to support future extension in vpc configuration
-		if *createdVpc.ServiceGateway.AutoSnat {
+		if createdVpc.ServiceGateway != nil && createdVpc.ServiceGateway.AutoSnat != nil && *createdVpc.ServiceGateway.AutoSnat {
 			snatIP, err = r.Service.GetDefaultSNATIP(*createdVpc)
 			if err != nil {
 				log.Error(err, "failed to read default SNAT ip from VPC", "VPC", createdVpc.Id)

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -233,6 +233,11 @@ func (service *SubnetService) GetSubnetStatus(subnet *model.VpcSubnet) ([]model.
 		log.Error(err, "no subnet status found")
 		return nil, err
 	}
+	if statusList.Results[0].NetworkAddress == nil || statusList.Results[0].GatewayAddress == nil {
+		err := fmt.Errorf("invalid status result: %+v", statusList.Results[0])
+		log.Error(err, "subnet status does not have network address or gateway address", "subnet.Id", subnet.Id)
+		return nil, err
+	}
 	return statusList.Results, nil
 }
 

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -6,6 +6,7 @@ package subnetport
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -248,6 +249,11 @@ func (service *SubnetPortService) GetGatewayPrefixForSubnetPort(obj *v1alpha1.Su
 		return "", -1, err
 	}
 	status := statusList.Results[0]
+	if status.GatewayAddress == nil {
+		err := fmt.Errorf("invalid status result: %+v", status)
+		log.Error(err, "subnet status does not have gateway address", "nsxSubnetPath", nsxSubnetPath)
+		return "", -1, err
+	}
 	gateway, err := util.RemoveIPPrefix(*status.GatewayAddress)
 	if err != nil {
 		return "", -1, err

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -179,13 +179,13 @@ func InitializeVPC(service common.Service) (*VPCService, error) {
 	VPCService.VPCNSNetworkConfigStore = VPCNsNetworkConfigStore{
 		VPCNSNetworkConfigMap: make(map[string]string),
 	}
-	//initialize vpc store, lbs store and ip blocks store
+	// initialize vpc store, lbs store and ip blocks store
 	go VPCService.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypeVpc, nil, VPCService.VpcStore)
 	wg.Add(1)
 	go VPCService.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypeLBService, nil, VPCService.LbsStore)
 	go VPCService.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypeIPBlock, nil, VPCService.IpblockStore)
 
-	//initalize avi rule related store
+	// initialize avi rule related store
 	if enableAviAllowRule {
 		VPCService.RuleStore = &AviRuleStore{ResourceStore: common.ResourceStore{
 			Indexer:     cache.NewIndexer(keyFuncAVI, nil),
@@ -496,6 +496,12 @@ func (s *VPCService) GetAVISubnetInfo(vpc model.Vpc) (string, string, error) {
 
 	if len(statusList.Results) == 0 {
 		log.Info("AVI subnet status not found", "VPC", vpc.Id)
+		return "", "", err
+	}
+
+	if statusList.Results[0].NetworkAddress == nil {
+		err := fmt.Errorf("invalid status result: %+v", statusList.Results[0])
+		log.Error(err, "subnet status does not have network address", "Subnet", common.AVISubnetLBID)
 		return "", "", err
 	}
 


### PR DESCRIPTION
Fix the panic caused by invalid memory address or nil pointer dereference when an unexpected NSX response is received.