### PR TITLE
Remove updating status in deleteFail/deleteSuccess

### DIFF
--- a/pkg/controllers/staticroute/staticroute_controller.go
+++ b/pkg/controllers/staticroute/staticroute_controller.go
@@ -48,7 +48,6 @@ type StaticRouteReconciler struct {
 }
 
 func deleteFail(r *StaticRouteReconciler, c context.Context, o *v1alpha1.StaticRoute, e *error) {
-	r.setStaticRouteReadyStatusFalse(c, o, metav1.Now(), e)
 	r.Recorder.Event(o, v1.EventTypeWarning, common.ReasonFailDelete, fmt.Sprintf("%v", *e))
 	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerDeleteFailTotal, common.MetricResTypeStaticRoute)
 }

--- a/pkg/controllers/staticroute/staticroute_controller_test.go
+++ b/pkg/controllers/staticroute/staticroute_controller_test.go
@@ -236,7 +236,6 @@ func TestStaticRouteReconciler_Reconcile(t *testing.T) {
 		return nil
 	})
 
-	k8sClient.EXPECT().Status().Times(1).Return(fakewriter)
 	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "CreateOrUpdateStaticRoute", func(_ *staticroute.StaticRouteService, namespace string, obj *v1alpha1.StaticRoute) error {
 		return nil
 	})


### PR DESCRIPTION
In most cases, the CR may be not existed while updating the status. It's useless to update the status