### PR TITLE
Create new tokenProvider for cleanup command

### DIFF
--- a/pkg/clean/clean.go
+++ b/pkg/clean/clean.go
@@ -55,6 +55,7 @@ func Clean(ctx context.Context, cf *config.NSXOperatorConfig, log *logr.Logger, 
 	if err := cf.ValidateConfigFromCmd(); err != nil {
 		return errors.Join(nsxutil.ValidationFailed, err)
 	}
+	cf.LibMode = true
 	nsxClient := nsx.GetClient(cf)
 	if nsxClient == nil {
 		return nsxutil.GetNSXClientFailed

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -111,9 +111,18 @@ func TestConfig_GetTokenProvider(t *testing.T) {
 	vcConfig.VCEndPoint = "127.0.0.1"
 	vcConfig.SsoDomain = "vsphere@local"
 	vcConfig.HttpsPort = 443
+	vcConfig.VCUser = "admin"
+	vcConfig.VCPassword = "password"
 	nsxConfig := &NSXOperatorConfig{VCConfig: vcConfig, NsxConfig: &NsxConfig{}}
 	tokenProvider := nsxConfig.GetTokenProvider()
 	assert.NotNil(t, tokenProvider)
+
+	newTokenProvider := nsxConfig.GetTokenProvider()
+	assert.Equal(t, tokenProvider, newTokenProvider)
+
+	nsxConfig.LibMode = true
+	newTokenProvider = nsxConfig.GetTokenProvider()
+	assert.True(t, tokenProvider != newTokenProvider)
 }
 
 func TestConfig_GetHA(t *testing.T) {


### PR DESCRIPTION
 The cleanup command, it's called by wcpsvc as a lib. Wcpsvc
  may call have multiple cleanup instances.
  The tokenProvider should have no global cache when LibMode is true
  Remove tokenProvider cache for cleanup