### PR TITLE
Fix the system VPCNetworkConfiguration update issue

### DIFF
--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -193,7 +193,6 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					return true, "", nil
 				})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "ValidateGatewayConnectionStatus", func(_ *vpc.VPCService, _ *servicecommon.VPCNetworkConfigInfo) (bool, string, error) {
-					assert.FailNow(t, "should not be called")
 					return true, "", nil
 				})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, _ *v1alpha1.NetworkInfo, _ *servicecommon.VPCNetworkConfigInfo, _ vpc.LBProvider) (*model.Vpc, error) {


### PR DESCRIPTION
Imaging that if there is a system VPCNetworkConfiguration with the status `gatewayConnectionReady`, it won’t 
 call the `r.Service.ValidateGatewayConnectionStatus` to sync the status; even the spec of this `VPCNetworkConfiguration` is changed.