### PR TITLE
Remove pod annotation "nsx.vmware.com/attachment" and "nsx.vmware.com/mac"

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -83,8 +83,6 @@ const (
 	AnnotationSharedVPCNamespace       string = "nsx.vmware.com/shared_vpc_namespace"
 	AnnotationDefaultNetworkConfig     string = "nsx.vmware.com/default"
 	AnnotationAttachmentRef            string = "nsx.vmware.com/attachment_ref"
-	AnnotationPodMAC                   string = "nsx.vmware.com/mac"
-	AnnotationPodAttachment            string = "nsx.vmware.com/attachment"
 	TagScopePodName                    string = "nsx-op/pod_name"
 	TagScopePodUID                     string = "nsx-op/pod_uid"
 	ValueMajorVersion                  string = "1"


### PR DESCRIPTION
Previously, we put the IP/MAC in the pod annotation in case of the backup/restore. For now, we don't support the b/r so remove them.