### PR TITLE
 Support immutable fields in Subnet/Subnetset

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
@@ -59,6 +59,9 @@ spec:
                     default: false
                     type: boolean
                 type: object
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               accessMode:
                 description: Access mode of Subnet, accessible only from within VPC
                   or from outside VPC.
@@ -89,6 +92,15 @@ spec:
                 - message: Value is immutable
                   rule: self == oldSelf
             type: object
+            x-kubernetes-validations:
+            - message: DHCPConfig is required once set
+              rule: '!has(oldSelf.DHCPConfig) || has(self.DHCPConfig)'
+            - message: ipv4SubnetSize is required once set
+              rule: '!has(oldSelf.ipv4SubnetSize) || has(self.ipv4SubnetSize)'
+            - message: accessMode is required once set
+              rule: '!has(oldSelf.accessMode) || has(self.accessMode)'
+            - message: ipAddresses is required once set
+              rule: '!has(oldSelf.ipAddresses) || has(self.ipAddresses)'
           status:
             description: SubnetStatus defines the observed state of Subnet.
             properties:

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
@@ -59,6 +59,9 @@ spec:
                     default: false
                     type: boolean
                 type: object
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               accessMode:
                 description: Access mode of Subnet, accessible only from within VPC
                   or from outside VPC.
@@ -79,6 +82,13 @@ spec:
                 - message: Value is immutable
                   rule: self == oldSelf
             type: object
+            x-kubernetes-validations:
+            - message: DHCPConfig is required once set
+              rule: '!has(oldSelf.DHCPConfig) || has(self.DHCPConfig)'
+            - message: accessMode is required once set
+              rule: '!has(oldSelf.accessMode) || has(self.accessMode)'
+            - message: ipv4SubnetSize is required once set
+              rule: '!has(oldSelf.ipv4SubnetSize) || has(self.ipv4SubnetSize)'
           status:
             description: SubnetSetStatus defines the observed state of SubnetSet.
             properties:

--- a/pkg/apis/vpc/v1alpha1/subnet_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnet_types.go
@@ -16,6 +16,10 @@ const (
 )
 
 // SubnetSpec defines the desired state of Subnet.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.DHCPConfig) || has(self.DHCPConfig)", message="DHCPConfig is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.ipv4SubnetSize) || has(self.ipv4SubnetSize)", message="ipv4SubnetSize is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.accessMode) || has(self.accessMode)", message="accessMode is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.ipAddresses) || has(self.ipAddresses)", message="ipAddresses is required once set"
 type SubnetSpec struct {
 	// Size of Subnet based upon estimated workload count.
 	// +kubebuilder:validation:Maximum:=65536
@@ -32,6 +36,7 @@ type SubnetSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	IPAddresses []string `json:"ipAddresses,omitempty"`
 	// DHCPConfig DHCP configuration.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	DHCPConfig DHCPConfig `json:"DHCPConfig,omitempty"`
 }
 

--- a/pkg/apis/vpc/v1alpha1/subnetset_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetset_types.go
@@ -8,6 +8,9 @@ import (
 )
 
 // SubnetSetSpec defines the desired state of SubnetSet.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.DHCPConfig) || has(self.DHCPConfig)", message="DHCPConfig is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.accessMode) || has(self.accessMode)", message="accessMode is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.ipv4SubnetSize) || has(self.ipv4SubnetSize)", message="ipv4SubnetSize is required once set"
 type SubnetSetSpec struct {
 	// Size of Subnet based upon estimated workload count.
 	// +kubebuilder:validation:Maximum:=65536
@@ -19,6 +22,7 @@ type SubnetSetSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	AccessMode AccessMode `json:"accessMode,omitempty"`
 	// DHCPConfig DHCP configuration.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	DHCPConfig DHCPConfig `json:"DHCPConfig,omitempty"`
 }
 

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -95,6 +95,12 @@ func (service *SubnetService) CreateOrUpdateSubnet(obj client.Object, vpcInfo co
 			changed = true
 		} else {
 			changed = common.CompareResource(SubnetToComparable(existingSubnet), SubnetToComparable(nsxSubnet))
+			if changed {
+				// Only tags are expected to be updated
+				// inherit other fields from the existing Subnet
+				existingSubnet.Tags = nsxSubnet.Tags
+				nsxSubnet = existingSubnet
+			}
 		}
 		if !changed {
 			log.Info("subnet not changed, skip updating", "subnet.Id", uid)


### PR DESCRIPTION
NSX does not support change either from static IP Allocation to DHCP or from DHCP to static IP Allocation.
This PR updates the Subnet/SubnetSet CRD to make DHCPConfig immutable;

and also 
- Prevent all the immutable fields in Subnet/SubnetSet from being updated from a value to empty
- Fixes a bug in subnet update to inherit other fields from the existing Subnet
to avoid overriding some immutable fields like IP Addresses and IP Blocks by empty during
the update.

Testing done:
- Subnet CRD:
  - Define a Subnet with DHCPConfig enabled, and try to change the spec.DHCPConfig.enableDHCP to false. Got `The Subnet "subnet-test" is invalid: spec.DHCPConfig: Invalid value: "object": Value is immutable`
  - Define a Subnet with DHCPConfig enabled, try to remove the spec.DHCPConfig and apply. Got `The Subnet "subnet-test" is invalid: spec: Invalid value: "object": DHCPConfig is required once set`
  - Define a Subnet with ipv4SubnetSize, accessMode and ipAddresses defined, try to remove all of them and apply. Got
    ```
    The Subnet "subnet-test" is invalid: 
    * spec: Invalid value: "object": ipv4SubnetSize is required once set
    * spec: Invalid value: "object": accessMode is required once set
    * spec: Invalid value: "object": ipAddresses is required once set
    ```
- Subnetset CRD
  - Define a Subnetset with DHCPConfig enabled, and try to change the spec.DHCPConfig.enableDHCP to false. Got `The SubnetSet "subnetset-public01" is invalid: spec.DHCPConfig: Invalid value: "object": Value is immutable`
  - Define a Subnetset with DHCPConfig enabled, try to remove the spec.DHCPConfig and apply. Got `The SubnetSet "subnetset-public01" is invalid: spec: Invalid value: "object": DHCPConfig is required once set`
  - Define a Subnetset with ipv4SubnetSize and accessMode defined, try to remove all of them and apply. Got
    ```
      The SubnetSet "subnetset-public01" is invalid: 
      * spec: Invalid value: "object": accessMode is required once set
      * spec: Invalid value: "object": ipv4SubnetSize is required once set
    ```
- Add label to namespace `kubectl label namespace ns-3 test=true` and see the subnet in NSX got updated with tag
```
{
    "scope": "test",
    "tag": "true"
}
```