### PR TITLE
Remove NSXResourcePath in subnet CR

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
@@ -140,8 +140,6 @@ spec:
                 items:
                   type: string
                 type: array
-              nsxResourcePath:
-                type: string
             type: object
         type: object
     served: true

--- a/pkg/apis/vpc/v1alpha1/subnet_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnet_types.go
@@ -37,7 +37,6 @@ type SubnetSpec struct {
 
 // SubnetStatus defines the observed state of Subnet.
 type SubnetStatus struct {
-	NSXResourcePath     string      `json:"nsxResourcePath,omitempty"`
 	NetworkAddresses    []string    `json:"networkAddresses,omitempty"`
 	GatewayAddresses    []string    `json:"gatewayAddresses,omitempty"`
 	DHCPServerAddresses []string    `json:"DHCPServerAddresses,omitempty"`

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -170,7 +170,6 @@ func (r *SubnetReconciler) updateSubnetStatus(obj *v1alpha1.Subnet) error {
 			obj.Status.DHCPServerAddresses = append(obj.Status.DHCPServerAddresses, *status.DhcpServerAddress)
 		}
 	}
-	obj.Status.NSXResourcePath = *nsxSubnet.Path
 	return nil
 }
 


### PR DESCRIPTION
Testing done:

1. Apply the new subnet CRD without NSXResourcePath.
2. Create a new subnet CR and a subnetport CR under the subnet.
3. Confirm that the new NSX subnet port can be created.