### PR TITLE
Remove rule index from rule/group ID/name for VPC and unify NSX resource name for VPC and T1

### DIFF
--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -35,19 +35,19 @@ func TestBuildSecurityPolicy(t *testing.T) {
 	)
 
 	podSelectorRule0Name00 := "rule-with-pod-ns-selector_ingress_allow"
-	podSelectorRule0IDPort000 := "sp_uidA_0_2c822e90b1377b346014adfa583f08a99dee52a8_0_0"
+	podSelectorRule0IDPort000 := "sp_uidA_2c822e90b1377b346014adfa583f08a99dee52a8_0_0_0"
 
 	podSelectorRule1Name00 := "rule-with-ns-selector_ingress_allow"
-	podSelectorRule1IDPort000 := "sp_uidA_1_2a4595d0dd582c2ae5613245ad7b39de5ade2e20_0_0"
+	podSelectorRule1IDPort000 := "sp_uidA_2a4595d0dd582c2ae5613245ad7b39de5ade2e20_1_0_0"
 
 	vmSelectorRule0Name00 := "rule-with-VM-selector_egress_isolation"
-	vmSelectorRule0IDPort000 := "sp_uidB_0_67410606c486d2ba38002ed076a2a4211c9d49b5_0_0"
+	vmSelectorRule0IDPort000 := "sp_uidB_67410606c486d2ba38002ed076a2a4211c9d49b5_0_0_0"
 
 	vmSelectorRule1Name00 := "rule-with-ns-selector_egress_isolation"
-	vmSelectorRule1IDPort000 := "sp_uidB_1_7d721f087be35f0bf318f4847b5acdc3d2b91446_0_0"
+	vmSelectorRule1IDPort000 := "sp_uidB_7d721f087be35f0bf318f4847b5acdc3d2b91446_1_0_0"
 
 	vmSelectorRule2Name00 := "all_egress_isolation"
