### PR TITLE
Update Namespace default SubnetSize at runtime

### DIFF
--- a/pkg/controllers/namespace/namespace_controller.go
+++ b/pkg/controllers/namespace/namespace_controller.go
@@ -84,7 +84,7 @@ func (r *NamespaceReconciler) createNetworkInfoCR(ctx context.Context, obj clien
 	return networkInfoCR, nil
 }
 
-func (r *NamespaceReconciler) createDefaultSubnetSet(ns string) error {
+func (r *NamespaceReconciler) createDefaultSubnetSet(ns string, defaultSubnetSize int) error {
 	defaultSubnetSets := map[string]string{
 		types.DefaultVMSubnetSet:  types.LabelDefaultVMSubnetSet,
 		types.DefaultPodSubnetSet: types.LabelDefaultPodSubnetSet,
@@ -125,6 +125,7 @@ func (r *NamespaceReconciler) createDefaultSubnetSet(ns string) error {
 			} else if name == types.DefaultPodSubnetSet {
 				obj.Spec.AccessMode = v1alpha1.AccessMode(v1alpha1.AccessModeProject)
 			}
+			obj.Spec.IPv4SubnetSize = defaultSubnetSize
 			if err := r.Client.Create(context.Background(), obj); err != nil {
 				return err
 			}
@@ -237,7 +238,7 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if _, err := r.createNetworkInfoCR(ctx, obj, ns); err != nil {
 			return common.ResultRequeueAfter10sec, nil
 		}
-		if err := r.createDefaultSubnetSet(ns); err != nil {
+		if err := r.createDefaultSubnetSet(ns, nc.DefaultSubnetSize); err != nil {
 			return common.ResultRequeueAfter10sec, nil
 		}
 		return common.ResultNormal, nil

--- a/pkg/controllers/networkinfo/vpcnetworkconfig_handler_test.go
+++ b/pkg/controllers/networkinfo/vpcnetworkconfig_handler_test.go
@@ -139,8 +139,6 @@ func TestBuildNetworkConfigInfo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			nc, e := buildNetworkConfigInfo(tt.nc)
 			assert.Nil(t, e)
-			// assert.Equal(t, tt.gw, nc.DefaultGatewayPath)
-			// assert.Equal(t, tt.edge, nc.EdgeClusterPath)
 			assert.Equal(t, tt.org, nc.Org)
 			assert.Equal(t, tt.project, nc.NSXProject)
 			assert.Equal(t, tt.subnetSize, nc.DefaultSubnetSize)

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -76,8 +76,9 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 				updateFail(r, ctx, obj, "")
 				return ResultRequeue, err
 			}
-
-			obj.Spec.IPv4SubnetSize = vpcNetworkConfig.DefaultSubnetSize
+			if obj.Spec.IPv4SubnetSize == 0 {
+				obj.Spec.IPv4SubnetSize = vpcNetworkConfig.DefaultSubnetSize
+			}
 			if err := r.Client.Update(ctx, obj); err != nil {
 				log.Error(err, "add finalizer", "subnet", req.NamespacedName)
 				updateFail(r, ctx, obj, "")

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -69,14 +69,14 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 				obj.Spec.AccessMode = v1alpha1.AccessMode(v1alpha1.AccessModePrivate)
 			}
 
-			vpcNetworkConfig := r.VPCService.GetVPCNetworkConfigByNamespace(obj.Namespace)
-			if vpcNetworkConfig == nil {
-				err := fmt.Errorf("operate failed: cannot get configuration for Subnet CR")
-				log.Error(nil, "failed to find VPCNetworkConfig for Subnet CR", "subnet", req.NamespacedName, "namespace %s", obj.Namespace)
-				updateFail(r, ctx, obj, "")
-				return ResultRequeue, err
-			}
 			if obj.Spec.IPv4SubnetSize == 0 {
+				vpcNetworkConfig := r.VPCService.GetVPCNetworkConfigByNamespace(obj.Namespace)
+				if vpcNetworkConfig == nil {
+					err := fmt.Errorf("operate failed: cannot get configuration for Subnet CR")
+					log.Error(nil, "failed to find VPCNetworkConfig for Subnet CR", "subnet", req.NamespacedName, "namespace %s", obj.Namespace)
+					updateFail(r, ctx, obj, "")
+					return ResultRequeue, err
+				}
 				obj.Spec.IPv4SubnetSize = vpcNetworkConfig.DefaultSubnetSize
 			}
 			if err := r.Client.Update(ctx, obj); err != nil {

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -64,7 +64,6 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if !controllerutil.ContainsFinalizer(obj, servicecommon.SubnetFinalizerName) {
 			controllerutil.AddFinalizer(obj, servicecommon.SubnetFinalizerName)
 
-			// will delete AccessMode
 			if obj.Spec.AccessMode == "" {
 				log.Info("obj.Spec.AccessMode set", "subnet", req.NamespacedName)
 				obj.Spec.AccessMode = v1alpha1.AccessMode(v1alpha1.AccessModePrivate)

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -61,18 +61,18 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerUpdateTotal, MetricResTypeSubnetSet)
 		if !controllerutil.ContainsFinalizer(obj, servicecommon.SubnetSetFinalizerName) {
 			controllerutil.AddFinalizer(obj, servicecommon.SubnetSetFinalizerName)
-			vpcNetworkConfig := r.VPCService.GetVPCNetworkConfigByNamespace(obj.Namespace)
-			if vpcNetworkConfig == nil {
-				err := fmt.Errorf("failed to find VPCNetworkConfig for namespace %s", obj.Namespace)
-				log.Error(err, "operate failed, would retry exponentially", "subnet", req.NamespacedName)
-				updateFail(r, ctx, obj, "")
-				return ResultRequeue, err
-			}
 
 			if obj.Spec.AccessMode == "" {
 				obj.Spec.AccessMode = v1alpha1.AccessMode(v1alpha1.AccessModePrivate)
 			}
 			if obj.Spec.IPv4SubnetSize == 0 {
+				vpcNetworkConfig := r.VPCService.GetVPCNetworkConfigByNamespace(obj.Namespace)
+				if vpcNetworkConfig == nil {
+					err := fmt.Errorf("failed to find VPCNetworkConfig for namespace %s", obj.Namespace)
+					log.Error(err, "operate failed, would retry exponentially", "subnet", req.NamespacedName)
+					updateFail(r, ctx, obj, "")
+					return ResultRequeue, err
+				}
 				obj.Spec.IPv4SubnetSize = vpcNetworkConfig.DefaultSubnetSize
 			}
 			if err := r.Client.Update(ctx, obj); err != nil {

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -72,8 +72,9 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if obj.Spec.AccessMode == "" {
 				obj.Spec.AccessMode = v1alpha1.AccessMode(v1alpha1.AccessModePrivate)
 			}
-			obj.Spec.IPv4SubnetSize = vpcNetworkConfig.DefaultSubnetSize
-
+			if obj.Spec.IPv4SubnetSize == 0 {
+				obj.Spec.IPv4SubnetSize = vpcNetworkConfig.DefaultSubnetSize
+			}
 			if err := r.Client.Update(ctx, obj); err != nil {
 				log.Error(err, "add finalizer", "subnetset", req.NamespacedName)
 				updateFail(r, ctx, obj, "")


### PR DESCRIPTION
Update Namespace default SubnetSize at runtime

1. There is a `VPCNetworkConfiguration` in the Cluster with `defaultSubnetSize: 32`, now we change the defaultSubnetSize from 32 to 16:

```
kubectl get VPCNetworkConfiguration wenqi2  -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: VPCNetworkConfiguration
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"VPCNetworkConfiguration","metadata":{"annotations":{},"name":"wenqi2"},"spec":{"defaultSubnetSize":32,"nsxProject":"/orgs/default/projects/nsx_operator_e2e_test","privateIPs":["172.191.0.0/16"],"vpcConnectivityProfile":"/orgs/default/projects/nsx_operator_e2e_test/vpc-connectivity-profiles/default"}}
  creationTimestamp: "2024-08-21T06:43:51Z"
  generation: 5
  name: wenqi2
  resourceVersion: "8588470"
  uid: 46a04316-5d48-4961-9bd1-5d77d0973c2d
spec:
  defaultSubnetSize: 16
  nsxProject: /orgs/default/projects/nsx_operator_e2e_test
  privateIPs:
  - 172.191.0.0/16
  vpcConnectivityProfile: /orgs/default/projects/nsx_operator_e2e_test/vpc-connectivity-profiles/default
status:
  vpcs:
  - lbSubnetPath: /orgs/default/projects/nsx_operator_e2e_test/vpcs/wenqi2-6e46aef6-f247-4742-aabd-1203f4dc493b/subnets/_AVI_SUBNET--LB
    name: wenqi2-6e46aef6-f247-4742-aabd-1203f4dc493b
```

2. Create a namespace `wenqi-test-0826-7` with annotation: `nsx.vmware.com/vpc_network_config: wenqi2`
```
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    ako.vmware.com/tenant-name: nsx_operator_e2e_test
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"nsx.vmware.com/vpc_network_config":"wenqi2"},"name":"wenqi-test-0826-7"}}
    nsx.vmware.com/vpc_network_config: wenqi2
  creationTimestamp: "2024-08-26T08:00:01Z"
  labels:
    kubernetes.io/metadata.name: wenqi-test-0826-7
  name: wenqi-test-0826-7
  resourceVersion: "8584753"
  uid: bd17637e-954e-46c4-806f-b50c455e2893
spec:
  finalizers:
  - kubernetes
status:
  phase: Active
```

3. The new `subnetset` in the namespace `wenqi-test-0826-7` with the `IPV4SUBNETSIZE` equal to the `defaultSubnetSize` in `VPCNetworkConfiguration`.
```
kubectl get subnetset -n wenqi-test-0826-7
NAME          ACCESSMODE   IPV4SUBNETSIZE   IPADDRESSES
pod-default   PrivateTGW   16               
vm-default    Private      16   
```

4. Update the `defaultSubnetSize` in `VPCNetworkConfiguration`

![image](https://github.com/user-attachments/assets/cf82650f-d628-42a4-941b-800003b7ea3c)

5. Create a new `Subnetset` in Namespace 
![image](https://github.com/user-attachments/assets/34b5d998-c62f-41be-af59-ff62d65103ef)

6. Check the `ipv4SubnetSize` value in new `Subnetset`
![image](https://github.com/user-attachments/assets/a9201c7d-5eb9-4eb9-b85a-8b4007327056)
