### PR TITLE
Add unit-test for Subnet controller

### DIFF
--- a/pkg/controllers/subnet/namespace_handler.go
+++ b/pkg/controllers/subnet/namespace_handler.go
@@ -64,9 +64,17 @@ var PredicateFuncsNs = predicate.Funcs{
 	},
 }
 
-func requeueSubnet(c client.Client, ns string, q workqueue.RateLimitingInterface) error {
+func listSubnet(c client.Client, ctx context.Context, options ...client.ListOption) (*v1alpha1.SubnetList, error) {
 	subnetList := &v1alpha1.SubnetList{}
-	err := c.List(context.Background(), subnetList, client.InNamespace(ns))
+	err := c.List(ctx, subnetList, options...)
+	if err != nil {
+		return nil, err
+	}
+	return subnetList, nil
+}
+
+func requeueSubnet(c client.Client, ns string, q workqueue.RateLimitingInterface) error {
+	subnetList, err := listSubnet(c, context.Background(), client.InNamespace(ns))
 	if err != nil {
 		log.Error(err, "Failed to list all the Subnets")
 		return err

--- a/pkg/controllers/subnet/namespace_handler_test.go
+++ b/pkg/controllers/subnet/namespace_handler_test.go
@@ -3,126 +3,159 @@ package subnet
 import (
 	"context"
 	"testing"
-	"time"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/workqueue"
+	ctlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 )
 
-type MockRateLimitingInterface struct {
-	mock.Mock
+func TestEnqueueRequestForNamespace_Create(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	e := &EnqueueRequestForNamespace{Client: client}
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	e.Create(context.TODO(), event.CreateEvent{}, queue)
+	// No asserts here because Create does nothing, just ensuring no errors.
 }
 
-func (m *MockRateLimitingInterface) Add(item interface{}) {
+func TestEnqueueRequestForNamespace_Delete(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	e := &EnqueueRequestForNamespace{Client: client}
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	e.Delete(context.TODO(), event.DeleteEvent{}, queue)
+	// No asserts here because Delete does nothing, just ensuring no errors.
 }
 
-func (m *MockRateLimitingInterface) Len() int {
-	return 0
+func TestEnqueueRequestForNamespace_Generic(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	e := &EnqueueRequestForNamespace{Client: client}
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	e.Generic(context.TODO(), event.GenericEvent{}, queue)
+	// No asserts here because Generic does nothing, just ensuring no errors.
 }
 
-func (m *MockRateLimitingInterface) Get() (item interface{}, shutdown bool) {
-	return
-}
+func TestEnqueueRequestForNamespace_Update(t *testing.T) {
+	// Prepare test data
+	oldNamespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-namespace",
+			Labels: map[string]string{"env": "test"},
+		},
+	}
 
-func (m *MockRateLimitingInterface) Done(item interface{}) {
-	return
-}
+	newNamespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-namespace",
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
 
-func (m *MockRateLimitingInterface) ShutDown() {
-}
+	client := fake.NewClientBuilder().WithObjects(newNamespace).Build()
+	e := &EnqueueRequestForNamespace{Client: client}
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
-func (m *MockRateLimitingInterface) ShutDownWithDrain() {
-}
+	updateEvent := event.UpdateEvent{
+		ObjectOld: oldNamespace,
+		ObjectNew: newNamespace,
+	}
 
-func (m *MockRateLimitingInterface) ShuttingDown() bool {
-	return true
-}
+	subnet := v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-subnet",
+			Namespace: "test-namespace",
+		},
+	}
+	subnetList := &v1alpha1.SubnetList{
+		TypeMeta: metav1.TypeMeta{},
+		ListMeta: metav1.ListMeta{},
+		Items:    []v1alpha1.Subnet{subnet},
+	}
 
-func (m *MockRateLimitingInterface) AddAfter(item interface{}, duration time.Duration) {
-	return
-}
+	e.Update(context.TODO(), updateEvent, queue)
+	assert.Equal(t, 0, queue.Len(), "Expected 1 item to be requeued")
 
-func (m *MockRateLimitingInterface) AddRateLimited(item interface{}) {
-	m.Called(item)
-}
-
-func (m *MockRateLimitingInterface) Forget(item interface{}) {
-	m.Called(item)
-}
-
-func (m *MockRateLimitingInterface) NumRequeues(item interface{}) int {
-	args := m.Called(item)
-	return args.Int(0)
-}
-
-func TestEnqueueRequestForNamespace(t *testing.T) {
-	fakeClient := fake.NewClientBuilder().Build()
-	queue := new(MockRateLimitingInterface)
-	handler := &EnqueueRequestForNamespace{Client: fakeClient}
-
-	t.Run("Update event with changed labels", func(t *testing.T) {
-		oldNamespace := &v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "test-ns",
-				Labels: map[string]string{"key": "old"},
-			},
-		}
-		newNamespace := &v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "test-ns",
-				Labels: map[string]string{"key": "new"},
-			},
-		}
-		updateEvent := event.UpdateEvent{
-			ObjectOld: oldNamespace,
-			ObjectNew: newNamespace,
-		}
-		queue.On("Add", mock.Anything).Return()
-
-		handler.Update(context.Background(), updateEvent, queue)
+	patches := gomonkey.ApplyFunc(listSubnet, func(c ctlclient.Client, ctx context.Context, options ...ctlclient.ListOption) (*v1alpha1.SubnetList, error) {
+		return subnetList, nil
 	})
+	defer patches.Reset()
 
-	t.Run("Update event with unchanged labels", func(t *testing.T) {
-		oldNamespace := &v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "test-ns",
-				Labels: map[string]string{"key": "same"},
-			},
-		}
-		newNamespace := &v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "test-ns",
-				Labels: map[string]string{"key": "same"},
-			},
-		}
-		updateEvent := event.UpdateEvent{
-			ObjectOld: oldNamespace,
-			ObjectNew: newNamespace,
-		}
+	e.Update(context.TODO(), updateEvent, queue)
+	assert.Equal(t, 1, queue.Len(), "Expected 1 item to be requeued")
+}
 
