### PR TITLE
Remove staticroute finalizer

### DIFF
--- a/pkg/controllers/staticroute/staticroute_controller.go
+++ b/pkg/controllers/staticroute/staticroute_controller.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -18,9 +19,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 
@@ -72,28 +70,64 @@ func deleteSuccess(r *StaticRouteReconciler, _ context.Context, o *v1alpha1.Stat
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteSuccessTotal, common.MetricResTypeStaticRoute)
 }
 
+func (r *StaticRouteReconciler) listStaticRouteCRIDs() (sets.Set[string], error) {
+	staticRouteList := &v1alpha1.StaticRouteList{}
+	err := r.Client.List(context.Background(), staticRouteList)
+	if err != nil {
+		log.Error(err, "failed to list StaticRoute CRs")
+		return nil, err
+	}
+
+	CRStaticRouteSet := sets.New[string]()
+	for _, staticroute := range staticRouteList.Items {
+		CRStaticRouteSet.Insert(string(staticroute.UID))
+	}
+	return CRStaticRouteSet, nil
+}
+
+func (r *StaticRouteReconciler) deleteStaticRouteByName(ns, name string) error {
+	CRPolicySet, err := r.listStaticRouteCRIDs()
+	if err != nil {
+		return err
+	}
+	nsxStaticRoutes := r.Service.ListStaticRouteByName(ns, name)
+	for _, item := range nsxStaticRoutes {
+		uid := util.FindTag(item.Tags, commonservice.TagScopeStaticRouteCRUID)
+		if CRPolicySet.Has(uid) {
+			log.Info("skipping deletion, StaticRoute CR still exists in K8s", "staticrouteUID", uid, "nsxStatciRouteId", *item.Id)
+			continue
+		}
+
+		log.Info("deleting StaticRoute", "StaticRouteUID", uid, "nsxStaticRouteId", *item.Id)
+		path := strings.Split(*item.Path, "/")
+		if err := r.Service.DeleteStaticRouteByPath(path[2], path[4], path[6], *item.Id); err != nil {
+			log.Error(err, "failed to delete StaticRoute", "StaticRouteUID", uid, "nsxStaticRouteId", *item.Id)
+			return err
+		}
+		log.Info("successfully deleted StaticRoute", "StaticRouteUID", uid, "nsxStaticRouteId", *item.Id)
+	}
+	return nil
+}
+
 func (r *StaticRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	obj := &v1alpha1.StaticRoute{}
 	log.Info("reconciling staticroute CR", "staticroute", req.NamespacedName)
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerSyncTotal, common.MetricResTypeStaticRoute)
 
 	if err := r.Client.Get(ctx, req.NamespacedName, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			if err := r.deleteStaticRouteByName(req.Namespace, req.Name); err != nil {
+				return ResultRequeue, err
+			} else {
+				return ResultNormal, nil
+			}
+		}
 		log.Error(err, "unable to fetch static route CR", "req", req.NamespacedName)
-		return ResultNormal, client.IgnoreNotFound(err)
+		return ResultRequeue, err
 	}
 
 	if obj.ObjectMeta.DeletionTimestamp.IsZero() {
 		metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateTotal, common.MetricResTypeStaticRoute)
-		if !controllerutil.ContainsFinalizer(obj, commonservice.StaticRouteFinalizerName) {
-			controllerutil.AddFinalizer(obj, commonservice.StaticRouteFinalizerName)
-			if err := r.Client.Update(ctx, obj); err != nil {
-				log.Error(err, "add finalizer", "staticroute", req.NamespacedName)
-				updateFail(r, ctx, obj, &err)
-				return ResultRequeue, err
-			}
-			log.V(1).Info("added finalizer on staticroute CR", "staticroute", req.NamespacedName)
-		}
-
 		if err := r.Service.CreateOrUpdateStaticRoute(req.Namespace, obj); err != nil {
 			updateFail(r, ctx, obj, &err)
 			// TODO: if error is not retriable, not requeue
@@ -105,27 +139,14 @@ func (r *StaticRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 		updateSuccess(r, ctx, obj)
 	} else {
-		if controllerutil.ContainsFinalizer(obj, commonservice.StaticRouteFinalizerName) {
-			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, common.MetricResTypeStaticRoute)
-			// TODO, update the value from 'default' to actual value， get OrgID, ProjectID, VPCID depending on obj.Namespace from vpc store
-			if err := r.Service.DeleteStaticRoute(obj); err != nil {
-				log.Error(err, "delete failed, would retry exponentially", "staticroute", req.NamespacedName)
-				deleteFail(r, ctx, obj, &err)
-				return ResultRequeue, err
-			}
-			controllerutil.RemoveFinalizer(obj, commonservice.StaticRouteFinalizerName)
-			if err := r.Client.Update(ctx, obj); err != nil {
-				deleteFail(r, ctx, obj, &err)
-				return ResultRequeue, err
-			}
-			log.V(1).Info("removed finalizer", "staticroute", req.NamespacedName)
-			deleteSuccess(r, ctx, obj)
-		} else {
-			// only print a message because it's not a normal case
-			log.Info("finalizers cannot be recognized", "staticroute", req.NamespacedName)
+		metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteTotal, common.MetricResTypeStaticRoute)
+		if err := r.Service.DeleteStaticRoute(obj); err != nil {
+			log.Error(err, "delete failed, would retry exponentially", "staticroute", req.NamespacedName)
+			deleteFail(r, ctx, obj, &err)
+			return ResultRequeue, err
 		}
+		deleteSuccess(r, ctx, obj)
 	}
