### PR TITLE
Unify the printer columns for VPCNetworkConfiguration (#767)

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
@@ -15,13 +15,9 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - description: NSXProject the Namespace associated with
-      jsonPath: .spec.nsxProject
-      name: NSXProject
-      type: string
-    - description: PrivateIPs assigned to the Namespace
-      jsonPath: .spec.privateIPs
-      name: PrivateIPs
+    - description: NSX VPC path the Namespace is associated with
+      jsonPath: .status.vpcs[0].vpcPath
+      name: VPCPath
       type: string
     name: v1alpha1
     schema:

--- a/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
@@ -65,8 +65,7 @@ type VPCInfo struct {
 
 // VPCNetworkConfiguration is the Schema for the vpcnetworkconfigurations API.
 // +kubebuilder:resource:scope="Cluster"
-// +kubebuilder:printcolumn:name="NSXProject",type=string,JSONPath=`.spec.nsxProject`,description="NSXProject the Namespace associated with"
-// +kubebuilder:printcolumn:name="PrivateIPs",type=string,JSONPath=`.spec.privateIPs`,description="PrivateIPs assigned to the Namespace"
+// +kubebuilder:printcolumn:name="VPCPath",type=string,JSONPath=`.status.vpcs[0].vpcPath`,description="NSX VPC path the Namespace is associated with"
 type VPCNetworkConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This change has removed "PrivateIPs" and "NSXProject" from the additional printer columns of VPCNetworkConfiguration CR, and added the VPC path in the print by consuming field ".status.vpcs[0].vpcPath". This is because,
1.the field ".spec.privateIPs" is not set in the case of using a pre-created
  VPC, which leads to the printer is empty in the corresponding CR
2.the VPC path has included the path of NSX project, which makes the contents
  in column of NSXProject looks duplicated.