### PR TITLE
Check loadbalancer type

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -411,13 +411,6 @@ func (nsxConfig *NsxConfig) ValidateConfigFromCmd() error {
 	return nsxConfig.validate(true)
 }
 
-func (nsxConfig *NsxConfig) NSXLBEnabled() bool {
-	if nsxConfig.UseAVILoadBalancer == false && (nsxConfig.UseNSXLoadBalancer == nil || *nsxConfig.UseNSXLoadBalancer == true) {
-		return true
-	}
-	return false
-}
-
 func (nsxConfig *NsxConfig) GetNSXLBSize() string {
 	lbsSize := nsxConfig.NSXLBSize
 	if lbsSize == "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
@@ -175,56 +174,6 @@ func TestNSXOperatorConfig_GetCACert(t *testing.T) {
 			}
 			assert.Equalf(t, tt.want, operatorConfig.GetCACert(), "GetCACert()")
 			assert.Equalf(t, tt.want, operatorConfig.configCache.nsxCA, "GetCACert()")
-		})
-	}
-}
-
-func TestNsxConfig_NSXLBEnabled(t *testing.T) {
-	type fields struct {
-		UseAVILB              bool
-		UseNativeLoadBalancer *bool
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   bool
-	}{{
-		name: "avilb",
-		fields: fields{
-			UseAVILB:              true,
-			UseNativeLoadBalancer: nil,
-		},
-		want: false,
-	}, {
-		name: "nsxlbnil",
-		fields: fields{
-			UseAVILB:              false,
-			UseNativeLoadBalancer: nil,
-		},
-		want: true,
-	}, {
-		name: "nsxlbtrue",
-		fields: fields{
-			UseAVILB:              false,
-			UseNativeLoadBalancer: pointy.Bool(true),
-		},
-		want: true,
-	}, {
-		name: "nsxlbfalse",
-		fields: fields{
-			UseAVILB:              false,
-			UseNativeLoadBalancer: pointy.Bool(false),
-		},
-		want: false,
-	},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			nsxConfig := &NsxConfig{
-				UseAVILoadBalancer: tt.fields.UseAVILB,
-				UseNSXLoadBalancer: tt.fields.UseNativeLoadBalancer,
-			}
-			assert.Equalf(t, tt.want, nsxConfig.NSXLBEnabled(), "NSXLBEnabled()")
 		})
 	}
 }

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -114,7 +114,7 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// if lb vpc enabled, read avi subnet path and cidr
 		// nsx bug, if set LoadBalancerVpcEndpoint.Enabled to false, when read this vpc back,
 		// LoadBalancerVpcEndpoint.Enabled will become a nil pointer.
-		if r.Service.NSXConfig.NsxConfig.UseAVILoadBalancer && createdVpc.LoadBalancerVpcEndpoint.Enabled != nil && *createdVpc.LoadBalancerVpcEndpoint.Enabled {
+		if !r.Service.NSXLBEnabled() && createdVpc.LoadBalancerVpcEndpoint.Enabled != nil && *createdVpc.LoadBalancerVpcEndpoint.Enabled {
 			path, cidr, err = r.Service.GetAVISubnetInfo(*createdVpc)
 			if err != nil {
 				log.Error(err, "failed to read lb subnet path and cidr", "VPC", createdVpc.Id)

--- a/pkg/nsx/services/realizestate/realize_state.go
+++ b/pkg/nsx/services/realizestate/realize_state.go
@@ -4,7 +4,6 @@
 package realizestate
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
@@ -35,6 +34,7 @@ func IsRealizeStateError(err error) bool {
 // CheckRealizeState allows the caller to check realize status of entityType with retries.
 // backoff defines the maximum retries and the wait interval between two retries.
 func (service *RealizeStateService) CheckRealizeState(backoff wait.Backoff, intentPath, entityType string) error {
+	// TODO， ask NSX if there were multiple realize states could we check only the latest one?
 	vpcInfo, err := common.ParseVPCResourcePath(intentPath)
 	if err != nil {
 		return err
@@ -55,7 +55,6 @@ func (service *RealizeStateService) CheckRealizeState(backoff wait.Backoff, inte
 			if *result.State == model.GenericPolicyRealizedResource_STATE_REALIZED {
 				return nil
 			}
-			return errors.New(*result.State)
 		}
 		return fmt.Errorf("%s not realized", entityType)
 	})

--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -34,6 +34,9 @@ import (
 
 var log = &logger.Log
 
+var HttpCommonError = errors.New("received HTTP Error")
+var HttpNotFoundError = errors.New("received HTTP Not Found Error")
+
 // ErrorDetail is error detail which info extracted from http.Response.Body.
 type ErrorDetail struct {
 	StatusCode         int
@@ -247,7 +250,10 @@ func HandleHTTPResponse(response *http.Response, result interface{}, debug bool)
 	body, err := io.ReadAll(response.Body)
 	defer response.Body.Close()
 	if !(response.StatusCode == http.StatusOK || response.StatusCode == http.StatusAccepted) {
-		err := errors.New("received HTTP Error")
+		err := HttpCommonError
+		if response.StatusCode == http.StatusNotFound {
+			err = HttpNotFoundError
+		}
 		log.Error(err, "handle http response", "status", response.StatusCode, "request URL", response.Request.URL, "response body", string(body))
 		return err, nil
 	}


### PR DESCRIPTION
    Check loadbalancer type
    
    if use_avi_lb is true in the config, nsx-operator will also check
    1. if alb endpoint existed
    2. no nsx lbs resources found
    if all conditions met, nsx-operator will return 'avi', else return
    'nsx-lb'
    
    Test Done:
    1. set use_avi_lb true in config, get avi endpoint, no nsx lbs , return "avi"
    2. set use_avi_lb true in config, no avi endpoint, return "nsx-lb"
    3. set use_avi_lb false in config, return "nsx-lb"