### PR TITLE
Set VPCNetworkConfiguration status when no ExternalIPBlocks exist in VPCConnectivityProfile

### DIFF
--- a/pkg/apis/vpc/v1alpha1/condition_types.go
+++ b/pkg/apis/vpc/v1alpha1/condition_types.go
@@ -8,9 +8,10 @@ import (
 type ConditionType string
 
 const (
-	Ready                  ConditionType = "Ready"
-	GatewayConnectionReady ConditionType = "GatewayConnectionReady"
-	AutoSnatEnabled        ConditionType = "AutoSnatEnabled"
+	Ready                      ConditionType = "Ready"
+	GatewayConnectionReady     ConditionType = "GatewayConnectionReady"
+	AutoSnatEnabled            ConditionType = "AutoSnatEnabled"
+	ExternalIPBlocksConfigured ConditionType = "ExternalIPBlocksConfigured"
 )
 
 // Condition defines condition of custom resource.

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -144,7 +144,6 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			if len(vpcConnectivityProfile.ExternalIpBlocks) == 0 {
 				setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx, r.Client, vpcNetworkConfiguration, false)
 				log.Error(err, "there is no ExternalIPBlock in VPC ConnectivityProfile", "VPC", req.NamespacedName)
-				return common.ResultRequeue, fmt.Errorf("no ExternalIPBlock in VPC ConnectivityProfile, VPC: %s", req.NamespacedName)
 			} else {
 				setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx, r.Client, vpcNetworkConfiguration, true)
 			}

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -139,11 +139,14 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			log.Error(err, "failed to get NSX VPC ConnectivityProfile object", "vpcConnectivityProfileName", vpcConnectivityProfileName)
 			return common.ResultRequeue, err
 		}
-		if len(vpcConnectivityProfile.ExternalIpBlocks) == 0 {
-			if ncName == commonservice.SystemVPCNetworkConfigurationName {
-				setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx, r.Client, vpcNetworkConfiguration)
+
+		if ncName == commonservice.SystemVPCNetworkConfigurationName {
+			if len(vpcConnectivityProfile.ExternalIpBlocks) == 0 {
+				setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx, r.Client, vpcNetworkConfiguration, false)
 				log.Error(err, "there is no ExternalIPBlock in VPC ConnectivityProfile", "VPC", req.NamespacedName)
 				return common.ResultRequeue, fmt.Errorf("no ExternalIPBlock in VPC ConnectivityProfile, VPC: %s", req.NamespacedName)
+			} else {
+				setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx, r.Client, vpcNetworkConfiguration, true)
 			}
 		}
 		isEnableAutoSNAT := func() bool {

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -143,7 +143,7 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			if ncName == commonservice.SystemVPCNetworkConfigurationName {
 				setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx, r.Client, vpcNetworkConfiguration)
 				log.Error(err, "there is no ExternalIPBlock in VPC ConnectivityProfile", "VPC", req.NamespacedName)
-				return common.ResultRequeue, err
+				return common.ResultRequeue, fmt.Errorf("no ExternalIPBlock in VPC ConnectivityProfile, VPC: %s", req.NamespacedName)
 			}
 		}
 		isEnableAutoSNAT := func() bool {

--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -543,7 +543,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					Times: 1,
 				}})
 				patches.ApplyFunc(setVPCNetworkConfigurationStatusWithNoExternalIPBlock,
-					func(_ context.Context, _ client.Client, _ *v1alpha1.VPCNetworkConfiguration) {
+					func(_ context.Context, _ client.Client, _ *v1alpha1.VPCNetworkConfiguration, _ bool) {
 						t.Log("setVPCNetworkConfigurationStatusWithNoExternalIPBlock")
 					})
 				return patches

--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -142,7 +142,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					return false, nil
 				})
 				patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
-					Values: gomonkey.Params{model.VpcConnectivityProfile{}, nil},
+					Values: gomonkey.Params{model.VpcConnectivityProfile{ExternalIpBlocks: []string{"fake-ip-block"}}, nil},
 					Times:  1,
 				}})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetNSXLBSPath", func(_ *vpc.VPCService, _ string) string {
