### PR TITLE
Delete SecurityPolicy on the real API version object

### DIFF
--- a/pkg/controllers/securitypolicy/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller.go
@@ -183,7 +183,7 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	} else {
 		if controllerutil.ContainsFinalizer(obj, finalizerName) {
 			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, MetricResType)
-			if err := r.Service.DeleteSecurityPolicy(obj, false, servicecommon.ResourceTypeSecurityPolicy); err != nil {
+			if err := r.Service.DeleteSecurityPolicy(realObj.UID, false, servicecommon.ResourceTypeSecurityPolicy); err != nil {
 				log.Error(err, "deletion failed, would retry exponentially", "securitypolicy", req.NamespacedName)
 				deleteFail(r, &ctx, realObj, &err)
 				return ResultRequeue, err
@@ -426,7 +426,6 @@ func shouldReconcile(securityPolicy *v1alpha1.SecurityPolicy, q workqueue.RateLi
 			},
 		})
 	}
-
 }
 
 func StartSecurityPolicyController(mgr ctrl.Manager, commonService servicecommon.Service, vpcService servicecommon.VPCServiceProvider) {


### PR DESCRIPTION
Now that SecurityPolicy controller supports both crd.nsx.vmware.com and nsx.vmware.com API version group CRD for VPC and T1, respectively.

So, it's needed to call SecurityPolicy deletion on the real API version object either from crd.nsx.vmware.com or nsx.vmware.com, this is decided by VPC network configuration.


**Test done:**
1. Create SecurityPolicy on VPC mode with crd.nsx.vmware.com version CR, and delete it successfully after creation. 
Also NSX API call to delete the related NSX objects.

2. Create SecurityPolicy on T1 mode with nsx.vmware.com version CR, and delete it successfully after creation. 
Also NSX API call to delete the related NSX objects.