### PR TITLE
Add ipaddressallocation cleanup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -184,7 +184,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			log.Error(err, "failed to initialize subnet commonService")
 			os.Exit(1)
 		}
-		ipAddressAllocationService, err := ipaddressallocationservice.InitializeIPAddressAllocation(commonService, vpcService)
+		ipAddressAllocationService, err := ipaddressallocationservice.InitializeIPAddressAllocation(commonService, vpcService, false)
 		if err != nil {
 			log.Error(err, "failed to initialize ipaddressallocation commonService", "controller", "IPAddressAllocation")
 		}

--- a/pkg/clean/clean.go
+++ b/pkg/clean/clean.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/ipaddressallocation"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy"
 	sr "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/staticroute"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnet"
@@ -161,12 +162,18 @@ func InitializeCleanupService(cf *config.NSXOperatorConfig, nsxClient *nsx.Clien
 			return subnetport.InitializeSubnetPort(service)
 		}
 	}
+	wrapInitializeIPAddressAllocation := func(service common.Service) cleanupFunc {
+		return func() (cleanup, error) {
+			return ipaddressallocation.InitializeIPAddressAllocation(service, vpcService, true)
+		}
+	}
 	// TODO: initialize other CR services
 	cleanupService = cleanupService.
 		AddCleanupService(wrapInitializeSubnetPort(commonService)).
 		AddCleanupService(wrapInitializeSubnetService(commonService)).
 		AddCleanupService(wrapInitializeSecurityPolicy(commonService)).
 		AddCleanupService(wrapInitializeStaticRoute(commonService)).
+		AddCleanupService(wrapInitializeIPAddressAllocation(commonService)).
 		AddCleanupService(wrapInitializeVPC(commonService))
 
 	return cleanupService, nil

