### PR TITLE
Change VPC CR Conditions

### DIFF
--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_controller.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_controller.go
@@ -70,13 +70,13 @@ func updateFail(r *IPAddressAllocationReconciler, c context.Context, o *v1alpha1
 func (r *IPAddressAllocationReconciler) setReadyStatusFalse(ctx context.Context, ipaddressallocation *v1alpha1.IPAddressAllocation, transitionTime metav1.Time, err *error) {
 	conditions := []v1alpha1.Condition{
 		{
-			Type:    v1alpha1.Ready,
-			Status:  v1.ConditionFalse,
-			Message: "NSX IPAddressAllocation could not be created or updated",
-			Reason: fmt.Sprintf(
+			Type:   v1alpha1.Ready,
+			Status: v1.ConditionFalse,
+			Message: fmt.Sprintf(
 				"error occurred while processing the IPAddressAllocation CR. Error: %v",
 				*err,
 			),
+			Reason:             "IPAddressAllocationNotReady",
 			LastTransitionTime: transitionTime,
 		},
 	}
@@ -93,7 +93,7 @@ func (r *IPAddressAllocationReconciler) setReadyStatusTrue(ctx context.Context, 
 			Type:               v1alpha1.Ready,
 			Status:             v1.ConditionTrue,
 			Message:            "NSX IPAddressAllocation has been successfully created/updated",
-			Reason:             "",
+			Reason:             "IPAddressAllocationReady",
 			LastTransitionTime: transitionTime,
 		},
 	}

--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_controller_test.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_controller_test.go
@@ -51,7 +51,7 @@ func TestIPAddressAllocationController_setReadyStatusTrue(t *testing.T) {
 			Type:               v1alpha1.Ready,
 			Status:             v1.ConditionTrue,
 			Message:            "NSX IPAddressAllocation has been successfully created/updated",
-			Reason:             "",
+			Reason:             "IPAddressAllocationReady",
 			LastTransitionTime: transitionTime,
 		},
 	}

--- a/pkg/controllers/securitypolicy/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller.go
@@ -243,7 +243,7 @@ func (r *SecurityPolicyReconciler) setSecurityPolicyReadyStatusTrue(ctx context.
 			Type:               v1alpha1.Ready,
 			Status:             v1.ConditionTrue,
 			Message:            "NSX Security Policy has been successfully created/updated",
-			Reason:             "NSX API returned 200 response code for PATCH",
+			Reason:             "SecurityPolicyReady",
 			LastTransitionTime: transitionTime,
 		},
 	}
@@ -253,13 +253,13 @@ func (r *SecurityPolicyReconciler) setSecurityPolicyReadyStatusTrue(ctx context.
 func (r *SecurityPolicyReconciler) setSecurityPolicyReadyStatusFalse(ctx context.Context, secPolicy *v1alpha1.SecurityPolicy, transitionTime metav1.Time, err *error) {
 	newConditions := []v1alpha1.Condition{
 		{
-			Type:    v1alpha1.Ready,
-			Status:  v1.ConditionFalse,
-			Message: "NSX Security Policy could not be created/updated",
-			Reason: fmt.Sprintf(
+			Type:   v1alpha1.Ready,
+			Status: v1.ConditionFalse,
+			Message: fmt.Sprintf(
 				"error occurred while processing the SecurityPolicy CR. Error: %v",
 				*err,
 			),
+			Reason:             "SecurityPolicyNotReady",
 			LastTransitionTime: transitionTime,
 		},
 	}

--- a/pkg/controllers/staticroute/staticroute_controller.go
+++ b/pkg/controllers/staticroute/staticroute_controller.go
@@ -135,7 +135,7 @@ func (r *StaticRouteReconciler) setStaticRouteReadyStatusTrue(ctx context.Contex
 			Type:               v1alpha1.Ready,
 			Status:             v1.ConditionTrue,
 			Message:            "NSX Static Route has been successfully created/updated",
-			Reason:             "NSX API returned 200 response code for PATCH",
+			Reason:             "StaticRouteReady",
 			LastTransitionTime: transitionTime,
 		},
 	}
@@ -147,8 +147,8 @@ func (r *StaticRouteReconciler) setStaticRouteReadyStatusFalse(ctx context.Conte
 		{
 			Type:               v1alpha1.Ready,
 			Status:             v1.ConditionFalse,
-			Message:            "NSX Static Route could not be created/updated/deleted",
-			Reason:             fmt.Sprintf("Error occurred while processing the Static Route CR. Please check the config and try again. Error: %v", *err),
+			Message:            fmt.Sprintf("Error occurred while processing the Static Route CR. Please check the config and try again. Error: %v", *err),
+			Reason:             "StaticRouteNotReady",
 			LastTransitionTime: transitionTime,
 		},
 	}

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -177,7 +177,7 @@ func (r *SubnetReconciler) setSubnetReadyStatusTrue(ctx context.Context, subnet 
 			Type:               v1alpha1.Ready,
 			Status:             v1.ConditionTrue,
 			Message:            "NSX Subnet has been successfully created/updated",
-			Reason:             "SubnetCreated",
+			Reason:             "SubnetReady",
 			LastTransitionTime: transitionTime,
 		},
 	}

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -322,7 +322,7 @@ func (r *SubnetPortReconciler) setSubnetPortReadyStatusTrue(ctx context.Context,
 			Type:               v1alpha1.Ready,
 			Status:             v1.ConditionTrue,
 			Message:            "NSX subnet port has been successfully created/updated",
-			Reason:             "NSX API returned 200 response code for PATCH",
+			Reason:             "SubnetPortReady",
 			LastTransitionTime: transitionTime,
 		},
 	}
@@ -332,13 +332,13 @@ func (r *SubnetPortReconciler) setSubnetPortReadyStatusTrue(ctx context.Context,
 func (r *SubnetPortReconciler) setSubnetPortReadyStatusFalse(ctx context.Context, subnetPort *v1alpha1.SubnetPort, transitionTime metav1.Time, err *error) {
 	newConditions := []v1alpha1.Condition{
 		{
-			Type:    v1alpha1.Ready,
-			Status:  v1.ConditionFalse,
-			Message: "NSX subnet port could not be created/updated",
-			Reason: fmt.Sprintf(
+			Type:   v1alpha1.Ready,
+			Status: v1.ConditionFalse,
+			Message: fmt.Sprintf(
 				"error occurred while processing the SubnetPort CR. Error: %v",
 				*err,
 			),
+			Reason:             "SubnetPortNotReady",
 			LastTransitionTime: transitionTime,
 		},
 	}


### PR DESCRIPTION
For IPAddressAllocation, SecurityPolicy, StaticRoute, SubnetPort CR, change to use "reason" for simplified message and "message" for details messages. according to https://github.com/kubernetes/apimachinery/blob/d4f471b82f0a17cda946aeba446770563f92114d/pkg/apis/meta/v1/types.go#L1407 Reason : reason contains a programmatic identifier indicating the reason for the condition Message : message is a human readable message indicating details about the transition