### PR TITLE
Fix delete ipaddressallocation bug

### DIFF
--- a/pkg/nsx/services/ipaddressallocation/compare.go
+++ b/pkg/nsx/services/ipaddressallocation/compare.go
@@ -13,12 +13,15 @@ type (
 
 type Comparable = common.Comparable
 
-func (iap *IpAddressAllocation) Key() string {
-	return *iap.Id
+func (ipa *IpAddressAllocation) Key() string {
+	return *ipa.Id
 }
 
-func (iap *IpAddressAllocation) Value() data.DataValue {
-	s := &IpAddressAllocation{Id: iap.Id, DisplayName: iap.DisplayName, Tags: iap.Tags, AllocationSize: iap.AllocationSize, IpAddressBlockVisibility: iap.IpAddressBlockVisibility}
+func (ipa *IpAddressAllocation) Value() data.DataValue {
+	if ipa == nil {
+		return nil
+	}
+	s := &IpAddressAllocation{Id: ipa.Id, DisplayName: ipa.DisplayName, Tags: ipa.Tags, AllocationSize: ipa.AllocationSize, IpAddressBlockVisibility: ipa.IpAddressBlockVisibility}
 	dataValue, _ := ComparableToIpAddressAllocation(s).GetDataValue__()
 	return dataValue
 }

--- a/pkg/nsx/services/ipaddressallocation/store.go
+++ b/pkg/nsx/services/ipaddressallocation/store.go
@@ -84,7 +84,7 @@ func (ipAddressAllocationStore *IPAddressAllocationStore) GetByIndex(uid types.U
 		nsxIPAddressAllocation = t
 	} else {
 		log.Info("did not get ipaddressallocation with index", "UID", string(uid))
-		return nsxIPAddressAllocation, nil
+		return nil, nil
 	}
 	return nsxIPAddressAllocation, nil
 }


### PR DESCRIPTION
Fix this issue that if failed to create ipaddressallocation, to delete the stale also failed, for the reason that can't find the resource. Besides, also update patching error including getting error info to status.