--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -588,6 +588,8 @@ func CasttoPointer(obj interface{}) interface{} {
 		return &v
 	case model.IpAddressBlock:
 		return &v
+	case model.VpcIpAddressAllocation:
+		return &v
 	default:
 		objType := reflect.TypeOf(obj)
 		log.Info("Unsupported type", "objType", objType)


### PR DESCRIPTION
Manually add two records, one is with cluster Scope:nsx-op/cluster, Tag:d215b1fa-5432-498f-9214-d7da8bd4731f, another is with Scope:ncp/cluster,Tag:d215b1fa-5432-498f-9214-d7da8bd4731f
```
{
  "allocation_size": 32,
  "display_name": "ipa-ncp-test6",
  "id": "ipa_0e408107-2805-430f-9691-920077d4252g",
  "tags": [
    {
      "scope": "nsx-op/cluster",
      "tag": "d215b1fa-5432-498f-9214-d7da8bd4731f"
    }
  ]
}

```

```
{
  "allocation_size": 32,
  "display_name": "ipa-ncp-test6",
  "id": "ipa_0e408107-2805-430f-9691-920077d4252g",
  "tags": [
    {
      "scope": "ncp/cluster",
      "tag": "d215b1fa-5432-498f-9214-d7da8bd4731f"
    }
  ]
}

```

Run clean command, log output

```
2024-08-27 01:57:19.101	DEBUG	ipaddressallocation/store.go:56	delete ipAddressAllocation from store	{"ipAddressAllocation": {"Links":null,"Schema":null,"Self":null,"Revision":0,"CreateTime":1724664728334,"CreateUser":"admin","LastModifiedTime":1724664728334,"LastModifiedUser":"admin","Protection":"NOT_PROTECTED","SystemOwned":false,"Description":null,"DisplayName":"ipa-ncp-test5","Id":"ipa-ncp-test5","ResourceType":"VpcIpAddressAllocation","Tags":[{"Scope":"ncp/cluster","Tag":"d215b1fa-5432-498f-9214-d7da8bd4731f"}],"OriginSiteId":null,"OwnerId":"61149896-4c50-4441-a9d5-2f686e1cecff","ParentPath":"/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e","Path":"/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e/ip-address-allocations/ipa-ncp-test5","RealizationId":"7f7b644e-96bf-448c-8d3c-e7f33fefa5b0","RelativePath":"ipa-ncp-test5","RemotePath":"","UniqueId":"7f7b644e-96bf-448c-8d3c-e7f33fefa5b0","Children":null,"MarkedForDelete":true,"Overridden":false,"AllocationIp":null,"AllocationIps":"172.160.0.128/27","AllocationSize":32,"IpAddressBlockVisibility":"EXTERNAL","IpAddressType":"IPV4","IpBlock":null}}
2024-08-27 01:57:19.102	DEBUG	ipaddressallocation/ipaddressallocation.go:179	successfully deleted nsxIPAddressAllocation	{"nsxIPAddressAllocation": {"Links":null,"Schema":null,"Self":null,"Revision":0,"CreateTime":1724664728334,"CreateUser":"admin","LastModifiedTime":1724664728334,"LastModifiedUser":"admin","Protection":"NOT_PROTECTED","SystemOwned":false,"Description":null,"DisplayName":"ipa-ncp-test5","Id":"ipa-ncp-test5","ResourceType":"VpcIpAddressAllocation","Tags":[{"Scope":"ncp/cluster","Tag":"d215b1fa-5432-498f-9214-d7da8bd4731f"}],"OriginSiteId":null,"OwnerId":"61149896-4c50-4441-a9d5-2f686e1cecff","ParentPath":"/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e","Path":"/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e/ip-address-allocations/ipa-ncp-test5","RealizationId":"7f7b644e-96bf-448c-8d3c-e7f33fefa5b0","RelativePath":"ipa-ncp-test5","RemotePath":"","UniqueId":"7f7b644e-96bf-448c-8d3c-e7f33fefa5b0","Children":null,"MarkedForDelete":true,"Overridden":false,"AllocationIp":null,"AllocationIps":"172.160.0.128/27","AllocationSize":32,"IpAddressBlockVisibility":"EXTERNAL","IpAddressType":"IPV4","IpBlock":null}}
2024-08-27 01:57:19.118	LEVEL(-2)	util/utils.go:318	http request	{"url": "https://10.221.156.85/policy/api/v1/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e/ip-address-allocations/ipa-ncp-test4", "body": "{}", "head": {"Content-Type":["application/json"],"Cookie":["JSESSIONID=BA872B4F51679D826AFCEB39E5F0F713; Path=/; HttpOnly; Secure; SameSite=Lax"],"User-Agent":["vAPI/0.6.0 Go/go1.22.5 (linux; amd64)"],"Vapi-Ctx-Opid":["07f2c477-89c1-4056-ac2d-7ad6ef47a61c"],"X-Xsrf-Token":["18bc6fb2-d42e-41e0-bb27-abcfac6d4f02"]}}
2024-08-27 01:57:19.265	DEBUG	nsx/transport.go:58	RoundTrip request	{"request": "https://10.221.156.85/policy/api/v1/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e/ip-address-allocations/ipa-ncp-test4", "method": "DELETE", "transTime": 0.146197851}
2024-08-27 01:57:19.265	LEVEL(-2)	util/utils.go:141	http response	{"status code": 200, "body": ""}
2024-08-27 01:57:19.265	DEBUG	util/utils.go:144	body length is 0
2024-08-27 01:57:19.265	DEBUG	ipaddressallocation/store.go:56	delete ipAddressAllocation from store	{"ipAddressAllocation": {"Links":null,"Schema":null,"Self":null,"Revision":0,"CreateTime":1724664623841,"CreateUser":"admin","LastModifiedTime":1724664623841,"LastModifiedUser":"admin","Protection":"NOT_PROTECTED","SystemOwned":false,"Description":null,"DisplayName":"ipa-ncp-test4","Id":"ipa-ncp-test4","ResourceType":"VpcIpAddressAllocation","Tags":[{"Scope":"nsx-op/cluster","Tag":"d215b1fa-5432-498f-9214-d7da8bd4731f"}],"OriginSiteId":null,"OwnerId":"61149896-4c50-4441-a9d5-2f686e1cecff","ParentPath":"/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e","Path":"/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e/ip-address-allocations/ipa-ncp-test4","RealizationId":"ec4b3c4f-b507-4c5a-a5f7-6b9964c92928","RelativePath":"ipa-ncp-test4","RemotePath":"","UniqueId":"ec4b3c4f-b507-4c5a-a5f7-6b9964c92928","Children":null,"MarkedForDelete":true,"Overridden":false,"AllocationIp":null,"AllocationIps":"172.160.0.96/27","AllocationSize":32,"IpAddressBlockVisibility":"EXTERNAL","IpAddressType":"IPV4","IpBlock":null}}

2024-08-27 01:57:19.285	LEVEL(-2)	util/utils.go:318	http request	{"url": "https://10.221.156.85/policy/api/v1/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e/ip-address-allocations/ipa-ncp-test6", "body": "{}", "head": {"Content-Type":["application/json"],"Cookie":["JSESSIONID=BA872B4F51679D826AFCEB39E5F0F713; Path=/; HttpOnly; Secure; SameSite=Lax"],"User-Agent":["vAPI/0.6.0 Go/go1.22.5 (linux; amd64)"],"Vapi-Ctx-Opid":["7d471a21-66f4-43bc-bf0c-6d288a5b1cd8"],"X-Xsrf-Token":["18bc6fb2-d42e-41e0-bb27-abcfac6d4f02"]}}
2024-08-27 01:57:19.454	DEBUG	nsx/transport.go:58	RoundTrip request	{"request": "https://10.221.156.85/policy/api/v1/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e/ip-address-allocations/ipa-ncp-test6", "method": "DELETE", "transTime": 0.167810623}
2024-08-27 01:57:19.454	LEVEL(-2)	util/utils.go:141	http response	{"status code": 200, "body": ""}
2024-08-27 01:57:19.455	DEBUG	util/utils.go:144	body length is 0
2024-08-27 01:57:19.455	DEBUG	ipaddressallocation/store.go:56	delete ipAddressAllocation from store	{"ipAddressAllocation": {"Links":null,"Schema":null,"Self":null,"Revision":0,"CreateTime":1724723318818,"CreateUser":"admin","LastModifiedTime":1724723318818,"LastModifiedUser":"admin","Protection":"NOT_PROTECTED","SystemOwned":false,"Description":null,"DisplayName":"ipa-ncp-test6","Id":"ipa-ncp-test6","ResourceType":"VpcIpAddressAllocation","Tags":[{"Scope":"nsx-op/cluster","Tag":"d215b1fa-5432-498f-9214-d7da8bd4731f"}],"OriginSiteId":null,"OwnerId":"61149896-4c50-4441-a9d5-2f686e1cecff","ParentPath":"/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e","Path":"/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e/ip-address-allocations/ipa-ncp-test6","RealizationId":"5ceee224-572f-4285-b12d-287cb5f2fcc6","RelativePath":"ipa-ncp-test6","RemotePath":"","UniqueId":"5ceee224-572f-4285-b12d-287cb5f2fcc6","Children":null,"MarkedForDelete":true,"Overridden":false,"AllocationIp":null,"AllocationIps":"172.160.0.64/27","AllocationSize":32,"IpAddressBlockVisibility":"EXTERNAL","IpAddressType":"IPV4","IpBlock":null}}
2024-08-27 01:57:19.455	DEBUG	ipaddressallocation/ipaddressallocation.go:179	successfully deleted nsxIPAddressAllocation	{"nsxIPAddressAllocation": {"Links":null,"Schema":null,"Self":null,"Revision":0,"CreateTime":1724723318818,"CreateUser":"admin","LastModifiedTime":1724723318818,"LastModifiedUser":"admin","Protection":"NOT_PROTECTED","SystemOwned":false,"Description":null,"DisplayName":"ipa-ncp-test6","Id":"ipa-ncp-test6","ResourceType":"VpcIpAddressAllocation","Tags":[{"Scope":"nsx-op/cluster","Tag":"d215b1fa-5432-498f-9214-d7da8bd4731f"}],"OriginSiteId":null,"OwnerId":"61149896-4c50-4441-a9d5-2f686e1cecff","ParentPath":"/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e","Path":"/orgs/default/projects/nsx_operator_e2e_test/vpcs/customized-ns-7d29c7d8-c862-459a-a641-3f95cf9df28e/ip-address-allocations/ipa-ncp-test6","RealizationId":"5ceee224-572f-4285-b12d-287cb5f2fcc6","RelativePath":"ipa-ncp-test6","RemotePath":"","UniqueId":"5ceee224-572f-4285-b12d-287cb5f2fcc6","Children":null,"MarkedForDelete":true,"Overridden":false,"AllocationIp":null,"AllocationIps":"172.160.0.64/27","AllocationSize":32,"IpAddressBlockVisibility":"EXTERNAL","IpAddressType":"IPV4","IpBlock":null}}
```

search results

```
➜ curl -sku 'admin:Admin!23Admin'  "https://10.221.156.85/policy/api/v1/search/query?query=resource_type:VpcIpAddressAllocation%20AND%20tags.scope:ncp%5C%2Fcluster%20AND%20marked_for_delete:false&page_size=1000"
{
  "results" : [ ],
  "result_count" : 0
}%                                                                                                                                                                                                                                                                                                                        ^[[A
➜ curl -sku 'admin:Admin!23Admin'  "https://10.221.156.85/policy/api/v1/search/query?query=resource_type:VpcIpAddressAllocation%20AND%20tags.scope:nsx-op%5C%2Fcluster%20AND%20marked_for_delete:false&page_size=1000"
{
  "results" : [ ],
  "result_count" : 0
}%  
```

Succeed to delete all.