### PR TITLE
Add annotation to network policy for invalid license error

### DIFF
--- a/pkg/controllers/common/types.go
+++ b/pkg/controllers/common/types.go
@@ -23,6 +23,9 @@ const (
 	MetricResTypeNode                = "node"
 	MetricResTypeServiceLb           = "servicelb"
 	MaxConcurrentReconciles          = 8
+	NSXOperatorError                 = "nsx-op/error"
+	//sync the error with NCP side
+	ErrorNoDFWLicense = "NO_DFW_LICENSE"
 
 	LabelK8sMasterRole  = "node-role.kubernetes.io/master"
 	LabelK8sControlRole = "node-role.kubernetes.io/control-plane"

--- a/pkg/controllers/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controllers/networkpolicy/networkpolicy_controller.go
@@ -65,6 +65,35 @@ func deleteSuccess(r *NetworkPolicyReconciler, _ context.Context, o *networkingv
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteSuccessTotal, MetricResType)
 }
 
+func setNetworkPolicyErrorAnnotation(ctx context.Context, networkPolicy *networkingv1.NetworkPolicy, client client.Client, info string) {
+	if networkPolicy.Annotations == nil {
+		networkPolicy.Annotations = make(map[string]string)
+	}
+	if networkPolicy.Annotations[common.NSXOperatorError] == info {
+		return
+	}
+	networkPolicy.Annotations[common.NSXOperatorError] = info
+	updateErr := client.Update(ctx, networkPolicy)
+	if updateErr != nil {
+		log.Error(updateErr, "Failed to update NetworkPolicy with error annotation")
+	}
+	log.Info("update NetworkPolicy with error annotation", "error", info)
+}
+
+func cleanNetworkPolicyErrorAnnotation(ctx context.Context, networkPolicy *networkingv1.NetworkPolicy, client client.Client) {
+	if networkPolicy.Annotations == nil {
+		return
+	}
+	if _, exists := networkPolicy.Annotations[common.NSXOperatorError]; exists {
+		delete(networkPolicy.Annotations, common.NSXOperatorError)
+	}
+	updateErr := client.Update(ctx, networkPolicy)
+	if updateErr != nil {
+		log.Error(updateErr, "Failed to clean NetworkPolicy annotation")
+	}
+	log.Info("clean NetworkPolicy annotation")
+}
+
 func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	networkPolicy := &networkingv1.NetworkPolicy{}
 	log.Info("reconciling networkpolicy", "networkpolicy", req.NamespacedName)
@@ -90,14 +119,21 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err := r.Service.CreateOrUpdateSecurityPolicy(networkPolicy); err != nil {
 			if errors.As(err, &nsxutil.RestrictionError{}) {
 				log.Error(err, err.Error(), "networkpolicy", req.NamespacedName)
+				setNetworkPolicyErrorAnnotation(ctx, networkPolicy, r.Client, common.ErrorNoDFWLicense)
 				updateFail(r, ctx, networkPolicy, &err)
 				return ResultNormal, nil
+			}
+			if nsxutil.IsInvalidLicense(err) {
+				log.Error(err, err.Error(), "networkpolicy", req.NamespacedName)
+				setNetworkPolicyErrorAnnotation(ctx, networkPolicy, r.Client, common.ErrorNoDFWLicense)
+				os.Exit(1)
 			}
 			log.Error(err, "create or update failed, would retry exponentially", "networkpolicy", req.NamespacedName)
 			updateFail(r, ctx, networkPolicy, &err)
 			return ResultRequeue, err
 		}
 		updateSuccess(r, ctx, networkPolicy)
+		cleanNetworkPolicyErrorAnnotation(ctx, networkPolicy, r.Client)
 	} else {
 		if controllerutil.ContainsFinalizer(networkPolicy, servicecommon.NetworkPolicyFinalizerName) {
 			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, MetricResType)

--- a/pkg/controllers/securitypolicy/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller.go
@@ -86,6 +86,35 @@ func deleteSuccess(r *SecurityPolicyReconciler, _ context.Context, o *v1alpha1.S
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteSuccessTotal, MetricResType)
 }
 