@@ -203,7 +203,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					return false, nil
 				})
 				patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
-					Values: gomonkey.Params{model.VpcConnectivityProfile{}, nil},
+					Values: gomonkey.Params{model.VpcConnectivityProfile{ExternalIpBlocks: []string{"fake-ip-block"}}, nil},
 					Times:  1,
 				}})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetNSXLBSPath", func(_ *vpc.VPCService, _ string) string {
@@ -308,6 +308,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				})
 				patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{model.VpcConnectivityProfile{
+						ExternalIpBlocks: []string{"fake-ip-block"},
 						ServiceGateway: &model.VpcServiceGatewayConfig{
 							Enable: servicecommon.Bool(true),
 							NatConfig: &model.VpcNatConfig{
@@ -386,7 +387,8 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				})
 				patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{model.VpcConnectivityProfile{
-						ServiceGateway: nil,
+						ExternalIpBlocks: []string{"fake-ip-block"},
+						ServiceGateway:   nil,
 					}, nil},
 					Times: 1,
 				}})
@@ -459,6 +461,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				})
 				patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{model.VpcConnectivityProfile{
+						ExternalIpBlocks: []string{"fake-ip-block"},
 						ServiceGateway: &model.VpcServiceGatewayConfig{
 							Enable: servicecommon.Bool(true),
 							NatConfig: &model.VpcNatConfig{
@@ -490,6 +493,64 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 			args:    requestArgs,
 			want:    common.ResultNormal,
 			wantErr: false,
+		},
+		{
+			name: "VPCNetworkConfigurationStatusWithNoExternalIPBlockInSystemVPC",
+			prepareFunc: func(t *testing.T, r *NetworkInfoReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &v1alpha1.NetworkInfo{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: requestArgs.req.Namespace,
+						Name:      requestArgs.req.Name,
+					},
+				}))
+				assert.NoError(t, r.Client.Create(ctx, &v1alpha1.VPCNetworkConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "system",
+					},
+				}))
+				patches = gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetNetworkconfigNameFromNS", func(_ *vpc.VPCService, _ string) (string, error) {
+					return servicecommon.SystemVPCNetworkConfigurationName, nil
+
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetVPCNetworkConfig", func(_ *vpc.VPCService, _ string) (servicecommon.VPCNetworkConfigInfo, bool) {
+					return servicecommon.VPCNetworkConfigInfo{
+						VPCConnectivityProfile: "/orgs/default/projects/nsx_operator_e2e_test/vpc-connectivity-profiles/default",
+						Org:                    "default",
+						NSXProject:             "project-quality",
+					}, true
+
+				})
+				patches.ApplyFunc(getGatewayConnectionStatus, func(_ context.Context, _ *v1alpha1.VPCNetworkConfiguration) (bool, string, error) {
+					return false, "", nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "ValidateGatewayConnectionStatus", func(_ *vpc.VPCService, _ *servicecommon.VPCNetworkConfigInfo) (bool, string, error) {
+					return true, "", nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, _ *v1alpha1.NetworkInfo, _ *servicecommon.VPCNetworkConfigInfo) (*model.Vpc, error) {
+					return &model.Vpc{
+						DisplayName: servicecommon.String("vpc-name"),
+						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
+						Id:          servicecommon.String("vpc-id"),
+					}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "IsSharedVPCNamespaceByNS", func(_ *vpc.VPCService, _ string) (bool, error) {
+					return false, nil
+				})
+				patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.VpcConnectivityProfile{
+						ServiceGateway: nil,
+					}, nil},
+					Times: 1,
+				}})
+				patches.ApplyFunc(setVPCNetworkConfigurationStatusWithNoExternalIPBlock,
+					func(_ context.Context, _ client.Client, _ *v1alpha1.VPCNetworkConfiguration) {
+						t.Log("setVPCNetworkConfigurationStatusWithNoExternalIPBlock")
+					})
+				return patches
+			},
+			args:    requestArgs,
+			want:    common.ResultRequeue,
+			wantErr: true,
 		},
 	}
 

