### PR TITLE
check license from nsxt side

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -gcflags=all=-l ./... -coverprofile cover.out
 
 ##@ Build
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,10 @@ import (
 const (
 	nsxOperatorDefaultConf = "/etc/nsx-operator/nsxop.ini"
 	vcHostCACertPath       = "/etc/vmware/wcp/tls/vmca.pem"
+	// LicenseInterval is the timeout for checking license status
+	LicenseInterval = 7200
+	// LicenseIntervalForDFW is the timeout for checking license status while no DFW license enabled
+	LicenseIntervalForDFW = 1800
 )
 
 var (
@@ -45,16 +49,17 @@ type CoeConfig struct {
 }
 
 type NsxConfig struct {
-	NsxApiUser           string   `ini:"nsx_api_user"`
-	NsxApiPassword       string   `ini:"nsx_api_password"`
-	NsxApiCertFile       string   `ini:"nsx_api_cert_file"`
-	NsxApiPrivateKeyFile string   `ini:"nsx_api_private_key_file"`
-	NsxApiManagers       []string `ini:"nsx_api_managers"`
-	CaFile               []string `ini:"ca_file"`
-	Thumbprint           []string `ini:"thumbprint"`
-	Insecure             bool     `ini:"insecure"`
-	SingleTierSrTopology bool     `ini:"single_tier_sr_topology"`
-	EnforcementPoint     string   `ini:"enforcement_point"`
+	NsxApiUser                string   `ini:"nsx_api_user"`
+	NsxApiPassword            string   `ini:"nsx_api_password"`
+	NsxApiCertFile            string   `ini:"nsx_api_cert_file"`
+	NsxApiPrivateKeyFile      string   `ini:"nsx_api_private_key_file"`
+	NsxApiManagers            []string `ini:"nsx_api_managers"`
+	CaFile                    []string `ini:"ca_file"`
+	Thumbprint                []string `ini:"thumbprint"`
+	Insecure                  bool     `ini:"insecure"`
+	SingleTierSrTopology      bool     `ini:"single_tier_sr_topology"`
+	EnforcementPoint          string   `ini:"enforcement_point"`
+	LicenseValidationInterval int      `ini:"license_validation_interval"`
 }
 
 type K8sConfig struct {

--- a/pkg/controllers/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
 	_ "github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
@@ -90,6 +92,26 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 
 		if err := r.Service.CreateOrUpdateSecurityPolicy(obj); err != nil {
+			// check if invalid license
+			apiErr, _ := nsxutil.DumpAPIError(err)
+			if apiErr != nil {
+				invalidLicense := false
+				errorMessage := ""
+				for _, apiErrItem := range apiErr.RelatedErrors {
+					if *apiErrItem.ErrorCode == nsxutil.InvalidLicenseErrorCode {
+						invalidLicense = true
+						errorMessage = *apiErrItem.ErrorMessage
+					}
+				}
+				if *apiErr.ErrorCode == nsxutil.InvalidLicenseErrorCode {
+					invalidLicense = true
+					errorMessage = *apiErr.ErrorMessage
+				}
+				if invalidLicense {
+					log.Error(err, "Invalid license, nsx-operator will restart", "error message", errorMessage)
+					os.Exit(1)
+				}
+			}
 			log.Error(err, "operate failed, would retry exponentially", "securitypolicy", req.NamespacedName)
 			updateFail(r, &ctx, obj, &err)
 			return ctrl.Result{}, err

--- a/pkg/nsx/services/firewall.go
+++ b/pkg/nsx/services/firewall.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
@@ -71,6 +72,11 @@ func InitializeSecurityPolicy(NSXClient *nsx.Client, cf *config.NSXOperatorConfi
 }
 
 func (service *SecurityPolicyService) CreateOrUpdateSecurityPolicy(obj *v1alpha1.SecurityPolicy) error {
+	if !nsxutil.IsLicensed(nsxutil.FeatureDFW) {
+		log.Info("no DFW license, skip creating SecurityPolicy.")
+		return nsxutil.RestrictionError{Desc: "no DFW license"}
+	}
+
 	nsxSecurityPolicy, nsxGroups, err := service.buildSecurityPolicy(obj)
 	if err != nil {
 		log.Error(err, "failed to build SecurityPolicy")

--- a/pkg/nsx/util/errors.go
+++ b/pkg/nsx/util/errors.go
@@ -7,6 +7,10 @@ import (
 	"fmt"
 )
 
+const (
+	InvalidLicenseErrorCode = 505
+)
+
 type NsxError interface {
 	setDetail(detail *ErrorDetail)
 	Error() string
@@ -536,5 +540,13 @@ type PageMaxError struct {
 }
 
 func (err PageMaxError) Error() string {
+	return err.Desc
+}
+
+type RestrictionError struct {
+	Desc string
+}
+
+func (err RestrictionError) Error() string {
 	return err.Desc
 }

--- a/pkg/nsx/util/license.go
+++ b/pkg/nsx/util/license.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"sync"
+)
+
+const (
+	FeatureContainer        = "CONTAINER"
+	FeatureDFW              = "DFW"
+	LicenseContainerNetwork = "CONTAINER_NETWORKING"
+	LicenseDFW              = "DFW"
+	LicenseContainer        = "CONTAINER"
+)
+
+var (
+	licenseMutex        sync.Mutex
+	licenseMap          = map[string]bool{}
+	Features_to_check   = []string{}
+	Feature_license_map = map[string][]string{FeatureContainer: {LicenseContainerNetwork,
+		LicenseContainer},
+		FeatureDFW: {LicenseDFW}}
+)
+
+func init() {
+	for k := range Feature_license_map {
+		Features_to_check = append(Features_to_check, k)
+		licenseMap[k] = false
+	}
+}
+
+type NsxLicense struct {
+	Results []struct {
+		FeatureName string `json:"feature_name"`
+		IsLicensed  bool   `json:"is_licensed"`
+	} `json:"results"`
+	ResultCount int `json:"result_count"`
+}
+
+func IsLicensed(feature string) bool {
+	licenseMutex.Lock()
+	defer licenseMutex.Unlock()
+	return licenseMap[feature]
+}
+
+func UpdateLicense(feature string, isLicensed bool) {
+	licenseMutex.Lock()
+	licenseMap[feature] = isLicensed
+	licenseMutex.Unlock()
+}
+
+func searchLicense(licenses *NsxLicense, licenseNames []string) bool {
+	license := false
+	for _, licenseName := range licenseNames {
+		for _, feature := range licenses.Results {
+			if feature.FeatureName == licenseName {
+				return feature.IsLicensed
+			}
+		}
+	}
+	return license
+}
+
+func UpdateFeatureLicense(licenses *NsxLicense) {
+	for _, feature := range Features_to_check {
+		licenseNames := Feature_license_map[feature]
+		license := searchLicense(licenses, licenseNames)
+		UpdateLicense(feature, license)
+		log.V(1).Info("update license", "feature", feature, "license", license)
+	}
+}

--- a/pkg/nsx/util/license_test.go
+++ b/pkg/nsx/util/license_test.go
@@ -1,0 +1,132 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLicensed(t *testing.T) {
+	licenseMap[FeatureContainer] = true
+	assert.True(t, IsLicensed(FeatureContainer))
+
+	licenseMap[FeatureDFW] = false
+	assert.False(t, IsLicensed(FeatureDFW))
+}
+
+func TestUpdateLicense(t *testing.T) {
+	UpdateLicense(FeatureDFW, true)
+	assert.True(t, licenseMap[FeatureDFW])
+
+	UpdateLicense(FeatureDFW, false)
+	assert.False(t, licenseMap[FeatureDFW])
+}
+
+func TestSearchLicense(t *testing.T) {
+	licenses := &NsxLicense{
+		Results: []struct {
+			FeatureName string `json:"feature_name"`
+			IsLicensed  bool   `json:"is_licensed"`
+		}{
+			{
+				FeatureName: LicenseContainer,
+				IsLicensed:  true,
+			},
+			{
+				FeatureName: LicenseDFW,
+				IsLicensed:  false,
+			},
+		},
+	}
+
+	// Search for license that exists
+	assert.True(t, searchLicense(licenses, Feature_license_map[FeatureContainer]))
+
+	// Search for license that does not exist
+	assert.False(t, searchLicense(licenses, []string{"IDFW"}))
+
+	// Search with empty results
+	licenses.Results = []struct {
+		FeatureName string `json:"feature_name"`
+		IsLicensed  bool   `json:"is_licensed"`
+	}{}
+	assert.False(t, searchLicense(licenses, Feature_license_map[FeatureContainer]))
+
+	licenses = &NsxLicense{
+		Results: []struct {
+			FeatureName string `json:"feature_name"`
+			IsLicensed  bool   `json:"is_licensed"`
+		}{
+			{
+				FeatureName: LicenseContainerNetwork,
+				IsLicensed:  true,
+			},
+			{
+				FeatureName: LicenseDFW,
+				IsLicensed:  false,
+			},
+			{
+				FeatureName: LicenseContainer,
+				IsLicensed:  false,
+			},
+		},
+	}
+	assert.True(t, searchLicense(licenses, Feature_license_map[FeatureContainer]))
+
+	licenses = &NsxLicense{
+		Results: []struct {
+			FeatureName string `json:"feature_name"`
+			IsLicensed  bool   `json:"is_licensed"`
+		}{
+			{
+				FeatureName: LicenseContainerNetwork,
+				IsLicensed:  false,
+			},
+
+			{
+				FeatureName: LicenseContainer,
+				IsLicensed:  true,
+			},
+		},
+	}
+	assert.False(t, searchLicense(licenses, Feature_license_map[FeatureContainer]))
+}
+
+func TestUpdateFeatureLicense(t *testing.T) {
+
+	// Normal case
+	licenses := &NsxLicense{
+		Results: []struct {
+			FeatureName string `json:"feature_name"`
+			IsLicensed  bool   `json:"is_licensed"`
+		}{
+			{FeatureName: LicenseDFW, IsLicensed: true},
+			{FeatureName: LicenseContainer, IsLicensed: true},
+		},
+	}
+
+	UpdateFeatureLicense(licenses)
+	assert.True(t, IsLicensed(FeatureDFW))
+	assert.True(t, IsLicensed(FeatureContainer))
+
+	// Empty license list
+	licenses.Results = nil
+	UpdateFeatureLicense(licenses)
+	assert.False(t, IsLicensed(FeatureDFW))
+	assert.False(t, IsLicensed(FeatureContainer))
+
+	licenses = &NsxLicense{
+		Results: []struct {
+			FeatureName string `json:"feature_name"`
+			IsLicensed  bool   `json:"is_licensed"`
+		}{
+			{FeatureName: LicenseDFW, IsLicensed: false},
+			{FeatureName: LicenseContainerNetwork, IsLicensed: false},
+			{FeatureName: LicenseContainer, IsLicensed: true},
+		},
+	}
+
+	UpdateFeatureLicense(licenses)
+	assert.False(t, IsLicensed(FeatureDFW))
+	assert.False(t, IsLicensed(FeatureContainer))
+}

--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -13,6 +13,11 @@ import (
 	"strconv"
 	"strings"
 
+	apierrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -242,4 +247,89 @@ func HandleHTTPResponse(response *http.Response, result interface{}, debug bool)
 		return err, body
 	}
 	return nil, body
+}
+
+// if ApiError is nil, check ErrorTypeEnum, such as ServiceUnavailable
+// if both return value are nil, the error is not on the list
+// there is no httpstatus, ApiError does't include it
+func DumpAPIError(err error) (*model.ApiError, *apierrors.ErrorTypeEnum) {
+	switch i := err.(type) {
+	case apierrors.AlreadyExists:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.AlreadyInDesiredState:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.Canceled:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.ConcurrentChange:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.Error:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.FeatureInUse:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.InternalServerError:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.InvalidRequest:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.InvalidArgument:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.InvalidElementConfiguration:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.InvalidElementType:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.NotAllowedInCurrentState:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.NotFound:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.OperationNotFound:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.ResourceBusy:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.ResourceInUse:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.ResourceInaccessible:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.ServiceUnavailable:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.TimedOut:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.UnableToAllocateResource:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.Unauthenticated:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.Unauthorized:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.UnexpectedInput:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.Unsupported:
+		return castApiError(i.Data), i.ErrorType
+	case apierrors.UnverifiedPeer:
+		return castApiError(i.Data), i.ErrorType
+	default:
+		log.Info("dump api error", "error not supported", err)
+		return nil, nil
+	}
+}
+
+func castApiError(apiErrorDataValue *data.StructValue) *model.ApiError {
+	info := "dump api error"
+	if apiErrorDataValue == nil {
+		log.Info(info, "no extra error info", apiErrorDataValue)
+		return nil
+	}
+	var typeConverter = bindings.NewTypeConverter()
+	data, err := typeConverter.ConvertToGolang(apiErrorDataValue, model.ApiErrorBindingType())
+	if err != nil && isEmptyAPIError(data.(model.ApiError)) {
+		log.Error(err[0], info)
+		return nil
+	}
+	apiError, ok := data.(model.ApiError)
+	if !ok {
+		log.Info(info, "error raw data", data)
+		return nil
+	}
+	return &apiError
+}
+
+func isEmptyAPIError(apiError model.ApiError) bool {
+	return (apiError.ErrorCode == nil && apiError.ErrorMessage == nil)
 }

--- a/pkg/third_party/retry/retry_test.go
+++ b/pkg/third_party/retry/retry_test.go
@@ -160,7 +160,7 @@ func TestMaxDelay(t *testing.T) {
 	dur := time.Since(start)
 	assert.Error(t, err)
 	assert.True(t, dur > 170*time.Millisecond, "5 times with maximum delay retry is longer than 170ms")
-	assert.True(t, dur < 200*time.Millisecond, "5 times with maximum delay retry is shorter than 200ms")
+	assert.True(t, dur < 250*time.Millisecond, "5 times with maximum delay retry is shorter than 250ms")
 }
 
 func TestBackOffDelay(t *testing.T) {


### PR DESCRIPTION
While init, it will check the license from nsxt side. If CONTAINER license is disable, it will reboot. If DFW license is disable, security policy will be only response for DELETE operation. It will run a routine to check license periodically. If there is no DFW license, it will check license more frequently

SecurityPolicy controller will check if error is invalid license error.

Test Done:
case:no CONTAINER license
1. if no CONTAINER license, nsx-operator should reset 

case:CONTAINER license enable, DFW disable
1. nsx-operator could bootup
2. security policy failed to create or update
3. security policy could be deleted 

case:CONTAINER license enable, DFW enable -> CONTAINER disable, DFW disable
1. nsx-operator restart due to DFW changed 

case:no DFW license, but nsx-operator try to create security policy
1. nsx-operator restart due to invalid license error