### PR TITLE
Cherry pick changes

### DIFF
--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -5,7 +5,6 @@ package networkinfo
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -45,6 +44,54 @@ var (
 	MetricResType = common.MetricResTypeNetworkInfo
 )
 
+const (
+	NamespaceNetworkReady corev1.NamespaceConditionType = "NamespaceNetworkReady"
+
+	NSReasonVPCNetConfigNotReady string = "VPCNetworkConfigurationNotReady"
+	NSReasonVPCNotReady          string = "VPCNotReady"
+	NSReasonVPCSnatNotReady      string = "VPCSnatNotReady"
+)
+
+var (
+	nsMsgVPCNetCfgGetError        = newNsUnreadyMessage("Error happened to get VPC network configuration: %v", NSReasonVPCNetConfigNotReady)
+	nsMsgSystemVPCNetCfgNotFound  = newNsUnreadyMessage("Error happened to get system VPC network configuration: %v", NSReasonVPCNetConfigNotReady)
+	nsMsgVPCGwConnectionGetError  = newNsUnreadyMessage("Error happened to validate system VPC gateway connection readiness: %v", NSReasonVPCNetConfigNotReady)
+	nsMsgVPCGwConnectionNotReady  = newNsUnreadyMessage("System VPC gateway connection is not ready", NSReasonVPCNetConfigNotReady)
+	nsMsgVPCCreateUpdateError     = newNsUnreadyMessage("Error happened to create or update VPC: %v", NSReasonVPCNotReady)
+	nsMsgVPCNsxLBSNotReady        = newNsUnreadyMessage("Error happened to get NSX LBS path in VPC: %v", NSReasonVPCNotReady)
+	nsMsgVPCAviSubnetError        = newNsUnreadyMessage("Error happened to get Avi Load balancer Subnet info: %v", NSReasonVPCNotReady)
+	nsMsgVPCGetExtIPBlockError    = newNsUnreadyMessage("Error happened to get external IP blocks: %v", NSReasonVPCNotReady)
+	nsMsgVPCNoExternalIPBlock     = newNsUnreadyMessage("System VPC has no external IP blocks", NSReasonVPCNotReady)
+	nsMsgVPCAutoSNATDisabled      = newNsUnreadyMessage("SNAT is not enabled in System VPC", NSReasonVPCSnatNotReady)
+	nsMsgVPCDefaultSNATIPGetError = newNsUnreadyMessage("Default SNAT IP is not allocated in VPC: %v", NSReasonVPCSnatNotReady)
+	nsMsgVPCIsReady               = newNsUnreadyMessage("", "")
+)
+
+type nsUnreadyMessage struct {
+	reason string
+	msg    string
+}
+
+func newNsUnreadyMessage(msg string, reason string) *nsUnreadyMessage {
+	return &nsUnreadyMessage{
+		msg:    msg,
+		reason: reason,
+	}
+}
+
+func (m *nsUnreadyMessage) getNSNetworkCondition(options ...interface{}) *corev1.NamespaceCondition {
+	cond := &corev1.NamespaceCondition{
+		Type:   NamespaceNetworkReady,
+		Status: corev1.ConditionTrue,
+	}
+	if m.reason != "" {
+		cond.Status = corev1.ConditionFalse
+		cond.Reason = m.reason
+		cond.Message = fmt.Sprintf(m.msg, options...)
+	}
+	return cond
+}
+
 // NetworkInfoReconciler NetworkInfoReconcile reconciles a NetworkInfo object
 // Actually it is more like a shell, which is used to manage nsx VPC
 type NetworkInfoReconciler struct {
@@ -60,13 +107,13 @@ func (r *NetworkInfoReconciler) GetVpcConnectivityProfilePathByVpcPath(vpcPath s
 	// TODO, if needs to add a cache for it
 	VPCResourceInfo, err := commonservice.ParseVPCResourcePath(vpcPath)
 	if err != nil {
-		log.Error(err, "failed to parse VPC path", "VPC Path", vpcPath)
+		log.Error(err, "Failed to parse VPC path", "VPC Path", vpcPath)
 		return "", err
 	}
 	// pre created VPC may have more than one attachment, list all the attachment and select the first one
 	vpcAttachmentsListResult, err := r.Service.NSXClient.VpcAttachmentClient.List(VPCResourceInfo.OrgID, VPCResourceInfo.ProjectID, VPCResourceInfo.VPCID, nil, nil, nil, nil, nil, nil)
 	if err != nil {
-		log.Error(err, "failed to list VPC attachment", "VPC Path", vpcPath)
+		log.Error(err, "Failed to list VPC attachment", "VPC Path", vpcPath)
 		return "", err
 	}
 	vpcAttachments := vpcAttachmentsListResult.Results
@@ -75,7 +122,7 @@ func (r *NetworkInfoReconciler) GetVpcConnectivityProfilePathByVpcPath(vpcPath s
 		return *vpcAttachments[0].VpcConnectivityProfile, nil
 	} else {
 		err := fmt.Errorf("no VPC attachment found")
-		log.Error(err, "list VPC attachment", "VPC Path", vpcPath)
+		log.Error(err, "List VPC attachment", "VPC Path", vpcPath)
 		return "", err
 	}
 }
@@ -110,58 +157,68 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		deleteSuccess(r, ctx, networkInfoCR)
 		return common.ResultNormal, nil
 	}
