### PR TITLE
Delete the vs/lb pool created for pre-created VPC

### DIFF
--- a/pkg/clean/clean.go
+++ b/pkg/clean/clean.go
@@ -174,8 +174,8 @@ func InitializeCleanupService(cf *config.NSXOperatorConfig, nsxClient *nsx.Clien
 		AddCleanupService(wrapInitializeSubnetService(commonService)).
 		AddCleanupService(wrapInitializeSecurityPolicy(commonService)).
 		AddCleanupService(wrapInitializeStaticRoute(commonService)).
-		AddCleanupService(wrapInitializeIPAddressAllocation(commonService)).
-		AddCleanupService(wrapInitializeVPC(commonService))
+		AddCleanupService(wrapInitializeVPC(commonService)).
+		AddCleanupService(wrapInitializeIPAddressAllocation(commonService))
 
 	return cleanupService, nil
 }

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -90,6 +90,8 @@ type Client struct {
 	RealizedStateClient            realized_state.RealizedEntitiesClient
 	IPAddressAllocationClient      vpcs.IpAddressAllocationsClient
 	VPCLBSClient                   vpcs.VpcLbsClient
+	VpcLbVirtualServersClient      vpcs.VpcLbVirtualServersClient
+	VpcLbPoolsClient               vpcs.VpcLbPoolsClient
 	ProjectClient                  orgs.ProjectsClient
 	TransitGatewayClient           projects.TransitGatewaysClient
 	TransitGatewayAttachmentClient transit_gateways.AttachmentsClient
@@ -182,6 +184,8 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 	realizedStateClient := realized_state.NewRealizedEntitiesClient(restConnector(cluster))
 	ipAddressAllocationClient := vpcs.NewIpAddressAllocationsClient(restConnector(cluster))
 	vpcLBSClient := vpcs.NewVpcLbsClient(restConnector(cluster))
+	vpcLbVirtualServersClient := vpcs.NewVpcLbVirtualServersClient(restConnector(cluster))
+	vpcLbPoolsClient := vpcs.NewVpcLbPoolsClient(restConnector(cluster))
 
 	vpcSecurityClient := vpcs.NewSecurityPoliciesClient(restConnector(cluster))
 	vpcRuleClient := vpc_sp.NewRulesClient(restConnector(cluster))
@@ -228,6 +232,8 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 		VPCSecurityClient:              vpcSecurityClient,
 		VPCRuleClient:                  vpcRuleClient,
 		VPCLBSClient:                   vpcLBSClient,
+		VpcLbVirtualServersClient:      vpcLbVirtualServersClient,
+		VpcLbPoolsClient:               vpcLbPoolsClient,
 		ProjectClient:                  projectClient,
 		NSXChecker:                     *nsxChecker,
 		NSXVerChecker:                  *nsxVersionChecker,

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -21,10 +21,12 @@ const (
 	MaxIdLength                        int    = 255
 	MaxNameLength                      int    = 255
 	MaxSubnetNameLength                int    = 80
+	VPCLbResourcePathMinSegments       int    = 8
 	PriorityNetworkPolicyAllowRule     int    = 2010
 	PriorityNetworkPolicyIsolationRule int    = 2090
 	TagScopeNCPCluster                 string = "ncp/cluster"
 	TagScopeNCPProjectUID              string = "ncp/project_uid"
+	TagScopeNCPCreateFor               string = "ncp/created_for"
 	TagScopeNCPVIFProjectUID           string = "ncp/vif_project_uid"
 	TagScopeNCPPod                     string = "ncp/pod"
 	TagScopeNCPVNETInterface           string = "ncp/vnet_interface"
@@ -175,6 +177,8 @@ var (
 	ResourceTypeLBSourceIpPersistenceProfile = "LBSourceIpPersistenceProfile"
 	ResourceTypeLBHttpMonitorProfile         = "LBHttpMonitorProfile"
 	ResourceTypeLBTcpMonitorProfile          = "LBTcpMonitorProfile"
+	ResourceTypeLBVirtualServer              = "LBVirtualServer"
+	ResourceTypeLBPool                       = "LBPool"
 
 	// ResourceTypeClusterControlPlane is used by NSXServiceAccountController
 	ResourceTypeClusterControlPlane = "clustercontrolplane"

--- a/pkg/nsx/services/vpc/builder.go
+++ b/pkg/nsx/services/vpc/builder.go
@@ -32,6 +32,20 @@ func generateLBSKey(lbs model.LBService) (string, error) {
 	return combineVPCIDAndLBSID(vpcID, *lbs.Id), nil
 }
 
+func generateVirtualServerKey(vs model.LBVirtualServer) (string, error) {
+	if vs.Path == nil || *vs.Path == "" {
+		return "", fmt.Errorf("LBVirtualServer path is nil or empty")
+	}
+	return *vs.Path, nil
+}
+
+func generatePoolKey(pool model.LBPool) (string, error) {
+	if pool.Path == nil || *pool.Path == "" {
+		return "", fmt.Errorf("LBPool path is nil or empty")
+	}
+	return *pool.Path, nil
+}
+
 func combineVPCIDAndLBSID(vpcID, lbsID string) string {
 	return fmt.Sprintf("%s_%s", vpcID, lbsID)
 }

--- a/pkg/nsx/services/vpc/store.go
+++ b/pkg/nsx/services/vpc/store.go
@@ -15,6 +15,10 @@ func keyFunc(obj interface{}) (string, error) {
 		return *v.Id, nil
 	case *model.LBService:
 		return generateLBSKey(*v)
+	case *model.LBVirtualServer:
+		return generateVirtualServerKey(*v)
+	case *model.LBPool:
+		return generatePoolKey(*v)
 	default:
 		return "", errors.New("keyFunc doesn't support unknown type")
 	}


### PR DESCRIPTION
The pre-created VPC is shared by many ns. Once the ns deleted, the pre-created VPC will not be deleted.
But the vs/lb pool created for service under pre-created VPC should be released.

Delete vs/lb pool created for SLB by NCP in cleanup

Test Done:
Using the ncp/cluster and ncp/created_for=SLB to filter the vs/lb ppool
1. create the svc under one ns
2. crack the code to delete the vs/lb pool before deleting VPC
3. run cleanup to check if vs/lb pool created by NCP have been deleted 