### PR TITLE
[Pre-VPC] Periodically sync pre-created VPC to NetworkInfo CR

### DIFF
--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -11,18 +11,22 @@ import (
 	"testing"
 
 	"github.com/agiledragon/gomonkey"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
@@ -700,7 +704,6 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				}))
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetNetworkconfigNameFromNS", func(_ *vpc.VPCService, _ string) (string, error) {
 					return "pre-vpc-nc", nil
-
 				})
 				patches.ApplyMethod(reflect.TypeOf(r), "GetVpcConnectivityProfilePathByVpcPath", func(_ *NetworkInfoReconciler, _ string) (string, error) {
 					return "connectivity_profile", nil
@@ -886,6 +889,7 @@ func TestNetworkInfoReconciler_CollectGarbage(t *testing.T) {
 		r.CollectGarbage(ctx)
 	})
 }
+
 func TestNetworkInfoReconciler_GetVpcConnectivityProfilePathByVpcPath(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -967,4 +971,106 @@ func TestNetworkInfoReconciler_GetVpcConnectivityProfilePathByVpcPath(t *testing
 			}
 		})
 	}
+}
+
+func TestSyncPreCreatedVpcIPs(t *testing.T) {
+	stopSig := "stop"
+	getQueuedReqs := func(queue workqueue.RateLimitingInterface) []reconcile.Request {
+		var requests []reconcile.Request
+		for {
+			obj, shutdown := queue.Get()
+			if shutdown {
+				return requests
+			}
+			if val, ok := obj.(string); ok && val == stopSig {
+				return requests
+			}
+			req, _ := obj.(reconcile.Request)
+			requests = append(requests, req)
+		}
+	}
+
+	r := createNetworkInfoReconciler()
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	r.Client = k8sClient
+	r.queue = workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(),
+		workqueue.RateLimitingQueueConfig{
+			Name: "test",
+		})
+	defer r.queue.ShuttingDown()
+
+	v1alpha1.AddToScheme(r.Scheme)
+	ctx := context.TODO()
+
+	k8sClient.EXPECT().List(ctx, gomock.Any()).Return(nil).Do(
+		func(_ context.Context, list client.ObjectList, opts ...*client.ListOption) error {
+			networkInfos, _ := list.(*v1alpha1.NetworkInfoList)
+			networkInfos.Items = []v1alpha1.NetworkInfo{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: "ns1"},
+					VPCs: []v1alpha1.VPCState{
+						{PrivateIPs: []string{"1.1.1.0/24"}},
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: "ns2"},
+					VPCs: []v1alpha1.VPCState{
+						{PrivateIPs: []string{"1.1.1.0/24"}},
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: "ns3"},
+					VPCs: []v1alpha1.VPCState{
+						{PrivateIPs: []string{"1.1.1.0/24", "1.1.2.0/24"}},
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: "ns5"},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: "ns6"},
+					VPCs: []v1alpha1.VPCState{
+						{PrivateIPs: []string{"1.1.1.0/24"}},
+					},
+				},
+			}
+
+			return nil
+		})
+
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetAllVPCsFromNSX", func(_ *vpc.VPCService) map[string]model.Vpc {
+		return map[string]model.Vpc{
+			"/orgs/default/projects/p1/vpcs/vpc1": {
+				PrivateIps: []string{"1.1.1.0/24"},
+			},
+			"/orgs/default/projects/p1/vpcs/vpc2": {
+				PrivateIps: []string{"1.1.1.0/24", "1.1.2.0/24"},
+			},
+			"/orgs/default/projects/p1/vpcs/vpc3": {
+				PrivateIps: []string{"1.1.1.0/24", "1.1.3.0/24"},
+			},
+			"/orgs/default/projects/p1/vpcs/vpc5": {
+				PrivateIps: []string{"1.1.1.0/24"},
+			},
+		}
+	})
+	patches.ApplyMethod(reflect.TypeOf(r.Service), "GetNamespacesWithPreCreatedVPCs", func(_ *vpc.VPCService) map[string]string {
+		return map[string]string{
+			"ns1": "/orgs/default/projects/p1/vpcs/vpc1",
+			"ns2": "/orgs/default/projects/p1/vpcs/vpc2",
+			"ns3": "/orgs/default/projects/p1/vpcs/vpc3",
+			"ns4": "/orgs/default/projects/p1/vpcs/vpc4",
+			"ns5": "/orgs/default/projects/p1/vpcs/vpc5",
+			"ns6": "/orgs/default/projects/p1/vpcs/vpc6",
+		}
+	})
+	defer patches.Reset()
+
+	expRequests := []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: "net1", Namespace: "ns2"}},
+		{NamespacedName: types.NamespacedName{Name: "net1", Namespace: "ns3"}},
+		{NamespacedName: types.NamespacedName{Name: "net1", Namespace: "ns6"}},
+	}
+
+	r.syncPreCreatedVpcIPs(ctx)
+	r.queue.Add(stopSig)
+	requests := getQueuedReqs(r.queue)
+	assert.ElementsMatch(t, expRequests, requests)
 }

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1206,14 +1206,14 @@ func (s *VPCService) GetVPCFromNSXByPath(vpcPath string) (*model.Vpc, error) {
 	return &vpc, nil
 }
 