+
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateTotal, common.MetricResTypeNetworkInfo)
 	// TODO:
 	// 1. check whether the logic to get VPC network config can be replaced by GetVPCNetworkConfigByNamespace
 	// 2. sometimes the variable nc points to a VPCNetworkInfo, sometimes it's a VPCNetworkConfiguration, we need to distinguish between them.
-	ncName, err := r.Service.GetNetworkconfigNameFromNS(networkInfoCR.Namespace)
+	nc, err := r.getNetworkConfigInfo(networkInfoCR)
 	if err != nil {
-		log.Error(err, "Failed to get network config name for VPC when creating NSX VPC", "NetworkInfo", networkInfoCR.Name)
 		updateFail(r, ctx, networkInfoCR, &err, r.Client, nil)
-		return common.ResultRequeueAfter10sec, err
-	}
-	nc, _exist := r.Service.GetVPCNetworkConfig(ncName)
-	if !_exist {
-		message := fmt.Sprintf("Failed to read network config %s when creating NSX VPC", ncName)
-		log.Info(message)
-		updateFail(r, ctx, networkInfoCR, &err, r.Client, nil)
-		return common.ResultRequeueAfter10sec, errors.New(message)
-	}
-	log.Info("Fetched network config from store", "NetworkConfig", ncName)
-	vpcNetworkConfiguration := &v1alpha1.VPCNetworkConfiguration{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: commonservice.SystemVPCNetworkConfigurationName}, vpcNetworkConfiguration)
-	if err != nil {
-		log.Error(err, "Failed to get system VPCNetworkConfiguration")
-		updateFail(r, ctx, networkInfoCR, &err, r.Client, nil)
-		return common.ResultRequeueAfter10sec, err
-	}
-	gatewayConnectionReady, _, err := getGatewayConnectionStatus(ctx, vpcNetworkConfiguration)
-	if err != nil {
-		log.Error(err, "Failed to get the gateway connection status", "NetworkInfo", req.NamespacedName)
+		setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCNetCfgGetError.getNSNetworkCondition(err))
 		return common.ResultRequeueAfter10sec, err
 	}
 
