### PR TITLE
Fix NSX rule deleted not saved in store

### DIFF
--- a/pkg/nsx/services/securitypolicy/expand.go
+++ b/pkg/nsx/services/securitypolicy/expand.go
@@ -33,6 +33,7 @@ func (service *SecurityPolicyService) expandRule(obj *v1alpha1.SecurityPolicy, r
 			return nil, nil, err
 		}
 		nsxRules = append(nsxRules, nsxRule)
+		return nsxGroups, nsxRules, nil
 	}
 
 	// Check if there is a namedport in the rule

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -860,7 +860,7 @@ func TestDleleteVPCSecurityPolicy(t *testing.T) {
 			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
 
 			assert.NoError(t, fakeService.securityPolicyStore.Apply(tt.inputPolicy))
-			assert.NoError(t, fakeService.ruleStore.Apply(tt.inputPolicy))
+			assert.NoError(t, fakeService.ruleStore.Apply(&tt.inputPolicy.Rules))
 
 			patches := tt.prepareFunc(t, fakeService)
 			defer patches.Reset()

--- a/pkg/nsx/services/securitypolicy/store.go
+++ b/pkg/nsx/services/securitypolicy/store.go
@@ -146,8 +146,8 @@ func (securityPolicyStore *SecurityPolicyStore) GetByIndex(key string, value str
 }
 
 func (ruleStore *RuleStore) Apply(i interface{}) error {
-	sp := i.(*model.SecurityPolicy)
-	for _, rule := range sp.Rules {
+	rules := i.(*[]model.Rule)
+	for _, rule := range *rules {
 		tempRule := rule
 		if rule.MarkedForDelete != nil && *rule.MarkedForDelete {
 			err := ruleStore.Delete(&tempRule)
@@ -217,7 +217,7 @@ func (shareStore *ShareStore) Apply(i interface{}) error {
 			}
 		} else {
 			err := shareStore.Add(&tempShare)
-			log.V(1).Info("add share to store", "group", tempShare)
+			log.V(1).Info("add share to store", "share", tempShare)
 			if err != nil {
 				return err
 			}

--- a/pkg/nsx/services/securitypolicy/store_test.go
+++ b/pkg/nsx/services/securitypolicy/store_test.go
@@ -328,7 +328,7 @@ func TestRuleStore_Apply(t *testing.T) {
 		args    args
 		wantErr assert.ErrorAssertionFunc
 	}{
-		{"1", args{i: &sp}, assert.NoError},
+		{"1", args{i: &sp.Rules}, assert.NoError},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This patch is to the fix the issue that NSX rules are not deleted from the store even the rules have been deleted from NSX.

Test done:
1. Create SecurityPolicy with yaml below:
```
apiVersion: nsx.vmware.com/v1alpha1
kind: SecurityPolicy
metadata:
  name: sp-allow-ingress-on-d2-vm-from-ns-d1-ns-d3
spec:
  appliedTo:
    - vmSelector:
        matchLabels:
          dept: d2
  rules:
    - direction: in
      action: allow
      sources:
        - namespaceSelector:
            matchLabels:
              dept: d1
    - direction: out
      action: drop
      sources:
        - namespaceSelector:
            matchLabels:
              dept: d3
```
2. Update the yaml to add one more rule:
```
apiVersion: nsx.vmware.com/v1alpha1
kind: SecurityPolicy
metadata:
  name: sp-allow-ingress-on-d2-vm-from-ns-d1-ns-d3
spec:
  appliedTo:
    - vmSelector:
        matchLabels:
          dept: d2
  rules:
    - direction: in
      action: allow
      sources:
        - namespaceSelector:
            matchLabels:
              dept: d1
    - direction: in
      action: drop
      sources:
        - podSelector:
            matchLabels:
              dptpod: ncp-test-d2
          namespaceSelector:
            matchLabels:
              dept: d2
    - direction: out
      action: drop
      sources:
        - namespaceSelector:
            matchLabels:
              dept: d3
```
3. Remove second rule and verify.
4. Delete first rule and verify.
5. Add the first rule allow rule again to verify store and NSX side, both are consistent. 