### PR TITLE
Remove NetworkPolicy/SecurityPolicy Finalizer

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -103,11 +103,8 @@ const (
 	IPPoolTypePublic  = "Public"
 	IPPoolTypePrivate = "Private"
 
-	NSXServiceAccountFinalizerName = "nsxserviceaccount.nsx.vmware.com/finalizer"
-	T1SecurityPolicyFinalizerName  = "securitypolicy.nsx.vmware.com/finalizer"
-
-	SecurityPolicyFinalizerName      = "securitypolicy.crd.nsx.vmware.com/finalizer"
-	NetworkPolicyFinalizerName       = "networkpolicy.crd.nsx.vmware.com/finalizer"
+	NSXServiceAccountFinalizerName   = "nsxserviceaccount.nsx.vmware.com/finalizer"
+	T1SecurityPolicyFinalizerName    = "securitypolicy.nsx.vmware.com/finalizer"
 	StaticRouteFinalizerName         = "staticroute.crd.nsx.vmware.com/finalizer"
 	SubnetFinalizerName              = "subnet.crd.nsx.vmware.com/finalizer"
 	SubnetSetFinalizerName           = "subnetset.crd.nsx.vmware.com/finalizer"

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -144,6 +144,7 @@ func (s *SecurityPolicyService) setUpStore(indexScope string) {
 			keyFunc, cache.Indexers{
 				indexScope:                      indexBySecurityPolicyUID,
 				common.TagScopeNetworkPolicyUID: indexByNetworkPolicyUID,
+				common.TagScopeNamespace:        indexBySecurityPolicyNamespace,
 			}),
 		BindingType: model.SecurityPolicyBindingType(),
 	}}
@@ -1102,6 +1103,30 @@ func (service *SecurityPolicyService) ListSecurityPolicyID() sets.Set[string] {
 func (service *SecurityPolicyService) ListNetworkPolicyID() sets.Set[string] {
 	indexScope := common.TagScopeNetworkPolicyUID
 	return service.getGCSecurityPolicyIDSet(indexScope)
+}
+
+func (service *SecurityPolicyService) ListSecurityPolicyByName(ns, name string) []*model.SecurityPolicy {
+	var result []*model.SecurityPolicy
+	securityPolicies := service.securityPolicyStore.GetByIndex(common.TagScopeNamespace, ns)
+	for _, securityPolicy := range securityPolicies {
+		securityPolicyCRName := nsxutil.FindTag(securityPolicy.Tags, common.TagValueScopeSecurityPolicyName)
+		if securityPolicyCRName == name {
+			result = append(result, securityPolicy)
+		}
+	}
+	return result
+}
+
+func (service *SecurityPolicyService) ListNetworkPolicyByName(ns, name string) []*model.SecurityPolicy {
+	var result []*model.SecurityPolicy
+	securityPolicies := service.securityPolicyStore.GetByIndex(common.TagScopeNamespace, ns)
+	for _, securityPolicy := range securityPolicies {
+		securityPolicyCRName := nsxutil.FindTag(securityPolicy.Tags, common.TagScopeNetworkPolicyName)
+		if securityPolicyCRName == name {
+			result = append(result, securityPolicy)
+		}
+	}
+	return result
 }
 
 func (service *SecurityPolicyService) Cleanup(ctx context.Context) error {

--- a/pkg/nsx/services/securitypolicy/store.go
+++ b/pkg/nsx/services/securitypolicy/store.go
@@ -76,6 +76,15 @@ func indexGroupFunc(obj interface{}) ([]string, error) {
 	}
 }
 
+func indexBySecurityPolicyNamespace(obj interface{}) ([]string, error) {
+	switch o := obj.(type) {
+	case *model.SecurityPolicy:
+		return filterTag(o.Tags, common.TagScopeNamespace), nil
+	default:
+		return nil, errors.New("indexBySecurityPolicyNamespace doesn't support unknown type")
+	}
+}
+
 var filterRuleTag = func(v []model.Tag) []string {
 	res := make([]string, 0, 5)
 	for _, tag := range v {


### PR DESCRIPTION
Remove NetworkPolicy/SecurityPolicy Finalizer

This patch is to
1. Remove Finalizer for NetworkPolicy CR.
2. Remove Finalizer for SecurityPolicy in VPC network.
3. For T1 network work, the upgrade SecurityPolicy from V4.1.2 still has existing finalizer,
however, the new created SecurityPolicy has no finalizer any longer after upgrade.

After Finalizer is removed, the deletion process of NetworkPolicy/SecurityPolicy is modified
1. Add a new indexer function for tag nsx-op/namespace for SecurityPolicy store.

2. Once the K8s CR(NetworkPolicy/SecurityPolicy) is deleted, the CR will be deleted at once usually
if without finalizer. So, there no deletion timestamp could be found in the CR.
It's needed to handle K8s deletion even when k8s client finds that the CR not found.

3.Using nsx-op/namespace tag to fileter the corresponding NSX resources in the same namespace with
delete request, and then comparing CR name tag value, either SecurityPolicy CR or NetworkPolciy CR,
with delete request CR name to filter the NSX SecurityPolicy resources to be deleted.

4.If there are multiple NSX resources with the same CR anme tag value in the NSX store.
It's must check the the K8s CR exist to decide which CR was deleted
already, or the new created in the same namespace with the same name.

Test done:
1. Create NetworkPolicy in VPC modeand delete it
2. Create SecurityPolicy in VPC mode and delete it
3. Create SecurityPolicy in T1 mode and delete it
4. Upgrade case:
 Create SecurityPolicy in T1 in V4.1.2, and then restart NSX operator with this patch.   
 1). After restarted, checking the previous added finalizer exists as well.


```
finalizers:
 - securitypolicy.nsx.vmware.com/finalizer
```
   2). Checking the new nsx-op/security_policy_namespaced_name tag is added in the upgraded SecurityPolicy.

  3). Deleting the SecurityPolicy CR, and check log to see that NSX SecurityPolicy was deleted after the finalizer was removed.

```
2024-10-10 07:59:38.402	INFO	securitypolicy/securitypolicy_controller.go:140	reconciling SecurityPolicy CR	{"securitypolicy": {"name":"sp-namedport-web","namespace":"web"}}
2024-10-10 07:59:38.403	INFO	securitypolicy/securitypolicy_controller.go:214	reconciling CR to delete securitypolicy	{"securitypolicy": {"name":"sp-namedport-web","namespace":"web"}}
2024-10-10 07:59:38.422	DEBUG	securitypolicy/securitypolicy_controller.go:225	removed finalizer	{"securitypolicy": {"name":"sp-namedport-web","namespace":"web"}}
2024-10-10 07:59:38.942	INFO	securitypolicy/securitypolicy_controller.go:140	reconciling SecurityPolicy CR	{"securitypolicy": {"name":"sp-namedport-web","namespace":"web"}}
2024-10-10 07:59:38.942	DEBUG	recorder/recorder.go:104	SecurityPolicy CR has been successfully deleted	{"type": "Normal", "object": {"kind":"SecurityPolicy","namespace":"web","name":"sp-namedport-web","uid":"1144beda-6e32-479e-8a6f-61b89e4db6c6","apiVersion":"nsx.vmware.com/v1alpha1","resourceVersion":"21807188"}, "reason": "SuccessfulDelete"}
```




