### PR TITLE
Remove SubnetPort/Pod Finalizer

### DIFF
--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
@@ -77,41 +78,37 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		})
 	defer patchesGetSubnetByPath.Reset()
 
-	// not found
-	errNotFound := errors.New("not found")
-	k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errNotFound)
-	_, err := r.Reconcile(ctx, req)
-	assert.Equal(t, err, errNotFound)
-
-	// update fails
-	sp := &v1alpha1.SubnetPort{}
-	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
-		func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
-			v1sp := obj.(*v1alpha1.SubnetPort)
-			v1sp.Spec.Subnet = "subnet1"
-			return nil
-		})
-	subnet := &v1alpha1.Subnet{}
-	k8sClient.EXPECT().Get(ctx, gomock.Any(), subnet).Return(nil).AnyTimes().Do(
-		func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
-			s := obj.(*v1alpha1.Subnet)
-			s.Name = sp.Spec.Subnet
-			return nil
-		})
-	err = errors.New("Update failed")
-	k8sClient.EXPECT().Update(ctx, gomock.Any()).Return(err)
-	patchesSuccess := gomonkey.ApplyFunc(updateSuccess,
-		func(r *SubnetPortReconciler, c context.Context, o *v1alpha1.SubnetPort) {
-		})
-	defer patchesSuccess.Reset()
-	patchesUpdateFail := gomonkey.ApplyFunc(updateFail,
-		func(r *SubnetPortReconciler, c context.Context, o *v1alpha1.SubnetPort, e *error) {
-		})
-	defer patchesUpdateFail.Reset()
+	// fail to get
+	errFailToGet := errors.New("failed to get CR")
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errFailToGet)
 	_, ret := r.Reconcile(ctx, req)
+	assert.Equal(t, errFailToGet, ret)
+
+	// not found and deletion success
+	errNotFound := apierrors.NewNotFound(v1alpha1.Resource("subnetport"), "")
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errNotFound)
+
+	patchesDeleteSubnetPortByName := gomonkey.ApplyFunc((*SubnetPortReconciler).deleteSubnetPortByName,
+		func(r *SubnetPortReconciler, ctx context.Context, ns string, name string) error {
+			return nil
+		})
+	defer patchesDeleteSubnetPortByName.Reset()
+	_, ret = r.Reconcile(ctx, req)
+	assert.Equal(t, nil, ret)
+
+	// not found and deletion failed
+	err := errors.New("Deletion failed")
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errNotFound)
+	patchesDeleteSubnetPortByName = gomonkey.ApplyFunc((*SubnetPortReconciler).deleteSubnetPortByName,
+		func(r *SubnetPortReconciler, ctx context.Context, ns string, name string) error {
+			return err
+		})
+	defer patchesDeleteSubnetPortByName.Reset()
+	_, ret = r.Reconcile(ctx, req)
 	assert.Equal(t, err, ret)
 
 	// both subnet and subnetset are configured
+	sp := &v1alpha1.SubnetPort{}
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
 		func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 			v1sp := obj.(*v1alpha1.SubnetPort)
@@ -119,6 +116,10 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			v1sp.Spec.SubnetSet = "subnetset2"
 			return nil
 		})
+	patchesUpdateFail := gomonkey.ApplyFunc(updateFail,
+		func(r *SubnetPortReconciler, c context.Context, o *v1alpha1.SubnetPort, e *error) {
+		})
+	defer patchesUpdateFail.Reset()
 	err = errors.New("subnet and subnetset should not be configured at the same time")
 	_, ret = r.Reconcile(ctx, req)
 	assert.Equal(t, err, ret)
@@ -135,7 +136,6 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			return requests
 		})
 	defer patchesVmMapFunc.Reset()
-	k8sClient.EXPECT().Update(ctx, gomock.Any()).Return(nil)
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
 		func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 			v1sp := obj.(*v1alpha1.SubnetPort)
@@ -155,8 +155,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 	defer patchesCreateOrUpdateSubnetPort.Reset()
 	_, ret = r.Reconcile(ctx, req)
 	assert.Equal(t, err, ret)
+
 	// happy path
