### PR TITLE
Fix delete static route using ID

### DIFF
--- a/pkg/nsx/services/staticroute/staticroute.go
+++ b/pkg/nsx/services/staticroute/staticroute.go
@@ -145,7 +145,7 @@ func (service *StaticRouteService) DeleteStaticRoute(obj *v1alpha1.StaticRoute) 
 	if err != nil {
 		return err
 	}
-	return service.DeleteStaticRouteByPath(vpcResourceInfo.OrgID, vpcResourceInfo.ProjectID, vpcResourceInfo.ID, id)
+	return service.DeleteStaticRouteByPath(vpcResourceInfo.OrgID, vpcResourceInfo.ProjectID, vpcResourceInfo.VPCID, id)
 }
 
 func (service *StaticRouteService) ListStaticRoute() []*model.StaticRoutes {


### PR DESCRIPTION
While deleting static route, operator used the Id as VPCID. 
Fix that issue

Test Done:
1. replace nsx-operator binary in the live env 
2. check if the orphan static route has been deleted.