### PR TITLE
Support Subnet/SubnetSet AccessMode immutable

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
@@ -67,6 +67,9 @@ spec:
                 - Public
                 - PrivateTGW
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               advancedConfig:
                 description: Subnet advanced configuration.
                 properties:

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
@@ -67,6 +67,9 @@ spec:
                 - Public
                 - PrivateTGW
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               advancedConfig:
                 description: Subnet advanced configuration.
                 properties:

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/prometheus/client_golang v1.16.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.4
-	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240812065223-970ecf0e07ab
+	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240813023528-cb525458c6ee
 	github.com/vmware-tanzu/nsx-operator/pkg/client v0.0.0-20240102061654-537b080e159f
 	github.com/vmware-tanzu/vm-operator/api v1.8.2
 	github.com/vmware/govmomi v0.27.4

--- a/pkg/apis/vpc/v1alpha1/subnet_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnet_types.go
@@ -17,6 +17,7 @@ type SubnetSpec struct {
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// Access mode of Subnet, accessible only from within VPC or from outside VPC.
 	// +kubebuilder:validation:Enum=Private;Public;PrivateTGW
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	AccessMode AccessMode `json:"accessMode,omitempty"`
 	// Subnet CIDRS.
 	// +kubebuilder:validation:MinItems=0

--- a/pkg/apis/vpc/v1alpha1/subnetset_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetset_types.go
@@ -15,6 +15,7 @@ type SubnetSetSpec struct {
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// Access mode of Subnet, accessible only from within VPC or from outside VPC.
 	// +kubebuilder:validation:Enum=Private;Public;PrivateTGW
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	AccessMode AccessMode `json:"accessMode,omitempty"`
 	// Subnet advanced configuration.
 	AdvancedConfig AdvancedConfig `json:"advancedConfig,omitempty"`

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -3,7 +3,7 @@ module github.com/vmware-tanzu/nsx-operator/pkg/client
 go 1.22.5
 
 require (
-	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240812065223-970ecf0e07ab
+	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240813023528-cb525458c6ee
 	k8s.io/apimachinery v0.30.3
 	k8s.io/client-go v0.30.3
 )

--- a/pkg/client/go.sum
+++ b/pkg/client/go.sum
@@ -76,8 +76,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240812065223-970ecf0e07ab h1:L7xGtf3QZVvnrxKZY5kfgSJWvbeI6OrN/WKKYCkHyq4=
-github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240812065223-970ecf0e07ab/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240813023528-cb525458c6ee h1:zbDYJ7kIfZRin5ifeezrLuiNhMezUqEaRtrEcrB5/4M=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240813023528-cb525458c6ee/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
For NSX subnet, once it is created, it's not allowed to change accessMode.
To support this restriction, for the Subnet/Subnetset CR, we also
add a method to make accessMode immutable once created.

This patch is to:
Change Subnet and SubnetSet CR definition to make Subnet/SubnetSet
accessMode is immutable once the CR is created.

Aslo, this patch is to
1. Remove checking pod-default subnetset in subnet controller.
2. Fix the issue that subnet CR spec is not updated after creating CR.

**Test done**:
subnet Test yaml:
```
cat vpctest-subnet-dhcp.yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: user-pod-subnet-dhcp1
  namespace: vpc-test
spec:
  DHCPConfig:
    enableDHCP: true
  advancedConfig:
    staticIPAllocation:
      enable: false
  ipv4SubnetSize: 64
  #accessMode: Private
  accessMode: Publicd
```
 
1. Use invalid accessMode "Publicd"
kubectl apply -f vpctest-subnet-dhcp.yaml
output:
```
The Subnet "user-pod-subnet-dhcp1" is invalid:
* spec.accessMode: Unsupported value: "Publicd": supported values: "Private", "Public", "PrivateTGW"
* <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
```

2. Create subnet with accessMode "Public"
accessMode: Public
kubectl apply -f vpctest-subnet-dhcp.yaml
output: subnet user-pod-subnet-dhcp1 CR is created correctly.
```
subnet.crd.nsx.vmware.com/user-pod-subnet-dhcp1 created
kubectl get Subnet -A
NAMESPACE   NAME                    ACCESSMODE   IPV4SUBNETSIZE   IPADDRESSES
vpc-test    user-pod-subnet-dhcp1   Public       64
```

3. Change subnet CR user-pod-subnet-dhcp1 accessMode to Private
accessMode is not allowed to change any more.
kubectl apply -f vpctest-subnet-dhcp.yaml
output: 
```
`The Subnet "user-pod-subnet-dhcp1" is invalid: spec.accessMode: Invalid value: "string": Value is immutable`
 kubectl get Subnet -A
NAMESPACE   NAME                    ACCESSMODE   IPV4SUBNETSIZE   IPADDRESSES
vpc-test    user-pod-subnet-dhcp1   Public       64
```
4.  Apply a subnet test yaml without accessMode set.
subnet Test yaml:
```
cat user-pod-subnet-dhcp2.yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: user-pod-subnet-dhcp2
  namespace: vpc-test
spec:
  DHCPConfig:
    enableDHCP: true
  advancedConfig:
    staticIPAllocation:
      enable: false
  ipv4SubnetSize: 64
  #accessMode: Public
```
kubectl apply -f vpctest-subnet-dhcp.yaml, get
```
kubectl get subnet -nvpc-test    user-pod-subnet-dhcp2
NAME                    ACCESSMODE   IPV4SUBNETSIZE   IPADDRESSES
user-pod-subnet-dhcp2   Private      64
```
accessMode is set as Private by subnet controller since it's empty.
And then change accessMode, and apply this yaml again.
`accessMode: Public`
we get accessMode is not allowed to change.
```
kubectl apply -f ./vpctest-subnet-dhcp.yaml
The Subnet "user-pod-subnet-dhcp2" is invalid: spec.accessMode: Invalid value: "string": Value is immutable
```

5. Do the similar test for the SubnetSet yaml