### PR TITLE
Remove private ip block store in VPC

### DIFF
--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -242,10 +242,6 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 						deleteFail(r, ctx, obj, &err, r.Client)
 						return common.ResultRequeueAfter10sec, err
 					}
-					if err := r.Service.DeleteIPBlockInVPC(*vpc); err != nil {
-						log.Error(err, "failed to delete private ip blocks for VPC", "VPC", req.NamespacedName)
-						return common.ResultRequeueAfter10sec, err
-					}
 				}
 			}
 
@@ -340,10 +336,6 @@ func (r *NetworkInfoReconciler) CollectGarbage(ctx context.Context) {
 			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteFailTotal, common.MetricResTypeNetworkInfo)
 		} else {
 			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteSuccessTotal, common.MetricResTypeNetworkInfo)
-			if err := r.Service.DeleteIPBlockInVPC(elem); err != nil {
-				log.Error(err, "failed to delete private ip blocks for VPC", "VPC", *elem.DisplayName)
-			}
-			log.Info("deleted private ip blocks for VPC", "VPC", *elem.DisplayName)
 		}
 	}
 }

--- a/pkg/nsx/services/vpc/builder.go
+++ b/pkg/nsx/services/vpc/builder.go
@@ -17,19 +17,6 @@ var (
 	defaultLBSName          = "default"
 )
 
-// private ip block cidr is not unique, there maybe different ip blocks using same cidr, but for different vpc cr
-// using cidr_vpccruid as key so that it could quickly check if ipblocks already created.
-func generateIPBlockKey(block model.IpAddressBlock) string {
-	cidr := block.Cidr
-	nsUID := ""
-	for _, tag := range block.Tags {
-		if *tag.Scope == common.TagScopeNamespaceUID {
-			nsUID = *tag.Tag
-		}
-	}
-	return *cidr + "_" + nsUID
-}
-
 func generateLBSKey(lbs model.LBService) (string, error) {
 	if lbs.ConnectivityPath == nil || *lbs.ConnectivityPath == "" {
 		return "", fmt.Errorf("ConnectivityPath is nil or empty")

--- a/pkg/nsx/services/vpc/compare.go
+++ b/pkg/nsx/services/vpc/compare.go
@@ -7,11 +7,10 @@ import (
 )
 
 // currently we only support appending public/private cidrs
-// so only comparing list size is enough to identify if vcp changed
+// so only comparing list size is enough to identify if VPC changed
 func IsVPCChanged(nc common.VPCNetworkConfigInfo, vpc *model.Vpc) bool {
 	if len(nc.PrivateIPs) != len(vpc.PrivateIps) {
 		return true
 	}
-
 	return false
 }


### PR DESCRIPTION
The private ipblocks in VPC are now maintained by nsx, nsx operator will not do operations on these nsx resources, so vpc service do not need to build its store anymore.

Remove the private ip blocks store and its related logics.