-
 	return ResultNormal, nil
 }
 
@@ -198,12 +219,6 @@ func getExistingConditionOfType(conditionType v1alpha1.StaticRouteStatusConditio
 func (r *StaticRouteReconciler) setupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.StaticRoute{}).
-		WithEventFilter(predicate.Funcs{
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				// Suppress Delete events to avoid filtering them out in the Reconcile function
-				return false
-			},
-		}).
 		WithOptions(
 			controller.Options{
 				MaxConcurrentReconciles: common.NumReconcile(),

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -108,7 +108,6 @@ const (
 
 	SecurityPolicyFinalizerName      = "securitypolicy.crd.nsx.vmware.com/finalizer"
 	NetworkPolicyFinalizerName       = "networkpolicy.crd.nsx.vmware.com/finalizer"
-	StaticRouteFinalizerName         = "staticroute.crd.nsx.vmware.com/finalizer"
 	SubnetFinalizerName              = "subnet.crd.nsx.vmware.com/finalizer"
 	SubnetSetFinalizerName           = "subnetset.crd.nsx.vmware.com/finalizer"
 	SubnetPortFinalizerName          = "subnetport.crd.nsx.vmware.com/finalizer"

--- a/pkg/nsx/services/staticroute/staticroute.go
+++ b/pkg/nsx/services/staticroute/staticroute.go
@@ -40,6 +40,7 @@ func InitializeStaticRoute(commonService common.Service, vpcService common.VPCSe
 	staticRouteStore := &StaticRouteStore{}
 	staticRouteStore.Indexer = cache.NewIndexer(keyFunc, cache.Indexers{
 		common.TagScopeStaticRouteCRUID: indexFunc,
+		common.TagScopeNamespace:        indexStaticRouteNamespace,
 	})
 	staticRouteStore.BindingType = model.StaticRoutesBindingType()
 	staticRouteService.StaticRouteStore = staticRouteStore
@@ -146,6 +147,19 @@ func (service *StaticRouteService) DeleteStaticRoute(obj *v1alpha1.StaticRoute) 
 		return err
 	}
 	return service.DeleteStaticRouteByPath(vpcResourceInfo.OrgID, vpcResourceInfo.ProjectID, vpcResourceInfo.VPCID, id)
+}
+
+func (service *StaticRouteService) ListStaticRouteByName(ns, name string) []*model.StaticRoutes {
+	var result []*model.StaticRoutes
+	staticroutes := service.StaticRouteStore.GetByIndex(common.TagScopeNamespace, ns)
+	for _, staticroute := range staticroutes {
+		sr := staticroute.(*model.StaticRoutes)
+		tagname := nsxutil.FindTag(sr.Tags, common.TagScopeStaticRouteCRName)
+		if tagname == name {
+			result = append(result, staticroute.(*model.StaticRoutes))
+		}
+	}
+	return result
 }
 
 func (service *StaticRouteService) ListStaticRoute() []*model.StaticRoutes {

--- a/pkg/nsx/services/staticroute/store.go
+++ b/pkg/nsx/services/staticroute/store.go
@@ -29,17 +29,26 @@ func indexFunc(obj interface{}) ([]string, error) {
 	res := make([]string, 0, 5)
 	switch v := obj.(type) {
 	case *model.StaticRoutes:
-		return filterTag(v.Tags), nil
+		return filterTag(v.Tags, common.TagScopeStaticRouteCRUID), nil
 	default:
 		break
 	}
 	return res, nil
 }
 
-var filterTag = func(v []model.Tag) []string {
+func indexStaticRouteNamespace(obj interface{}) ([]string, error) {
+	switch o := obj.(type) {
+	case *model.StaticRoutes:
+		return filterTag(o.Tags, common.TagScopeNamespace), nil
+	default:
+		return nil, errors.New("indexByStaticRouteNamespace doesn't support unknown type")
+	}
+}
+
+var filterTag = func(v []model.Tag, tagScope string) []string {
 	res := make([]string, 0, 5)
 	for _, tag := range v {
-		if *tag.Scope == common.TagScopeStaticRouteCRUID {
+		if *tag.Scope == tagScope {
 			res = append(res, *tag.Tag)
 		}
 	}


### PR DESCRIPTION
The finalizer may block the deletion since the NSX resource may take long time to delete. Remove the finalizer so the deleting operation will return immediately