-	k8sClient.EXPECT().Update(ctx, gomock.Any()).Return(nil)
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
 		func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 			v1sp := obj.(*v1alpha1.SubnetPort)
@@ -184,6 +184,10 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			return portState, nil
 		})
 	defer patchesCreateOrUpdateSubnetPort.Reset()
+	patchesSuccess := gomonkey.ApplyFunc(updateSuccess,
+		func(r *SubnetPortReconciler, c context.Context, o *v1alpha1.SubnetPort) {
+		})
+	defer patchesSuccess.Reset()
 	_, ret = r.Reconcile(ctx, req)
 	assert.Equal(t, nil, ret)
 
@@ -194,15 +198,14 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			v1sp.Spec.Subnet = "subnet1"
 			time := metav1.Now()
 			v1sp.ObjectMeta.DeletionTimestamp = &time
-			v1sp.Finalizers = []string{common.SubnetPortFinalizerName}
 			return nil
 		})
 	err = errors.New("DeleteSubnetPort failed")
-	patchesDeleteSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPort,
+	patchesDeleteSubnetPortById := gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPortById,
 		func(s *subnetport.SubnetPortService, uid string) error {
 			return err
 		})
-	defer patchesDeleteSubnetPort.Reset()
+	defer patchesDeleteSubnetPortById.Reset()
 	patchesCreateOrUpdateSubnetPort = gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
 		func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string) (*model.SegmentPortState, error) {
 			assert.FailNow(t, "should not be called")
@@ -216,26 +219,6 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 	_, ret = r.Reconcile(ctx, req)
 	assert.Equal(t, err, ret)
 
-	// handle deletion event - update subnetport failed in deletion event
-	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
-		func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
-			v1sp := obj.(*v1alpha1.SubnetPort)
-			v1sp.Spec.Subnet = "subnet1"
-			time := metav1.Now()
-			v1sp.ObjectMeta.DeletionTimestamp = &time
-			v1sp.Finalizers = []string{common.SubnetPortFinalizerName}
-			return nil
-		})
-	err = errors.New("Update failed")
-	k8sClient.EXPECT().Update(ctx, gomock.Any()).Return(err)
-	patchesDeleteSubnetPort = gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPort,
-		func(s *subnetport.SubnetPortService, uid string) error {
-			return nil
-		})
-	defer patchesDeleteSubnetPort.Reset()
-	_, ret = r.Reconcile(ctx, req)
-	assert.Equal(t, err, ret)
-
 	// handle deletion event - successfully deleted
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
 		func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
@@ -243,41 +226,24 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			v1sp.Spec.Subnet = "subnet1"
 			time := metav1.Now()
 			v1sp.ObjectMeta.DeletionTimestamp = &time
-			v1sp.Finalizers = []string{common.SubnetPortFinalizerName}
 			return nil
 		})
-	k8sClient.EXPECT().Update(ctx, gomock.Any()).Return(nil)
-	patchesDeleteSubnetPort = gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPort,
+	patchesDeleteSubnetPortById = gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPortById,
 		func(s *subnetport.SubnetPortService, uid string) error {
 			return nil
 		})