-		queue.On("Add", mock.Anything).Return()
+func TestPredicateFuncsNs_UpdateFunc(t *testing.T) {
+	oldNamespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-namespace",
+			Labels: map[string]string{"env": "test"},
+		},
+	}
 
-		handler.Update(context.Background(), updateEvent, queue)
+	newNamespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-namespace",
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
 
-		queue.AssertNotCalled(t, "Add", mock.Anything)
-	})
+	updateEvent := event.UpdateEvent{
+		ObjectOld: oldNamespace,
+		ObjectNew: newNamespace,
+	}
 
-	t.Run("Requeue subnet function", func(t *testing.T) {
-		ns := "test-ns"
+	// Test the update function logic in PredicateFuncsNs
+	result := PredicateFuncsNs.UpdateFunc(updateEvent)
+	assert.True(t, result, "Expected update event to trigger requeue")
 
-		schem := fake.NewClientBuilder().Build().Scheme()
-		v1alpha1.AddToScheme(schem)
-		queue.On("Add", mock.Anything).Return()
+	// Test with no label change
+	noChangeEvent := event.UpdateEvent{
+		ObjectOld: oldNamespace,
+		ObjectNew: oldNamespace,
+	}
 
-		err := requeueSubnet(fakeClient, ns, queue)
+	result = PredicateFuncsNs.UpdateFunc(noChangeEvent)
+	assert.False(t, result, "Expected no action when labels have not changed")
 
-		assert.NoError(t, err)
-		queue.AssertNumberOfCalls(t, "Add", 0)
-	})
+	res := PredicateFuncsNs.CreateFunc(event.CreateEvent{Object: newNamespace})
+	assert.False(t, res, "Expected no action when labels have not changed")
+
+	res = PredicateFuncsNs.DeleteFunc(event.DeleteEvent{Object: newNamespace})
+	assert.False(t, res, "Expected no action when labels have not changed")
+}
+
+func TestRequeueSubnetSet(t *testing.T) {
+	// Prepare test data
+	subnet := &v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-subnet",
+			Namespace: "test-namespace",
+		},
+	}
+
+	scheme := clientgoscheme.Scheme
+	v1alpha1.AddToScheme(scheme)
+
+	// Test for empty namespace (no SubnetSets found)
+	emptyClient := fake.NewClientBuilder().Build()
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	err := requeueSubnet(emptyClient, "empty-namespace", queue)
+	assert.NoError(t, err, "Expected no error with empty namespace")
+	assert.Equal(t, 0, queue.Len(), "Expected no items to be requeued for empty namespace")
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(subnet).Build()
+	queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	err = requeueSubnet(client, "test-namespace", queue)
+	assert.NoError(t, err, "Expected no error while requeueing SubnetSets")
+	assert.Equal(t, 1, queue.Len(), "Expected 1 item to be requeued")
 }

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -354,8 +354,7 @@ func (r *SubnetReconciler) setupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *SubnetReconciler) listSubnetIDsFromCRs(ctx context.Context) ([]string, error) {
-	crdSubnetList := &v1alpha1.SubnetList{}
-	err := r.Client.List(ctx, crdSubnetList)
+	crdSubnetList, err := listSubnet(r.Client, ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -193,9 +193,10 @@ func (r *SubnetReconciler) deleteSubnetByName(name, ns string) error {
 }
 
 func (r *SubnetReconciler) updateSubnetStatus(obj *v1alpha1.Subnet) error {
-	nsxSubnet := r.SubnetService.SubnetStore.GetByKey(r.SubnetService.BuildSubnetID(obj))
-	if nsxSubnet == nil {
-		return errors.New("failed to get NSX Subnet from store")
+	// if the nsxSubnet is nil, GetSubnetByKey will return error: NSX subnet not found in store
+	nsxSubnet, err := r.SubnetService.GetSubnetByKey(r.SubnetService.BuildSubnetID(obj))
+	if err != nil {
+		return fmt.Errorf("failed to get NSX Subnet from store: %v", err)
 	}
 	obj.Status.NetworkAddresses = obj.Status.NetworkAddresses[:0]
 	obj.Status.GatewayAddresses = obj.Status.GatewayAddresses[:0]

--- a/pkg/controllers/subnet/subnet_controller_test.go
+++ b/pkg/controllers/subnet/subnet_controller_test.go
@@ -14,7 +14,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -138,16 +140,20 @@ func (recorder fakeRecorder) Eventf(object runtime.Object, eventtype, reason, me
 func (recorder fakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
 }
 
-func createFakeSubnetReconciler() *SubnetReconciler {
+func createFakeSubnetReconciler(objs []client.Object) *SubnetReconciler {
+	newScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(newScheme))
+	utilruntime.Must(v1alpha1.AddToScheme(newScheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme).WithObjects(objs...).Build()
 	service := &vpc.VPCService{
 		Service: common.Service{
-			Client:    nil,
+			Client:    fakeClient,
 			NSXClient: &nsx.Client{},
 		},
 	}
 	subnetService := &subnet.SubnetService{
 		Service: common.Service{
-			Client:    nil,
+			Client:    fakeClient,
 			NSXClient: &nsx.Client{},
 
 			NSXConfig: &config.NSXOperatorConfig{
@@ -162,14 +168,14 @@ func createFakeSubnetReconciler() *SubnetReconciler {
 
 	subnetPortService := &subnetport.SubnetPortService{
 		Service: common.Service{
-			Client:    nil,
+			Client:    fakeClient,
 			NSXClient: &nsx.Client{},
 		},
 		SubnetPortStore: nil,
 	}
 
 	return &SubnetReconciler{
-		Client:            fake.NewClientBuilder().Build(),
+		Client:            fakeClient,
 		Scheme:            fake.NewClientBuilder().Build().Scheme(),
 		VPCService:        service,
 		SubnetService:     subnetService,
@@ -179,162 +185,308 @@ func createFakeSubnetReconciler() *SubnetReconciler {
 }
 
 func TestSubnetReconciler_Reconcile(t *testing.T) {
-	req := ctrl.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: "default",
-			Name:      "test-subnet",
-		},
-	}
-
-	createNewSubnet := func() *v1alpha1.Subnet {
-		return &v1alpha1.Subnet{
+	subnetName := "test-subnet"
+	subnetID := "fake-subnet-uid"
+	createNewSubnet := func(specs ...bool) *v1alpha1.Subnet {
+		subnetCR := &v1alpha1.Subnet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-subnet",
+				Name:      subnetName,
 				Namespace: "default",
-				UID:       "fake-subnet-uid",
+				UID:       types.UID(subnetID),
 			},
 			Spec: v1alpha1.SubnetSpec{
 				IPv4SubnetSize: 0,
 				AccessMode:     "",
 			},
 		}
+		if len(specs) > 0 && specs[0] {
+			subnetCR.Finalizers = []string{"test-Finalizers"}
+			subnetCR.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		}
+		return subnetCR
 	}
 
-	reconciler := createFakeSubnetReconciler()
-	ctx := context.Background()
+	testCases := []struct {
+		name             string
+		req              ctrl.Request
+		expectRes        ctrl.Result
+		expectErrStr     string
+		patches          func(r *SubnetReconciler) *gomonkey.Patches
+		existingSubnetCR *v1alpha1.Subnet
+		expectSubnetCR   *v1alpha1.Subnet
+	}{
+		{
+			name: "Subnet CR not found",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
+			patches: func(r *SubnetReconciler) *gomonkey.Patches {
+				return gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "deleteSubnetByName", func(_ *SubnetReconciler, name, ns string) error {
+					return nil
+				})
+			},
+			expectRes:        ResultNormal,
+			existingSubnetCR: nil,
+		},
+		{
+			name: "Delete Subnet CR success",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
+			patches: func(r *SubnetReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "deleteSubnetByID", func(_ *SubnetReconciler, id string) error {
+					return nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService.SubnetStore), "GetByIndex", func(_ *subnet.SubnetStore, key string, value string) []*model.VpcSubnet {
+					id1 := "fake-id"
+					path := "fake-path"
+					tags := []model.Tag{
+						{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-subnet-uid-2")},
+						{Scope: common.String(common.TagScopeSubnetCRName), Tag: common.String(subnetName)},
+					}
+					vpcSubnetSkip := model.VpcSubnet{Id: &id1, Path: &path, Tags: tags}
 
-	// When the Subnet CR does not exist
-	t.Run("Subnet CR not found", func(t *testing.T) {
-		v1alpha1.AddToScheme(reconciler.Scheme)
-		patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(reconciler), "deleteSubnetByName", func(_ *SubnetReconciler, name, ns string) error {
-			return nil
-		})
-		defer patches.Reset()
+					id2 := "fake-id-1"
+					path2 := "fake-path-2"
+					tagStale := []model.Tag{
+						{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-subnet-uid-stale")},
+						{Scope: common.String(common.TagScopeSubnetCRName), Tag: common.String(subnetName)},
+					}
+					vpcSubnetDelete := model.VpcSubnet{Id: &id2, Path: &path2, Tags: tagStale}
+					return []*model.VpcSubnet{
+						&vpcSubnetSkip, &vpcSubnetDelete,
+					}
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetPortService), "GetPortsOfSubnet", func(_ *subnetport.SubnetPortService, _ string) (ports []*model.VpcSubnetPort) {
+					return nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "DeleteSubnet", func(_ *subnet.SubnetService, subnet model.VpcSubnet) error {
+					return nil
+				})
+				return patches
+			},
+			expectRes: ResultNormal,
+		},
+		{
+			name: "Delete Subnet CR failed to delete NSX Subnet",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
+			patches: func(r *SubnetReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService.SubnetStore), "GetByIndex", func(_ *subnet.SubnetStore, key string, value string) []*model.VpcSubnet {
+					id1 := "fake-id"
+					path := "fake-path"
+					tags := []model.Tag{
+						{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-subnet-uid-2")},
+						{Scope: common.String(common.TagScopeSubnetCRName), Tag: common.String(subnetName)},
+					}
+					vpcSubnetSkip := model.VpcSubnet{Id: &id1, Path: &path, Tags: tags}
 
-		result, err := reconciler.Reconcile(ctx, req)
+					id2 := "fake-id-1"
+					path2 := "fake-path-2"
+					tagStale := []model.Tag{
+						{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-subnet-uid-stale")},
+						{Scope: common.String(common.TagScopeSubnetCRName), Tag: common.String(subnetName)},
+					}
+					vpcSubnetDelete := model.VpcSubnet{Id: &id2, Path: &path2, Tags: tagStale}
+					return []*model.VpcSubnet{
+						&vpcSubnetSkip, &vpcSubnetDelete,
+					}
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetPortService), "GetPortsOfSubnet", func(_ *subnetport.SubnetPortService, _ string) (ports []*model.VpcSubnetPort) {
+					return nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "DeleteSubnet", func(_ *subnet.SubnetService, subnet model.VpcSubnet) error {
+					return errors.New("failed to delete NSX Subnet")
+				})
+				return patches
+			},
+			expectRes:    ResultRequeue,
+			expectErrStr: "failed to delete NSX Subnet",
+		},
+		{
+			name: "Get Subnet CR return other error should retry",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
+			patches: func(r *SubnetReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.Client), "Get", func(_ client.Client, _ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return errors.New("get Subnet CR error")
+				})
+				patches.ApplyPrivateMethod(reflect.TypeOf(r), "deleteSubnetByName", func(_ *SubnetReconciler, name, ns string) error {
+					return nil
+				})
+				return patches
+			},
+			expectErrStr:     "get Subnet CR error",
+			expectRes:        ResultRequeue,
+			existingSubnetCR: nil,
+		},
+		{
+			name: "Subnet CR with finalizer delete success",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
+			patches: func(r *SubnetReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "deleteSubnetByID", func(_ *SubnetReconciler, _ string) error {
+					return nil
+				})
+				return patches
+			},
+			expectRes:        ResultNormal,
+			existingSubnetCR: createNewSubnet(true),
+		},
+		{
+			name: "Subnet CR with finalizer",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
+			patches: func(r *SubnetReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService.SubnetStore), "GetByIndex", func(_ *subnet.SubnetStore, key string, value string) []*model.VpcSubnet {
+					id1 := "fake-id"
+					path := "fake-path"
+					tags := []model.Tag{
+						{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-subnet-uid-2")},
+						{Scope: common.String(common.TagScopeSubnetCRName), Tag: common.String(subnetName)},
+					}
+					vpcSubnetSkip := model.VpcSubnet{Id: &id1, Path: &path, Tags: tags}
 
-		assert.NoError(t, err)
-		assert.Equal(t, ctrl.Result{}, result)
-		patches.Reset()
-	})
+					id2 := "fake-id-1"
+					path2 := "fake-path-2"
+					tagStale := []model.Tag{
+						{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String(subnetID)},
+						{Scope: common.String(common.TagScopeSubnetCRName), Tag: common.String(subnetName)},
+					}
+					vpcSubnetDelete := model.VpcSubnet{Id: &id2, Path: &path2, Tags: tagStale}
+					return []*model.VpcSubnet{
+						&vpcSubnetSkip, &vpcSubnetDelete,
+					}
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetPortService), "GetPortsOfSubnet", func(_ *subnetport.SubnetPortService, _ string) (ports []*model.VpcSubnetPort) {
+					return nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "DeleteSubnet", func(_ *subnet.SubnetService, subnet model.VpcSubnet) error {
+					return nil
+				})
+				return patches
+			},
+			expectRes:        ResultNormal,
+			existingSubnetCR: createNewSubnet(true),
+		},
+		{
+			name: "Subnet CR with finalizer delete failed",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
+			patches: func(r *SubnetReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService.SubnetStore), "GetByIndex", func(_ *subnet.SubnetStore, key string, value string) []*model.VpcSubnet {
+					id1 := "fake-id"
+					path := "fake-path"
+					tags := []model.Tag{
+						{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-subnet-uid-2")},
+						{Scope: common.String(common.TagScopeSubnetCRName), Tag: common.String(subnetName)},
+					}
+					vpcSubnetSkip := model.VpcSubnet{Id: &id1, Path: &path, Tags: tags}
 
-	t.Run("Get Subnet CR return other error should retry", func(t *testing.T) {
-		v1alpha1.AddToScheme(reconciler.Scheme)
-		patches := gomonkey.ApplyMethod(reflect.TypeOf(reconciler.Client), "Get", func(_ client.Client, _ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
-			return errors.New("get Subnet CR error")
-		})
-		defer patches.Reset()
-		patches.ApplyPrivateMethod(reflect.TypeOf(reconciler), "deleteSubnetByName", func(_ *SubnetReconciler, name, ns string) error {
-			return nil
-		})
+					id2 := "fake-id-1"
+					path2 := "fake-path-2"
+					tagStale := []model.Tag{
+						{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String(subnetID)},
+						{Scope: common.String(common.TagScopeSubnetCRName), Tag: common.String(subnetName)},
+					}
+					vpcSubnetDelete := model.VpcSubnet{Id: &id2, Path: &path2, Tags: tagStale}
+					return []*model.VpcSubnet{
+						&vpcSubnetSkip, &vpcSubnetDelete,
+					}
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetPortService), "GetPortsOfSubnet", func(_ *subnetport.SubnetPortService, _ string) (ports []*model.VpcSubnetPort) {
+					return nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "DeleteSubnet", func(_ *subnet.SubnetService, subnet model.VpcSubnet) error {
+					return errors.New("delete NSX Subnet failed")
+				})
+				return patches
+			},
+			expectRes:        ResultRequeue,
+			expectErrStr:     "delete NSX Subnet failed",
+			existingSubnetCR: createNewSubnet(true),
+		},
+		{
+			name: "Create or Update Subnet Failure",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
+			patches: func(r *SubnetReconciler) *gomonkey.Patches {
+				vpcConfig := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 16}
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
+					return vpcConfig
+				})
 
-		result, err := reconciler.Reconcile(ctx, req)
+				tags := []model.Tag{{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-tag")}}
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "GenerateSubnetNSTags", func(_ *subnet.SubnetService, obj client.Object) []model.Tag {
+					return tags
+				})
 
-		assert.ErrorContains(t, err, "get Subnet CR error")
-		assert.Equal(t, ResultRequeue, result)
-	})
+				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "ListVPCInfo", func(_ *vpc.VPCService, ns string) []common.VPCResourceInfo {
+					return []common.VPCResourceInfo{
+						{OrgID: "org-id", ProjectID: "project-id", VPCID: "vpc-id", ID: "fake-id"},
+					}
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (string, error) {
+					return "", errors.New("create or update failed")
+				})
+				return patches
+			},
+			existingSubnetCR: createNewSubnet(),
+			expectErrStr:     "create or update failed",
+			expectRes:        ResultRequeue,
+		},
+		{
+			name: "Update Subnet CR spec success",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
+			patches: func(r *SubnetReconciler) *gomonkey.Patches {
+				vpcConfig := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 16}
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
+					return vpcConfig
+				})
 
-	// When the Subnet CR is being deleted should delete the Subnet and return no error
-	t.Run("Subnet CR being deleted", func(t *testing.T) {
-		t.Log("When the Subnet CR is being deleted should delete the Subnet and return no error")
-		v1alpha1.AddToScheme(reconciler.Scheme)
-		subnetCR := createNewSubnet()
-		now := metav1.NewTime(time.Now())
-		subnetCR.DeletionTimestamp = &now
+				tags := []model.Tag{{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-tag")}}
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "GenerateSubnetNSTags", func(_ *subnet.SubnetService, obj client.Object) []model.Tag {
+					return tags
+				})
 
-		createErr := reconciler.Client.Create(ctx, subnetCR)
-		defer reconciler.Client.Delete(ctx, subnetCR)
-		assert.NoError(t, createErr)
+				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "ListVPCInfo", func(_ *vpc.VPCService, ns string) []common.VPCResourceInfo {
+					return []common.VPCResourceInfo{
+						{OrgID: "org-id", ProjectID: "project-id", VPCID: "vpc-id", ID: "fake-id"},
+					}
+				})
 
-		patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(reconciler), "deleteSubnetByID", func(_ *SubnetReconciler, _ string) error {
-			return nil
-		})
-		defer patches.Reset()
-		patches.ApplyMethod(reflect.TypeOf(reconciler.Client), "Delete", func(_ client.Client, _ context.Context, _ client.Object, _ ...client.DeleteOption) error {
-			return nil
-		})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (string, error) {
+					return "", nil
+				})
 
-		result, err := reconciler.Reconcile(ctx, req)
+				patches.ApplyPrivateMethod(reflect.TypeOf(r), "updateSubnetStatus", func(_ *SubnetReconciler, obj *v1alpha1.Subnet) error {
+					return nil
+				})
+				return patches
+			},
+			existingSubnetCR: createNewSubnet(),
+			expectSubnetCR: &v1alpha1.Subnet{
+				Spec:   v1alpha1.SubnetSpec{IPv4SubnetSize: 16, AccessMode: "Private", IPAddresses: []string(nil), DHCPConfig: v1alpha1.DHCPConfig{EnableDHCP: false}},
+				Status: v1alpha1.SubnetStatus{},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			objs := []client.Object{}
+			if testCase.existingSubnetCR != nil {
+				objs = append(objs, testCase.existingSubnetCR)
+			}
+			reconciler := createFakeSubnetReconciler(objs)
+			ctx := context.Background()
 
-		assert.ErrorContains(t, err, "VPCNetworkConfig not found")
-		assert.Equal(t, ResultRequeue, result)
-	})
+			v1alpha1.AddToScheme(reconciler.Scheme)
+			patches := testCase.patches(reconciler)
+			defer patches.Reset()
 
-	// When an error occurs during reconciliation, should return an error and requeue"
-	t.Run("Create or Update Subnet Failure", func(t *testing.T) {
-		v1alpha1.AddToScheme(reconciler.Scheme)
+			result, err := reconciler.Reconcile(ctx, testCase.req)
+			if testCase.expectErrStr != "" {
+				assert.ErrorContains(t, err, testCase.expectErrStr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, testCase.expectRes, result)
 
-		subnetCR := createNewSubnet()
-		createErr := reconciler.Client.Create(ctx, subnetCR)
-		assert.NoError(t, createErr)
-		defer reconciler.Client.Delete(ctx, subnetCR)
-
-		vpcConfig := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 16}
-		patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(reconciler.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
-			return vpcConfig
-		})
-		defer patches.Reset()
-
-		tags := []model.Tag{{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-tag")}}
-		patches.ApplyMethod(reflect.TypeOf(reconciler.SubnetService), "GenerateSubnetNSTags", func(_ *subnet.SubnetService, obj client.Object) []model.Tag {
-			return tags
-		})
-
-		patches.ApplyMethod(reflect.TypeOf(reconciler.VPCService), "ListVPCInfo", func(_ *vpc.VPCService, ns string) []common.VPCResourceInfo {
-			return []common.VPCResourceInfo{
-				{OrgID: "org-id", ProjectID: "project-id", VPCID: "vpc-id", ID: "fake-id"},
+			if testCase.expectSubnetCR != nil {
+				actualSubnetCR := &v1alpha1.Subnet{}
+				assert.NoError(t, reconciler.Client.Get(ctx, testCase.req.NamespacedName, actualSubnetCR))
+				assert.Equal(t, testCase.expectSubnetCR.Spec, actualSubnetCR.Spec)
 			}
 		})
-
-		patches.ApplyMethod(reflect.TypeOf(reconciler.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (string, error) {
-			return "", errors.New("create or update failed")
-		})
-
-		result, err := reconciler.Reconcile(ctx, req)
-
-		assert.Error(t, err)
-		assert.Equal(t, ctrl.Result{Requeue: true}, result)
-	})
-
-	// When updating the Subnet spec, should update the Subnet CR spec if not set
-	t.Run("Update Subnet CR spec", func(t *testing.T) {
-		v1alpha1.AddToScheme(reconciler.Scheme)
-
-		subnetCR := createNewSubnet()
-		createErr := reconciler.Client.Create(ctx, subnetCR)
-		assert.NoError(t, createErr)
-		defer reconciler.Client.Delete(ctx, subnetCR)
-
-		vpcConfig := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 16}
-		patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(reconciler.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
-			return vpcConfig
-		})
-		defer patches.Reset()
-
-		tags := []model.Tag{{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-tag")}}
-		patches.ApplyMethod(reflect.TypeOf(reconciler.SubnetService), "GenerateSubnetNSTags", func(_ *subnet.SubnetService, obj client.Object) []model.Tag {
-			return tags
-		})
-
-		patches.ApplyMethod(reflect.TypeOf(reconciler.VPCService), "ListVPCInfo", func(_ *vpc.VPCService, ns string) []common.VPCResourceInfo {
-			return []common.VPCResourceInfo{
-				{OrgID: "org-id", ProjectID: "project-id", VPCID: "vpc-id", ID: "fake-id"},
-			}
-		})
-
-		patches.ApplyMethod(reflect.TypeOf(reconciler.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (string, error) {
-			return "", nil
-		})
-
-		patches.ApplyPrivateMethod(reflect.TypeOf(reconciler), "updateSubnetStatus", func(_ *SubnetReconciler, obj *v1alpha1.Subnet) error {
-			return nil
-		})
-
-		result, err := reconciler.Reconcile(ctx, req)
-
-		assert.NoError(t, err)
-		assert.NoError(t, reconciler.Client.Get(ctx, req.NamespacedName, subnetCR))
-		assert.Equal(t, 16, subnetCR.Spec.IPv4SubnetSize)
-		assert.Equal(t, ctrl.Result{}, result)
-	})
+	}
 }


### PR DESCRIPTION
Add unit-test for Subnet controller

```
go test -v -coverprofile .coverage/cover.out ./pkg/controllers/subnet/...
=== RUN   TestEnqueueRequestForNamespace_Create
--- PASS: TestEnqueueRequestForNamespace_Create (0.00s)
=== RUN   TestEnqueueRequestForNamespace_Delete
--- PASS: TestEnqueueRequestForNamespace_Delete (0.00s)
=== RUN   TestEnqueueRequestForNamespace_Generic
--- PASS: TestEnqueueRequestForNamespace_Generic (0.00s)
=== RUN   TestEnqueueRequestForNamespace_Update
--- PASS: TestEnqueueRequestForNamespace_Update (0.00s)
=== RUN   TestPredicateFuncsNs_UpdateFunc
--- PASS: TestPredicateFuncsNs_UpdateFunc (0.00s)
=== RUN   TestRequeueSubnetSet
--- PASS: TestRequeueSubnetSet (0.00s)
=== RUN   TestSubnetReconciler_GarbageCollector
=== RUN   TestSubnetReconciler_GarbageCollector/Delete_stale_NSX_Subnets_success
=== RUN   TestSubnetReconciler_GarbageCollector/Should_not_delete_NSX_Subnet_when_the_Subnet_CR_existes
=== RUN   TestSubnetReconciler_GarbageCollector/Delete_NSX_Subnet_error
--- PASS: TestSubnetReconciler_GarbageCollector (0.00s)
    --- PASS: TestSubnetReconciler_GarbageCollector/Delete_stale_NSX_Subnets_success (0.00s)
    --- PASS: TestSubnetReconciler_GarbageCollector/Should_not_delete_NSX_Subnet_when_the_Subnet_CR_existes (0.00s)
    --- PASS: TestSubnetReconciler_GarbageCollector/Delete_NSX_Subnet_error (0.00s)
=== RUN   TestSubnetReconciler_Reconcile
=== RUN   TestSubnetReconciler_Reconcile/Subnet_CR_not_found
=== RUN   TestSubnetReconciler_Reconcile/Delete_Subnet_CR_success
=== RUN   TestSubnetReconciler_Reconcile/Delete_Subnet_CR_failed_to_delete_NSX_Subnet
=== RUN   TestSubnetReconciler_Reconcile/Delete_Subnet_CR_with_stale_SubnetPort
=== RUN   TestSubnetReconciler_Reconcile/Get_Subnet_CR_return_other_error_should_retry
=== RUN   TestSubnetReconciler_Reconcile/Subnet_CR_with_finalizer_delete_success
=== RUN   TestSubnetReconciler_Reconcile/Subnet_CR_with_finalizer
=== RUN   TestSubnetReconciler_Reconcile/Subnet_CR_with_finalizer_delete_failed
=== RUN   TestSubnetReconciler_Reconcile/Create_or_Update_Subnet_with_create_NSX_Subnet_failure
=== RUN   TestSubnetReconciler_Reconcile/Update_Subnet_CR_spec_success
=== RUN   TestSubnetReconciler_Reconcile/Update_Subnet_CR_with_update_status_error
=== RUN   TestSubnetReconciler_Reconcile/Create_or_Update_Subnet_with_VPCNetworkConfig_not_found_failure
=== RUN   TestSubnetReconciler_Reconcile/Create_or_Update_Subnet_with_generate_Subnet_tags_failure
=== RUN   TestSubnetReconciler_Reconcile/Create_or_Update_Subnet_with_No_VPC_info_found_failure
--- PASS: TestSubnetReconciler_Reconcile (0.03s)
    --- PASS: TestSubnetReconciler_Reconcile/Subnet_CR_not_found (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Delete_Subnet_CR_success (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Delete_Subnet_CR_failed_to_delete_NSX_Subnet (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Delete_Subnet_CR_with_stale_SubnetPort (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Get_Subnet_CR_return_other_error_should_retry (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Subnet_CR_with_finalizer_delete_success (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Subnet_CR_with_finalizer (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Subnet_CR_with_finalizer_delete_failed (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Create_or_Update_Subnet_with_create_NSX_Subnet_failure (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Update_Subnet_CR_spec_success (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Update_Subnet_CR_with_update_status_error (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Create_or_Update_Subnet_with_VPCNetworkConfig_not_found_failure (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Create_or_Update_Subnet_with_generate_Subnet_tags_failure (0.00s)
    --- PASS: TestSubnetReconciler_Reconcile/Create_or_Update_Subnet_with_No_VPC_info_found_failure (0.00s)
=== RUN   TestStartSubnetController
=== RUN   TestStartSubnetController/StartSubnetController_with_webhook
=== RUN   TestStartSubnetController/StartSubnetController_return_error
--- PASS: TestStartSubnetController (0.00s)
    --- PASS: TestStartSubnetController/StartSubnetController_with_webhook (0.00s)
    --- PASS: TestStartSubnetController/StartSubnetController_return_error (0.00s)
PASS
coverage: 88.8% of statements
ok      github.com/vmware-tanzu/nsx-operator/pkg/controllers/subnet     1.270s  coverage: 88.8% of statements
```