### PR TITLE
Fix leader eletion issue

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -166,6 +166,9 @@ func StartIPAddressAllocationController(mgr ctrl.Manager, ipAddressAllocationSer
 
 func main() {
 	log.Info("starting NSX Operator")
+	// see https://github.com/operator-framework/operator-sdk/issues/1813
+	leaseDuration := 30 * time.Second
+	renewDeadline := 20 * time.Second
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,
 		HealthProbeBindAddress:  config.ProbeAddr,
@@ -173,6 +176,8 @@ func main() {
 		LeaderElection:          cf.HAEnabled(),
 		LeaderElectionNamespace: nsxOperatorNamespace,
 		LeaderElectionID:        "nsx-operator",
+		LeaseDuration:           &leaseDuration,
+		RenewDeadline:           &renewDeadline,
 	})
 	if err != nil {
 		log.Error(err, "failed to init manager")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,7 +56,7 @@ func init() {
 }
 
 func (operatorConfig *NSXOperatorConfig) HAEnabled() bool {
-	if operatorConfig.EnableHA == nil || *operatorConfig.EnableHA == true {
+	if operatorConfig.EnableHA != nil && *operatorConfig.EnableHA == true {
 		return true
 	}
 	return false

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -119,7 +119,7 @@ func TestConfig_GetHA(t *testing.T) {
 	configFilePath = "../mock/nsxop.ini"
 	cf, err := NewNSXOperatorConfigFromFile()
 	assert.Equal(t, err, nil)
-	assert.Equal(t, cf.HAEnabled(), true)
+	assert.Equal(t, cf.HAEnabled(), false)
 }
 
 func TestNSXOperatorConfig_GetCACert(t *testing.T) {


### PR DESCRIPTION
Found an error when running nsx-operator container:

```
E0725 06:42:01.554212       1 leaderelection.go:369] Failed to update lock: Put "https://172.24.0.1:443/apis/coordination.k8s.io/v1/namespaces/vmware-system-nsx/leases/nsx-operator": context deadline exceeded
I0725 06:42:01.583400       1 leaderelection.go:285] failed to renew lease vmware-system-nsx/nsx-operator: timed out waiting for the condition
2024-07-25 06:42:01.584 ERROR   cmd/main.go:289 failed to start manager {"error": "leader election lost"}
```