### PR TITLE
Add omitempty for Conditions in VPCNetworkConfigurationStatus

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
@@ -148,8 +148,6 @@ spec:
                   - name
                   type: object
                 type: array
-            required:
-            - conditions
             type: object
         type: object
     served: true

--- a/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
@@ -51,7 +51,7 @@ type VPCNetworkConfigurationStatus struct {
 	// VPCs describes VPC info, now it includes lb Subnet info which are needed for AKO.
 	VPCs []VPCInfo `json:"vpcs,omitempty"`
 	// Conditions describe current state of VPCNetworkConfiguration.
-	Conditions []Condition `json:"conditions"`
+	Conditions []Condition `json:"conditions,omitempty"`
 }
 
 // VPCInfo defines VPC info needed by tenant admin.


### PR DESCRIPTION
Otherwise, the NSX operator cannot update the status for non-system VPC because in that kind of VPC, its vpcnetworkconfiguration doesn't have the conditions and the NSX operator will report the following error:

"VPCNetworkConfiguration.crd.nsx.vmware.com \"xxx\" is invalid: conditions: Required value"

(cherry picked from commit e78eb0b5e3a6d6f346d3158dc0906f9c9d4b93b3)