### PR TITLE
Add day2 lb provider checking

### DIFF
--- a/pkg/nsx/services/vpc/builder_test.go
+++ b/pkg/nsx/services/vpc/builder_test.go
@@ -92,11 +92,12 @@ func TestBuildNSXVPC(t *testing.T) {
 	clusterStr := "cluster1"
 
 	for _, tc := range []struct {
-		name         string
-		existingVPC  *model.Vpc
-		ncPrivateIps []string
-		useAVILB     bool
-		expVPC       *model.Vpc
+		name              string
+		existingVPC       *model.Vpc
+		ncPrivateIps      []string
+		useAVILB          bool
+		expVPC            *model.Vpc
+		lbProviderChanged bool
 	}{
 		{
 			name:         "existing VPC not change",
@@ -104,7 +105,8 @@ func TestBuildNSXVPC(t *testing.T) {
 			existingVPC: &model.Vpc{
 				PrivateIps: []string{"192.168.1.0/24"},
 			},
-			useAVILB: true,
+			useAVILB:          true,
+			lbProviderChanged: false,
 		},
 		{
 			name: "existing VPC changes private IPv4 blocks",
@@ -116,11 +118,13 @@ func TestBuildNSXVPC(t *testing.T) {
 			expVPC: &model.Vpc{
 				PrivateIps: []string{"192.168.3.0/24"},
 			},
+			lbProviderChanged: false,
 		},
 		{
-			name:         "create new VPC with AVI load balancer enabled",
-			ncPrivateIps: []string{"192.168.3.0/24"},
-			useAVILB:     true,
+			name:              "create new VPC with AVI load balancer enabled",
+			ncPrivateIps:      []string{"192.168.3.0/24"},
+			useAVILB:          true,
+			lbProviderChanged: false,
 			expVPC: &model.Vpc{
 				Id:                      common.String("ns1-netinfouid1"),
 				DisplayName:             common.String("ns1-netinfouid1"),
@@ -137,9 +141,10 @@ func TestBuildNSXVPC(t *testing.T) {
 			},
 		},
 		{
-			name:         "create new VPC with AVI load balancer disabled",
-			ncPrivateIps: []string{"192.168.3.0/24"},
-			useAVILB:     false,
+			name:              "create new VPC with AVI load balancer disabled",
+			ncPrivateIps:      []string{"192.168.3.0/24"},
+			useAVILB:          false,
+			lbProviderChanged: false,
 			expVPC: &model.Vpc{
 				Id:            common.String("ns1-netinfouid1"),
 				DisplayName:   common.String("ns1-netinfouid1"),
@@ -154,10 +159,47 @@ func TestBuildNSXVPC(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:         "update VPC with AVI load balancer disabled -> enabled",
+			ncPrivateIps: []string{"192.168.3.0/24"},
+			existingVPC: &model.Vpc{
+				Id:            common.String("ns1-netinfouid1"),
+				DisplayName:   common.String("ns1-netinfouid1"),
+				PrivateIps:    []string{"192.168.3.0/24"},
+				IpAddressType: common.String("IPV4"),
+			},
+			useAVILB:          true,
+			lbProviderChanged: true,
+			expVPC: &model.Vpc{
+				Id:                      common.String("ns1-netinfouid1"),
+				DisplayName:             common.String("ns1-netinfouid1"),
+				LoadBalancerVpcEndpoint: &model.LoadBalancerVPCEndpoint{Enabled: common.Bool(true)},
+				PrivateIps:              []string{"192.168.3.0/24"},
+				IpAddressType:           common.String("IPV4"),
+			},
+		},
+		{
+			name:         "update VPC with NSX load balancer disabled -> enabled",
+			ncPrivateIps: []string{"192.168.3.0/24"},
+			existingVPC: &model.Vpc{
+				Id:            common.String("ns1-netinfouid1"),
+				DisplayName:   common.String("ns1-netinfouid1"),
+				PrivateIps:    []string{"192.168.3.0/24"},
+				IpAddressType: common.String("IPV4"),
+			},
+			useAVILB:          false,
+			lbProviderChanged: true,
+			expVPC: &model.Vpc{
+				Id:            common.String("ns1-netinfouid1"),
+				DisplayName:   common.String("ns1-netinfouid1"),
+				PrivateIps:    []string{"192.168.3.0/24"},
+				IpAddressType: common.String("IPV4"),
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			nc.PrivateIPs = tc.ncPrivateIps
-			got, err := buildNSXVPC(netInfoObj, nsObj, nc, clusterStr, tc.existingVPC, tc.useAVILB)
+			got, err := buildNSXVPC(netInfoObj, nsObj, nc, clusterStr, tc.existingVPC, tc.useAVILB, tc.lbProviderChanged)
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expVPC, got)
 		})

--- a/pkg/nsx/services/vpc/clean_avi.go
+++ b/pkg/nsx/services/vpc/clean_avi.go
@@ -38,7 +38,16 @@ func CleanAviSubnetPorts(ctx context.Context, cluster *nsx.Cluster, vpcPath stri
 	log.Info("Deleting Avi subnetports started")
 
 	allPaths, err := httpGetAviPortsPaths(cluster, vpcPath)
+	/*
+	 in the e2e test, this GET operation return 400 instead of 404.
+	 "error": "StatusCode is 400,ErrorCode is 500012,Detail is The path=[/orgs/default/projects/nsx_operator_e2e_test/vpcs/kube-system-c996c9c6-50df-429c-8202-2287c0822791/subnets/_AVI_SUBNET--LB] is invalid
+	 so add checking HttpBadRequest.
+	*/
 	if err != nil {
+		if errors.Is(err, nsxutil.HttpNotFoundError) || errors.Is(err, nsxutil.HttpBadRequest) {
+			log.Info("No Avi subnetports found")
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -35,6 +35,7 @@ var log = &logger.Log
 
 var HttpCommonError = errors.New("received HTTP Error")
 var HttpNotFoundError = errors.New("received HTTP Not Found Error")
+var HttpBadRequest = errors.New("received HTTP Bad Request Error")
 
 // ErrorDetail is error detail which info extracted from http.Response.Body.
 type ErrorDetail struct {
@@ -252,6 +253,9 @@ func HandleHTTPResponse(response *http.Response, result interface{}, debug bool)
 		err := HttpCommonError
 		if response.StatusCode == http.StatusNotFound {
 			err = HttpNotFoundError
+		}
+		if response.StatusCode == http.StatusBadRequest {
+			err = HttpBadRequest
 		}
 		log.Error(err, "handle http response", "status", response.StatusCode, "request URL", response.Request.URL, "response body", string(body))
 		return err, nil


### PR DESCRIPTION
    Add day2 lb provider checking
    
    For day0, if there is no lb provider, only VPC will be created.
    For day2, lb provider should be ready.
    For day2, nsx-operator will check lb provider to create
    lbs for nsx-lb  or set endpoint for avi-lb
    
    While get avi port in cleanup, return nil if not found
    
   Test Done:
    Case 1:
    1. set use_avi_lb = true in ncp.ini
       alb_endpoint is absent
       *vpcConnectivityProfile.ServiceGateway.Enable is true
    2. run the manager, check if lb provider is nsx-lb
    Case 2:
    1. set use_avi_lb = false
       *vpcConnectivityProfile.ServiceGateway.Enable is false
       check if lb provider is none-lb
       create a ns, check if only vpc created
    2. update the *vpcConnectivityProfile.ServiceGateway.Enable to true
        check if lbs has been created in system ns
    Case 3:
    1. set use_avi_lb = true in ncp.ini
       alb_endpoint is created
       check if lb provider type is avi-lb