### PR TITLE
Add webhook to prevent SubnetSet/Subnet deletion with stale SubnetPort

### DIFF
--- a/build/yaml/webhook/manifests.yaml
+++ b/build/yaml/webhook/manifests.yaml
@@ -14,10 +14,7 @@ webhooks:
       # kubebuilder webhookpath.
       path: /validate-crd-nsx-vmware-com-v1alpha1-subnetset
   failurePolicy: Fail
-  name: default.subnetset.validating.crd.nsx.vmware.com
-  objectSelector:
-    matchExpressions:
-    - { key: nsxoperator.vmware.com/default-subnetset-for, operator: In, values: ["Pod", "VirtualMachine"] }
+  name: subnetset.validating.crd.nsx.vmware.com
   rules:
   - apiGroups:
     - crd.nsx.vmware.com
@@ -49,4 +46,23 @@ webhooks:
     - UPDATE
     resources:
     - addressbindings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: vmware-system-nsx-operator-webhook-service
+      namespace: vmware-system-nsx
+      path: /validate-crd-nsx-vmware-com-v1alpha1-subnet
+  failurePolicy: Fail
+  name: subnet.validating.crd.nsx.vmware.com
+  rules:
+  - apiGroups:
+    - crd.nsx.vmware.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - DELETE
+    resources:
+    - subnets
   sideEffects: None

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -221,10 +221,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 		// Start controllers which only supports VPC
 		StartNetworkInfoController(mgr, vpcService, ipblocksInfoService)
 		StartNamespaceController(mgr, cf, vpcService)
-		// Start subnet/subnetset controller.
-		if err := subnet.StartSubnetController(mgr, subnetService, subnetPortService, vpcService); err != nil {
-			os.Exit(1)
-		}
+
 		var hookServer webhook.Server
 		if _, err := os.Stat(config.WebhookCertDir); errors.Is(err, os.ErrNotExist) {
 			log.Error(err, "server cert not found, disabling webhook server", "cert", config.WebhookCertDir)
@@ -237,6 +234,10 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 				log.Error(err, "failed to add hook server")
 				os.Exit(1)
 			}
+		}
+		// Start Subnet/SubnetSet controller.
+		if err := subnet.StartSubnetController(mgr, subnetService, subnetPortService, vpcService, hookServer); err != nil {
+			os.Exit(1)
 		}
 		if err := subnetset.StartSubnetSetController(mgr, subnetService, subnetPortService, vpcService, hookServer); err != nil {
 			os.Exit(1)

--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -207,14 +207,20 @@ func TestGetDefaultSubnetSet(t *testing.T) {
 					return nil
 				})
 			},
-			expectedErr: "default subnetset multiple default subnetsets found",
+			expectedErr: "multiple default subnetsets found",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.prepareFunc(t)
-			GetDefaultSubnetSet(k8sClient, context.TODO(), "ns-1", "")
+			result, err := GetDefaultSubnetSet(k8sClient, context.TODO(), "ns-1", "")
+			if tt.expectedErr != "" {
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			}
 		})
 	}
 

