### PR TITLE
Improve Subnet/SubnetSet GC

### DIFF
--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -382,8 +382,8 @@ func (r *SubnetReconciler) collectGarbage(ctx context.Context) {
 	crdSubnetIDsSet := sets.New[string](crdSubnetIDs...)
 
 	subnetUIDs := r.SubnetService.ListSubnetIDsFromNSXSubnets()
-	subnetSetIDsToDelete := subnetUIDs.Difference(crdSubnetIDsSet)
-	for subnetSetID := range subnetSetIDsToDelete {
+	subnetIDsToDelete := subnetUIDs.Difference(crdSubnetIDsSet)
+	for subnetSetID := range subnetIDsToDelete {
 		nsxSubnets := r.SubnetService.ListSubnetCreatedBySubnet(string(subnetSetID))
 		metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteTotal, common.MetricResTypeSubnet)
 

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -383,16 +383,16 @@ func (r *SubnetReconciler) collectGarbage(ctx context.Context) {
 
 	subnetUIDs := r.SubnetService.ListSubnetIDsFromNSXSubnets()
 	subnetIDsToDelete := subnetUIDs.Difference(crdSubnetIDsSet)
-	for subnetSetID := range subnetIDsToDelete {
-		nsxSubnets := r.SubnetService.ListSubnetCreatedBySubnet(string(subnetSetID))
+	for subnetID := range subnetIDsToDelete {
+		nsxSubnets := r.SubnetService.ListSubnetCreatedBySubnet(string(subnetID))
 		metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteTotal, common.MetricResTypeSubnet)
 
 		log.Info("Subnet garbage collection, cleaning stale Subnets", "Count", len(nsxSubnets))
 		if err := r.deleteSubnets(nsxSubnets); err != nil {
-			log.Error(err, "Subnet garbage collection, failed to delete NSX subnet", "SubnetUID", subnetSetID)
+			log.Error(err, "Subnet garbage collection, failed to delete NSX subnet", "SubnetUID", subnetID)
 			metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteFailTotal, common.MetricResTypeSubnet)
 		} else {
-			log.Info("Subnet garbage collection, successfully deleted NSX subnet", "SubnetUID", subnetSetID)
+			log.Info("Subnet garbage collection, successfully deleted NSX subnet", "SubnetUID", subnetID)
 			metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteSuccessTotal, common.MetricResTypeSubnet)
 		}
 	}

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -384,7 +384,7 @@ func (r *SubnetReconciler) collectGarbage(ctx context.Context) {
 	subnetUIDs := r.SubnetService.ListSubnetIDsFromNSXSubnets()
 	subnetIDsToDelete := subnetUIDs.Difference(crdSubnetIDsSet)
 	for subnetID := range subnetIDsToDelete {
-		nsxSubnets := r.SubnetService.ListSubnetCreatedBySubnet(string(subnetID))
+		nsxSubnets := r.SubnetService.ListSubnetCreatedBySubnet(subnetID)
 		metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteTotal, common.MetricResTypeSubnet)
 
 		log.Info("Subnet garbage collection, cleaning stale Subnets", "Count", len(nsxSubnets))

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -72,7 +72,7 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 	if !subnetsetCR.ObjectMeta.DeletionTimestamp.IsZero() {
 		metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteTotal, MetricResTypeSubnetSet)
-		err := r.deleteSubnetForSubnetSet(*subnetsetCR, false)
+		err := r.deleteSubnetForSubnetSet(*subnetsetCR, false, false)
 		if err != nil {
 			log.Error(err, "Failed to delete NSX Subnet, retrying", "SubnetSet", req.NamespacedName)
 			deleteFail(r, ctx, subnetsetCR, err.Error())
@@ -261,36 +261,34 @@ func (r *SubnetSetReconciler) CollectGarbage(ctx context.Context) {
 	defer func() {
 		log.Info("SubnetSet garbage collection completed", "duration(ms)", time.Since(startTime).Milliseconds())
 	}()
-	subnetSetList := &v1alpha1.SubnetSetList{}
-	err := r.Client.List(ctx, subnetSetList)
+
+	crdSubnetSetList := &v1alpha1.SubnetSetList{}
+	err := r.Client.List(ctx, crdSubnetSetList)
 	if err != nil {
-		log.Error(err, "Failed to list SubnetSet CR")
-		return
-	}
-	var nsxSubnetList []*model.VpcSubnet
-	for _, subnetSet := range subnetSetList.Items {
-		nsxSubnetList = append(nsxSubnetList, r.SubnetService.ListSubnetCreatedBySubnetSet(string(subnetSet.UID))...)
-	}
-	if len(nsxSubnetList) == 0 {
+		log.Error(err, "Failed to list Subnet CRs")
 		return
 	}
 
-	subnetSetIDs := sets.New[string]()
-	for _, subnetSet := range subnetSetList.Items {
-		if err := r.deleteSubnetForSubnetSet(subnetSet, true); err != nil {
+	crdSubnetSetIDsSet := sets.New[string]()
+	for _, subnetSet := range crdSubnetSetList.Items {
+		crdSubnetSetIDsSet.Insert(string(subnetSet.UID))
+		if err := r.deleteSubnetForSubnetSet(subnetSet, true, true); err != nil {
 			metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteFailTotal, MetricResTypeSubnetSet)
 		} else {
 			metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteSuccessTotal, MetricResTypeSubnetSet)
 		}
-		subnetSetIDs.Insert(string(subnetSet.UID))
 	}
-	for _, subnet := range nsxSubnetList {
-		if !r.SubnetService.IsOrphanSubnet(*subnet, subnetSetIDs) {
-			continue
-		}
-		if err := r.SubnetService.DeleteSubnet(*subnet); err != nil {
+
+	subnetSetIDs := r.SubnetService.ListSubnetSetIDsFromNSXSubnets()
+	subnetSetIDsToDelete := subnetSetIDs.Difference(crdSubnetSetIDsSet)
+	for subnetSetID := range subnetSetIDsToDelete {
+		nsxSubnets := r.SubnetService.ListSubnetCreatedBySubnetSet(subnetSetID)
+		log.Info("SubnetSet garbage collection, cleaning stale Subnets for SubnetSet", "Count", len(nsxSubnets))
+		if _, err := r.deleteSubnets(nsxSubnets); err != nil {
+			log.Error(err, "SubnetSet garbage collection, failed to delete NSX subnet", "SubnetSetUID", subnetSetID)
 			metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteFailTotal, MetricResTypeSubnetSet)
 		} else {
+			log.Info("SubnetSet garbage collection, successfully deleted NSX subnet", "SubnetSetUID", subnetSetID)
 			metrics.CounterInc(r.SubnetService.NSXConfig, metrics.ControllerDeleteSuccessTotal, MetricResTypeSubnetSet)
 		}
 	}
@@ -301,59 +299,60 @@ func (r *SubnetSetReconciler) deleteSubnetBySubnetSetName(ctx context.Context, s
 	return r.deleteStaleSubnets(ctx, nsxSubnets)
 }
 
-func (r *SubnetSetReconciler) deleteSubnetForSubnetSet(obj v1alpha1.SubnetSet, updateStatus bool) error {
-	nsxSubnets := r.SubnetService.SubnetStore.GetByIndex(servicecommon.TagScopeSubnetSetCRUID, string(obj.GetUID()))
-	if err := r.deleteSubnets(nsxSubnets); err != nil {
-		return err
-	}
+func (r *SubnetSetReconciler) deleteSubnetForSubnetSet(subnetSet v1alpha1.SubnetSet, updateStatus, ignoreStaleSubnetPort bool) error {
+	nsxSubnets := r.SubnetService.SubnetStore.GetByIndex(servicecommon.TagScopeSubnetSetCRUID, string(subnetSet.GetUID()))
+	hasStaleSubnetPort, deleteErr := r.deleteSubnets(nsxSubnets)
 	if updateStatus {
-		err := r.SubnetService.UpdateSubnetSetStatus(&obj)
-		if err != nil {
+		if err := r.SubnetService.UpdateSubnetSetStatus(&subnetSet); err != nil {
 			return err
 		}
 	}
+	if deleteErr != nil {
+		return deleteErr
+	}
+	if hasStaleSubnetPort && !ignoreStaleSubnetPort {
+		return fmt.Errorf("stale Subnet ports found while deleting Subnet for SubnetSet %s/%s", subnetSet.Name, subnetSet.Namespace)
+	}
 	return nil
 }
 
-func (r *SubnetSetReconciler) listSubnetSetIDsFromCRs(ctx context.Context) ([]string, error) {
-	crdSubnetSetList := &v1alpha1.SubnetSetList{}
-	err := r.Client.List(ctx, crdSubnetSetList)
-	if err != nil {
-		return nil, err
-	}
-
-	crdSubnetSetIDs := make([]string, 0, len(crdSubnetSetList.Items))
-	for _, sr := range crdSubnetSetList.Items {
-		crdSubnetSetIDs = append(crdSubnetSetIDs, string(sr.UID))
-	}
-	return crdSubnetSetIDs, nil
-}
-
-func (r *SubnetSetReconciler) deleteSubnets(nsxSubnets []*model.VpcSubnet) error {
+// deleteSubnets deletes all the specified NSX Subnets.
+// If any of the Subnets have stale SubnetPorts, they are skipped. The final result returns true.
+// If there is an error while deleting any NSX Subnet, it is skipped, and the final result returns an error.
+func (r *SubnetSetReconciler) deleteSubnets(nsxSubnets []*model.VpcSubnet) (hasStalePort bool, err error) {
+	hitError := false
 	for _, nsxSubnet := range nsxSubnets {
+		r.SubnetService.LockSubnet(nsxSubnet.Path)
 		portNums := len(r.SubnetPortService.GetPortsOfSubnet(*nsxSubnet.Id))
 		if portNums > 0 {
-			return fmt.Errorf("fail to delete Subnet/%s from SubnetSet CR, there is stale ports", *nsxSubnet.Id)
+			r.SubnetService.UnlockSubnet(nsxSubnet.Path)
+			hasStalePort = true
+			log.Info("Skipped deleting NSX Subnet due to stale ports", "nsxSubnet", *nsxSubnet.Id)
+			continue
 		}
-		r.SubnetService.LockSubnet(nsxSubnet.Path)
 		err := r.SubnetService.DeleteSubnet(*nsxSubnet)
 		if err != nil {
+			hitError = true
 			r.SubnetService.UnlockSubnet(nsxSubnet.Path)
-			return fmt.Errorf("fail to delete Subnet/%s from SubnetSet CR: %+v", *nsxSubnet.Id, err)
+			log.Error(fmt.Errorf("failed to delete NSX Subnet/%s: %+v", *nsxSubnet.Id, err), "Skipping to next subnet")
+			continue
 		}
 		r.SubnetService.UnlockSubnet(nsxSubnet.Path)
 	}
-	log.Info("Successfully deleted all Subnets", "subnetCount", len(nsxSubnets))
-	return nil
+	if hitError {
+		err = errors.New("one or more errors occurred while deleting subnets, ")
+		return
+	}
+	log.Info("Successfully deleted all specified NSX Subnets", "subnetCount", len(nsxSubnets))
+	return
 }
 
 func (r *SubnetSetReconciler) deleteStaleSubnets(ctx context.Context, nsxSubnets []*model.VpcSubnet) error {
-	crdSubnetSetIDs, err := r.listSubnetSetIDsFromCRs(ctx)
+	crdSubnetSetIDsSet, err := r.SubnetService.ListSubnetSetID(ctx)
 	if err != nil {
 		log.Error(err, "Failed to list Subnet CRs")
 		return err
 	}
-	crdSubnetSetIDsSet := sets.NewString(crdSubnetSetIDs...)
 	nsxSubnetsToDelete := make([]*model.VpcSubnet, 0, len(nsxSubnets))
 	for _, nsxSubnet := range nsxSubnets {
 		uid := nsxutil.FindTag(nsxSubnet.Tags, servicecommon.TagScopeSubnetSetCRUID)
@@ -364,7 +363,11 @@ func (r *SubnetSetReconciler) deleteStaleSubnets(ctx context.Context, nsxSubnets
 		nsxSubnetsToDelete = append(nsxSubnetsToDelete, nsxSubnet)
 	}
 	log.Info("Cleaning stale Subnets for SubnetSet", "Count", len(nsxSubnetsToDelete))
-	return r.deleteSubnets(nsxSubnetsToDelete)
+	hasStaleSubnetPort, err := r.deleteSubnets(nsxSubnetsToDelete)
+	if err != nil || hasStaleSubnetPort {
+		return fmt.Errorf("failed to delete stale Subnets, error: %v, hasStaleSubnetPort: %t", err, hasStaleSubnetPort)
+	}
+	return nil
 }
 
 func StartSubnetSetController(mgr ctrl.Manager, subnetService *subnet.SubnetService,

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -353,17 +353,8 @@ func (service *SubnetService) ListSubnetIDsFromNSXSubnets() sets.Set[string] {
 }
 
 // ListIndexFuncValues returns all the indexed values of the given index
-// // Index maps the indexed value to a set of keys in the store that match on that value
-// type Index map[string]sets.String
-//
-//	func (i *storeIndex) getIndexValues(indexName string) []string {
-//		index := i.indices[indexName]
-//		names := make([]string, 0, len(index))
-//		for key := range index {
-//			names = append(names, key)
-//		}
-//		return names
-//	}
+// Index maps the indexed value to a set of keys in the store that match on that value: type Index map[string]sets.String
+// see the getIndexValues function in k8s.io/client-go/tools/cache/thread_safe_store.go
 func (service *SubnetService) ListAllSubnet() []*model.VpcSubnet {
 	var allNSXSubnets []*model.VpcSubnet
 	// ListSubnetCreatedBySubnet

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -360,13 +360,13 @@ func (service *SubnetService) ListAllSubnet() []*model.VpcSubnet {
 	// ListSubnetCreatedBySubnet
 	subnets := service.SubnetStore.ListIndexFuncValues(common.TagScopeSubnetCRUID)
 	for subnetID := range subnets {
-		nsxSubnets := service.ListSubnetCreatedBySubnet(string(subnetID))
+		nsxSubnets := service.ListSubnetCreatedBySubnet(subnetID)
 		allNSXSubnets = append(allNSXSubnets, nsxSubnets...)
 	}
 	// ListSubnetCreatedBySubnetSet
 	subnetSets := service.SubnetStore.ListIndexFuncValues(common.TagScopeSubnetSetCRUID)
 	for subnetSetID := range subnetSets {
-		nsxSubnets := service.ListSubnetCreatedBySubnetSet(string(subnetSetID))
+		nsxSubnets := service.ListSubnetCreatedBySubnetSet(subnetSetID)
 		allNSXSubnets = append(allNSXSubnets, nsxSubnets...)
 	}
 	return allNSXSubnets


### PR DESCRIPTION
Improve Subnet/SubnetSet GC

Improve NSX Subnet CleanUp

For Subnet garbage collection (GC): 
Retrieve the Subnet CRUID values of all Subnets from the store, and delete the corresponding stale Subnets for those whose UID is not found in the existing Subnet CRs in Kubernetes.

For SubnetSet garbage collection (GC), two tasks need to be handled:

1. For each existing SubnetSet CR, delete any Subnet under it that does not have a SubnetPort attached.
2. Retrieve the SubnetSet CRUID values of all Subnets from the store, and delete the corresponding stale Subnets for those whose SubnetSet UID is not found in the existing SubnetSet CRs in Kubernetes.
