### PR TITLE
Move vpcPath to NetworkConfigurations CR

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_networkinfos.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_networkinfos.yaml
@@ -61,7 +61,6 @@ spec:
               required:
               - defaultSNATIP
               - name
-              - vpcPath
               type: object
             type: array
         required:

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
@@ -129,8 +129,12 @@ spec:
                       description: NSXLoadBalancerPath is the NSX Policy path for
                         the NSX Load Balancer.
                       type: string
+                    vpcPath:
+                      description: NSX Policy path for VPC.
+                      type: string
                   required:
                   - name
+                  - vpcPath
                   type: object
                 type: array
             type: object

--- a/pkg/apis/vpc/v1alpha1/networkinfo_types.go
+++ b/pkg/apis/vpc/v1alpha1/networkinfo_types.go
@@ -33,14 +33,14 @@ type NetworkInfoList struct {
 type VPCState struct {
 	// VPC name.
 	Name string `json:"name"`
-	// NSX Policy path for VPC.
-	VPCPath string `json:"vpcPath"`
 	// Default SNAT IP for Private Subnets.
 	DefaultSNATIP string `json:"defaultSNATIP"`
 	// LoadBalancerIPAddresses (AVI SE Subnet CIDR or NSX LB SNAT IPs).
 	LoadBalancerIPAddresses string `json:"loadBalancerIPAddresses,omitempty"`
 	// Private CIDRs used for the VPC.
 	PrivateIPs []string `json:"privateIPs,omitempty"`
+	// NSX Policy path for VPC.
+	VPCPath string `json:"vpcPath,omitempty"`
 }
 
 func init() {

--- a/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
@@ -51,6 +51,8 @@ type VPCInfo struct {
 	AVISESubnetPath string `json:"lbSubnetPath,omitempty"`
 	// NSXLoadBalancerPath is the NSX Policy path for the NSX Load Balancer.
 	NSXLoadBalancerPath string `json:"nsxLoadBalancerPath,omitempty"`
+	// NSX Policy path for VPC.
+	VPCPath string `json:"vpcPath"`
 }
 
 // +genclient

--- a/pkg/controllers/namespace/namespace_controller.go
+++ b/pkg/controllers/namespace/namespace_controller.go
@@ -49,7 +49,7 @@ func (r *NamespaceReconciler) getDefaultNetworkConfigName() (string, error) {
 	return nc.Name, nil
 }
 
-func (r *NamespaceReconciler) createNetworkInfoCR(ctx context.Context, obj client.Object, ns string, ncName string) (*v1alpha1.NetworkInfo, error) {
+func (r *NamespaceReconciler) createNetworkInfoCR(ctx context.Context, obj client.Object, ns string) (*v1alpha1.NetworkInfo, error) {
 	networkInfos := &v1alpha1.NetworkInfoList{}
 	r.Client.List(ctx, networkInfos, client.InNamespace(ns))
 	if len(networkInfos.Items) > 0 {
@@ -234,7 +234,7 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return common.ResultRequeueAfter10sec, nil
 		}
 
-		if _, err := r.createNetworkInfoCR(ctx, obj, ns, ncName); err != nil {
+		if _, err := r.createNetworkInfoCR(ctx, obj, ns); err != nil {
 			return common.ResultRequeueAfter10sec, nil
 		}
 		if err := r.createDefaultSubnetSet(ns); err != nil {

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -167,7 +167,6 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				log.Error(err, "failed to read default SNAT ip from VPC", "VPC", createdVpc.Id)
 				state := &v1alpha1.VPCState{
 					Name:                    *createdVpc.DisplayName,
-					VPCPath:                 *createdVpc.Path,
 					DefaultSNATIP:           "",
 					LoadBalancerIPAddresses: "",
 					PrivateIPs:              privateIPs,
@@ -202,7 +201,6 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				log.Error(err, "failed to read lb subnet path and cidr", "VPC", createdVpc.Id)
 				state := &v1alpha1.VPCState{
 					Name:                    *createdVpc.DisplayName,
-					VPCPath:                 *createdVpc.Path,
 					DefaultSNATIP:           snatIP,
 					LoadBalancerIPAddresses: "",
 					PrivateIPs:              privateIPs,
@@ -214,13 +212,13 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 		state := &v1alpha1.VPCState{
 			Name:                    *createdVpc.DisplayName,
-			VPCPath:                 *createdVpc.Path,
 			DefaultSNATIP:           snatIP,
 			LoadBalancerIPAddresses: cidr,
 			PrivateIPs:              privateIPs,
+			VPCPath:                 *createdVpc.Path,
 		}
 		// AKO needs to know the AVI subnet path created by NSX
-		setVPCNetworkConfigurationStatusWithLBS(ctx, r.Client, ncName, state.Name, path, r.Service.GetNSXLBSPath(*createdVpc.Id))
+		setVPCNetworkConfigurationStatusWithLBS(ctx, r.Client, ncName, state.Name, path, r.Service.GetNSXLBSPath(*createdVpc.Id), *createdVpc.Path)
 		updateSuccess(r, ctx, obj, r.Client, state, nc.Name, path)
 	} else {
 		if controllerutil.ContainsFinalizer(obj, commonservice.NetworkInfoFinalizerName) {


### PR DESCRIPTION
1. Move vpcPath parameter from NetworkInfo CR to NetworkConfiguration CR.
2. Refactor NetworkInfo e2e test to align with new solution.