### PR TITLE
Using reflect to get pointer

### DIFF
--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -26,7 +26,6 @@ import (
 	apierrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
-	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
@@ -553,46 +552,16 @@ func FindTag(tags []model.Tag, tagScope string) string {
 }
 
 func CasttoPointer(obj interface{}) interface{} {
-	switch v := obj.(type) {
-	case mpmodel.PrincipalIdentity:
-		return &v
-	case model.Rule:
-		return &v
-	case model.StaticRoutes:
-		return &v
-	case model.HostTransportNode:
-		return &v
-	case model.ClusterControlPlane:
-		return &v
-	case model.IpAddressPool:
-		return &v
-	case model.GenericPolicyRealizedResource:
-		return &v
-	case model.Vpc:
-		return &v
-	case model.LBService:
-		return &v
-	case model.IpAddressPoolBlockSubnet:
-		return &v
-	case model.Group:
-		return &v
-	case model.SecurityPolicy:
-		return &v
-	case model.Share:
-		return &v
-	case model.SegmentPort:
-		return &v
-	case model.VpcSubnet:
-		return &v
-	case model.VpcSubnetPort:
-		return &v
-	case model.IpAddressBlock:
-		return &v
-	default:
-		objType := reflect.TypeOf(obj)
-		log.Info("Unsupported type", "objType", objType)
+	if obj == nil {
 		return nil
 	}
+	if reflect.TypeOf(obj).Kind() == reflect.Ptr {
+		return obj
+	}
+
+	pointer := reflect.New(reflect.TypeOf(obj))
+	pointer.Elem().Set(reflect.ValueOf(obj))
+	return pointer.Interface()
 }
 
 func UpdateURL(reqUrl *url.URL, nsxtHost string) {

--- a/pkg/nsx/util/utils_test.go
+++ b/pkg/nsx/util/utils_test.go
@@ -515,26 +515,50 @@ Hce3uM6Xn8sAglod/r+0onZ09yoiH2Qj5EY50wUIOPtey2ilhuhwoo/M7Nt/yomF
 }
 
 func TestCasttoPointer(t *testing.T) {
+	var share *model.Share
+	Id := "test-id"
+	principalI := mpmodel.PrincipalIdentity{Id: &Id}
+	rule := model.Rule{Id: &Id}
+	tag := model.Tag{Scope: &Id}
+	lbs := model.LBService{Id: &Id}
+	share = nil
 	tests := []struct {
 		name string
 		obj  interface{}
 		want interface{}
 	}{
+
 		{
 			name: "PrincipalIdentity",
-			obj:  mpmodel.PrincipalIdentity{},
-			want: &mpmodel.PrincipalIdentity{},
+			obj:  principalI,
+			want: &principalI,
 		},
 		{
 			name: "Rule",
-			obj:  model.Rule{},
-			want: &model.Rule{},
+			obj:  rule,
+			want: &rule,
 		},
 		// Add more test cases for other types
 		{
-			name: "UnsupportedType",
-			obj:  model.Tag{},
+			name: "Tag",
+			obj:  tag,
+			want: &tag,
+		},
+		{
+			name: "LBService pointer",
+			obj:  &lbs,
+			want: &lbs,
+		},
+		{
+			name: "nil",
+			obj:  nil,
 			want: nil,
+		},
+
+		{
+			name: "typed nil",
+			obj:  share,
+			want: share,
 		},
 	}
 


### PR DESCRIPTION
It's easy to forget to add type support in CasttoPointer. 
Change CasttoPointer to use reflect. 
The performance will be worse but no need to add each new type for it