+	ncName := nc.Name
+	log.Info("Fetched network config from store", "NetworkConfig", ncName)
+
+	systemVpcNetCfg := &v1alpha1.VPCNetworkConfiguration{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: commonservice.SystemVPCNetworkConfigurationName}, systemVpcNetCfg)
+	if err != nil {
+		log.Error(err, "Failed to get system VPCNetworkConfiguration")
+		updateFail(r, ctx, networkInfoCR, &err, r.Client, nil)
+		setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgSystemVPCNetCfgNotFound.getNSNetworkCondition(err))
+		return common.ResultRequeueAfter10sec, err
+	}
+
+	retryWithSystemVPC := false
+	var systemNSCondition *corev1.NamespaceCondition
+
+	gatewayConnectionReady, _ := getGatewayConnectionStatus(ctx, systemVpcNetCfg)
 	gatewayConnectionReason := ""
 	if !gatewayConnectionReady {
-		if ncName == commonservice.SystemVPCNetworkConfigurationName {
-			gatewayConnectionReady, gatewayConnectionReason, err = r.Service.ValidateGatewayConnectionStatus(&nc)
-			log.Info("got the gateway connection status", "gatewayConnectionReady", gatewayConnectionReady, "gatewayConnectionReason", gatewayConnectionReason)
-			if err != nil {
-				log.Error(err, "Failed to validate the edge and gateway connection", "Org", nc.Org, "Project", nc.NSXProject)
-				updateFail(r, ctx, networkInfoCR, &err, r.Client, nil)
-				return common.ResultRequeueAfter10sec, err
-			}
-			setVPCNetworkConfigurationStatusWithGatewayConnection(ctx, r.Client, vpcNetworkConfiguration, gatewayConnectionReady, gatewayConnectionReason)
-		} else {
+		// Retry after 60s if the gateway connection is not ready in system VPC.
+		if ncName != commonservice.SystemVPCNetworkConfigurationName {
 			log.Info("Skipping reconciliation due to unready system gateway connection", "NetworkInfo", req.NamespacedName)
+			setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCGwConnectionNotReady.getNSNetworkCondition())
 			return common.ResultRequeueAfter60sec, nil
 		}
+
+		// Re-check the gateway connection readiness in system VPC on NSX.
+		gatewayConnectionReady, gatewayConnectionReason, err = r.Service.ValidateGatewayConnectionStatus(&nc)
+		log.Info("Got the gateway connection status", "gatewayConnectionReady", gatewayConnectionReady, "gatewayConnectionReason", gatewayConnectionReason)
+		if err != nil {
+			log.Error(err, "Failed to validate the edge and gateway connection", "Org", nc.Org, "Project", nc.NSXProject)
+			updateFail(r, ctx, networkInfoCR, &err, r.Client, nil)
+			setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCGwConnectionGetError.getNSNetworkCondition(err))
+			return common.ResultRequeueAfter10sec, err
+		}
+		setVPCNetworkConfigurationStatusWithGatewayConnection(ctx, r.Client, systemVpcNetCfg, gatewayConnectionReady, gatewayConnectionReason)
+
+		// Retry after 60s if the gateway connection is still not ready in system VPC.
+		if !gatewayConnectionReady {
+			log.Info("Requeue NetworkInfo CR because VPCNetworkConfiguration system is not ready", "gatewayConnectionReason", gatewayConnectionReason, "req", req)
+			retryWithSystemVPC = true
+			systemNSCondition = nsMsgVPCGwConnectionNotReady.getNSNetworkCondition()
+		}
 	}
+
 	lbProvider := r.Service.GetLBProvider()
 	createdVpc, err := r.Service.CreateOrUpdateVPC(networkInfoCR, &nc, lbProvider)
 	if err != nil {
 		log.Error(err, "Failed to create or update VPC", "NetworkInfo", req.NamespacedName)
 		updateFail(r, ctx, networkInfoCR, &err, r.Client, nil)
+		setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCCreateUpdateError.getNSNetworkCondition(err))
 		return common.ResultRequeueAfter10sec, err
 	}
 
@@ -174,23 +231,30 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		vpcPath := *createdVpc.Path
 		vpcConnectivityProfilePath, err = r.GetVpcConnectivityProfilePathByVpcPath(vpcPath)
 		if err != nil {
-			log.Error(err, "failed to get VPC connectivity profile path", "path", vpcPath)
+			log.Error(err, "Failed to get VPC connectivity profile path", "path", vpcPath)
 			updateFail(r, ctx, networkInfoCR, &err, r.Client, nil)
 			return common.ResultRequeueAfter10sec, err
 		}
