### PR TITLE
Fix the PrinterColumns for subnet/subnetset CR

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
@@ -24,8 +24,8 @@ spec:
       name: IPv4SubnetSize
       type: string
     - description: CIDRs for the Subnet
-      jsonPath: .status.ipAddresses[*]
-      name: IPAddresses
+      jsonPath: .status.networkAddresses[*]
+      name: NetworkAddresses
       type: string
     name: v1alpha1
     schema:

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
@@ -23,9 +23,9 @@ spec:
       jsonPath: .spec.ipv4SubnetSize
       name: IPv4SubnetSize
       type: string
-    - description: CIDRs for the Subnet
-      jsonPath: .status.subnets[*].ipAddresses[*]
-      name: IPAddresses
+    - description: CIDRs for the SubnetSet
+      jsonPath: .status.subnets[*].networkAddresses[*]
+      name: NetworkAddresses
       type: string
     name: v1alpha1
     schema:

--- a/pkg/apis/vpc/v1alpha1/subnet_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnet_types.go
@@ -51,7 +51,7 @@ type SubnetStatus struct {
 // Subnet is the Schema for the subnets API.
 // +kubebuilder:printcolumn:name="AccessMode",type=string,JSONPath=`.spec.accessMode`,description="Access mode of Subnet"
 // +kubebuilder:printcolumn:name="IPv4SubnetSize",type=string,JSONPath=`.spec.ipv4SubnetSize`,description="Size of Subnet"
-// +kubebuilder:printcolumn:name="IPAddresses",type=string,JSONPath=`.status.ipAddresses[*]`,description="CIDRs for the Subnet"
+// +kubebuilder:printcolumn:name="NetworkAddresses",type=string,JSONPath=`.status.networkAddresses[*]`,description="CIDRs for the Subnet"
 type Subnet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/vpc/v1alpha1/subnetset_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetset_types.go
@@ -44,7 +44,7 @@ type SubnetSetStatus struct {
 // SubnetSet is the Schema for the subnetsets API.
 // +kubebuilder:printcolumn:name="AccessMode",type=string,JSONPath=`.spec.accessMode`,description="Access mode of Subnet"
 // +kubebuilder:printcolumn:name="IPv4SubnetSize",type=string,JSONPath=`.spec.ipv4SubnetSize`,description="Size of Subnet"
-// +kubebuilder:printcolumn:name="IPAddresses",type=string,JSONPath=`.status.subnets[*].ipAddresses[*]`,description="CIDRs for the Subnet"
+// +kubebuilder:printcolumn:name="NetworkAddresses",type=string,JSONPath=`.status.subnets[*].networkAddresses[*]`,description="CIDRs for the SubnetSet"
 type SubnetSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
```
Testing done:

Apply the new CRD in the testbed, and check the NETWORKADDRESSES column can
show the networks:

NAME          ACCESSMODE   IPV4SUBNETSIZE   NETWORKADDRESSES
test-subnet   Private      16               172.26.0.0/28
```