### PR TITLE
Requeue the networkinfo event when the GatewayConnectionStatus is not ready

### DIFF
--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -92,17 +92,17 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return common.ResultRequeueAfter10sec, err
 		}
 
-		reason := ""
+		gatewayConnectionReason := ""
 		if !gatewayConnectionReady {
 			if ncName == commonservice.SystemVPCNetworkConfigurationName {
-				gatewayConnectionReady, reason, err = r.Service.ValidateGatewayConnectionStatus(&nc)
-				log.Info("got the gateway connection status", "gatewayConnectionReady", gatewayConnectionReady, "reason", reason)
+				gatewayConnectionReady, gatewayConnectionReason, err = r.Service.ValidateGatewayConnectionStatus(&nc)
+				log.Info("got the gateway connection status", "gatewayConnectionReady", gatewayConnectionReady, "gatewayConnectionReason", gatewayConnectionReason)
 				if err != nil {
 					log.Error(err, "failed to validate the edge and gateway connection", "org", nc.Org, "project", nc.NSXProject)
 					updateFail(r, ctx, obj, &err, r.Client, nil)
 					return common.ResultRequeueAfter10sec, err
 				}
-				setVPCNetworkConfigurationStatusWithGatewayConnection(ctx, r.Client, vpcNetworkConfiguration, gatewayConnectionReady, reason)
+				setVPCNetworkConfigurationStatusWithGatewayConnection(ctx, r.Client, vpcNetworkConfiguration, gatewayConnectionReady, gatewayConnectionReason)
 			} else {
 				log.Info("skipping reconciling the network info because the system gateway connection is not ready", "NetworkInfo", req.NamespacedName)
 				return common.ResultRequeueAfter60sec, nil
@@ -146,14 +146,13 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			updateFail(r, ctx, obj, &err, r.Client, nil)
 			return common.ResultRequeueAfter10sec, err
 		}
-
+		hasExternalIPs := true
 		if ncName == commonservice.SystemVPCNetworkConfigurationName {
 			if len(vpcConnectivityProfile.ExternalIpBlocks) == 0 {
-				setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx, r.Client, vpcNetworkConfiguration, false)
+				hasExternalIPs = false
 				log.Error(err, "there is no ExternalIPBlock in VPC ConnectivityProfile", "VPC", req.NamespacedName)
-			} else {
-				setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx, r.Client, vpcNetworkConfiguration, true)
 			}
+			setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx, r.Client, vpcNetworkConfiguration, hasExternalIPs)
 		}
 		// currently, auto snat is not exposed, and use default value True
 		// checking autosnat to support future extension in vpc configuration
@@ -180,13 +179,8 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				updateFail(r, ctx, obj, &err, r.Client, nil)
 				return common.ResultRequeueAfter10sec, err
 			}
-			if autoSnatEnabled {
-				log.Info("detected that the AutoSnat is enabled", "req", req.NamespacedName)
-				setVPCNetworkConfigurationStatusWithSnatEnabled(ctx, r.Client, vpcNetworkConfiguration, true)
-			} else {
-				log.Info("detected that the AutoSnat is disabled", "req", req.NamespacedName)
-				setVPCNetworkConfigurationStatusWithSnatEnabled(ctx, r.Client, vpcNetworkConfiguration, false)
-			}
+			log.Info("got the AutoSnat status", "autoSnatEnabled", autoSnatEnabled, "req", req.NamespacedName)
+			setVPCNetworkConfigurationStatusWithSnatEnabled(ctx, r.Client, vpcNetworkConfiguration, autoSnatEnabled)
 		}
 
 		// if lb vpc enabled, read avi subnet path and cidr
@@ -221,6 +215,10 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// AKO needs to know the AVI subnet path created by NSX
 		setVPCNetworkConfigurationStatusWithLBS(ctx, r.Client, ncName, state.Name, path, nsxLBSPath, *createdVpc.Path)
 		updateSuccess(r, ctx, obj, r.Client, state, nc.Name, path)
+		if ncName == commonservice.SystemVPCNetworkConfigurationName && (!gatewayConnectionReady || !autoSnatEnabled || !hasExternalIPs) {
+			log.Info("requeuing the NetworkInfo CR because VPCNetworkConfiguration system is not ready", "gatewayConnectionReason", gatewayConnectionReason, "autoSnatEnabled", autoSnatEnabled, "hasExternalIPs", hasExternalIPs, "req", req)
+			return common.ResultRequeueAfter60sec, nil
+		}
 	} else {
 		if controllerutil.ContainsFinalizer(obj, commonservice.NetworkInfoFinalizerName) {
 			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, common.MetricResTypeNetworkInfo)

--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -160,7 +160,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 
 			},
 			args:    requestArgs,
-			want:    common.ResultNormal,
+			want:    common.ResultRequeueAfter60sec,
 			wantErr: false,
 		},
 		{
@@ -224,7 +224,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 
 			},
 			args:    requestArgs,
-			want:    common.ResultNormal,
+			want:    common.ResultRequeueAfter60sec,
 			wantErr: false,
 		},
 		{
@@ -480,7 +480,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 
 			},
 			args:    requestArgs,
-			want:    common.ResultNormal,
+			want:    common.ResultRequeueAfter60sec,
 			wantErr: false,
 		},
 		{
@@ -639,7 +639,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				return patches
 			},
 			args:    requestArgs,
-			want:    common.ResultNormal,
+			want:    common.ResultRequeueAfter60sec,
 			wantErr: false,
 		}, {
 			name: "Pre-create VPC success case",


### PR DESCRIPTION
Testing done:
1. Remove the project's edge and start the NSX operator, check the vpcnetworkconfiguration system:
```
  - lastTransitionTime: "2024-09-06T09:57:43Z"
    reason: EdgeMissingInProject
    status: "False"
    type: GatewayConnectionReady
```
2. Re-add the project edge, found the NSX operator log printed
```
    2024-09-06 09:57:49.847 INFO    networkinfo/networkinfo_controller.go:225       requeuing the networkinfo because GatewayConnectionStatus is not ready  {"req": {"name":"kube-system","namespace":"kube-system"}, "gatewayConnectionReason": "EdgeMissingInProject"}
```
   and check the vpcnetworkconfiguration system after about 1 minutes:
```
  - lastTransitionTime: "2024-09-06T09:58:50Z"
    status: "True"
    type: GatewayConnectionReady
```