-		// Retrieve NSX lbs path if Avi is not used with the pre-created VPC.
-		if createdVpc.LoadBalancerVpcEndpoint == nil || createdVpc.LoadBalancerVpcEndpoint.Enabled == nil ||
-			!*createdVpc.LoadBalancerVpcEndpoint.Enabled {
+		// Retrieve NSX lbs path if Supervisor is configuring with NSX LB.
+		if lbProvider == vpc.NSXLB {
 			nsxLBSPath, err = r.Service.GetLBSsFromNSXByVPC(vpcPath)
 			if err != nil {
-				log.Error(err, "failed to get NSX LBS path with pre-created VPC", "VPC", createdVpc.Path)
+				log.Error(err, "Failed to get NSX LBS path with pre-created VPC", "VPC", vpcPath)
 				updateFail(r, ctx, networkInfoCR, &err, r.Client, nil)
+				setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCNsxLBSNotReady.getNSNetworkCondition(err))
+				return common.ResultRequeueAfter10sec, err
+			}
+			if nsxLBSPath == "" {
+				log.Error(nil, "NSX LB path is not set with pre-created VPC", "VPC", vpcPath)
+				err = fmt.Errorf("NSX LB does not exist")
+				setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCNsxLBSNotReady.getNSNetworkCondition(err))
 				return common.ResultRequeueAfter10sec, err
 			}
 		}
 	} else {
 		privateIPs = nc.PrivateIPs
 		vpcConnectivityProfilePath = nc.VPCConnectivityProfile
+		nsxLBSPath = r.Service.GetDefaultNSXLBSPathByVPC(*createdVpc.Id)
 	}
 
 	snatIP, path, cidr := "", "", ""
@@ -199,16 +263,20 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err != nil {
 		log.Error(err, "Failed to get VPC connectivity profile", "NetworkInfo", req.NamespacedName)
 		updateFail(r, ctx, networkInfoCR, &err, r.Client, nil)
+		setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCGetExtIPBlockError.getNSNetworkCondition(err))
 		return common.ResultRequeueAfter10sec, err
 	}
-	hasExternalIPs := true
+	// Check external IP blocks on system VPC network config.
 	if ncName == commonservice.SystemVPCNetworkConfigurationName {
-		if len(vpcConnectivityProfile.ExternalIpBlocks) == 0 {
-			hasExternalIPs = false
+		hasExternalIPs := len(vpcConnectivityProfile.ExternalIpBlocks) > 0
+		setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx, r.Client, systemVpcNetCfg, hasExternalIPs)
+		if !hasExternalIPs && !retryWithSystemVPC {
 			log.Error(err, "There is no ExternalIPBlock in VPC ConnectivityProfile", "NetworkInfo", req.NamespacedName)
+			retryWithSystemVPC = true
+			systemNSCondition = nsMsgVPCNoExternalIPBlock.getNSNetworkCondition()
 		}
-		setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx, r.Client, vpcNetworkConfiguration, hasExternalIPs)
 	}
+
 	// currently, auto snat is not exposed, and use default value True
 	// checking autosnat to support future extension in VPC configuration
 	autoSnatEnabled := r.Service.IsEnableAutoSNAT(vpcConnectivityProfile)
@@ -223,19 +291,18 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				PrivateIPs:              privateIPs,
 			}
 			updateFail(r, ctx, networkInfoCR, &err, r.Client, state)
+			setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCDefaultSNATIPGetError.getNSNetworkCondition(err))
 			return common.ResultRequeueAfter10sec, err
 		}
 	}
 	if ncName == commonservice.SystemVPCNetworkConfigurationName {
-		vpcNetworkConfiguration := &v1alpha1.VPCNetworkConfiguration{}
-		err := r.Client.Get(ctx, types.NamespacedName{Name: ncName}, vpcNetworkConfiguration)
-		if err != nil {
-			log.Error(err, "Failed to get VPCNetworkConfiguration", "Name", ncName)
-			updateFail(r, ctx, networkInfoCR, &err, r.Client, nil)
-			return common.ResultRequeueAfter10sec, err
-		}
 		log.Info("Got the AutoSnat status", "autoSnatEnabled", autoSnatEnabled, "NetworkInfo", req.NamespacedName)
-		setVPCNetworkConfigurationStatusWithSnatEnabled(ctx, r.Client, vpcNetworkConfiguration, autoSnatEnabled)
+		setVPCNetworkConfigurationStatusWithSnatEnabled(ctx, r.Client, systemVpcNetCfg, autoSnatEnabled)
+		if !autoSnatEnabled && !retryWithSystemVPC {
+			log.Info("Requeue NetworkInfo CR because VPCNetworkConfiguration system is not ready", "autoSnatEnabled", autoSnatEnabled, "req", req)
+			retryWithSystemVPC = true
+			systemNSCondition = nsMsgVPCAutoSNATDisabled.getNSNetworkCondition()
+		}
 	}
 
 	// if lb VPC enabled, read avi subnet path and cidr
