### PR TITLE
Fix subnet/subneset ipv4_subnet_size setting

### DIFF
--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -50,20 +50,22 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (
 	switch o := obj.(type) {
 	case *v1alpha1.Subnet:
 		nsxSubnet = &model.VpcSubnet{
-			Id:          String(service.BuildSubnetID(o)),
-			AccessMode:  String(util.Capitalize(string(o.Spec.AccessMode))),
-			DhcpConfig:  service.buildDHCPConfig(o.Spec.DHCPConfig.EnableDHCP, int64(o.Spec.IPv4SubnetSize-4)),
-			DisplayName: String(service.buildSubnetName(o)),
+			Id:             String(service.BuildSubnetID(o)),
+			AccessMode:     String(util.Capitalize(string(o.Spec.AccessMode))),
+			Ipv4SubnetSize: Int64(int64(o.Spec.IPv4SubnetSize)),
+			DhcpConfig:     service.buildDHCPConfig(o.Spec.DHCPConfig.EnableDHCP, int64(o.Spec.IPv4SubnetSize-4)),
+			DisplayName:    String(service.buildSubnetName(o)),
 		}
 		staticIpAllocation = o.Spec.AdvancedConfig.StaticIPAllocation.Enable
 		nsxSubnet.IpAddresses = o.Spec.IPAddresses
 	case *v1alpha1.SubnetSet:
 		index := uuid.NewString()
 		nsxSubnet = &model.VpcSubnet{
-			Id:          String(service.buildSubnetSetID(o, index)),
-			AccessMode:  String(util.Capitalize(string(o.Spec.AccessMode))),
-			DhcpConfig:  service.buildDHCPConfig(o.Spec.DHCPConfig.EnableDHCP, int64(o.Spec.IPv4SubnetSize-4)),
-			DisplayName: String(service.buildSubnetSetName(o, index)),
+			Id:             String(service.buildSubnetSetID(o, index)),
+			AccessMode:     String(util.Capitalize(string(o.Spec.AccessMode))),
+			Ipv4SubnetSize: Int64(int64(o.Spec.IPv4SubnetSize)),
+			DhcpConfig:     service.buildDHCPConfig(o.Spec.DHCPConfig.EnableDHCP, int64(o.Spec.IPv4SubnetSize-4)),
+			DisplayName:    String(service.buildSubnetSetName(o, index)),
 		}
 		staticIpAllocation = o.Spec.AdvancedConfig.StaticIPAllocation.Enable
 	default:


### PR DESCRIPTION
Fix the bug that the NSX subnet IPv4SubnetSize is not set by user-defined CR, either from subnet CR or subnetset CR.
The value of IPv4SubnetSize is only set from vpcnetworkconfiguration if there is no value defined in subnet CR or subnetset CR.