### PR TITLE
Support refreshing cert for webhook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,6 @@ test: manifests generate fmt vet envtest .coverage ## Run tests .
 build: generate fmt vet ## Build manager binary.
 	@mkdir -p $(BINDIR)
 	GOOS=linux go build -o $(BINDIR)/manager $(GOFLAGS) -ldflags '$(LDFLAGS)' cmd/main.go
-	GOOS=linux go build -o $(BINDIR)/webhookcert $(GOFLAGS) -ldflags '$(LDFLAGS)' cmd/webhookcert/main.go
 
 .PHONY: build-clean
 build-clean: generate fmt vet ## Build clean binary.

--- a/build/image/photon/Dockerfile
+++ b/build/image/photon/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /source
 
 COPY . /source
 RUN CGO_ENABLED=0 go build -o manager cmd/main.go
-RUN CGO_ENABLED=0 go build -o webhookcert cmd/webhookcert/main.go
 RUN CGO_ENABLED=0 go build -o clean cmd_clean/main.go
 
 FROM photon
@@ -13,7 +12,6 @@ RUN tdnf -y install shadow && \
     useradd -s /bin/bash nsx-operator
 
 COPY --from=golang-build /source/manager /usr/local/bin/
-COPY --from=golang-build /source/webhookcert /usr/local/bin/
 COPY --from=golang-build /source/clean /usr/local/bin/
 
 USER nsx-operator

--- a/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
+++ b/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
@@ -24,7 +24,7 @@ var (
 type IPAddressAllocation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
-	
+
 	Spec   IPAddressAllocationSpec   `json:"spec"`
 	Status IPAddressAllocationStatus `json:"status,omitempty"`
 }


### PR DESCRIPTION
Test done:

Using `ticker := time.NewTicker(10 * time.Second)`, the webhook certificates were successfully refreshed, the secrets were updated without issues, and the webhook functionality remained unaffected.

Also need to update yaml mount readonly, remember.