--- a/pkg/controllers/subnet/subnet_controller_test.go
+++ b/pkg/controllers/subnet/subnet_controller_test.go
@@ -730,7 +730,7 @@ func TestStartSubnetController(t *testing.T) {
 			patches := testCase.patches()
 			defer patches.Reset()
 
-			err := StartSubnetController(mockMgr, subnetService, subnetPortService, vpcService)
+			err := StartSubnetController(mockMgr, subnetService, subnetPortService, vpcService, nil)
 
 			if testCase.expectErrStr != "" {
 				assert.ErrorContains(t, err, testCase.expectErrStr)

--- a/pkg/controllers/subnet/subnet_webhook.go
+++ b/pkg/controllers/subnet/subnet_webhook.go
@@ -1,0 +1,69 @@
+package subnet
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+)
+
+var NSXOperatorSA = "system:serviceaccount:vmware-system-nsx:ncp-svc-account"
+
+// Create validator instead of using the existing one in controller-runtime because the existing one can't
+// inspect admission.Request in Handle function.
+
+// +kubebuilder:webhook:path=/validate-crd-nsx-vmware-com-v1alpha1-subnet,mutating=false,failurePolicy=fail,sideEffects=None,groups=crd.nsx.vmware.com,resources=subnets,verbs=delete,versions=v1alpha1,name=subnet.validating.crd.nsx.vmware.com,admissionReviewVersions=v1
+
+type SubnetValidator struct {
+	Client  client.Client
+	decoder admission.Decoder
+}
+
+// Handle handles admission requests.
+func (v *SubnetValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	subnet := &v1alpha1.Subnet{}
+
+	var err error
+	if req.Operation == admissionv1.Delete {
+		err = v.decoder.DecodeRaw(req.OldObject, subnet)
+	} else {
+		err = v.decoder.Decode(req, subnet)
+	}
+	if err != nil {
+		log.Error(err, "error while decoding Subnet", "Subnet", req.Namespace+"/"+req.Name)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	log.V(1).Info("Handling request", "user", req.UserInfo.Username, "operation", req.Operation)
+	switch req.Operation {
+	case admissionv1.Delete:
+		if req.UserInfo.Username != NSXOperatorSA {
+			hasSubnetPort, err := v.checkSubnetPort(ctx, subnet.Namespace, subnet.Name)
+			if err != nil {
+				return admission.Errored(http.StatusBadRequest, err)
+			}
+			if hasSubnetPort {
+				return admission.Denied(fmt.Sprintf("Subnet %s/%s with stale SubnetPorts cannot be deleted", subnet.Namespace, subnet.Name))
+			}
+		}
+	}
+	return admission.Allowed("")
+}
+
+func (v *SubnetValidator) checkSubnetPort(ctx context.Context, ns string, subnetName string) (bool, error) {
+	crdSubnetPorts := &v1alpha1.SubnetPortList{}
+	err := v.Client.List(ctx, crdSubnetPorts, client.InNamespace(ns))
+	if err != nil {
+		return false, fmt.Errorf("failed to list SubnetPort: %v", err)
+	}
+	for _, crdSubnetPort := range crdSubnetPorts.Items {
+		if crdSubnetPort.Spec.Subnet == subnetName {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/controllers/subnet/subnet_webhook_test.go
+++ b/pkg/controllers/subnet/subnet_webhook_test.go
@@ -1,0 +1,134 @@
+package subnet
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
+)
+
+func TestSubnetValidator_Handle(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	defer mockCtl.Finish()
+
+	scheme := clientgoscheme.Scheme
+	v1alpha1.AddToScheme(scheme)
+	decoder := admission.NewDecoder(scheme)
+	v := &SubnetValidator{
+		Client:  k8sClient,
+		decoder: decoder,
+	}
+
+	req1, _ := json.Marshal(&v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-1",
+			Name:      "subnet-1",
+		},
+	})
+	type args struct {
+		req admission.Request
+	}
+	tests := []struct {
+		name        string
+		args        args
+		prepareFunc func(t *testing.T)
+		want        admission.Response
+	}{
+		{
+			name: "DeleteSuccess",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{Raw: req1},
+			}}},
+			prepareFunc: func(t *testing.T) {
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					a := list.(*v1alpha1.SubnetPortList)
+					a.Items = append(a.Items, v1alpha1.SubnetPort{
+						ObjectMeta: metav1.ObjectMeta{Name: "subnetport-1", Namespace: "ns-1"},
+						Spec: v1alpha1.SubnetPortSpec{
+							Subnet: "subnet-2",
+						},
+					})
+					return nil
+				})
+			},
+			want: admission.Allowed(""),
+		},
+		{
+			name: "DeleteDenied",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{Raw: req1},
+			}}},
+			prepareFunc: func(t *testing.T) {
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					a := list.(*v1alpha1.SubnetPortList)
+					a.Items = append(a.Items, v1alpha1.SubnetPort{
+						ObjectMeta: metav1.ObjectMeta{Name: "subnetport-1", Namespace: "ns-1"},
+						Spec: v1alpha1.SubnetPortSpec{
+							Subnet: "subnet-1",
+						},
+					})
+					return nil
+				})
+			},
+			want: admission.Denied("Subnet ns-1/subnet-1 with stale SubnetPorts cannot be deleted"),
+		},
+		{
+			name: "ListSubnetPortFailure",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{Raw: req1},
+			}}},
+			prepareFunc: func(t *testing.T) {
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("list failure"))
+			},
+			want: admission.Errored(http.StatusBadRequest, errors.New("failed to list SubnetPort: list failure")),
+		},
+		{
+			name: "DecodeOldSubnetFailure",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+			}}},
+			want: admission.Errored(http.StatusBadRequest, errors.New("there is no content to decode")),
+		},
+		{
+			name: "DecodeSubnetFailure",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+			}}},
+			want: admission.Errored(http.StatusBadRequest, errors.New("there is no content to decode")),
+		},
+		{
+			name: "CreateSubnet",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Object:    runtime.RawExtension{Raw: req1},
+			}}},
+			want: admission.Allowed(""),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.prepareFunc != nil {
+				tt.prepareFunc(t)
+			}
+			res := v.Handle(context.TODO(), tt.args.req)
+			assert.Equal(t, tt.want, res)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds webhook server for SubnetSet and Subnet to block the deletion of SubnetSet/Subnet if there are stale SubnetPorts under it.

Testing done:
- Create a Subnet and a SubnetPort using that Subnet, trying to delete that Subnet with be blocked with `Error from server (Forbidden): admission webhook "subnet.validating.crd.nsx.vmware.com" denied the request: Subnet ns-1/subnet-test with stale SubnetPorts cannot be deleted`
- Create a SubnetSet and a SubnetPort using that SubnetSet, trying to delete that SubnetSet with be blocked with `Error from server (Forbidden): admission webhook "subnetset.validating.crd.nsx.vmware.com" denied the request: SubnetSet ns-1/subnetset-test with stale SubnetPorts cannot be deleted`