@@ -252,6 +319,7 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				PrivateIPs:              privateIPs,
 			}
 			updateFail(r, ctx, networkInfoCR, &err, r.Client, state)
+			setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCAviSubnetError.getNSNetworkCondition(err))
 			return common.ResultRequeueAfter10sec, err
 		}
 	}
@@ -264,17 +332,16 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		VPCPath:                 *createdVpc.Path,
 	}
 
-	if !isPreCreatedVPC {
-		nsxLBSPath = r.Service.GetDefaultNSXLBSPathByVPC(*createdVpc.Id)
-	}
 	// AKO needs to know the AVI subnet path created by NSX
 	setVPCNetworkConfigurationStatusWithLBS(ctx, r.Client, ncName, state.Name, path, nsxLBSPath, *createdVpc.Path)
 	updateSuccess(r, ctx, networkInfoCR, r.Client, state, nc.Name, path)
-	if ncName == commonservice.SystemVPCNetworkConfigurationName && (!gatewayConnectionReady || !autoSnatEnabled || !hasExternalIPs) {
-		log.Info("Requeue NetworkInfo CR because VPCNetworkConfiguration system is not ready", "gatewayConnectionReason", gatewayConnectionReason, "autoSnatEnabled", autoSnatEnabled, "hasExternalIPs", hasExternalIPs, "req", req)
+
+	if retryWithSystemVPC {
+		setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, systemNSCondition)
 		return common.ResultRequeueAfter60sec, nil
 	}
 
+	setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCIsReady.getNSNetworkCondition())
 	return common.ResultNormal, nil
 }
 
@@ -463,7 +530,7 @@ func (r *NetworkInfoReconciler) syncPreCreatedVpcIPs(ctx context.Context) {
 	networkInfos := &v1alpha1.NetworkInfoList{}
 	err := r.Client.List(ctx, networkInfos)
 	if err != nil {
-		log.Error(err, "failed to list NetworkInfos")
+		log.Error(err, "Failed to list NetworkInfos")
 		return
 	}
 	networkInfoMap := make(map[string]v1alpha1.NetworkInfo)
@@ -518,4 +585,18 @@ func (r *NetworkInfoReconciler) getQueue(controllerName string, rateLimiter rate
 		})
 	}
 	return r.queue
+}
+
+func (r *NetworkInfoReconciler) getNetworkConfigInfo(networkInfoCR *v1alpha1.NetworkInfo) (commonservice.VPCNetworkConfigInfo, error) {
+	ncName, err := r.Service.GetNetworkconfigNameFromNS(networkInfoCR.Namespace)
+	if err != nil {
+		log.Error(err, "Failed to get network config name for VPC when creating NSX VPC", "NetworkInfo", networkInfoCR.Name)
+		return commonservice.VPCNetworkConfigInfo{}, err
+	}
+	nc, _exist := r.Service.GetVPCNetworkConfig(ncName)
+	if !_exist {
+		log.Error(nil, fmt.Sprintf("network config %s does not exist when creating NSX VPC", ncName))
+		return commonservice.VPCNetworkConfigInfo{}, fmt.Errorf("VPCNetworkConfig %s not found", ncName)
+	}
+	return nc, nil
 }

--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -11,18 +11,22 @@ import (
 	"testing"
 
 	"github.com/agiledragon/gomonkey"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
@@ -700,7 +704,6 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				}))
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetNetworkconfigNameFromNS", func(_ *vpc.VPCService, _ string) (string, error) {
 					return "pre-vpc-nc", nil
