### PR TITLE
Add GOSUMDB=off when do go-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin GOSUMDB=off go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
Add GOSUMDB=off to prevent go-build from checking the database. While buliding binary file with GOSUMDB, we will have the error below: go: sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0: sigs.k8s.io/controller-tools@v0.14.0: verifying module: sigs.k8s.io/controller-tools@v0.14.0: Get "https://sum.golang.org/lookup/sigs.k8s.io/controller-tools@v0.14.0": dial tcp 142.250.191.81:443: connect: connection refused