-func (service *VPCService) GetLBSsFromNSXByVPC(vpcPath string) (string, error) {
+func (s *VPCService) GetLBSsFromNSXByVPC(vpcPath string) (string, error) {
 	vpcResInfo, err := common.ParseVPCResourcePath(vpcPath)
 	if err != nil {
 		log.Error(err, "failed to parse VPCResourceInfo from the given VPC path", "VPC", vpcPath)
 		return "", err
 	}
 	includeMarkForDeleted := false
-	lbs, err := service.NSXClient.VPCLBSClient.List(vpcResInfo.OrgID, vpcResInfo.ProjectID, vpcResInfo.VPCID, nil, &includeMarkForDeleted, nil, nil, nil, nil)
+	lbs, err := s.NSXClient.VPCLBSClient.List(vpcResInfo.OrgID, vpcResInfo.ProjectID, vpcResInfo.VPCID, nil, &includeMarkForDeleted, nil, nil, nil, nil)
 	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to read LB services in VPC under from NSX", "VPC", vpcPath)
@@ -1225,6 +1225,44 @@ func (service *VPCService) GetLBSsFromNSXByVPC(vpcPath string) (string, error) {
 	}
 	lbsPath := *lbs.Results[0].Path
 	return lbsPath, nil
+}
+
+// GetAllVPCsFromNSX gets all the existing VPCs on NSX. It returns a map, the key is VPC's path, and the
+// value is the VPC resource.
+func (s *VPCService) GetAllVPCsFromNSX() map[string]model.Vpc {
+	store := &ResourceStore{ResourceStore: common.ResourceStore{
+		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{}),
+		BindingType: model.VpcBindingType(),
+	}}
+	query := fmt.Sprintf("(%s:%s)", common.ResourceType, common.ResourceTypeVpc)
+	count, searcherr := s.SearchResource("", query, store, nil)
+	if searcherr != nil {
+		log.Error(searcherr, "failed to query VPC from NSX", "query", query)
+	} else {
+		log.V(1).Info("query VPC", "count", count)
+	}
+	vpcMap := make(map[string]model.Vpc)
+	for _, obj := range store.List() {
+		vpc := *obj.(*model.Vpc)
+		vpcPath := vpc.Path
+		vpcMap[*vpcPath] = vpc
+	}
+	return vpcMap
+}
+
+// GetNamespacesWithPreCreatedVPCs returns a map of the Namespaces which use the pre-created VPCs. The
+// key of the map is the Namespace name, and the value is the pre-created VPC path used in the NetworkInfo
+// within this Namespace.
+func (s *VPCService) GetNamespacesWithPreCreatedVPCs() map[string]string {
+	nsVpcMap := make(map[string]string)
+	for ncName, cfg := range s.VPCNetworkConfigStore.VPCNetworkConfigMap {
+		if IsPreCreatedVPC(cfg) {
+			for _, ns := range s.GetNamespacesByNetworkconfigName(ncName) {
+				nsVpcMap[ns] = cfg.VPCPath
+			}
+		}
+	}
+	return nsVpcMap
 }
 
 func IsPreCreatedVPC(nc common.VPCNetworkConfigInfo) bool {

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apierrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -1347,5 +1349,115 @@ func TestVPCService_DeleteVPC(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func TestListAllVPCsFromNSX(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		vpcs      []*data.StructValue
+		err       error
+		expVpcMap map[string]model.Vpc
+	}{
+		{
+			name: "Failed to list VPC from NSX",
+			err:  fmt.Errorf("connection issue"),
+		},
+		{
+			name: "success",
+			vpcs: []*data.StructValue{
+				data.NewStructValue("",
+					map[string]data.DataValue{
+						"resource_type": data.NewStringValue("Vpc"),
+						"id":            data.NewStringValue("vpc1"),
+						"path":          data.NewStringValue("/orgs/default/projects/default/vpcs/vpc1"),
+					}),
+				data.NewStructValue("",
+					map[string]data.DataValue{
+						"resource_type": data.NewStringValue("Vpc"),
+						"id":            data.NewStringValue("vpc2"),
+						"path":          data.NewStringValue("/orgs/default/projects/default/vpcs/vpc2"),
+					}),
+			},
+			expVpcMap: map[string]model.Vpc{
+				"/orgs/default/projects/default/vpcs/vpc1": {
+					Id:           common.String("vpc1"),
+					Path:         common.String("/orgs/default/projects/default/vpcs/vpc1"),
+					ResourceType: common.String("Vpc"),
+				},
+				"/orgs/default/projects/default/vpcs/vpc2": {
+					Id:           common.String("vpc2"),
+					Path:         common.String("/orgs/default/projects/default/vpcs/vpc2"),
+					ResourceType: common.String("Vpc"),
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &VPCService{
+				Service: common.Service{},
+			}
+			searchResourcePatch := gomonkey.ApplyMethod(reflect.TypeOf(&s.Service), "SearchResource",
+				func(_ *common.Service, resourceTypeValue string, _ string, store common.Store, _ common.Filter) (uint64, error) {
+					for i := range tc.vpcs {
+						vpc := tc.vpcs[i]
+						store.TransResourceToStore(vpc)
+					}
+					return uint64(len(tc.vpcs)), tc.err
+				})
+			defer searchResourcePatch.Reset()
+			vpcMap := s.GetAllVPCsFromNSX()
+			require.Equal(t, len(tc.expVpcMap), len(vpcMap))
+			for k, v := range tc.expVpcMap {
+				actVpc, ok := vpcMap[k]
+				require.True(t, ok)
+				require.Equal(t, v, actVpc)
+			}
+		})
+	}
+}
+
+func TestListNamespacesWithPreCreatedVPCs(t *testing.T) {
+	svc := &VPCService{
+		VPCNetworkConfigStore: VPCNetworkInfoStore{
+			VPCNetworkConfigMap: map[string]common.VPCNetworkConfigInfo{
+				"net1": {
+					Name: "auto-vpc1",
+				},
+				"net2": {
+					Name:    "pre-vpc1",
+					VPCPath: "/orgs/default/projects/default/vpcs/vpc1",
+				},
+				"net3": {
+					Name:    "pre-vpc2",
+					VPCPath: "/orgs/default/projects/default/vpcs/vpc2",
+				},
+				"net4": {
+					Name:    "unknown-vpc",
+					VPCPath: "/orgs/default/projects/default/vpcs/vpc3",
+				},
+			},
+		},
+		VPCNSNetworkConfigStore: VPCNsNetworkConfigStore{
+			VPCNSNetworkConfigMap: map[string]string{
+				"ns1": "net1",
+				"ns2": "net2",
+				"ns3": "net3",
+				"ns4": "net3",
+			},
+		},
+	}
+	expVpcMap := map[string]string{
+		"ns2": "/orgs/default/projects/default/vpcs/vpc1",
+		"ns3": "/orgs/default/projects/default/vpcs/vpc2",
+		"ns4": "/orgs/default/projects/default/vpcs/vpc2",
+	}
+
+	nsVpcMap := svc.GetNamespacesWithPreCreatedVPCs()
+	require.Equal(t, len(expVpcMap), len(nsVpcMap))
+	for k, v := range expVpcMap {
+		vpcPath, ok := nsVpcMap[k]
+		require.True(t, ok)
+		require.Equal(t, v, vpcPath)
 	}
 }


### PR DESCRIPTION
This change has introduce a goroutine to periodically get the pre-created VPC configuration from NSX, and sync to the referred NetworkInfo CR's status if its private IPs are changed. The sync interval is 10m.

Test Done:
Before update the preVPC private IPs
```
# kubectl get networkinfos -n ns-2 -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  kind: NetworkInfo
  metadata:
    creationTimestamp: "2024-10-19T01:58:10Z"
    finalizers:
    - networkinfo.crd.nsx.vmware.com/finalizer
    generation: 4
    name: ns-2
    namespace: ns-2
    resourceVersion: "3089039"
    uid: df74c57a-ff46-4439-9132-027b1826b6ed
  vpcs:
  - defaultSNATIP: 192.168.0.70
    name: precreate-vpc-1
    privateIPs:
    - 182.26.0.0/24
    vpcPath: /orgs/default/projects/project-test-1/vpcs/precreate-vpc-1
kind: List
metadata:
  resourceVersion: ""
```
Added private IPs `"182.26.1.0/24"` in the VPC on NSX, then check the NetworkInfo CR after 10m. The new private IPs are added in the NetworkInfo CR.
```
# kubectl get networkinfos -n ns-2 -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  kind: NetworkInfo
  metadata:
    creationTimestamp: "2024-10-19T01:58:10Z"
    finalizers:
    - networkinfo.crd.nsx.vmware.com/finalizer
    generation: 5
    name: ns-2
    namespace: ns-2
    resourceVersion: "3095613"
    uid: df74c57a-ff46-4439-9132-027b1826b6ed
  vpcs:
  - defaultSNATIP: 192.168.0.70
    name: precreate-vpc-1
    privateIPs:
    - 182.26.0.0/24
    - 182.26.1.0/24
    vpcPath: /orgs/default/projects/project-test-1/vpcs/precreate-vpc-1
kind: List
metadata:
  resourceVersion: ""
```