-
 				})
 				patches.ApplyMethod(reflect.TypeOf(r), "GetVpcConnectivityProfilePathByVpcPath", func(_ *NetworkInfoReconciler, _ string) (string, error) {
 					return "connectivity_profile", nil
@@ -886,6 +889,7 @@ func TestNetworkInfoReconciler_CollectGarbage(t *testing.T) {
 		r.CollectGarbage(ctx)
 	})
 }
+
 func TestNetworkInfoReconciler_GetVpcConnectivityProfilePathByVpcPath(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -967,4 +971,106 @@ func TestNetworkInfoReconciler_GetVpcConnectivityProfilePathByVpcPath(t *testing
 			}
 		})
 	}
+}
+
+func TestSyncPreCreatedVpcIPs(t *testing.T) {
+	stopSig := "stop"
+	getQueuedReqs := func(queue workqueue.RateLimitingInterface) []reconcile.Request {
+		var requests []reconcile.Request
+		for {
+			obj, shutdown := queue.Get()
+			if shutdown {
+				return requests
+			}
+			if val, ok := obj.(string); ok && val == stopSig {
+				return requests
+			}
+			req, _ := obj.(reconcile.Request)
+			requests = append(requests, req)
+		}
+	}
+
+	r := createNetworkInfoReconciler()
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	r.Client = k8sClient
+	r.queue = workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(),
+		workqueue.RateLimitingQueueConfig{
+			Name: "test",
+		})
+	defer r.queue.ShuttingDown()
+
+	v1alpha1.AddToScheme(r.Scheme)
+	ctx := context.TODO()
+
+	k8sClient.EXPECT().List(ctx, gomock.Any()).Return(nil).Do(
+		func(_ context.Context, list client.ObjectList, opts ...*client.ListOption) error {
+			networkInfos, _ := list.(*v1alpha1.NetworkInfoList)
+			networkInfos.Items = []v1alpha1.NetworkInfo{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: "ns1"},
+					VPCs: []v1alpha1.VPCState{
+						{PrivateIPs: []string{"1.1.1.0/24"}},
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: "ns2"},
+					VPCs: []v1alpha1.VPCState{
+						{PrivateIPs: []string{"1.1.1.0/24"}},
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: "ns3"},
+					VPCs: []v1alpha1.VPCState{
+						{PrivateIPs: []string{"1.1.1.0/24", "1.1.2.0/24"}},
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: "ns5"},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{Name: "net1", Namespace: "ns6"},
+					VPCs: []v1alpha1.VPCState{
+						{PrivateIPs: []string{"1.1.1.0/24"}},
+					},
+				},
+			}
+
+			return nil
+		})
+
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetAllVPCsFromNSX", func(_ *vpc.VPCService) map[string]model.Vpc {
+		return map[string]model.Vpc{
+			"/orgs/default/projects/p1/vpcs/vpc1": {
+				PrivateIps: []string{"1.1.1.0/24"},
+			},
+			"/orgs/default/projects/p1/vpcs/vpc2": {
+				PrivateIps: []string{"1.1.1.0/24", "1.1.2.0/24"},
+			},
+			"/orgs/default/projects/p1/vpcs/vpc3": {
+				PrivateIps: []string{"1.1.1.0/24", "1.1.3.0/24"},
+			},
+			"/orgs/default/projects/p1/vpcs/vpc5": {
+				PrivateIps: []string{"1.1.1.0/24"},
+			},
+		}
+	})
+	patches.ApplyMethod(reflect.TypeOf(r.Service), "GetNamespacesWithPreCreatedVPCs", func(_ *vpc.VPCService) map[string]string {
+		return map[string]string{
+			"ns1": "/orgs/default/projects/p1/vpcs/vpc1",
+			"ns2": "/orgs/default/projects/p1/vpcs/vpc2",
+			"ns3": "/orgs/default/projects/p1/vpcs/vpc3",
+			"ns4": "/orgs/default/projects/p1/vpcs/vpc4",
+			"ns5": "/orgs/default/projects/p1/vpcs/vpc5",
+			"ns6": "/orgs/default/projects/p1/vpcs/vpc6",
+		}
+	})
+	defer patches.Reset()
+
+	expRequests := []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: "net1", Namespace: "ns2"}},
+		{NamespacedName: types.NamespacedName{Name: "net1", Namespace: "ns3"}},
+		{NamespacedName: types.NamespacedName{Name: "net1", Namespace: "ns6"}},
+	}
+
+	r.syncPreCreatedVpcIPs(ctx)
+	r.queue.Add(stopSig)
+	requests := getQueuedReqs(r.queue)
+	assert.ElementsMatch(t, expRequests, requests)
 }

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1208,14 +1208,14 @@ func (s *VPCService) GetVPCFromNSXByPath(vpcPath string) (*model.Vpc, error) {
 	return &vpc, nil
 }
 