-	vmSelectorRule2IDPort000 := "sp_uidB_2_a40c813916cc397fcd2260e48cc773d4c9b08565_0_0"
+	vmSelectorRule2IDPort000 := "sp_uidB_a40c813916cc397fcd2260e48cc773d4c9b08565_2_0_0"
 
 	tests := []struct {
 		name           string
@@ -96,7 +96,7 @@ func TestBuildSecurityPolicy(t *testing.T) {
 			name:        "security-policy-with-VM-selector For T1",
 			inputPolicy: &spWithVMSelector,
 			expectedPolicy: &model.SecurityPolicy{
-				DisplayName:    common.String("sp_ns1_spB"),
+				DisplayName:    common.String("spB"),
 				Id:             common.String("sp_uidB"),
 				Scope:          []string{"/infra/domains/k8scl-one/groups/sp_uidB_scope"},
 				SequenceNumber: &seq0,
@@ -201,19 +201,19 @@ func TestBuildSecurityPolicyForVPC(t *testing.T) {
 	defer patches.Reset()
 
 	podSelectorRule0Name00 := "rule-with-pod-ns-selector_ingress_allow"
-	podSelectorRule0IDPort000 := "spA_uidA_0_2c822e90b1377b346014adfa583f08a99dee52a8_0_0"
+	podSelectorRule0IDPort000 := "spA_uidA_2c822e90_all"
 
 	podSelectorRule1Name00 := "rule-with-ns-selector_ingress_allow"
-	podSelectorRule1IDPort000 := "spA_uidA_1_2a4595d0dd582c2ae5613245ad7b39de5ade2e20_0_0"
+	podSelectorRule1IDPort000 := "spA_uidA_2a4595d0_53"
 
 	vmSelectorRule0Name00 := "rule-with-VM-selector_egress_isolation"
-	vmSelectorRule0IDPort000 := "spB_uidB_0_67410606c486d2ba38002ed076a2a4211c9d49b5_0_0"
+	vmSelectorRule0IDPort000 := "spB_uidB_67410606_all"
 
 	vmSelectorRule1Name00 := "rule-with-ns-selector_egress_isolation"
-	vmSelectorRule1IDPort000 := "spB_uidB_1_7d721f087be35f0bf318f4847b5acdc3d2b91446_0_0"
+	vmSelectorRule1IDPort000 := "spB_uidB_7d721f08_all"
 
 	vmSelectorRule2Name00 := "all_egress_isolation"
-	vmSelectorRule2IDPort000 := "spB_uidB_2_a40c813916cc397fcd2260e48cc773d4c9b08565_0_0"
+	vmSelectorRule2IDPort000 := "spB_uidB_a40c8139_all"
 
 	tests := []struct {
 		name           string
@@ -234,10 +234,10 @@ func TestBuildSecurityPolicyForVPC(t *testing.T) {
 						Id:                &podSelectorRule0IDPort000,
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
-						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA_uidA_0_scope"},
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA_uidA_2c822e90_scope"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA_uidA_0_src"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA_uidA_2c822e90_src"},
 						Action:            &nsxRuleActionAllow,
 						Tags:              vpcBasicTags,
 					},
@@ -249,7 +249,7 @@ func TestBuildSecurityPolicyForVPC(t *testing.T) {
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA_uidA_1_src"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA_uidA_2a4595d0_src"},
 						Action:            &nsxRuleActionAllow,
 						ServiceEntries:    []*data.StructValue{serviceEntry},
 						Tags:              vpcBasicTags,
@@ -270,9 +270,9 @@ func TestBuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule0Name00,
 						Id:                &vmSelectorRule0IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB_uidB_0_dst"},
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB_uidB_67410606_dst"},
 						Direction:         &nsxRuleDirectionOut,
-						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB_uidB_0_scope"},
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB_uidB_67410606_scope"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
 						SourceGroups:      []string{"ANY"},
@@ -282,7 +282,7 @@ func TestBuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule1Name00,
 						Id:                &vmSelectorRule1IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spB_uidB_1_dst"},
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spB_uidB_7d721f08_dst"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
@@ -295,7 +295,7 @@ func TestBuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule2Name00,
 						Id:                &vmSelectorRule2IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB_uidB_2_dst"},
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB_uidB_a40c8139_dst"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq2,
@@ -354,7 +354,7 @@ func TestBuildTargetTags(t *testing.T) {
 	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyCRName
 	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyCRUID
 
-	ruleTagID0 := service.buildRuleID(&spWithPodSelector, &spWithPodSelector.Spec.Rules[0], 0, common.ResourceTypeSecurityPolicy)
+	ruleTagID0 := service.buildRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy)
 	tests := []struct {
 		name         string
 		inputPolicy  *v1alpha1.SecurityPolicy
@@ -437,7 +437,7 @@ func TestBuildTargetTags(t *testing.T) {
 }
 
 func TestBuildPeerTags(t *testing.T) {
-	ruleTagID0 := service.buildRuleID(&spWithPodSelector, &spWithPodSelector.Spec.Rules[0], 0, common.ResourceTypeSecurityPolicy)
+	ruleTagID0 := service.buildRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy)
 	tests := []struct {
 		name         string
 		inputPolicy  *v1alpha1.SecurityPolicy
@@ -825,10 +825,7 @@ func TestUpdateMixedExpressionsMatchExpression(t *testing.T) {
 }
 
 var securityPolicyWithMultipleNormalPorts = v1alpha1.SecurityPolicy{
-	ObjectMeta: v1.ObjectMeta{
-		Namespace: "null",
-		Name:      "null",
-	},
+	ObjectMeta: v1.ObjectMeta{Namespace: "ns1", Name: "spMulPorts", UID: "spMulPortsuidA"},
 	Spec: v1alpha1.SecurityPolicySpec{
 		Rules: []v1alpha1.SecurityPolicyRule{
 			{
@@ -862,30 +859,81 @@ var securityPolicyWithMultipleNormalPorts = v1alpha1.SecurityPolicy{
 					},
 				},
 			},
+			{
+				Action:    &allowAction,
+				Direction: &directionOut,
+				Ports: []v1alpha1.SecurityPolicyPort{
+					{
+						Protocol: "TCP",
+						Port:     intstr.IntOrString{Type: intstr.Int, IntVal: 80},
+					},
+					{
+						Protocol: "UDP",
+						Port:     intstr.IntOrString{Type: intstr.Int, IntVal: 1234},
+						EndPort:  1234,
+					},
+				},
+			},
 		},
 	},
 }
 
 var securityPolicyWithOneNamedPort = v1alpha1.SecurityPolicy{
-	ObjectMeta: v1.ObjectMeta{
-		Namespace: "null",
-		Name:      "null",
-	},
+	ObjectMeta: v1.ObjectMeta{Namespace: "ns1", Name: "spNamedPorts", UID: "spNamedPortsuidA"},
 	Spec: v1alpha1.SecurityPolicySpec{
 		Rules: []v1alpha1.SecurityPolicyRule{
 			{
-				Name:      "TCP.http_UDP.1234.1235_ingress_allow",
+				Name:      "user-defined-rule-namedport",
 				Action:    &allowAction,
 				Direction: &directionIn,
 				Ports: []v1alpha1.SecurityPolicyPort{
 					{
 						Protocol: "TCP",
-						Port:     intstr.IntOrString{Type: intstr.String, StrVal: "http"},
+						Port:     intstr.IntOrString{Type: intstr.String, StrVal: "http"}, // http port is 80
 					},
 					{
 						Protocol: "UDP",
 						Port:     intstr.IntOrString{Type: intstr.Int, IntVal: 1234},
 						EndPort:  1235,
+					},
+				},
+			},
+			{
+				Action:    &allowAction,
+				Direction: &directionIn,
+				Ports: []v1alpha1.SecurityPolicyPort{
+					{
+						Protocol: "TCP",
+						Port:     intstr.IntOrString{Type: intstr.String, StrVal: "https"}, // http port is 443
+					},
+					{
+						Protocol: "UDP",
+						Port:     intstr.IntOrString{Type: intstr.Int, IntVal: 1236},
+						EndPort:  1237,
+					},
+				},
+			},
+			{
+				Action:    &allowAction,
+				Direction: &directionIn,
+				Ports: []v1alpha1.SecurityPolicyPort{
+					{
+						Protocol: "TCP",
+						Port:     intstr.IntOrString{Type: intstr.String, StrVal: "web"},
+					},
+					{
+						Protocol: "UDP",
+						Port:     intstr.IntOrString{Type: intstr.Int, IntVal: 533},
+					},
+				},
+			},
+			{
+				Action:    &allowAction,
+				Direction: &directionIn,
+				Ports: []v1alpha1.SecurityPolicyPort{
+					{
+						Protocol: "TCP",
+						Port:     intstr.IntOrString{Type: intstr.String, StrVal: "db"},
 					},
 				},
 			},
@@ -896,21 +944,51 @@ var securityPolicyWithOneNamedPort = v1alpha1.SecurityPolicy{
 func TestBuildRulePortsString(t *testing.T) {
 	tests := []struct {
 		name                    string
-		inputPorts              *[]v1alpha1.SecurityPolicyPort
+		inputPorts              []v1alpha1.SecurityPolicyPort
 		suffix                  string
 		expectedRulePortsString string
 	}{
 		{
 			name:                    "build-string-for-multiple-ports-without-named-port",
-			inputPorts:              &securityPolicyWithMultipleNormalPorts.Spec.Rules[0].Ports,
+			inputPorts:              securityPolicyWithMultipleNormalPorts.Spec.Rules[0].Ports,
 			suffix:                  "ingress_allow",
 			expectedRulePortsString: "TCP.80_UDP.1234.1235_ingress_allow",
 		},
 		{
-			name:                    "build-string-for-multiple-ports-without-one-named-port",
-			inputPorts:              &securityPolicyWithOneNamedPort.Spec.Rules[0].Ports,
+			name:                    "build-string-for-multiple-ports-userdefinedrule-without-named-port",
+			inputPorts:              securityPolicyWithMultipleNormalPorts.Spec.Rules[1].Ports,
+			suffix:                  "egress_drop",
+			expectedRulePortsString: "TCP.88_UDP.1236.1237_egress_drop",
+		},
+		{
+			name:                    "build-string-for-multiple-ports-start-end-port-same-without-named-port",
+			inputPorts:              securityPolicyWithMultipleNormalPorts.Spec.Rules[2].Ports,
+			suffix:                  "egress_allow",
+			expectedRulePortsString: "TCP.80_UDP.1234.1234_egress_allow",
+		},
+		{
+			name:                    "build-string-for-multiple-ports-with-http-named-port",
+			inputPorts:              securityPolicyWithOneNamedPort.Spec.Rules[0].Ports,
 			suffix:                  "ingress_allow",
 			expectedRulePortsString: "TCP.http_UDP.1234.1235_ingress_allow",
+		},
+		{
+			name:                    "build-string-for-multiple-ports-with-https-named-port",
+			inputPorts:              securityPolicyWithOneNamedPort.Spec.Rules[1].Ports,
+			suffix:                  "ingress_allow",
+			expectedRulePortsString: "TCP.https_UDP.1236.1237_ingress_allow",
+		},
+		{
+			name:                    "build-string-for-multiple-ports-with-web-named-port",
+			inputPorts:              securityPolicyWithOneNamedPort.Spec.Rules[2].Ports,
+			suffix:                  "ingress_allow",
+			expectedRulePortsString: "TCP.web_UDP.533_ingress_allow",
+		},
+		{
+			name:                    "build-string-for-multiple-ports-with-db-named-port",
+			inputPorts:              securityPolicyWithOneNamedPort.Spec.Rules[3].Ports,
+			suffix:                  "ingress_allow",
+			expectedRulePortsString: "TCP.db_ingress_allow",
 		},
 		{
 			name:                    "build-string-for-nil-ports",
@@ -927,6 +1005,61 @@ func TestBuildRulePortsString(t *testing.T) {
 	}
 }
 
+func TestBuildRulePortsNumberString(t *testing.T) {
+	tests := []struct {
+		name                    string
+		inputPorts              []v1alpha1.SecurityPolicyPort
+		expectedRulePortsString string
+	}{
+		{
+			name:                    "build-string-for-multiple-ports-without-named-port",
+			inputPorts:              securityPolicyWithMultipleNormalPorts.Spec.Rules[0].Ports,
+			expectedRulePortsString: "80_1234.1235",
+		},
+		{
+			name:                    "build-string-for-multiple-ports-userdefinedrule-without-named-port",
+			inputPorts:              securityPolicyWithMultipleNormalPorts.Spec.Rules[1].Ports,
+			expectedRulePortsString: "88_1236.1237",
+		},
+		{
+			name:                    "build-string-for-multiple-ports-start-end-port-same-without-named-port",
+			inputPorts:              securityPolicyWithMultipleNormalPorts.Spec.Rules[2].Ports,
+			expectedRulePortsString: "80_1234.1234",
+		},
+		{
+			name:                    "build-string-for-multiple-ports-with-http-named-port",
+			inputPorts:              securityPolicyWithOneNamedPort.Spec.Rules[0].Ports,
+			expectedRulePortsString: "http_1234.1235",
+		},
+		{
+			name:                    "build-string-for-multiple-ports-with-https-named-port",
+			inputPorts:              securityPolicyWithOneNamedPort.Spec.Rules[1].Ports,
+			expectedRulePortsString: "https_1236.1237",
+		},
+		{
+			name:                    "build-string-for-multiple-ports-with-web-named-port",
+			inputPorts:              securityPolicyWithOneNamedPort.Spec.Rules[2].Ports,
+			expectedRulePortsString: "web_533",
+		},
+		{
+			name:                    "build-string-for-multiple-ports-with-db-named-port",
+			inputPorts:              securityPolicyWithOneNamedPort.Spec.Rules[3].Ports,
+			expectedRulePortsString: "db",
+		},
+		{
+			name:                    "build-string-for-nil-ports",
+			inputPorts:              nil,
+			expectedRulePortsString: "all",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedString := service.buildRulePortsNumberString(tt.inputPorts)
+			assert.Equal(t, tt.expectedRulePortsString, observedString)
+		})
+	}
+}
+
 func TestBuildRuleDisplayName(t *testing.T) {
 	tests := []struct {
 		name                    string
@@ -934,6 +1067,8 @@ func TestBuildRuleDisplayName(t *testing.T) {
 		inputRule               *v1alpha1.SecurityPolicyRule
 		ruleIdx                 int
 		portIdx                 int
+		hasNamedPort            bool
+		portNumber              int
 		createdFor              string
 		expectedRuleDisplayName string
 	}{
@@ -943,6 +1078,8 @@ func TestBuildRuleDisplayName(t *testing.T) {
 			inputRule:               &securityPolicyWithMultipleNormalPorts.Spec.Rules[0],
 			ruleIdx:                 0,
 			portIdx:                 0,
+			hasNamedPort:            false,
+			portNumber:              -1,
 			createdFor:              common.ResourceTypeNetworkPolicy,
 			expectedRuleDisplayName: "TCP.80_UDP.1234.1235_ingress_allow",
 		},
@@ -952,6 +1089,8 @@ func TestBuildRuleDisplayName(t *testing.T) {
 			inputRule:               &securityPolicyWithMultipleNormalPorts.Spec.Rules[1],
 			ruleIdx:                 1,
 			portIdx:                 0,
+			hasNamedPort:            false,
+			portNumber:              -1,
 			createdFor:              common.ResourceTypeNetworkPolicy,
 			expectedRuleDisplayName: "MultipleNormalPorts-rule1",
 		},
@@ -961,15 +1100,139 @@ func TestBuildRuleDisplayName(t *testing.T) {
 			inputRule:               &securityPolicyWithMultipleNormalPorts.Spec.Rules[1],
 			ruleIdx:                 1,
 			portIdx:                 0,
+			hasNamedPort:            false,
+			portNumber:              -1,
 			createdFor:              common.ResourceTypeSecurityPolicy,
 			expectedRuleDisplayName: "MultipleNormalPorts-rule1_egress_isolation",
+		},
+		{
+			name:                    "build-display-name-for-user-defined-rulename-with-one-named-http-port",
+			inputSecurityPolicy:     &securityPolicyWithOneNamedPort,
+			inputRule:               &securityPolicyWithOneNamedPort.Spec.Rules[0],
+			ruleIdx:                 0,
+			portIdx:                 0,
+			hasNamedPort:            true,
+			portNumber:              80,
+			createdFor:              common.ResourceTypeSecurityPolicy,
+			expectedRuleDisplayName: "user-defined-rule-namedport.TCP.80_ingress_allow",
+		},
+		{
+			name:                    "build-display-name-for-multiple-ports-with-one-named-https-port",
+			inputSecurityPolicy:     &securityPolicyWithOneNamedPort,
+			inputRule:               &securityPolicyWithOneNamedPort.Spec.Rules[1],
+			ruleIdx:                 1,
+			portIdx:                 0,
+			hasNamedPort:            true,
+			portNumber:              443,
+			createdFor:              common.ResourceTypeSecurityPolicy,
+			expectedRuleDisplayName: "TCP.https_UDP.1236.1237.TCP.443_ingress_allow",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			observedDisplayName, observedError := service.buildRuleDisplayName(tt.inputRule, tt.portIdx, -1, false, tt.createdFor)
+			observedDisplayName, observedError := service.buildRuleDisplayName(tt.inputRule, tt.portIdx, tt.hasNamedPort, tt.portNumber, tt.createdFor)
 			assert.Equal(t, tt.expectedRuleDisplayName, observedDisplayName)
 			assert.Equal(t, nil, observedError)
+		})
+	}
+}
+
+func TestBuildExpandedRuleID(t *testing.T) {
+	svc := &SecurityPolicyService{
+		Service: common.Service{
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{
+					Cluster: "cluster1",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                string
+		vpcEnabled          bool
+		inputSecurityPolicy *v1alpha1.SecurityPolicy
+		inputRule           *v1alpha1.SecurityPolicyRule
+		ruleIdx             int
+		portIdx             int
+		portAddressIdx      int
+		hasNamedPort        bool
+		portNumber          int
+		createdFor          string
+		expectedRuleID      string
+	}{
+		{
+			name:                "build-ruleID-for-multiple-ports-0-for-vpc",
+			vpcEnabled:          true,
+			inputSecurityPolicy: &securityPolicyWithMultipleNormalPorts,
+			inputRule:           &securityPolicyWithMultipleNormalPorts.Spec.Rules[0],
+			ruleIdx:             0,
+			portIdx:             0,
+			portAddressIdx:      0,
+			hasNamedPort:        false,
+			portNumber:          -1,
+			createdFor:          common.ResourceTypeSecurityPolicy,
+			expectedRuleID:      "spMulPorts_spMulPortsuidA_d0b8e36c_80_1234.1235",
+		},
+		{
+			name:                "build-ruleID-for-multiple-ports-0-for-T1",
+			vpcEnabled:          false,
+			inputSecurityPolicy: &securityPolicyWithMultipleNormalPorts,
+			inputRule:           &securityPolicyWithMultipleNormalPorts.Spec.Rules[0],
+			ruleIdx:             0,
+			portIdx:             0,
+			portAddressIdx:      0,
+			hasNamedPort:        false,
+			portNumber:          -1,
+			createdFor:          common.ResourceTypeSecurityPolicy,
+			expectedRuleID:      "sp_spMulPortsuidA_d0b8e36cf858e76624b9706c3c8e77b6006c0e10_0_0_0",
+		},
+		{
+			name:                "build-ruleID-for-multiple-ports-1-for-vpc-NP",
+			vpcEnabled:          true,
+			inputSecurityPolicy: &securityPolicyWithMultipleNormalPorts,
+			inputRule:           &securityPolicyWithMultipleNormalPorts.Spec.Rules[1],
+			ruleIdx:             1,
+			portIdx:             0,
+			portAddressIdx:      0,
+			hasNamedPort:        false,
+			portNumber:          -1,
+			createdFor:          common.ResourceTypeNetworkPolicy,
+			expectedRuleID:      "spMulPorts_spMulPortsuidA_555356be_88_1236.1237",
+		},
+		{
+			name:                "build-ruleID-for-multiple-ports-with-one-named-port-for-VPC",
+			vpcEnabled:          true,
+			inputSecurityPolicy: &securityPolicyWithOneNamedPort,
+			inputRule:           &securityPolicyWithOneNamedPort.Spec.Rules[0],
+			ruleIdx:             0,
+			portIdx:             0,
+			portAddressIdx:      0,
+			hasNamedPort:        true,
+			portNumber:          80,
+			createdFor:          common.ResourceTypeSecurityPolicy,
+			expectedRuleID:      "spNamedPorts_spNamedPortsuidA_3f7c7d8c_80",
+		},
+		{
+			name:                "build-ruleID-for-multiple-ports-with-one-named-port-for-T1",
+			vpcEnabled:          false,
+			inputSecurityPolicy: &securityPolicyWithOneNamedPort,
+			inputRule:           &securityPolicyWithOneNamedPort.Spec.Rules[0],
+			ruleIdx:             0,
+			portIdx:             0,
+			portAddressIdx:      0,
+			hasNamedPort:        true,
+			portNumber:          80,
+			createdFor:          common.ResourceTypeSecurityPolicy,
+			expectedRuleID:      "sp_spNamedPortsuidA_3f7c7d8c8449687178002f23599add04bf0c3250_0_0_0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc.NSXConfig.EnableVPCNetwork = tt.vpcEnabled
+			observedRuleID := svc.buildExpandedRuleID(tt.inputSecurityPolicy, tt.ruleIdx, tt.portIdx, tt.portAddressIdx, tt.hasNamedPort, tt.portNumber, tt.createdFor)
+			assert.Equal(t, tt.expectedRuleID, observedRuleID)
 		})
 	}
 }
@@ -1004,7 +1267,7 @@ func TestBuildSecurityPolicyName(t *testing.T) {
 				},
 			},
 			createdFor: common.ResourceTypeSecurityPolicy,
-			expName:    "sp_ns1_securitypolicy1",
+			expName:    "securitypolicy1",
 			expId:      "sp_uid1",
 		},
 		{
@@ -1052,7 +1315,7 @@ func TestBuildSecurityPolicyName(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			svc.NSXConfig.EnableVPCNetwork = tc.vpcEnabled
-			name := svc.buildSecurityPolicyName(tc.obj, tc.createdFor)
+			name := svc.buildSecurityPolicyName(tc.obj)
 			assert.Equal(t, tc.expName, name)
 			assert.True(t, len(name) <= common.MaxNameLength)
 			id := svc.buildSecurityPolicyID(tc.obj, tc.createdFor)
@@ -1093,51 +1356,51 @@ func TestBuildGroupName(t *testing.T) {
 			expId     string
 		}{
 			{
-				name:      "src rule without name",
+				name:      "src peer group for rule without user-defined name",
 				ruleIdx:   0,
 				isSource:  true,
 				enableVPC: true,
-				expName:   "sp1_0_src",
-				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_0_src",
+				expName:   "sp1_d0b8e36c_src",
+				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_d0b8e36c_src",
 			},
 			{
-				name:      "dst rule without name",
+				name:      "dst peer group for rule without user-defined name",
 				ruleIdx:   0,
 				isSource:  false,
 				enableVPC: true,
-				expName:   "sp1_0_dst",
-				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_0_dst",
+				expName:   "sp1_d0b8e36c_dst",
+				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_d0b8e36c_dst",
 			},
 			{
-				name:      "dst rule without name with T1",
+				name:      "dst peer group for rule without user-defined name for T1",
 				ruleIdx:   0,
 				isSource:  false,
 				enableVPC: false,
-				expName:   "sp1_0_dst",
+				expName:   "sp1_d0b8e36c_dst",
 				expId:     "sp_c5db1800-ce4c-11de-bedc-84a0de00c35b_0_dst",
 			},
 			{
-				name:      "src rule with name",
+				name:      "src peer group for rule with user-defined name",
 				ruleIdx:   1,
 				isSource:  true,
 				enableVPC: true,
-				expName:   "MultipleNormalPorts-rule1_src",
-				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_1_src",
+				expName:   "sp1_555356be_src",
+				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_555356be_src",
 			},
 			{
-				name:      "dst rule with name",
+				name:      "dst peer group for rule with user-defined name",
 				ruleIdx:   1,
 				isSource:  false,
 				enableVPC: true,
-				expName:   "MultipleNormalPorts-rule1_dst",
-				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_1_dst",
+				expName:   "sp1_555356be_dst",
+				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_555356be_dst",
 			},
 			{
-				name:      "dst rule with name with T1",
+				name:      "dst peer group for rule with user-defined name for T1",
 				ruleIdx:   1,
 				isSource:  false,
 				enableVPC: false,
-				expName:   "MultipleNormalPorts-rule1_dst",
+				expName:   "sp1_555356be_dst",
 				expId:     "sp_c5db1800-ce4c-11de-bedc-84a0de00c35b_1_dst",
 			},
 		} {
@@ -1161,31 +1424,45 @@ func TestBuildGroupName(t *testing.T) {
 			expId     string
 		}{
 			{
-				name:      "rule without name",
+				name:      "applied group for rule without user-defined name",
 				ruleIdx:   0,
 				enableVPC: true,
-				expName:   "sp1_0_scope",
-				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_0_scope",
+				expName:   "sp1_d0b8e36c_scope",
+				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_d0b8e36c_scope",
 			},
 			{
-				name:      "rule with name",
+				name:      "applied group for rule with user-defined name",
 				ruleIdx:   1,
 				enableVPC: true,
-				expName:   "MultipleNormalPorts-rule1_scope",
-				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_1_scope",
+				expName:   "sp1_555356be_scope",
+				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_555356be_scope",
+			},
+			{
+				name:      "applied group for rule without user-defined name",
+				ruleIdx:   0,
+				enableVPC: false,
+				expName:   "sp1_d0b8e36c_scope",
+				expId:     "sp_c5db1800-ce4c-11de-bedc-84a0de00c35b_0_scope",
+			},
+			{
+				name:      "applied group fpr rule with user-defined name for T1",
+				ruleIdx:   1,
+				enableVPC: false,
+				expName:   "sp1_555356be_scope",
+				expId:     "sp_c5db1800-ce4c-11de-bedc-84a0de00c35b_1_scope",
 			},
 			{
 				name:      "policy applied group",
 				ruleIdx:   -1,
 				enableVPC: true,
-				expName:   "ns1_sp1_scope",
+				expName:   "sp1_scope",
 				expId:     "sp1_c5db1800-ce4c-11de-bedc-84a0de00c35b_scope",
 			},
 			{
-				name:      "policy applied group with T1",
+				name:      "policy applied group for T1",
 				ruleIdx:   -1,
 				enableVPC: false,
-				expName:   "ns1_sp1_scope",
+				expName:   "sp1_scope",
 				expId:     "sp_c5db1800-ce4c-11de-bedc-84a0de00c35b_scope",
 			},
 		} {

--- a/pkg/nsx/services/securitypolicy/expand.go
+++ b/pkg/nsx/services/securitypolicy/expand.go
@@ -28,7 +28,7 @@ func (service *SecurityPolicyService) expandRule(obj *v1alpha1.SecurityPolicy, r
 	var nsxGroups []*model.Group
 
 	if len(rule.Ports) == 0 {
-		nsxRule, err := service.buildRuleBasicInfo(obj, rule, ruleIdx, 0, 0, -1, false, createdFor)
+		nsxRule, err := service.buildRuleBasicInfo(obj, rule, ruleIdx, 0, 0, false, -1, createdFor)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -39,7 +39,7 @@ func (service *SecurityPolicyService) expandRule(obj *v1alpha1.SecurityPolicy, r
 	// Check if there is a namedport in the rule
 	hasNamedPort := service.hasNamedPort(rule)
 	if !hasNamedPort {
-		nsxRule, err := service.buildRuleBasicInfo(obj, rule, ruleIdx, 0, 0, -1, false, createdFor)
+		nsxRule, err := service.buildRuleBasicInfo(obj, rule, ruleIdx, 0, 0, false, -1, createdFor)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -88,7 +88,7 @@ func (service *SecurityPolicyService) expandRuleByPort(obj *v1alpha1.SecurityPol
 		if err != nil {
 			// In case there is no more valid ip set selected, so clear the stale ip set group in NSX if stale ips exist
 			if errors.As(err, &nsxutil.NoEffectiveOption{}) {
-				groups := service.groupStore.GetByIndex(common.TagScopeRuleID, service.buildRuleID(obj, rule, ruleIdx, createdFor))
+				groups := service.groupStore.GetByIndex(common.TagScopeRuleID, service.buildRuleID(obj, ruleIdx, createdFor))
 				var ipSetGroup *model.Group
 				for _, group := range groups {
 					ipSetGroup = group
@@ -121,7 +121,7 @@ func (service *SecurityPolicyService) expandRuleByService(obj *v1alpha1.Security
 ) ([]*model.Group, *model.Rule, error) {
 	var nsxGroups []*model.Group
 
-	nsxRule, err := service.buildRuleBasicInfo(obj, rule, ruleIdx, portIdx, portAddressIdx, portAddress.Port, true, createdFor)
+	nsxRule, err := service.buildRuleBasicInfo(obj, rule, ruleIdx, portIdx, portAddressIdx, true, portAddress.Port, createdFor)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/nsx/services/securitypolicy/expand_test.go
+++ b/pkg/nsx/services/securitypolicy/expand_test.go
@@ -24,9 +24,23 @@ import (
 func TestSecurityPolicyService_buildRuleIPGroup(t *testing.T) {
 	sp := &v1alpha1.SecurityPolicy{
 		ObjectMeta: v1.ObjectMeta{Namespace: "ns1", Name: "spA", UID: "uidA"},
+		Spec: v1alpha1.SecurityPolicySpec{
+			Rules: []v1alpha1.SecurityPolicyRule{
+				{
+					Action:    &allowAction,
+					Direction: &directionIn,
+					Sources: []v1alpha1.SecurityPolicyPeer{
+						{
+							PodSelector: &v1.LabelSelector{
+								MatchLabels: map[string]string{"pod_selector_1": "pod_value_1"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
-	rule := v1alpha1.SecurityPolicyRule{}
 	nsxRule := model.Rule{
 		DisplayName:       &ruleNameWithPodSelector00,
 		Id:                &ruleIDPort000,
@@ -66,7 +80,7 @@ func TestSecurityPolicyService_buildRuleIPGroup(t *testing.T) {
 		DisplayName: &policyGroupName,
 		Expression:  []*data.StructValue{blockExpression},
 		// build ipset group tags from input securitypolicy and securitypolicy rule
-		Tags: service.buildPeerTags(sp, &rule, 0, false, false, false, common.ResourceTypeSecurityPolicy),
+		Tags: service.buildPeerTags(sp, &sp.Spec.Rules[0], 0, false, false, false, common.ResourceTypeSecurityPolicy),
 	}
 
 	type args struct {
@@ -82,7 +96,7 @@ func TestSecurityPolicyService_buildRuleIPGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, service.buildRuleIPSetGroup(sp, &rule, tt.args.obj, tt.args.ips, 0, common.ResourceTypeSecurityPolicy), "buildRuleIPSetGroup(%v, %v)",
+			assert.Equalf(t, tt.want, service.buildRuleIPSetGroup(sp, &sp.Spec.Rules[0], tt.args.obj, tt.args.ips, 0, common.ResourceTypeSecurityPolicy), "buildRuleIPSetGroup(%v, %v)",
 				tt.args.obj, tt.args.ips)
 		})
 	}

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -42,8 +42,8 @@ var (
 	tagScopeSecurityPolicyUID    = common.TagScopeSecurityPolicyUID
 	tagScopeRuleID               = common.TagScopeRuleID
 	tagScopeSelectorHash         = common.TagScopeSelectorHash
-	spName                       = "sp_ns1_spA"
-	spGroupName                  = "ns1_spA_scope"
+	spName                       = "spA"
+	spGroupName                  = "spA_scope"
 	spID                         = "sp_uidA"
 	spID2                        = "sp_uidB"
 	spGroupID                    = "sp_uidA_scope"
@@ -1073,11 +1073,11 @@ func TestCreateOrUpdateSecurityPolicy(t *testing.T) {
 	mockVPCService := common.MockVPCServiceProvider{}
 	fakeService.vpcService = &mockVPCService
 
-	podSelectorRule0IDPort000 := fakeService.buildExpandedRuleId(fakeService.buildRuleID(&spWithPodSelector, &spWithPodSelector.Spec.Rules[0], 0, common.ResourceTypeSecurityPolicy), 0, 0)
-	podSelectorRule1IDPort000 := fakeService.buildExpandedRuleId(fakeService.buildRuleID(&spWithPodSelector, &spWithPodSelector.Spec.Rules[1], 1, common.ResourceTypeSecurityPolicy), 0, 0)
+	podSelectorRule0IDPort000 := fakeService.buildExpandedRuleID(&spWithPodSelector, 0, 0, 0, false, -1, common.ResourceTypeSecurityPolicy)
+	podSelectorRule1IDPort000 := fakeService.buildExpandedRuleID(&spWithPodSelector, 1, 0, 0, false, -1, common.ResourceTypeSecurityPolicy)
 
-	podSelectorRule0Name00, _ := fakeService.buildRuleDisplayName(&spWithPodSelector.Spec.Rules[0], 0, -1, false, common.ResourceTypeSecurityPolicy)
-	podSelectorRule1Name00, _ := fakeService.buildRuleDisplayName(&spWithPodSelector.Spec.Rules[1], 0, -1, false, common.ResourceTypeSecurityPolicy)
+	podSelectorRule0Name00, _ := fakeService.buildRuleDisplayName(&spWithPodSelector.Spec.Rules[0], 0, false, -1, common.ResourceTypeSecurityPolicy)
+	podSelectorRule1Name00, _ := fakeService.buildRuleDisplayName(&spWithPodSelector.Spec.Rules[1], 0, false, -1, common.ResourceTypeSecurityPolicy)
 
 	type args struct {
 		spObj      *v1alpha1.SecurityPolicy
@@ -1494,13 +1494,13 @@ func TestGetFinalSecurityPolicyResouceFromNetworkPolicy(t *testing.T) {
 				Rules: []model.Rule{
 					{
 						DisplayName:       common.String("TCP.6001_ingress_allow"),
-						Id:                common.String("np-app-access_uidNP_allow_0_6c2a026ca143812daa72699fb924ee36b33b5cdc_0_0"),
+						Id:                common.String("np-app-access_uidNP_allow_6c2a026c_6001"),
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access_uidNP_allow_0_src"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access_uidNP_allow_6c2a026c_src"},
 						Action:            &nsxRuleActionAllow,
 						ServiceEntries:    []*data.StructValue{serviceEntry},
 						Tags:              npAllowBasicTags,
@@ -1516,7 +1516,7 @@ func TestGetFinalSecurityPolicyResouceFromNetworkPolicy(t *testing.T) {
 				Rules: []model.Rule{
 					{
 						DisplayName:       common.String("ingress_isolation"),
-						Id:                common.String("np-app-access_uidNP_isolation_0_114fed106ef3b5eae2a583f312435e84c02ca97f_0_0"),
+						Id:                common.String("np-app-access_uidNP_isolation_114fed10_all"),
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
 						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/np-app-access_uidNP_isolation_scope"},

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -31,10 +31,9 @@ import (
 )
 
 const (
-	wcpSystemResource       = "vmware-system-shared-t1"
-	HashLength          int = 8
-	SubnetTypeSubnet        = "subnet"
-	SubnetTypeSubnetSet     = "subnetset"
+	wcpSystemResource   = "vmware-system-shared-t1"
+	SubnetTypeSubnet    = "subnet"
+	SubnetTypeSubnetSet = "subnetset"
 )
 
 var (
@@ -106,11 +105,11 @@ func NormalizeId(name string) string {
 		return newName
 	}
 	hashString := Sha1(name)
-	nameLength := common.MaxIdLength - HashLength - 1
+	nameLength := common.MaxIdLength - common.HashLength - 1
 	for strings.ContainsAny(string(newName[nameLength-1]), "-._") {
 		nameLength--
 	}
-	newName = fmt.Sprintf("%s-%s", newName[:nameLength], hashString[:HashLength])
+	newName = fmt.Sprintf("%s-%s", newName[:nameLength], hashString[:common.HashLength])
 	return newName
 }
 
@@ -521,7 +520,7 @@ func Capitalize(s string) string {
 
 func GetRandomIndexString() string {
 	uuidStr := uuid.NewString()
-	return Sha1(uuidStr)[:HashLength]
+	return Sha1(uuidStr)[:common.HashLength]
 }
 
 // IsPowerOfTwo checks if a given number is a power of 2

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -30,7 +30,7 @@ func TestNormalizeName(t *testing.T) {
 	shortName := strings.Repeat("a", 256)
 	assert.Equal(t, NormalizeName(shortName), shortName)
 	longName := strings.Repeat("a", 257)
-	assert.Equal(t, NormalizeName(longName), fmt.Sprintf("%s_%s", strings.Repeat("a", 256-HashLength-1), "0c103888"))
+	assert.Equal(t, NormalizeName(longName), fmt.Sprintf("%s_%s", strings.Repeat("a", 256-common.HashLength-1), "0c103888"))
 }
 
 func TestNormalizeLabelKey(t *testing.T) {


### PR DESCRIPTION
This patch is to:
1. Remove SecurityPolicy rule index from rule ID and for VPC mode,
and keep T1 mode rule ID unchanged with rule index.
2. Remove SecurityPolicy rule index from group ID for VPC mode,
and keep T1 mode group ID unchanged with rule index.
3. Remove rule index from NSX group/rule name, and unify the NSX resource name for VPC and T1 network,
including SecurityPolicy, rule, and group.
4. Reduce length of rule hash string to 8 chars for VPC mode.

Test Done:
1. Create SecurityPolicy in VPC mode, do CRUD.
The SecurityPolicy CR name is: sp-app-access-policy-vpc
The generated NSX SecurityPolicy:
```
ID: sp-app-access-policy-vpc_36fcf0f9-170a-4346-bb14-9730e199bb49
Name: sp-app-access-policy-vpc
```

Policy appliedTo group:
```
ID: sp-app-access-policy-vpc_36fcf0f9-170a-4346-bb14-9730e199bb49_scope
Name: sp-app-access-policy-vpc_scope
```

For the rule with any ports:
```
    - direction: in
      action: drop
```
The build NSX Rule:
```
ID: sp-app-access-policy-vpc_36fcf0f9-170a-4346-bb14-9730e199bb49_d79c8ddf_all
Name: all_ingress_isolation
```

For rule:
```
    - direction: in
      action: allow
      sources:
        - vmSelector:
            matchLabels:
              app: coco
      ports:
        - protocol: TCP
          port: 8282
        - protocol: TCP
          port: 7000
          endPort: 7020
```
The build NSX rule:
```
ID: sp-app-access-policy-vpc_36fcf0f9-170a-4346-bb14-9730e199bb49_44b022be_8282_7000.7020
name: TCP.8282_TCP.7000.7020_ingress_allow
```

The rule appliedTo group:
```
ID: sp-app-access-policy-vpc_36fcf0f9-170a-4346-bb14-9730e199bb49_b7adc115_scope
Name:sp-app-access-policy-vpc_b7adc115_scope
```

Rule with user defined name:
```
  - direction: in
      name: rule-with-defined
      action: allow
      sources:
        - namespaceSelector:
            matchLabels:
              role: validate
          vmSelector:
            matchLabels:
              role: check
        - ipBlocks:
            - cidr: 100.64.232.1/32
      ports:
        - protocol: TCP
          port: 8081
```
          
```
ID: sp-app-access-policy-vpc_36fcf0f9-170a-4346-bb14-9730e199bb49_52658c89_8081
Name: rule-with-defined_ingress_allow
```

The source peer group for the this rule:
```
Path: /orgs/default/projects/dy-project1/infra/domains/default/groups/sp-app-access-policy-vpc_36fcf0f9-170a-4346-bb14-9730e199bb49_52658c89_src
ID: sp-app-access-policy-vpc_36fcf0f9-170a-4346-bb14-9730e199bb49_52658c89_src
Name: sp-app-access-policy-vpc_52658c89_src
```

The NSX Share for this source group:
```
ID: dy-project1_group_sp-app-access-policy-vpc_36fcf0f9-170a-4346-bb14-9730e199bb49_52658c89_src_share
Name: dy-project1_group_sp-app-access-policy-vpc_52658c89_src_share
```

2. Create NetworkPolicy in VPC mode, do CRUD.
The generated allow section SecurityPolicy:
```
ID: np-app-access_4a2afd8b-a5e8-4867-8515-fa4961b52f53_allow
Name: np-app-access
```
The generated isolation section SecurityPolicy:
```
ID: np-app-access_4a2afd8b-a5e8-4867-8515-fa4961b52f53_isolation
Name: np-app-access
```

3. Create SecurityPolicy in VPC mode, and do GC

4. Create NetworkPolicy in VPC mode, and do GC

5. Create SecurityPolicy with namedport in VPC mode
The rule with namedport:
```
      ports:
        - protocol: TCP
          port: db-port
        - protocol: UDP
          port: 5353
        - protocol: UDP
          port: 5354
```
The db-port will map to two ports number: 80 and 3366, so, the generated IPSet groups:
```
ID: sp-namedport-web_2cd759be-8d83-41e4-92d9-4eba6beab6cf_a347c628_3366_ipset
Name: TCP.db-port_UDP.5353_UDP.5354_TCP.3366_ingress_allow_ipset

ID: sp-namedport-web_2cd759be-8d83-41e4-92d9-4eba6beab6cf_a347c628_80_ipset
Name: TCP.db-port_UDP.5353_UDP.5354_TCP.80_ingress_allow_ipset
```
          
6. Create NetworkPolicy with namedport in VPC mode
For the same named port in the aforementioned, the generated IPSet groups:
```
ID: np-namedport-web_fd555fd3-04a6-4f6a-b035-79e587dd4767_allow_27cfee51_3366_ipset
Name: TCP.db-port_UDP.5353_UDP.5354_TCP.3366_ingress_allow_ipset

ID: np-namedport-web_fd555fd3-04a6-4f6a-b035-79e587dd4767_allow_27cfee51_80_ipset
Name: TCP.db-port_UDP.5353_UDP.5354_TCP.80_ingress_allow_ipset
```

7. Create SecurityPolicy in T1 mode, and do CRUD.

8. Create SecurityPolicy in T1 mode, and do GC.

9. T1 upgrade case:
Create a SecurityPolicy in v4.1.2 code, and start NSX operator with this patch to see if SecurityPolicy Name, group and rule name are changed as expected.
For the rule created in V4.1.2
```
    - direction: in
      action: allow
      sources:
        - namespaceSelector:
            matchLabels:
              role: test
      ports:
        - protocol: TCP
          port: 8082
          endPort: 8283
```
Before upgrade in V4.1.2         
```
ID:sp_e52e71f7-600a-4c67-b241-ce87c6dd191e_c2f3ed42f3e59c15731f8426d65e13676663e147_1_0_0
Name:sp-app-access-policy-1-0-0
```

After upgrade, ID is not changed.
```
ID:sp_e52e71f7-600a-4c67-b241-ce87c6dd191e_c2f3ed42f3e59c15731f8426d65e13676663e147_1_0_0
Name:TCP.8082.8283_ingress_allow
```