### PR TITLE
Build Subnet DHCPConfig with new NSX VPC 2.0 API

### DIFF
--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -63,7 +63,7 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (
 			Id:             String(service.BuildSubnetID(o)),
 			AccessMode:     String(convertAccessMode(util.Capitalize(string(o.Spec.AccessMode)))),
 			Ipv4SubnetSize: Int64(int64(o.Spec.IPv4SubnetSize)),
-			DhcpConfig:     service.buildDHCPConfig(o.Spec.DHCPConfig.EnableDHCP, int64(o.Spec.IPv4SubnetSize-4)),
+			DhcpConfig:     service.buildDHCPConfig(o.Spec.DHCPConfig.EnableDHCP),
 			DisplayName:    String(service.buildSubnetName(o)),
 		}
 		staticIpAllocation = !o.Spec.DHCPConfig.EnableDHCP
@@ -76,7 +76,7 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (
 			Id:             String(service.buildSubnetSetID(o, index)),
 			AccessMode:     String(convertAccessMode(util.Capitalize(string(o.Spec.AccessMode)))),
 			Ipv4SubnetSize: Int64(int64(o.Spec.IPv4SubnetSize)),
-			DhcpConfig:     service.buildDHCPConfig(o.Spec.DHCPConfig.EnableDHCP, int64(o.Spec.IPv4SubnetSize-4)),
+			DhcpConfig:     service.buildDHCPConfig(o.Spec.DHCPConfig.EnableDHCP),
 			DisplayName:    String(service.buildSubnetSetName(o, index)),
 		}
 		staticIpAllocation = !o.Spec.DHCPConfig.EnableDHCP
@@ -97,19 +97,11 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (
 	return nsxSubnet, nil
 }
 
-func (service *SubnetService) buildDHCPConfig(enableDHCP bool, poolSize int64) *model.VpcSubnetDhcpConfig {
+func (service *SubnetService) buildDHCPConfig(enableDHCP bool) *model.VpcSubnetDhcpConfig {
 	// Subnet DHCP is used by AVI, not needed for now. We need to explicitly mark enableDhcp = false,
 	// otherwise Subnet will use DhcpConfig inherited from VPC.
 	dhcpConfig := &model.VpcSubnetDhcpConfig{
 		EnableDhcp: Bool(enableDHCP),
-	}
-	if !enableDHCP {
-		dhcpConfig.StaticPoolConfig = &model.StaticPoolConfig{
-			// Number of IPs to be reserved in static ip pool.
-			// By default, if dhcp is enabled then static ipv4 pool size will be zero and all available IPs will be
-			// reserved in local dhcp pool. Maximum allowed value is 'subnet size - 4'.
-			Ipv4PoolSize: Int64(poolSize),
-		}
 	}
 	return dhcpConfig
 }


### PR DESCRIPTION
Based on new NSX VPC 2.0 API, we need to use below request body to create NSX subnet: {
        "id": "subnet-1",
        "resource_type": "VpcSubnet",
        "display_name": "Subnet 1",
        "description": "This is test VpcSubnet",
        "access_mode": "Private",
        "ipv4_subnet_size":64,
        "dhcp_config": {
            "enable_dhcp": false
        },
        "_revision": 0
    }