### PR TITLE
Fix the attachment id generation issue

### DIFF
--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -39,7 +39,7 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 	nsxSubnetPortName := service.BuildSubnetPortName(objMeta)
 	nsxSubnetPortID := service.BuildSubnetPortId(objMeta)
 	// use the subnetPort CR UID as the attachment uid generation to ensure the latter stable
-	nsxCIFID, err := uuid.NewRandomFromReader(bytes.NewReader([]byte(nsxSubnetPortID)))
+	nsxCIFID, err := uuid.NewRandomFromReader(bytes.NewReader([]byte(string(objMeta.UID))))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -52,7 +52,7 @@ func TestBuildSubnetPort(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name: "01",
+			name: "build-NSX-port-for-subnetport",
 			obj: &v1alpha1.SubnetPort{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1alpha1",
@@ -102,14 +102,14 @@ func TestBuildSubnetPort(t *testing.T) {
 				Attachment: &model.PortAttachment{
 					AllocateAddresses: common.String("DHCP"),
 					Type_:             common.String("STATIC"),
-					Id:                common.String("66616b65-5f73-4562-ae65-74706f72742d"),
+					Id:                common.String("32636365-6333-4239-ad37-3534362d3466"),
 					TrafficTag:        common.Int64(0),
 				},
 			},
 			expectedError: nil,
 		},
 		{
-			name: "02",
+			name: "build-NSX-port-for-pod",
 			obj: &corev1.Pod{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
@@ -159,7 +159,7 @@ func TestBuildSubnetPort(t *testing.T) {
 				Attachment: &model.PortAttachment{
 					AllocateAddresses: common.String("DHCP"),
 					Type_:             common.String("STATIC"),
-					Id:                common.String("66616b65-5f70-4f64-ad63-356462313830"),
+					Id:                common.String("63356462-3138-4030-ad63-6534632d3131"),
 					TrafficTag:        common.Int64(0),
 					AppId:             common.String("c5db1800-ce4c-11de-a935-8105ba7ace78"),
 					ContextId:         common.String("fake_context_id"),

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -92,6 +92,10 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 	existingSubnetPort := service.SubnetPortStore.GetByKey(*nsxSubnetPort.Id)
 	isChanged := true
 	if existingSubnetPort != nil {
+		// The existing port's attachment ID should not be changed in any case.
+		if existingSubnetPort.Attachment != nil {
+			nsxSubnetPort.Attachment.Id = existingSubnetPort.Attachment.Id
+		}
 		isChanged = servicecommon.CompareResource(SubnetPortToComparable(existingSubnetPort), SubnetPortToComparable(nsxSubnetPort))
 	}
 	if !isChanged {


### PR DESCRIPTION
If we use the NSX subnet port ID to generate the attachment id,
there may be the same id generated because the UUID generation logic
only read the first 16 bytes of the port ID. Then the NSX will report
the error "Port attachment ID xxx used by another segment port ...".

This patch will use the subnetport/pod UID as the input parameter.

Testing done: patch the fix in the problematic testbed and confirmed
that the issue can be fixed.