-func (service *VPCService) GetLBSsFromNSXByVPC(vpcPath string) (string, error) {
+func (s *VPCService) GetLBSsFromNSXByVPC(vpcPath string) (string, error) {
 	vpcResInfo, err := common.ParseVPCResourcePath(vpcPath)
 	if err != nil {
 		log.Error(err, "failed to parse VPCResourceInfo from the given VPC path", "VPC", vpcPath)
 		return "", err
 	}
 	includeMarkForDeleted := false
-	lbs, err := service.NSXClient.VPCLBSClient.List(vpcResInfo.OrgID, vpcResInfo.ProjectID, vpcResInfo.VPCID, nil, &includeMarkForDeleted, nil, nil, nil, nil)
+	lbs, err := s.NSXClient.VPCLBSClient.List(vpcResInfo.OrgID, vpcResInfo.ProjectID, vpcResInfo.VPCID, nil, &includeMarkForDeleted, nil, nil, nil, nil)
 	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "failed to read LB services in VPC under from NSX", "VPC", vpcPath)
@@ -1227,6 +1227,44 @@ func (service *VPCService) GetLBSsFromNSXByVPC(vpcPath string) (string, error) {
 	}
 	lbsPath := *lbs.Results[0].Path
 	return lbsPath, nil
+}
+
+// GetAllVPCsFromNSX gets all the existing VPCs on NSX. It returns a map, the key is VPC's path, and the
+// value is the VPC resource.
+func (s *VPCService) GetAllVPCsFromNSX() map[string]model.Vpc {
+	store := &ResourceStore{ResourceStore: common.ResourceStore{
+		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{}),
+		BindingType: model.VpcBindingType(),
+	}}
+	query := fmt.Sprintf("(%s:%s)", common.ResourceType, common.ResourceTypeVpc)
+	count, searcherr := s.SearchResource("", query, store, nil)
+	if searcherr != nil {
+		log.Error(searcherr, "failed to query VPC from NSX", "query", query)
+	} else {
+		log.V(1).Info("query VPC", "count", count)
+	}
+	vpcMap := make(map[string]model.Vpc)
+	for _, obj := range store.List() {
+		vpc := *obj.(*model.Vpc)
+		vpcPath := vpc.Path
+		vpcMap[*vpcPath] = vpc
+	}
+	return vpcMap
+}
+
+// GetNamespacesWithPreCreatedVPCs returns a map of the Namespaces which use the pre-created VPCs. The
+// key of the map is the Namespace name, and the value is the pre-created VPC path used in the NetworkInfo
+// within this Namespace.
+func (s *VPCService) GetNamespacesWithPreCreatedVPCs() map[string]string {
+	nsVpcMap := make(map[string]string)
+	for ncName, cfg := range s.VPCNetworkConfigStore.VPCNetworkConfigMap {
+		if IsPreCreatedVPC(cfg) {
+			for _, ns := range s.GetNamespacesByNetworkconfigName(ncName) {
+				nsVpcMap[ns] = cfg.VPCPath
+			}
+		}
+	}
+	return nsVpcMap
 }
 
 func IsPreCreatedVPC(nc common.VPCNetworkConfigInfo) bool {

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apierrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -1347,5 +1349,115 @@ func TestVPCService_DeleteVPC(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func TestListAllVPCsFromNSX(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		vpcs      []*data.StructValue
+		err       error
+		expVpcMap map[string]model.Vpc
+	}{
+		{
+			name: "Failed to list VPC from NSX",
+			err:  fmt.Errorf("connection issue"),
+		},
+		{
+			name: "success",
+			vpcs: []*data.StructValue{
+				data.NewStructValue("",
+					map[string]data.DataValue{
+						"resource_type": data.NewStringValue("Vpc"),
+						"id":            data.NewStringValue("vpc1"),
+						"path":          data.NewStringValue("/orgs/default/projects/default/vpcs/vpc1"),
+					}),
+				data.NewStructValue("",
+					map[string]data.DataValue{
+						"resource_type": data.NewStringValue("Vpc"),
+						"id":            data.NewStringValue("vpc2"),
+						"path":          data.NewStringValue("/orgs/default/projects/default/vpcs/vpc2"),
+					}),
+			},
+			expVpcMap: map[string]model.Vpc{
+				"/orgs/default/projects/default/vpcs/vpc1": {
+					Id:           common.String("vpc1"),
+					Path:         common.String("/orgs/default/projects/default/vpcs/vpc1"),
+					ResourceType: common.String("Vpc"),
+				},
+				"/orgs/default/projects/default/vpcs/vpc2": {
+					Id:           common.String("vpc2"),
+					Path:         common.String("/orgs/default/projects/default/vpcs/vpc2"),
+					ResourceType: common.String("Vpc"),
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &VPCService{
+				Service: common.Service{},
+			}
+			searchResourcePatch := gomonkey.ApplyMethod(reflect.TypeOf(&s.Service), "SearchResource",
+				func(_ *common.Service, resourceTypeValue string, _ string, store common.Store, _ common.Filter) (uint64, error) {
+					for i := range tc.vpcs {
+						vpc := tc.vpcs[i]
+						store.TransResourceToStore(vpc)
+					}
+					return uint64(len(tc.vpcs)), tc.err
+				})
+			defer searchResourcePatch.Reset()
+			vpcMap := s.GetAllVPCsFromNSX()
+			require.Equal(t, len(tc.expVpcMap), len(vpcMap))
+			for k, v := range tc.expVpcMap {
+				actVpc, ok := vpcMap[k]
+				require.True(t, ok)
+				require.Equal(t, v, actVpc)
+			}
+		})
+	}
+}
+
+func TestListNamespacesWithPreCreatedVPCs(t *testing.T) {
+	svc := &VPCService{
+		VPCNetworkConfigStore: VPCNetworkInfoStore{
+			VPCNetworkConfigMap: map[string]common.VPCNetworkConfigInfo{
+				"net1": {
+					Name: "auto-vpc1",
+				},
+				"net2": {
+					Name:    "pre-vpc1",
+					VPCPath: "/orgs/default/projects/default/vpcs/vpc1",
+				},
+				"net3": {
+					Name:    "pre-vpc2",
+					VPCPath: "/orgs/default/projects/default/vpcs/vpc2",
+				},
+				"net4": {
+					Name:    "unknown-vpc",
+					VPCPath: "/orgs/default/projects/default/vpcs/vpc3",
+				},
+			},
+		},
+		VPCNSNetworkConfigStore: VPCNsNetworkConfigStore{
+			VPCNSNetworkConfigMap: map[string]string{
+				"ns1": "net1",
+				"ns2": "net2",
+				"ns3": "net3",
+				"ns4": "net3",
+			},
+		},
+	}
+	expVpcMap := map[string]string{
+		"ns2": "/orgs/default/projects/default/vpcs/vpc1",
+		"ns3": "/orgs/default/projects/default/vpcs/vpc2",
+		"ns4": "/orgs/default/projects/default/vpcs/vpc2",
+	}
+
+	nsVpcMap := svc.GetNamespacesWithPreCreatedVPCs()
+	require.Equal(t, len(expVpcMap), len(nsVpcMap))
+	for k, v := range expVpcMap {
+		vpcPath, ok := nsVpcMap[k]
+		require.True(t, ok)
+		require.Equal(t, v, vpcPath)
 	}
 }


### PR DESCRIPTION
Cherry pick these changes:
https://github.com/vmware-tanzu/nsx-operator/pull/799: Periodically sync pre-created VPC private IPs to NetworkInfo CR
https://github.com/vmware-tanzu/nsx-operator/pull/807: Add condition on K8s Namespace if any VPC failure happens