+func setSecurityPolicyErrorAnnotation(ctx context.Context, securityPolicy *v1alpha1.SecurityPolicy, client client.Client, info string) {
+	if securityPolicy.Annotations == nil {
+		securityPolicy.Annotations = make(map[string]string)
+	}
+	if securityPolicy.Annotations[common.NSXOperatorError] == info {
+		return
+	}
+	securityPolicy.Annotations[common.NSXOperatorError] = info
+	updateErr := client.Update(ctx, securityPolicy)
+	if updateErr != nil {
+		log.Error(updateErr, "Failed to update SecurityPolicy with error annotation")
+	}
+	log.Info("update SecurityPolicy with error annotation", "error", info)
+}
+
+func cleanSecurityPolicyErrorAnnotation(ctx context.Context, securityPolicy *v1alpha1.SecurityPolicy, client client.Client) {
+	if securityPolicy.Annotations == nil {
+		return
+	}
+	if _, exists := securityPolicy.Annotations[common.NSXOperatorError]; exists {
+		delete(securityPolicy.Annotations, common.NSXOperatorError)
+	}
+	updateErr := client.Update(ctx, securityPolicy)
+	if updateErr != nil {
+		log.Error(updateErr, "Failed to clean SecurityPolicy annotation")
+	}
+	log.Info("clean SecurityPolicy annotation")
+}
+
 func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var obj client.Object
 	if securitypolicy.IsVPCEnabled(r.Service) {
@@ -153,34 +182,21 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if err := r.Service.CreateOrUpdateSecurityPolicy(realObj); err != nil {
 			if errors.As(err, &nsxutil.RestrictionError{}) {
 				log.Error(err, err.Error(), "securitypolicy", req.NamespacedName)
+				setSecurityPolicyErrorAnnotation(ctx, realObj, r.Client, common.ErrorNoDFWLicense)
 				updateFail(r, ctx, realObj, &err)
 				return ResultNormal, nil
 			}
-			// check if invalid license
-			apiErr, _ := nsxutil.DumpAPIError(err)
-			if apiErr != nil {
-				invalidLicense := false
-				errorMessage := ""
-				for _, apiErrItem := range apiErr.RelatedErrors {
-					if *apiErrItem.ErrorCode == nsxutil.InvalidLicenseErrorCode {
-						invalidLicense = true
-						errorMessage = *apiErrItem.ErrorMessage
-					}
-				}
-				if *apiErr.ErrorCode == nsxutil.InvalidLicenseErrorCode {
-					invalidLicense = true
-					errorMessage = *apiErr.ErrorMessage
-				}
-				if invalidLicense {
-					log.Error(err, "Invalid license, nsx-operator will restart", "error message", errorMessage)
-					os.Exit(1)
-				}
+			if nsxutil.IsInvalidLicense(err) {
+				log.Error(err, err.Error(), "securitypolicy", req.NamespacedName)
+				setSecurityPolicyErrorAnnotation(ctx, realObj, r.Client, common.ErrorNoDFWLicense)
+				os.Exit(1)
 			}
 			log.Error(err, "create or update failed, would retry exponentially", "securitypolicy", req.NamespacedName)
 			updateFail(r, ctx, realObj, &err)
 			return ResultRequeue, err
 		}
 		updateSuccess(r, ctx, realObj)
+		cleanSecurityPolicyErrorAnnotation(ctx, realObj, r.Client)
 	} else {
 		log.Info("reconciling CR to delete securitypolicy", "securitypolicy", req.NamespacedName)
 		if controllerutil.ContainsFinalizer(obj, finalizerName) {

--- a/pkg/nsx/services/ipaddressallocation/ipaddressallocation.go
+++ b/pkg/nsx/services/ipaddressallocation/ipaddressallocation.go
@@ -110,7 +110,7 @@ func (service *IPAddressAllocationService) Apply(nsxIPAddressAllocation *model.V
 		return err
 	}
 	errPatch := service.NSXClient.IPAddressAllocationClient.Patch(VPCInfo[0].OrgID, VPCInfo[0].ProjectID, VPCInfo[0].ID, *nsxIPAddressAllocation.Id, *nsxIPAddressAllocation)
-	errPatch = util.NSXApiError(errPatch)
+	errPatch = util.TransNSXApiError(errPatch)
 	if errPatch != nil {
 		// not return err, try to get it from nsx, in case if cidr not realized at the first time
 		// so it can be patched in the next time and reacquire cidr
@@ -118,7 +118,7 @@ func (service *IPAddressAllocationService) Apply(nsxIPAddressAllocation *model.V
 	}
 	// get back from nsx, it contains path which is used to parse vpc info when deleting
 	nsxIPAddressAllocationNew, errGet := service.NSXClient.IPAddressAllocationClient.Get(VPCInfo[0].OrgID, VPCInfo[0].ProjectID, VPCInfo[0].ID, *nsxIPAddressAllocation.Id)
-	errGet = util.NSXApiError(errGet)
+	errGet = util.TransNSXApiError(errGet)
 	if errGet != nil {
 		if errPatch != nil {
 			return fmt.Errorf("error get %s, error patch %s", errGet.Error(), errPatch.Error())

--- a/pkg/nsx/services/node/node.go
+++ b/pkg/nsx/services/node/node.go
@@ -83,7 +83,7 @@ func (service *NodeService) SyncNodeStore(nodeName string, deleted bool) error {
 		// node.NodeStore.Apply(updatedNode)
 	}
 	nodeResults, err := service.NSXClient.HostTransPortNodesClient.List("default", "default", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		return fmt.Errorf("failed to list HostTransportNodes: %s", err)
 	}

--- a/pkg/nsx/services/realizestate/realize_state.go
+++ b/pkg/nsx/services/realizestate/realize_state.go
@@ -44,7 +44,7 @@ func (service *RealizeStateService) CheckRealizeState(backoff wait.Backoff, inte
 		return !IsRealizeStateError(err)
 	}, func() error {
 		results, err := service.NSXClient.RealizedEntitiesClient.List(vpcInfo.OrgID, vpcInfo.ProjectID, intentPath, nil)
-		err = nsxutil.NSXApiError(err)
+		err = nsxutil.TransNSXApiError(err)
 		if err != nil {
 			return err
 		}

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -512,14 +512,14 @@ func (service *SecurityPolicyService) createOrUpdateSecurityPolicy(obj *v1alpha1
 		return err
 	}
 	err = service.NSXClient.InfraClient.Patch(*infraSecurityPolicy, &EnforceRevisionCheckParam)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to create or update SecurityPolicy", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
 		return err
 	}
 	// Get SecurityPolicy from NSX after HAPI call as NSX renders several fields like `path`/`parent_path`.
 	finalGetNSXSecurityPolicy, err := service.NSXClient.SecurityClient.Get(getDomain(service), *finalSecurityPolicy.Id)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to get SecurityPolicy", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
 		return err
@@ -665,7 +665,7 @@ func (service *SecurityPolicyService) deleteSecurityPolicy(sp types.UID) error {
 		return err
 	}
 	err = service.NSXClient.InfraClient.Patch(*infraSecurityPolicy, &EnforceRevisionCheckParam)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to delete SecurityPolicy", "nsxSecurityPolicyId", nsxSecurityPolicy.Id)
 		return err
@@ -809,10 +809,10 @@ func (service *SecurityPolicyService) createOrUpdateGroups(obj *v1alpha1.Securit
 			vpcId := (*vpcInfo).VPCID
 
 			err = service.NSXClient.VpcGroupClient.Patch(orgId, projectId, vpcId, *group.Id, *group)
-			err = nsxutil.NSXApiError(err)
+			err = nsxutil.TransNSXApiError(err)
 		} else {
 			err = service.NSXClient.GroupClient.Patch(getDomain(service), *group.Id, *group)
-			err = nsxutil.NSXApiError(err)
+			err = nsxutil.TransNSXApiError(err)
 		}
 	}
 
@@ -928,7 +928,7 @@ func (service *SecurityPolicyService) manipulateSecurityPolicy(nsxSecurityPolicy
 
 	// Create/update or delete SecurityPolicy together with groups, rules under VPC level and project groups, shares.
 	err = service.NSXClient.OrgRootClient.Patch(*orgRoot, &EnforceRevisionCheckParam)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to create/update or delete SecurityPolicy in VPC", "nsxSecurityPolicyId", nsxSecurityPolicy.Id)
 		return nsxGetSecurityPolicy, err
@@ -937,7 +937,7 @@ func (service *SecurityPolicyService) manipulateSecurityPolicy(nsxSecurityPolicy
 	if !isDelete {
 		// Get SecurityPolicy from NSX after HAPI call as NSX renders several fields like `path`/`parent_path`.
 		nsxGetSecurityPolicy, err = service.NSXClient.VPCSecurityClient.Get(vpcInfo.OrgID, vpcInfo.ProjectID, vpcInfo.VPCID, *nsxSecurityPolicy.Id)
-		err = nsxutil.NSXApiError(err)
+		err = nsxutil.TransNSXApiError(err)
 		if err != nil {
 			log.Error(err, "failed to get SecurityPolicy in VPC", "nsxSecurityPolicyId", nsxSecurityPolicy.Id)
 			return nsxGetSecurityPolicy, err
@@ -987,7 +987,7 @@ func (service *SecurityPolicyService) manipulateSecurityPolicyForDefaultProject(
 		}
 
 		err = service.NSXClient.InfraClient.Patch(*infraResource, &EnforceRevisionCheckParam)
-		err = nsxutil.NSXApiError(err)
+		err = nsxutil.TransNSXApiError(err)
 		if err != nil {
 			log.Error(err, "failed to create or update NSX infra Resource", "nsxSecurityPolicyId", nsxSecurityPolicy.Id)
 			return nsxGetSecurityPolicy, err
@@ -1004,7 +1004,7 @@ func (service *SecurityPolicyService) manipulateSecurityPolicyForDefaultProject(
 
 	// Create/update or delete SecurityPolicy together with groups, rules under VPC level.
 	err = service.NSXClient.OrgRootClient.Patch(*orgRoot, &EnforceRevisionCheckParam)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to create/update or delete SecurityPolicy in VPC", "nsxSecurityPolicyId", nsxSecurityPolicy.Id)
 		return nsxGetSecurityPolicy, err
@@ -1020,7 +1020,7 @@ func (service *SecurityPolicyService) manipulateSecurityPolicyForDefaultProject(
 			return nsxGetSecurityPolicy, err
 		}
 		err = service.NSXClient.InfraClient.Patch(*infraResource, &EnforceRevisionCheckParam)
-		err = nsxutil.NSXApiError(err)
+		err = nsxutil.TransNSXApiError(err)
 		if err != nil {
 			log.Error(err, "failed to delete NSX infra Resource", "nsxSecurityPolicyId", nsxSecurityPolicy.Id)
 			return nsxGetSecurityPolicy, err
@@ -1030,7 +1030,7 @@ func (service *SecurityPolicyService) manipulateSecurityPolicyForDefaultProject(
 	if !isDelete {
 		// Get SecurityPolicy from NSX after HAPI call as NSX renders several fields like `path`/`parent_path`.
 		nsxGetSecurityPolicy, err = service.NSXClient.VPCSecurityClient.Get(vpcInfo.OrgID, vpcInfo.ProjectID, vpcInfo.VPCID, *nsxSecurityPolicy.Id)
-		err = nsxutil.NSXApiError(err)
+		err = nsxutil.TransNSXApiError(err)
 		if err != nil {
 			log.Error(err, "failed to get SecurityPolicy in VPC", "nsxSecurityPolicyId", nsxSecurityPolicy.Id)
 			return nsxGetSecurityPolicy, err
@@ -1159,7 +1159,7 @@ func (service *SecurityPolicyService) gcInfraSharesGroups(sp types.UID, indexSco
 		return err
 	}
 	err = service.NSXClient.InfraClient.Patch(*infraResource, &EnforceRevisionCheckParam)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to delete NSX infra Resource in GC", "securityPolicyUID", sp)
 		return err

--- a/pkg/nsx/services/staticroute/staticroute.go
+++ b/pkg/nsx/services/staticroute/staticroute.go
@@ -84,7 +84,7 @@ func (service *StaticRouteService) CreateOrUpdateStaticRoute(namespace string, o
 		return err
 	}
 	staticRoute, err := service.NSXClient.StaticRouteClient.Get(vpc[0].OrgID, vpc[0].ProjectID, vpc[0].ID, *nsxStaticRoute.Id)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func (service *StaticRouteService) CreateOrUpdateStaticRoute(namespace string, o
 
 func (service *StaticRouteService) patch(orgId string, projectId string, vpcId string, st *model.StaticRoutes) error {
 	err := service.NSXClient.StaticRouteClient.Patch(orgId, projectId, vpcId, *st.Id, *st)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func (service *StaticRouteService) DeleteStaticRouteByPath(orgId string, project
 	}
 
 	if err := staticRouteClient.Delete(orgId, projectId, vpcId, *staticroute.Id); err != nil {
-		err = nsxutil.NSXApiError(err)
+		err = nsxutil.TransNSXApiError(err)
 		return err
 	}
 	if err := service.StaticRouteStore.Delete(staticroute); err != nil {

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -111,12 +111,12 @@ func (service *SubnetService) createOrUpdateSubnet(obj client.Object, nsxSubnet 
 		return "", err
 	}
 	if err = service.NSXClient.OrgRootClient.Patch(*orgRoot, &EnforceRevisionCheckParam); err != nil {
-		err = nsxutil.NSXApiError(err)
+		err = nsxutil.TransNSXApiError(err)
 		return "", err
 	}
 	// Get Subnet from NSX after patch operation as NSX renders several fields like `path`/`parent_path`.
 	if *nsxSubnet, err = service.NSXClient.SubnetsClient.Get(vpcInfo.OrgID, vpcInfo.ProjectID, vpcInfo.VPCID, *nsxSubnet.Id); err != nil {
-		err = nsxutil.NSXApiError(err)
+		err = nsxutil.TransNSXApiError(err)
 		return "", err
 	}
 	realizeService := realizestate.InitializeRealizeState(service.Service)
@@ -153,7 +153,7 @@ func (service *SubnetService) DeleteSubnet(nsxSubnet model.VpcSubnet) error {
 		return err
 	}
 	if err = service.NSXClient.OrgRootClient.Patch(*orgRoot, &EnforceRevisionCheckParam); err != nil {
-		err = nsxutil.NSXApiError(err)
+		err = nsxutil.TransNSXApiError(err)
 		// Subnets that are not deleted successfully will finally be deleted by GC.
 		log.Error(err, "failed to delete Subnet", "ID", *nsxSubnet.Id)
 		return err
@@ -201,14 +201,14 @@ func (service *SubnetService) IsOrphanSubnet(subnet model.VpcSubnet, subnetsetID
 func (service *SubnetService) DeleteIPAllocation(orgID, projectID, vpcID, subnetID string) error {
 	ipAllocations, err := service.NSXClient.IPAllocationClient.List(orgID, projectID, vpcID, subnetID, ipPoolID,
 		nil, nil, nil, nil, nil, nil)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to get ip-allocations", "Subnet", subnetID)
 		return err
 	}
 	for _, alloc := range ipAllocations.Results {
 		if err = service.NSXClient.IPAllocationClient.Delete(orgID, projectID, vpcID, subnetID, ipPoolID, *alloc.Id); err != nil {
-			err = nsxutil.NSXApiError(err)
+			err = nsxutil.TransNSXApiError(err)
 			log.Error(err, "failed to delete ip-allocation", "Subnet", subnetID, "ip-alloc", *alloc.Id)
 			return err
 		}
@@ -223,7 +223,7 @@ func (service *SubnetService) GetSubnetStatus(subnet *model.VpcSubnet) ([]model.
 		return nil, err
 	}
 	statusList, err := service.NSXClient.SubnetStatusClient.List(param.OrgID, param.ProjectID, param.VPCID, *subnet.Id)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to get subnet status")
 		return nil, err
@@ -247,7 +247,7 @@ func (service *SubnetService) getIPPoolUsage(nsxSubnet *model.VpcSubnet) (*model
 		return nil, err
 	}
 	ipPool, err := service.NSXClient.IPPoolClient.Get(param.OrgID, param.ProjectID, param.VPCID, *nsxSubnet.Id, ipPoolID)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to get ip-pool", "Subnet", *nsxSubnet.Id)
 		return nil, err

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -109,7 +109,7 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 		nsxSubnetPort = buildSubnetPortExternalAddressBindingFromExisting(nsxSubnetPort, existingSubnetPort)
 		log.Info("updating the NSX subnet port", "existingSubnetPort", existingSubnetPort, "desiredSubnetPort", nsxSubnetPort)
 		err = service.NSXClient.PortClient.Patch(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, *nsxSubnetPort.Id, *nsxSubnetPort)
-		err = nsxutil.NSXApiError(err)
+		err = nsxutil.TransNSXApiError(err)
 		if err != nil {
 			log.Error(err, "failed to create or update subnet port", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)
 			return nil, err
@@ -205,7 +205,7 @@ func (service *SubnetPortService) GetSubnetPortState(obj interface{}, nsxSubnetP
 	}
 	nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID := nsxutil.ParseVPCPath(nsxSubnetPath)
 	nsxSubnetPortState, err := service.NSXClient.PortStateClient.Get(nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID, nsxSubnetPortID, nil, nil)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to get subnet port state", "nsxSubnetPortID", nsxSubnetPortID, "nsxSubnetPath", nsxSubnetPath)
 		return nil, err
@@ -221,7 +221,7 @@ func (service *SubnetPortService) DeleteSubnetPort(portID string) error {
 	}
 	nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID := nsxutil.ParseVPCPath(*nsxSubnetPort.Path)
 	err := service.NSXClient.PortClient.Delete(nsxOrgID, nsxProjectID, nsxVPCID, nsxSubnetID, portID)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to delete subnetport", "nsxSubnetPort.Path", *nsxSubnetPort.Path)
 		return err
@@ -261,7 +261,7 @@ func (service *SubnetPortService) GetGatewayPrefixForSubnetPort(obj *v1alpha1.Su
 	}
 	// TODO: if the port is not the first on the same subnet, try to get the info from existing realized subnetport CR to avoid query NSX API again.
 	statusList, err := service.NSXClient.SubnetStatusClient.List(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID)
-	err = nsxutil.NSXApiError(err)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to get subnet status")
 		return "", -1, err


### PR DESCRIPTION
Add NO_DFW_LICENSE to network policy annotation when return error code is 505
Also check return error from NSX side if it's an invalid license error

Test Done:
Case 1:
1. reboot the nsx-operator
2. delete the license from nsx
3. create the network policy to check if there is annotation
4. check if nsx-operator restart
Case 2:
1. based on case 1
2. update the license of NSX
3. wait for some time
4. check if annotation has been removed