--- a/pkg/controllers/networkinfo/networkinfo_utils.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils.go
@@ -138,6 +138,7 @@ func setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx context.Context, 
 	if !hasExternalIPs {
 		newCondition.Status = v1.ConditionFalse
 		newCondition.Reason = svccommon.ReasonNoExternalIPBlocksInVPCConnectivityProfile
+		newCondition.Message = "No External IP Blocks exist in VPC Connectivity Profile"
 	} else {
 		newCondition.Status = v1.ConditionTrue
 	}

--- a/pkg/controllers/networkinfo/networkinfo_utils.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils.go
@@ -130,12 +130,17 @@ func setVPCNetworkConfigurationStatusWithSnatEnabled(ctx context.Context, client
 	}
 }
 
-func setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx context.Context, client client.Client, nc *v1alpha1.VPCNetworkConfiguration) {
+func setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx context.Context, client client.Client, nc *v1alpha1.VPCNetworkConfiguration, hasExternalIPs bool) {
 	newCondition := v1alpha1.Condition{
 		Type:               v1alpha1.ExternalIPBlocksConfigured,
-		Status:             v1.ConditionFalse,
 		LastTransitionTime: metav1.Time{},
-		Reason:             "No External IP Blocks exist in VPC Connectivity Profile",
+	}
+	if !hasExternalIPs {
+		newCondition.Status = v1.ConditionFalse
+		newCondition.Reason = "No External IP Blocks exist in VPC Connectivity Profile"
+	} else {
+		newCondition.Status = v1.ConditionTrue
+		newCondition.Reason = "External IP Blocks exist in VPC Connectivity Profile"
 	}
 	if mergeStatusCondition(ctx, &nc.Status.Conditions, &newCondition) {
 		if err := client.Status().Update(ctx, nc); err != nil {

--- a/pkg/controllers/networkinfo/networkinfo_utils.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils.go
@@ -140,7 +140,6 @@ func setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx context.Context, 
 		newCondition.Reason = "No External IP Blocks exist in VPC Connectivity Profile"
 	} else {
 		newCondition.Status = v1.ConditionTrue
-		newCondition.Reason = "External IP Blocks exist in VPC Connectivity Profile"
 	}
 	if mergeStatusCondition(ctx, &nc.Status.Conditions, &newCondition) {
 		if err := client.Status().Update(ctx, nc); err != nil {

--- a/pkg/controllers/networkinfo/networkinfo_utils.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils.go
@@ -137,7 +137,7 @@ func setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx context.Context, 
 	}
 	if !hasExternalIPs {
 		newCondition.Status = v1.ConditionFalse
-		newCondition.Reason = "No External IP Blocks exist in VPC Connectivity Profile"
+		newCondition.Reason = svccommon.ReasonNoExternalIPBlocksInVPCConnectivityProfile
 	} else {
 		newCondition.Status = v1.ConditionTrue
 	}

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -175,9 +175,10 @@ var (
 	ResourceTypeNode                = "HostTransportNode"
 
 	// Reasons for verification of gateway connection in day0
-	ReasonEdgeMissingInProject                     = "EdgeMissingInProject"
-	ReasonDistributedGatewayConnectionNotSupported = "DistributedGatewayConnectionNotSupported"
-	ReasonGatewayConnectionNotSet                  = "GatewayConnectionNotSet"
+	ReasonEdgeMissingInProject                       = "EdgeMissingInProject"
+	ReasonDistributedGatewayConnectionNotSupported   = "DistributedGatewayConnectionNotSupported"
+	ReasonGatewayConnectionNotSet                    = "GatewayConnectionNotSet"
+	ReasonNoExternalIPBlocksInVPCConnectivityProfile = "No External IP Blocks exist in VPC Connectivity Profile"
 )
 
 type Service struct {

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -178,7 +178,7 @@ var (
 	ReasonEdgeMissingInProject                       = "EdgeMissingInProject"
 	ReasonDistributedGatewayConnectionNotSupported   = "DistributedGatewayConnectionNotSupported"
 	ReasonGatewayConnectionNotSet                    = "GatewayConnectionNotSet"
-	ReasonNoExternalIPBlocksInVPCConnectivityProfile = "No External IP Blocks exist in VPC Connectivity Profile"
+	ReasonNoExternalIPBlocksInVPCConnectivityProfile = "ExternalIPBlockMissingInProfile"
 )
 
 type Service struct {


### PR DESCRIPTION
 Set VPCNetworkConfiguration status when no ExternalIPBlocks exist in VPCConnectivityProfile

1. Delete the `ExternalIPBlocks` in VPCConnectivityProfile
```
kubectl get VPCNetworkConfiguration system -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: VPCNetworkConfiguration
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"VPCNetworkConfiguration","metadata":{"annotations":{},"name":"system"},"spec":{"defaultSubnetSize":16,"nsxProject":"/orgs/default/projects/project-quality","privateIPs":["172.26.0.0/16"],"vpcConnectivityProfile":"/orgs/default/projects/project-quality/vpc-connectivity-profiles/default"}}
  creationTimestamp: "2024-08-28T06:16:03Z"
  generation: 1
  name: system
  resourceVersion: "11416467"
  uid: 7929b5b5-ee73-4904-841b-3b7affbe0eab
spec:
  defaultSubnetSize: 16
  nsxProject: /orgs/default/projects/project-quality
  privateIPs:
  - 172.26.0.0/16
  vpcConnectivityProfile: /orgs/default/projects/project-quality/vpc-connectivity-profiles/default
status:
  conditions:
  - lastTransitionTime: "2024-08-28T06:21:08Z"
    status: "True"
    type: GatewayConnectionReady
  - lastTransitionTime: "2024-08-28T06:21:09Z"
    reason: No External IP Blocks exist in VPC Connectivity Profile
    status: "False"
    type: ExternalIPBlocksConfigured
```
2. Add the `ExternalIPBlocks` in VPCConnectivityProfile
```
root@421d33084dd2d89f370e4df46c4385e2 [ ~ ]# kubectl get VPCNetworkConfiguration  system -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: VPCNetworkConfiguration
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"VPCNetworkConfiguration","metadata":{"annotations":{},"name":"system"},"spec":{"defaultSubnetSize":16,"nsxProject":"/orgs/default/projects/project-quality","privateIPs":["172.26.0.0/16"],"vpcConnectivityProfile":"/orgs/default/projects/project-quality/vpc-connectivity-profiles/default"}}
  creationTimestamp: "2024-08-28T06:16:03Z"
  generation: 1
  name: system
  resourceVersion: "12537557"
  uid: 7929b5b5-ee73-4904-841b-3b7affbe0eab
spec:
  defaultSubnetSize: 16
  nsxProject: /orgs/default/projects/project-quality
  privateIPs:
  - 172.26.0.0/16
  vpcConnectivityProfile: /orgs/default/projects/project-quality/vpc-connectivity-profiles/default
status:
  conditions:
  - lastTransitionTime: "2024-08-28T06:21:08Z"
    status: "True"
    type: GatewayConnectionReady
  - lastTransitionTime: "2024-08-29T01:32:48Z"
    reason: External IP Blocks exist in VPC Connectivity Profile
    status: "True"
    type: ExternalIPBlocksConfigured
  - lastTransitionTime: "2024-08-28T07:37:22Z"
    status: "True"
    type: AutoSnatEnabled
  vpcs:
  - lbSubnetPath: /orgs/default/projects/project-quality/vpcs/kube-system-12ae34d5-34ff-46f9-a3cc-e49b1b683bab/subnets/_AVI_SUBNET--LB
    name: kube-system-12ae34d5-34ff-46f9-a3cc-e49b1b683bab
```