### PR TITLE
Delete stale VPC status in VPCNetworkConfiguration when deleting NetworkInfo

### DIFF
--- a/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
+++ b/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
@@ -24,7 +24,7 @@ var (
 type IPAddressAllocation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
-	
+
 	Spec   IPAddressAllocationSpec   `json:"spec"`
 	Status IPAddressAllocationStatus `json:"status,omitempty"`
 }

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -258,13 +258,9 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				log.Error(err, "failed to get network config name for VPC when deleting NetworkInfo CR", "NetworkInfo", obj.Name)
 				return common.ResultRequeueAfter10sec, err
 			}
-			allVPCs := r.Service.ListVPC()
-			vpcAlive := sets.New[string]()
-			for _, vpcModel := range allVPCs {
-				vpcAlive.Insert(*vpcModel.DisplayName)
-			}
 			log.V(1).Info("removed finalizer", "NetworkInfo", req.NamespacedName)
-			deleteSuccess(r, ctx, obj, r.Client, vpcs, ncName, vpcAlive)
+			deleteVPCNetworkConfigurationStatus(ctx, r.Client, ncName, vpcs, r.Service.ListVPC())
+			deleteSuccess(r, ctx, obj)
 		} else {
 			// only print a message because it's not a normal case
 			log.Info("finalizers cannot be recognized", "NetworkInfo", req.NamespacedName)

--- a/pkg/controllers/networkinfo/networkinfo_utils.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
@@ -37,7 +38,12 @@ func updateSuccess(r *NetworkInfoReconciler, c context.Context, o *v1alpha1.Netw
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateSuccessTotal, common.MetricResTypeNetworkInfo)
 }
 
-func deleteSuccess(r *NetworkInfoReconciler, _ context.Context, o *v1alpha1.NetworkInfo) {
+func deleteSuccess(r *NetworkInfoReconciler, c context.Context, o *v1alpha1.NetworkInfo, client client.Client, staleVPCs []*model.Vpc, ncName string, allVPCs sets.Set[string]) {
+	staleVPCNames := sets.New[string]()
+	for _, vpc := range staleVPCs {
+		staleVPCNames.Insert(*vpc.DisplayName)
+	}
+	deleteVPCNetworkConfigurationStatus(c, client, ncName, staleVPCNames, allVPCs)
 	r.Recorder.Event(o, v1.EventTypeNormal, common.ReasonSuccessfulDelete, "NetworkInfo CR has been successfully deleted")
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteSuccessTotal, common.MetricResTypeNetworkInfo)
 }
@@ -81,7 +87,11 @@ func setVPCNetworkConfigurationStatusWithLBS(ctx context.Context, client client.
 		VPCPath:             vpcPath,
 	}}
 
-	client.Status().Update(ctx, nc)
+	if err := client.Status().Update(ctx, nc); err != nil {
+		log.Error(err, "Update VPCNetworkConfiguration status failed", "ncName", ncName, "vpcName", vpcName, "nc.Status.VPCs", nc.Status.VPCs)
+		return
+	}
+	log.Info("Updated VPCNetworkConfiguration status", "ncName", ncName, "vpcName", vpcName, "nc.Status.VPCs", nc.Status.VPCs)
 }
 
 func setVPCNetworkConfigurationStatusWithGatewayConnection(ctx context.Context, client client.Client, nc *v1alpha1.VPCNetworkConfiguration, gatewayConnectionReady bool, reason string) {
@@ -178,6 +188,27 @@ func getGatewayConnectionStatus(ctx context.Context, nc *v1alpha1.VPCNetworkConf
 		}
 	}
 	return gatewayConnectionReady, reason, nil
