### PR TITLE
Unify the printer columns for VPCNetworkConfiguration 

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
@@ -15,13 +15,9 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - description: NSXProject the Namespace associated with
-      jsonPath: .spec.nsxProject
-      name: NSXProject
-      type: string
-    - description: PrivateIPs assigned to the Namespace
-      jsonPath: .spec.privateIPs
-      name: PrivateIPs
+    - description: NSX VPC path the Namespace is associated with
+      jsonPath: .status.vpcs[0].vpcPath
+      name: VPCPath
       type: string
     name: v1alpha1
     schema:

--- a/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
@@ -65,8 +65,7 @@ type VPCInfo struct {
 
 // VPCNetworkConfiguration is the Schema for the vpcnetworkconfigurations API.
 // +kubebuilder:resource:scope="Cluster"
-// +kubebuilder:printcolumn:name="NSXProject",type=string,JSONPath=`.spec.nsxProject`,description="NSXProject the Namespace associated with"
-// +kubebuilder:printcolumn:name="PrivateIPs",type=string,JSONPath=`.spec.privateIPs`,description="PrivateIPs assigned to the Namespace"
+// +kubebuilder:printcolumn:name="VPCPath",type=string,JSONPath=`.status.vpcs[0].vpcPath`,description="NSX VPC path the Namespace is associated with"
 type VPCNetworkConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This change has removed the printer columns of private IPs and NSXProject from the additional printer columns of VPCNetworkConfiguration CR, and added the VPC path in the print by consuming field ".status.vpcs[0].vpcPath".

This is because,
1. the field ".spec.privateIPs" is not set in the case of using a pre-created VPC, which leads to the printer is empty in the corresponding CR
2. the VPC path has included the path of NSX project, which makes an additional column of NSXProject looks duplicated.

Test Done:
With this change, the output of command "kubectl get vpcnetworkconfigurations" looks as this,

```
# kubectl get vpcnetworkconfigurations
NAME                                                                  VPCPATH
default                                                               /orgs/default/projects/project-quality/vpcs/ft-dact-testns-user11-4-f0c83f65-38e8-4b36-b0fc-2cc2e522aaa3
imgpullbackoff-ns-d649d069-561c-4f85-90dd-2caeac1b3036                /orgs/default/projects/project-quality/vpcs/imgpullbackoff-ns-d3e17fc0-576f-4b56-a1ef-31a35df27fb5
largelayers-ns-57dc07f5-3b2e-467d-a26d-2f6c9d22102c                   /orgs/default/projects/project-quality/vpcs/largelayers-ns-f066181b-3a89-4303-9949-f994c261e58b
ood-ns-40742079-a383-4101-95cf-11faa0a362a7                           /orgs/default/projects/project-quality/vpcs/ood-ns-f8300c53-d890-4bad-8f72-1cb9e8ce2044
popularimages-ns-8c3f9232-348c-4643-a3f3-cb1d46266660                 /orgs/default/projects/project-quality/vpcs/popularimages-ns-7b948a6c-47f1-4ad2-b224-aabbd3500852
pre-vpc-c5852a8b-e633-4bb8-9821-2f78504fb801                          /orgs/default/projects/project-quality/vpcs/pre-vpc
pre-vpc3-0f5db49a-8d54-41ad-9b1c-3779f6c0702b                         /orgs/default/projects/project-quality/vpcs/pre-vpc3
sa-rolebindings-test-8be83728-0412-40db-bd2e-d598081a7651             /orgs/default/projects/project-quality/vpcs/sa-rolebindings-test-45a88b66-a833-49af-865c-b997138fd354
storage-class-test-1-4884b794-b310-41b1-b92b-43d209bb48ed             /orgs/default/projects/project-quality/vpcs/storage-class-test-1-5f629134-7958-4929-8726-8599c4e581cd
storage-class-test-2-46d7ff2e-52ed-43b0-9143-bd9c6d7eaf97             /orgs/default/projects/project-quality/vpcs/storage-class-test-2-fa516eb8-8ed1-48b6-8eae-0d3c8a54651d
storage-policy-test-d36f8523-8edc-4c2b-9e44-bf4d83b35159              /orgs/default/projects/project-quality/vpcs/storage-policy-test-5c5cbafc-71f9-420a-8513-2ea2c5b34fc7
svc-tkg-domain-c10-f3833cec-3c15-41f1-a332-53618cee6854               /orgs/default/projects/project-quality/vpcs/vmware-system-supervisor-services-vpc-f5e4e48b-82ea-4764-9be1-f71206a05904
svc-velero-domain-c10-03291c4a-631a-4587-b0b7-ac7c5be087d4            /orgs/default/projects/project-quality/vpcs/vmware-system-supervisor-services-vpc-f5e4e48b-82ea-4764-9be1-f71206a05904
system                                                                /orgs/default/projects/project-quality/vpcs/kube-system-49e330fa-f266-4fa2-bffc-7eaed4fe9fe9
test-dataprovider-ns-b8560e04-7842-45f0-9bf7-eff6a3205edb             /orgs/default/projects/project-quality/vpcs/test-dataprovider-ns-4abec4e1-86a4-48bc-a34e-36dee2c70e57
```

For a VPCNetworkConfiguration CR whose VPC is not yet created, the VPCPATH column is empty, e.g.,
```
# kubectl get vpcnetworkconfigurations test2-85968cf0-28ce-41a2-8c25-aba033150c34
NAME                                                                  VPCPATH
test2-85968cf0-28ce-41a2-8c25-aba033150c34                            
```