### PR TITLE
Support Subnet/Subnetset IPv4SubnetSize and Subnet IPAddresses immutable

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
@@ -77,11 +77,17 @@ spec:
                 maxItems: 2
                 minItems: 0
                 type: array
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               ipv4SubnetSize:
                 description: Size of Subnet based upon estimated workload count.
                 maximum: 65536
                 minimum: 16
                 type: integer
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
             type: object
           status:
             description: SubnetStatus defines the observed state of Subnet.

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
@@ -75,6 +75,9 @@ spec:
                 maximum: 65536
                 minimum: 16
                 type: integer
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
             type: object
           status:
             description: SubnetSetStatus defines the observed state of SubnetSet.

--- a/pkg/apis/vpc/v1alpha1/subnet_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnet_types.go
@@ -20,6 +20,7 @@ type SubnetSpec struct {
 	// Size of Subnet based upon estimated workload count.
 	// +kubebuilder:validation:Maximum:=65536
 	// +kubebuilder:validation:Minimum:=16
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// Access mode of Subnet, accessible only from within VPC or from outside VPC.
 	// +kubebuilder:validation:Enum=Private;Public;PrivateTGW
@@ -28,6 +29,7 @@ type SubnetSpec struct {
 	// Subnet CIDRS.
 	// +kubebuilder:validation:MinItems=0
 	// +kubebuilder:validation:MaxItems=2
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	IPAddresses []string `json:"ipAddresses,omitempty"`
 	// DHCPConfig DHCP configuration.
 	DHCPConfig DHCPConfig `json:"DHCPConfig,omitempty"`

--- a/pkg/apis/vpc/v1alpha1/subnetset_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetset_types.go
@@ -12,6 +12,7 @@ type SubnetSetSpec struct {
 	// Size of Subnet based upon estimated workload count.
 	// +kubebuilder:validation:Maximum:=65536
 	// +kubebuilder:validation:Minimum:=16
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// Access mode of Subnet, accessible only from within VPC or from outside VPC.
 	// +kubebuilder:validation:Enum=Private;Public;PrivateTGW

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -522,3 +522,8 @@ func GetRandomIndexString() string {
 	uuidStr := uuid.NewString()
 	return Sha1(uuidStr)[:HashLength]
 }
+
+// IsPowerOfTwo checks if a given number is a power of 2
+func IsPowerOfTwo(n int) bool {
+	return n > 0 && (n&(n-1)) == 0
+}


### PR DESCRIPTION
For NSX subnet, once it is created, it's not allowed to change IPv4SubnetSize and IPAddresses.
So, this patch is to
1. Change Subnet CR definition to make Subnet IPv4SubnetSize and IPAddresses are immutable once the CR is created.
2. Change Subnetset CR definition to make Subnetset IPv4SubnetSize is immutable once the CR is created.

Aslo, this patch is to
1. Add check for IPv4SubnetSize for Subnetset CR to see if is power of 2.

Test done:
subnet Test yaml:
cat vpctest-subnet-dhcp.yaml
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: test-subnet
  namespace: test
spec:
  DHCPConfig:
    enableDHCP: true
  ipv4SubnetSize: 33
  accessMode: Private
  #ipAddresses:
  #- 172.58.40.0/24
```
1. Create subnet CR with invalid size
kubectl apply -f vpctest-subnet-dhcp.yaml
output:
status:
  conditions:
  - lastTransitionTime: "2024-09-06T10:28:58Z"
    message: NSX Subnet could not be created/updated
    reason: SubnetNotReady

and change ipv4SubnetSize: 32 as valid size, which is not allowed to change ipv4SubnetSize field. User needs to delete the failed CR and recreate it. 
```
kubectl apply -f ./vpctest-subnet-dhcp.yaml
The Subnet "test-subnet" is invalid: spec.ipv4SubnetSize: Invalid value: "integer": Value is immutable    
```

2. Create subnet CR with valid size:32
```
 kubectl get subnet test-subnet -n test
NAME          ACCESSMODE   IPV4SUBNETSIZE   NETWORKADDRESSES
test-subnet   Private      32               172.48.0.0/27
```
and change ipv4SubnetSize to 64, 
```
kubectl apply -f ./vpctest-subnet-dhcp.yaml
The Subnet "test-subnet" is invalid: spec.ipv4SubnetSize: Invalid value: "integer": Value is immutable
```

3. Create subnet CR without ipv4SubnetSize, it will use the default ipv4SubnetSize:32 from vpcNetworkconfiguratinon CR.
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: test-subnet
  namespace: test
spec:
  DHCPConfig:
    enableDHCP: true
  #ipv4SubnetSize: 64
  accessMode: Private
  #ipAddresses:
  #- 172.58.40.0/24
```
kubectl get subnet test-subnet -n test
```
NAME          ACCESSMODE   IPV4SUBNETSIZE   NETWORKADDRESSES
test-subnet   Private      32               172.48.0.0/27
```

and change ipv4SubnetSize: 64 and apply it.
```
  kubectl apply -f .//vpctest-subnet-dhcp.yaml
The Subnet "test-subnet" is invalid: spec.ipv4SubnetSize: Invalid value: "integer": Value is immutable
```

4. Create subnet CR with ipAddresses:172.58.40.0/24
kubectl get subnet test-subnet -n test
```
NAME          ACCESSMODE   IPV4SUBNETSIZE   NETWORKADDRESSES
test-subnet   Private      32               172.58.40.0/24
```
and change ipAddresses: 172.58.42.0/24
kubectl apply -f ./vpctest-subnet-dhcp.yaml
The Subnet "test-subnet" is invalid: spec.ipAddresses: Invalid value: "array": Value is immutable


5. Do the same test for ipv4SubnetSize for subnetset,
cat vpctest-subnetset-dhcp.yaml
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetSet
metadata:
  name: user-pod-subnetset-dhcp
  namespace: test
spec:
  DHCPConfig:
    enableDHCP: true
  ipv4SubnetSize: 33
  accessMode: Private
```
Check CR status:
```
status:
  conditions:
  - lastTransitionTime: "2024-09-06T09:02:32Z"
    message: ipv4SubnetSize has invalied size 33,  which needs to be >= 16 and power
      of 2
    reason: SubnetSetNotReady
```

when changing ipv4SubnetSize:64, 
 ```
kubectl apply -f vpctest-subnetset-dhcp.yaml
The SubnetSet "user-pod-subnetset-dhcp" is invalid: spec.ipv4SubnetSize: Invalid value: "integer": Value is immutable

```