### PR TITLE
[TenantManager][ExternalAddressBinding] Add controller

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_addressbindings.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_addressbindings.yaml
@@ -57,7 +57,6 @@ spec:
             type: object
         required:
         - spec
-        - status
         type: object
     served: true
     storage: true

--- a/pkg/apis/vpc/v1alpha1/addressbinding_types.go
+++ b/pkg/apis/vpc/v1alpha1/addressbinding_types.go
@@ -24,7 +24,7 @@ type AddressBinding struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   AddressBindingSpec   `json:"spec"`
-	Status AddressBindingStatus `json:"status"`
+	Status AddressBindingStatus `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -121,21 +121,21 @@ func NodeIsMaster(node *v1.Node) bool {
 	return false
 }
 
-func GetVirtualMachineNameForSubnetPort(subnetPort *v1alpha1.SubnetPort) (string, error) {
+func GetVirtualMachineNameForSubnetPort(subnetPort *v1alpha1.SubnetPort) (string, string, error) {
 	annotations := subnetPort.GetAnnotations()
 	if annotations == nil {
-		return "", nil
+		return "", "", nil
 	}
 	attachmentRef, exist := annotations[servicecommon.AnnotationAttachmentRef]
 	if !exist {
-		return "", nil
+		return "", "", nil
 	}
 	array := strings.Split(attachmentRef, "/")
 	if len(array) != 3 || !strings.EqualFold(array[0], servicecommon.ResourceTypeVirtualMachine) {
 		err := fmt.Errorf("invalid annotation value of '%s': %s", servicecommon.AnnotationAttachmentRef, attachmentRef)
-		return "", err
+		return "", "", err
 	}
-	return array[1], nil
+	return array[1], array[2], nil
 }
 
 // NumReconcile now uses the fix number of concurrency

--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -15,8 +15,9 @@ func TestGetVirtualMachineNameForSubnetPort(t *testing.T) {
 		subnetPort *v1alpha1.SubnetPort
 	}
 	type want struct {
-		vm  string
-		err error
+		vm   string
+		port string
+		err  error
 	}
 	tests := []struct {
 		name string
@@ -31,12 +32,12 @@ func TestGetVirtualMachineNameForSubnetPort(t *testing.T) {
 						"nsx.vmware.com/attachment_ref": "virtualmachine/abc/port1",
 					},
 				}}},
-			want{vm: "abc", err: nil},
+			want{vm: "abc", port: "port1", err: nil},
 		},
 		{
 			"port_without_annotation",
 			args{&v1alpha1.SubnetPort{}},
-			want{vm: "", err: nil},
+			want{vm: "", port: "", err: nil},
 		},
 		{
 			"port_with_invalid_annotation",
@@ -46,14 +47,17 @@ func TestGetVirtualMachineNameForSubnetPort(t *testing.T) {
 						"nsx.vmware.com/attachment_ref": "invalid/abc",
 					},
 				}}},
-			want{vm: "", err: fmt.Errorf("invalid annotation value of 'nsx.vmware.com/attachment_ref': invalid/abc")},
+			want{vm: "", port: "", err: fmt.Errorf("invalid annotation value of 'nsx.vmware.com/attachment_ref': invalid/abc")},
 		},
 	}
 	for _, tt := range tests {
-		got, err := GetVirtualMachineNameForSubnetPort(tt.args.subnetPort)
+		got1, got2, err := GetVirtualMachineNameForSubnetPort(tt.args.subnetPort)
 		assert.Equal(t, err, tt.want.err)
-		if got != tt.want.vm {
-			t.Errorf("%s failed: got %s, want %s", tt.name, got, tt.want.vm)
+		if got1 != tt.want.vm {
+			t.Errorf("%s failed: got %s, want %s", tt.name, got1, tt.want.vm)
+		}
+		if got2 != tt.want.port {
+			t.Errorf("%s failed: got %s, want %s", tt.name, got2, tt.want.port)
 		}
 	}
 }

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -9,10 +9,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	controllercommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
@@ -30,6 +32,11 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 	objNamespace = objMeta.Namespace
 	if _, ok := obj.(*corev1.Pod); ok {
 		appId = string(objMeta.UID)
+	}
+	var externalAddressBinding *model.ExternalAddressBinding
+	switch o := obj.(type) {
+	case *v1alpha1.SubnetPort:
+		externalAddressBinding = service.buildExternalAddressBinding(o)
 	}
 	if nsxSubnet.DhcpConfig != nil && nsxSubnet.DhcpConfig.EnableDhcp != nil && *nsxSubnet.DhcpConfig.EnableDhcp {
 		allocateAddresses = "DHCP"
@@ -70,9 +77,10 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 			TrafficTag:        common.Int64(0),
 			Type_:             String("STATIC"),
 		},
-		Tags:       tags,
-		Path:       &nsxSubnetPortPath,
-		ParentPath: nsxSubnet.Path,
+		Tags:                   tags,
+		Path:                   &nsxSubnetPortPath,
+		ParentPath:             nsxSubnet.Path,
+		ExternalAddressBinding: externalAddressBinding,
 	}
 	if appId != "" {
 		nsxSubnetPort.Attachment.AppId = &appId
@@ -101,4 +109,62 @@ func getObjectMeta(obj interface{}) *metav1.ObjectMeta {
 
 func getCluster(service *SubnetPortService) string {
 	return service.NSXConfig.Cluster
+}
+
+func buildSubnetPortExternalAddressBindingFromExisting(subnetPort *model.VpcSubnetPort, existingSubnetPort *model.VpcSubnetPort) *model.VpcSubnetPort {
+	if existingSubnetPort == nil {
+		return subnetPort
+	}
+	if existingSubnetPort.ExternalAddressBinding != nil {
+		if subnetPort.ExternalAddressBinding != nil {
+			// update is not supported, keep existing ExternalAddressBinding
+			subnetPort.ExternalAddressBinding = &model.ExternalAddressBinding{}
+		}
+	}
+	return subnetPort
+}
+
+func (service *SubnetPortService) buildExternalAddressBinding(sp *v1alpha1.SubnetPort) *model.ExternalAddressBinding {
+	if service.GetAddressBindingBySubnetPort(sp) != nil {
+		return &model.ExternalAddressBinding{}
+	}
+	return nil
+}
+
+func (service *SubnetPortService) GetAddressBindingBySubnetPort(sp *v1alpha1.SubnetPort) *v1alpha1.AddressBinding {
+	vm, port, err := controllercommon.GetVirtualMachineNameForSubnetPort(sp)
+	if err != nil {
+		log.Error(err, "Failed to get VM name from SubnetPort", "namespace", sp.Namespace, "name", sp.Name, "annotations", sp.Annotations)
+		return nil
+	} else if vm == "" {
+		log.Info("Failed to get VM name from SubnetPort", "namespace", sp.Namespace, "name", sp.Name, "annotations", sp.Annotations)
+		return nil
+	}
+	abList := &v1alpha1.AddressBindingList{}
+	abIndexValue := fmt.Sprintf("%s/%s", sp.Namespace, vm)
+	err = service.Client.List(context.TODO(), abList, client.MatchingFields{util.AddressBindingNamespaceVMIndexKey: abIndexValue})
+	if err != nil {
+		log.Error(err, "Failed to list AddressBinding from cache", "indexValue", abIndexValue)
+		return nil
+	}
+	for _, ab := range abList.Items {
+		if ab.Spec.InterfaceName == "" {
+			spList := &v1alpha1.SubnetPortList{}
+			spIndexValue := fmt.Sprintf("%s/%s", ab.Namespace, ab.Spec.VMName)
+			err = service.Client.List(context.TODO(), spList, client.MatchingFields{util.SubnetPortNamespaceVMIndexKey: spIndexValue})
+			if err != nil || len(spList.Items) == 0 {
+				log.Error(err, "Failed to list SubnetPort from cache", "indexValue", spIndexValue)
+				return nil
+			}
+			if len(spList.Items) == 1 {
+				log.Info("Found default AddressBinding for SubnetPort", "namespace", sp.Namespace, "name", sp.Name, "defaultAddressBindingName", ab.Name, "VM", vm)
+				return &ab
+			}
+			log.Info("Found multiple SubnetPorts for a VM, ignore default AddressBinding for SubnetPort", "namespace", sp.Namespace, "name", sp.Name, "defaultAddressBindingName", ab.Name, "VM", vm)
+		} else if ab.Spec.InterfaceName == port {
+			log.V(1).Info("Found AddressBinding for SubnetPort", "namespace", sp.Namespace, "name", sp.Name, "addressBindingName", ab.Name)
+			return &ab
+		}
+	}
+	return nil
 }

--- a/pkg/nsx/services/subnetport/compare.go
+++ b/pkg/nsx/services/subnetport/compare.go
@@ -36,6 +36,10 @@ func (sp *SubnetPort) Value() data.DataValue {
 			Type_:             sp.Attachment.AllocateAddresses,
 		}
 	}
+	// only check existence of ExternalAddressBinding
+	if sp.ExternalAddressBinding != nil {
+		s.ExternalAddressBinding = &model.ExternalAddressBinding{}
+	}
 	dataValue, _ := ComparableToSubnetPort(s).GetDataValue__()
 	return dataValue
 }

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -1,0 +1,4 @@
+package util
+
+const SubnetPortNamespaceVMIndexKey = "index/SubnetPort/NamespaceVM"
+const AddressBindingNamespaceVMIndexKey = "index/AddressBinding/NamespaceVM"


### PR DESCRIPTION
Testing done:

Verified below cases with mocked VM code:
Create/Delete AddressBinding with 1 or 2 SubnetPorts per VM
Create/Delete AddressBinding (no InterfaceName) with 1 or 2 SubnetPort per VM
Create/Delete AddressBinding with no SubnetPort