-	defer patchesDeleteSubnetPort.Reset()
-	_, ret = r.Reconcile(ctx, req)
-	assert.Equal(t, nil, ret)
-
-	// handle deletion event - unknown finalizers
-	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
-		func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
-			v1sp := obj.(*v1alpha1.SubnetPort)
-			v1sp.Spec.Subnet = "subnet1"
-			time := metav1.Now()
-			v1sp.ObjectMeta.DeletionTimestamp = &time
-			return nil
-		})
-	patchesDeleteSubnetPort = gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPort,
-		func(s *subnetport.SubnetPortService, uid string) error {
-			assert.FailNow(t, "should not be called")
-			return nil
-		})
-	defer patchesDeleteSubnetPort.Reset()
+	defer patchesDeleteSubnetPortById.Reset()
 	_, ret = r.Reconcile(ctx, req)
 	assert.Equal(t, nil, ret)
 }
 
 func TestSubnetPortReconciler_GarbageCollector(t *testing.T) {
 	// gc collect item "2345", local store has more item than k8s cache
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
 	service := &subnetport.SubnetPortService{
 		Service: common.Service{
+			Client: k8sClient,
 			NSXConfig: &config.NSXOperatorConfig{
 				NsxConfig: &config.NsxConfig{
 					EnforcementPoint: "vmc-enforcementpoint",
@@ -293,13 +259,12 @@ func TestSubnetPortReconciler_GarbageCollector(t *testing.T) {
 			return a
 		})
 	defer patchesListNSXSubnetPortIDForCR.Reset()
-	patchesDeleteSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPort,
+	patchesDeleteSubnetPortById := gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPortById,
 		func(s *subnetport.SubnetPortService, uid string) error {
 			return nil
 		})
-	defer patchesDeleteSubnetPort.Reset()
-	mockCtl := gomock.NewController(t)
-	k8sClient := mock_client.NewMockClient(mockCtl)
+	defer patchesDeleteSubnetPortById.Reset()
+
 	r := &SubnetPortReconciler{
 		Client:            k8sClient,
 		Scheme:            nil,

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -105,9 +105,7 @@ const (
 	NSXServiceAccountFinalizerName   = "nsxserviceaccount.nsx.vmware.com/finalizer"
 	T1SecurityPolicyFinalizerName    = "securitypolicy.nsx.vmware.com/finalizer"
 	StaticRouteFinalizerName         = "staticroute.crd.nsx.vmware.com/finalizer"
-	SubnetPortFinalizerName          = "subnetport.crd.nsx.vmware.com/finalizer"
 	NetworkInfoFinalizerName         = "networkinfo.crd.nsx.vmware.com/finalizer"
-	PodFinalizerName                 = "pod.crd.nsx.vmware.com/finalizer"
 	IPPoolFinalizerName              = "ippool.crd.nsx.vmware.com/finalizer"
 	IPAddressAllocationFinalizerName = "ipaddressallocation.crd.nsx.vmware.com/finalizer"
 

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -51,9 +51,6 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 		return nil, err
 	}
 	nsxSubnetPortPath := fmt.Sprintf("%s/ports/%s", *nsxSubnet.Path, nsxSubnetPortID)
-	if err != nil {
-		return nil, err
-	}
 	namespace := &corev1.Namespace{}
 	namespacedName := types.NamespacedName{
 		Name: objNamespace,

--- a/pkg/nsx/services/subnetport/store.go
+++ b/pkg/nsx/services/subnetport/store.go
@@ -67,6 +67,24 @@ func subnetPortIndexBySubnetID(obj interface{}) ([]string, error) {
 	}
 }
 
+func subnetPortIndexNamespace(obj interface{}) ([]string, error) {
+	switch o := obj.(type) {
+	case *model.VpcSubnetPort:
+		return filterTag(o.Tags, common.TagScopeVMNamespace), nil
+	default:
+		return nil, errors.New("subnetPortIndexNamespace doesn't support unknown type")
+	}
+}
+
+func subnetPortIndexPodNamespace(obj interface{}) ([]string, error) {
+	switch o := obj.(type) {
+	case *model.VpcSubnetPort:
+		return filterTag(o.Tags, common.TagScopeNamespace), nil
+	default:
+		return nil, errors.New("subnetPortIndexPodNamespace doesn't support unknown type")
+	}
+}
+
 // SubnetPortStore is a store for SubnetPorts
 type SubnetPortStore struct {
 	common.ResourceStore


### PR DESCRIPTION
This PR removes the Finalizer in SubnetPort and Pod controller to provide a smooth
deletion experience for the user while ensure the stale NSX SubnetPort will be deleted
as expected.

Testing done:
- Create a SubnetPort and delete it. Observed the deletion will not stuck and check
   in the log that corresponding NSX SubnetPort will be deleted by the controller
   when a delete event is detected.
- Create a Pod and delete it. The deletion will still need a short period as we still have
   lifecycle-controller/system.vmware.com finalizer on the pod. But the log shows the
   corresponding NSX SubnetPort will be deleted by the controller when a delete event
   is detected.