+}
+
+func deleteVPCNetworkConfigurationStatus(ctx context.Context, client client.Client, ncName string, staleVPCNames, allVPCs sets.Set[string]) {
+	// read v1alpha1.VPCNetworkConfiguration by ncName
+	nc := &v1alpha1.VPCNetworkConfiguration{}
+	err := client.Get(ctx, apitypes.NamespacedName{Name: ncName}, nc)
+	if err != nil {
+		log.Error(err, "failed to get VPCNetworkConfiguration", "Name", ncName)
+		return
+	}
+	// iterate through VPCNetworkConfiguration.Status.VPCs, if vpcName does not exist in the staleVPCNames, append in new VPCs status
+	var newVPCInfos []v1alpha1.VPCInfo
+	for _, vpc := range nc.Status.VPCs {
+		if !staleVPCNames.Has(vpc.Name) && allVPCs.Has(vpc.Name) {
+			newVPCInfos = append(newVPCInfos, vpc)
+		}
+	}
+	nc.Status.VPCs = newVPCInfos
+	if err := client.Status().Update(ctx, nc); err != nil {
+		log.Error(err, "failed to update VPCNetworkConfiguration status", "Name", ncName)
+	}
 }
 
 func getNamespaceFromNSXVPC(nsxVPC *model.Vpc) string {


### PR DESCRIPTION
 # 1. Delete stale vpc status in VPCNetworkConfiguration when deleting NetworkInfo

1. The vpcnetworkconfigurations may have many stale vpc status under some circumstances.
For example, the default vpcnetworkconfigurations status:
kubectl get vpcnetworkconfigurations.crd.nsx.vmware.com default -o yaml
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: VPCNetworkConfiguration
metadata:
  annotations:
    [nsx.vmware.com/default](http://nsx.vmware.com/default): "true"
  creationTimestamp: "2024-08-13T14:40:15Z"
  generation: 1
  name: default
  resourceVersion: "274082"
  uid: 6847d91d-831c-408c-b717-3ff3ac421643
spec:
  defaultSubnetSize: 32
  nsxProject: /orgs/default/projects/project-quality
  privateIPs:
  - [172.26.0.0/16](http://172.26.0.0/16)
  vpcConnectivityProfile: /orgs/default/projects/project-quality/vpc-connectivity-profiles/default
status:
  vpcs:
  - name: svc-tkg-domain-c10-83abafb7-2201-42cc-8737-038807b90148
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-tkg-domain-c10-83abafb7-2201-42cc-8737-038807b90148/vpc-lbs/svc-tkg-domain-c10-83abafb7-2201-42cc-8737-038807b90148
  - name: svc-velero-domain-c10-736a9fc5-c776-469a-b464-08113f0d94e1
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-velero-domain-c10-736a9fc5-c776-469a-b464-08113f0d94e1/vpc-lbs/svc-velero-domain-c10-736a9fc5-c776-469a-b464-08113f0d94e1
  - name: svc-tkg-domain-c10-da85e7ed-7872-470f-b1bc-260c8994ba8c
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-tkg-domain-c10-da85e7ed-7872-470f-b1bc-260c8994ba8c/vpc-lbs/svc-tkg-domain-c10-da85e7ed-7872-470f-b1bc-260c8994ba8c
  - name: svc-velero-domain-c10-f884ac07-c90b-4472-bdd2-6c43105712fe
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-velero-domain-c10-f884ac07-c90b-4472-bdd2-6c43105712fe/vpc-lbs/svc-velero-domain-c10-f884ac07-c90b-4472-bdd2-6c43105712fe
  - name: svc-tkg-domain-c10-25329692-f8d4-4eca-a221-ea92d4d108b1
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-tkg-domain-c10-25329692-f8d4-4eca-a221-ea92d4d108b1/vpc-lbs/svc-tkg-domain-c10-25329692-f8d4-4eca-a221-ea92d4d108b1
  - name: svc-velero-domain-c10-16fbcc31-67a3-43ff-b98a-3d2eb247c298
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-velero-domain-c10-16fbcc31-67a3-43ff-b98a-3d2eb247c298/vpc-lbs/svc-velero-domain-c10-16fbcc31-67a3-43ff-b98a-3d2eb247c298
  - name: svc-velero-domain-c10-3672f12d-558a-4829-af5d-98a0b33e4f6a
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-velero-domain-c10-3672f12d-558a-4829-af5d-98a0b33e4f6a/vpc-lbs/svc-velero-domain-c10-3672f12d-558a-4829-af5d-98a0b33e4f6a
  - name: svc-tkg-domain-c10-e4b40ea8-d64a-4fa8-b8c4-440f6daa381c
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-tkg-domain-c10-e4b40ea8-d64a-4fa8-b8c4-440f6daa381c/vpc-lbs/svc-tkg-domain-c10-e4b40ea8-d64a-4fa8-b8c4-440f6daa381c
  - name: svc-velero-domain-c10-b17a6f77-c608-4471-8466-f206418dd09e
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-velero-domain-c10-b17a6f77-c608-4471-8466-f206418dd09e/vpc-lbs/svc-velero-domain-c10-b17a6f77-c608-4471-8466-f206418dd09e
  - name: svc-tkg-domain-c10-07813b0b-bcee-42a3-b698-fce98d5fb364
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-tkg-domain-c10-07813b0b-bcee-42a3-b698-fce98d5fb364/vpc-lbs/svc-tkg-domain-c10-07813b0b-bcee-42a3-b698-fce98d5fb364
  - name: svc-tkg-domain-c10-c9f15264-4762-47b9-972e-9e02274b68c4
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-tkg-domain-c10-c9f15264-4762-47b9-972e-9e02274b68c4/vpc-lbs/svc-tkg-domain-c10-c9f15264-4762-47b9-972e-9e02274b68c4
  - name: svc-velero-domain-c10-b1e858f1-65f1-4cba-ab56-614b34ec867c
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-velero-domain-c10-b1e858f1-65f1-4cba-ab56-614b34ec867c/vpc-lbs/svc-velero-domain-c10-b1e858f1-65f1-4cba-ab56-614b34ec867c
  - name: svc-tkg-domain-c10-b0182e42-530a-42ce-91c3-467a60a66153
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/svc-tkg-domain-c10-b0182e42-530a-42ce-91c3-467a60a66153/vpc-lbs/svc-tkg-domain-c10-b0182e42-530a-42ce-91c3-467a60a66153
```

2. That is because the controller did not delete the stale VPC status when we deleting the NetworkInfo, now we deployed the new nsx-operator and deleted the  NetworkInfo `svc-velero-domain-c10`
 
3. Check the default vpcnetworkconfigurations status again:

<img width="903" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/b90a54ae-7b65-4d68-aeb0-a486e6af98b1">


# 2. Other code optimizations.

Pass `context.Context` directly rather than passing its pointer. Also see: https://github.com/vmware-tanzu/nsx-operator/pull/714

