### PR TITLE
Fix the nil pointer dereference panic issue

### DIFF
--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1048,7 +1048,7 @@ func (vpcService *VPCService) EdgeClusterEnabled(nc *common.VPCNetworkConfigInfo
 		if getErr != nil {
 			return getErr
 		}
-		log.Info("VPC connectivity profile retrieved", "serviceGateway", *vpcConnectivityProfile.ServiceGateway)
+		log.Info("VPC connectivity profile retrieved", "profile", *vpcConnectivityProfile)
 		return nil
 	}); err != nil {
 		log.Error(err, "Failed to retrieve VPC connectivity profile", "profile", nc.VPCConnectivityProfile)
@@ -1096,6 +1096,7 @@ func (vpcService *VPCService) GetLBProvider() LBProvider {
 	log.Info("lb provider", "provider", globalLbProvider)
 	return globalLbProvider
 }
+
 func (vpcService *VPCService) getLBProvider(edgeEnable bool) LBProvider {
 	// if no Alb endpoint found, return nsx-lb
 	// if found, and nsx lbs found, return nsx-lb

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1048,7 +1048,7 @@ func (vpcService *VPCService) EdgeClusterEnabled(nc *common.VPCNetworkConfigInfo
 		if getErr != nil {
 			return getErr
 		}
-		log.Info("VPC connectivity profile retrieved", "profile", *vpcConnectivityProfile)
+		log.V(1).Info("VPC connectivity profile retrieved", "profile", *vpcConnectivityProfile)
 		return nil
 	}); err != nil {
 		log.Error(err, "Failed to retrieve VPC connectivity profile", "profile", nc.VPCConnectivityProfile)

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1033,29 +1033,30 @@ func (s *VPCService) GetDefaultNSXLBSPathByVPC(vpcID string) string {
 }
 
 func (vpcService *VPCService) EdgeClusterEnabled(nc *common.VPCNetworkConfigInfo) bool {
-	var vpcConnectivityProfile *model.VpcConnectivityProfile
-	var getErr error
-	if err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
+	isRetryableError := func(err error) bool {
 		if err == nil {
 			return false
 		}
-		_, errortype := nsxutil.DumpAPIError(err)
-		if errortype != nil && (*errortype == apierrors.ErrorType_SERVICE_UNAVAILABLE || *errortype == apierrors.ErrorType_TIMED_OUT) {
-			return true
-		} else {
-			return false
-		}
-	}, func() error {
+		_, errorType := nsxutil.DumpAPIError(err)
+		return errorType != nil && (*errorType == apierrors.ErrorType_SERVICE_UNAVAILABLE || *errorType == apierrors.ErrorType_TIMED_OUT)
+	}
+
+	var vpcConnectivityProfile *model.VpcConnectivityProfile
+	if err := retry.OnError(retry.DefaultBackoff, isRetryableError, func() error {
+		var getErr error
 		vpcConnectivityProfile, getErr = vpcService.GetVpcConnectivityProfile(nc, nc.VPCConnectivityProfile)
-		return getErr
-	}); err == nil {
-		log.Info("vpc connectivity profile", "service gateway enable", *vpcConnectivityProfile.ServiceGateway.Enable)
-		return vpcService.IsEnableAutoSNAT(vpcConnectivityProfile)
-	} else {
-		log.Error(getErr, "failed to get vpc connectivity profile", "vpc connectivity profile", nc.VPCConnectivityProfile)
+		if getErr != nil {
+			return getErr
+		}
+		log.Info("VPC connectivity profile retrieved", "serviceGateway", *vpcConnectivityProfile.ServiceGateway)
+		return nil
+	}); err != nil {
+		log.Error(err, "Failed to retrieve VPC connectivity profile", "profile", nc.VPCConnectivityProfile)
 		return false
 	}
+	return vpcService.IsEnableAutoSNAT(vpcConnectivityProfile)
 }
+
 func GetAlbEndpoint(cluster *nsx.Cluster) error {
 	_, err := cluster.HttpGet(albEndpointPath)
 	return err
@@ -1073,6 +1074,7 @@ func (vpcService *VPCService) IsEnableAutoSNAT(vpcConnectivityProfile *model.Vpc
 	}
 	return false
 }
+
 func (vpcService *VPCService) GetLBProvider() LBProvider {
 	lbProviderMutex.Lock()
 	defer lbProviderMutex.Unlock()

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -500,6 +500,14 @@ func TestEdgeClusterEnabled(t *testing.T) {
 	enable = vpcService.EdgeClusterEnabled(&nc)
 	assert.Equal(t, false, enable)
 	patch.Reset()
+
+	// Simulate the scenario when the VpcConnectivityProfile value returned by NSX is nil.
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(vpcService), "GetVpcConnectivityProfile", func(_ *VPCService, _ *common.VPCNetworkConfigInfo, _ string) (*model.VpcConnectivityProfile, error) {
+		return &model.VpcConnectivityProfile{}, nil
+	})
+	enable = vpcService.EdgeClusterEnabled(&nc)
+	assert.Equal(t, false, enable)
+	patch.Reset()
 }
 
 func TestGetLbProvider(t *testing.T) {


### PR DESCRIPTION
1. Fix the nil pointer dereference panic issue when handling the NSX return values
```
2024-09-12 09:30:54.238 ESC[34mINFOESC[0m       ESC[33mcontroller/controller.go:110ESC[0m       Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference        {"controller": "networkinfo", "controllerGroup": "crd.nsx.vmware.com", "controllerKind": "NetworkInfo", "NetworkInfo": {"name":"vmware-system-cert-manager","namespace":"vmware-system-cert-manager"}, "namespace": "vmware-system-cert-manager", "name": "vmware-system-cert-manager", "reconcileID": "2c59a438-0863-4a16-8f18-890e96fa75f0"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1ab68c9]

goroutine 471 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /Users/wenqiq/GO/src/nsx-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:111 +0x1e5
panic({0x1db3920?, 0x36515d0?})
        /Users/wenqiq/GO/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.darwin-amd64/src/runtime/panic.go:770 +0x132
github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc.(*VPCService).EdgeClusterEnabled(0x1d9b880?, 0xc000a88ef0)
        /Users/wenqiq/GO/src/nsx-operator/pkg/nsx/services/vpc/vpc.go:1037 +0x1a9
github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc.(*VPCService).GetLBProvider(0xc000178f50)
        /Users/wenqiq/GO/src/nsx-operator/pkg/nsx/services/vpc/vpc.go:1077 +0x2ad
github.com/vmware-tanzu/nsx-operator/pkg/controllers/networkinfo.(*NetworkInfoReconciler).Reconcile(0xc0004e6080, {0x24e6600, 0xc00086b830}, {{{0xc0009c7be0, 0x1a}, {0xc0009c7bc0, 0x1a}}})
        /Users/wenqiq/GO/src/nsx-operator/pkg/controllers/networkinfo/networkinfo_controller.go:113 +0xff6
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x24eb060?, {0x24e6600?, 0xc00086b830?}, {{{0xc0009c7be0?, 0xb?}, {0xc0009c7bc0?, 0x0?}}})
        /Users/wenqiq/GO/src/nsx-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0001d1080, {0x24e6638, 0xc0003618b0}, {0x1f27380, 0xc0005d02e0})
        /Users/wenqiq/GO/src/nsx-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311 +0x3bc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0001d1080, {0x24e6638, 0xc0003618b0})
        /Users/wenqiq/GO/src/nsx-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:261 +0x1c9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /Users/wenqiq/GO/src/nsx-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:222 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 157
        /Users/wenqiq/GO/src/nsx-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:218 +0x486
```
2. Update `EdgeClusterEnabled` function and add a cover unit test case
