### PR TITLE
Bump Golang to 1.23.1

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.21
+        go-version: 1.23.1
 
     - name: Run golangci-lint
       run: make golangci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,9 +2,10 @@
 run:
   tests: true
   timeout: 15m
-  skip-files:
-   - third_party/
-   - pkg/client/
+  issues:
+    exclude-files:
+     - third_party/
+     - pkg/client/
   skip-dirs-use-default: true
 
 linters-settings:
@@ -21,6 +22,9 @@ linters-settings:
       - name: superfluous-else
       - name: var-declaration
       - name: duplicated-imports
+  gosec:
+    excludes:
+      - G115
 
 linters:
   disable-all: true
@@ -31,7 +35,7 @@ linters:
     - staticcheck
     - gosec
     - goimports
-    - vet
+    - govet
     - revive
 
 issues:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOFLAGS            :=
 BINDIR             ?= $(CURDIR)/bin
 GO_FILES           := $(shell find . -type d -name '.cache' -prune -o -type f -name '*.go' -print)
 
-GOLANGCI_LINT_VERSION := v1.54.0
+GOLANGCI_LINT_VERSION := v1.61.0
 GOLANGCI_LINT_BINDIR  := $(CURDIR)/.golangci-bin
 GOLANGCI_LINT_BIN     := $(GOLANGCI_LINT_BINDIR)/$(GOLANGCI_LINT_VERSION)/golangci-lint
 

--- a/build/image/photon/Dockerfile
+++ b/build/image/photon/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.7 as golang-build
+FROM golang:1.23.1 as golang-build
 
 WORKDIR /source
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/nsx-operator
 
-go 1.22.5
+go 1.23.1
 
 replace (
 	github.com/vmware-tanzu/nsx-operator/pkg/apis => ./pkg/apis

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/nsx-operator/pkg/apis
 
-go 1.21
+go 1.23.1
 
 require (
 	k8s.io/api v0.26.1

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/nsx-operator/pkg/client
 
-go 1.22.5
+go 1.23.1
 
 require (
 	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.0.0-20240813023528-cb525458c6ee
@@ -19,6 +19,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -227,12 +227,6 @@ func parseCIDRRange(cidr string) (startIP, endIP net.IP, err error) {
 func calculateOffsetIP(ip net.IP, offset int) (net.IP, error) {
 	ipInt := ipToUint32(ip)
 	ipInt += uint32(offset)
-	if int(ipInt) < 0 {
-		return nil, fmt.Errorf("resulting IP is less than 0")
-	}
-	if ipInt > 0xFFFFFFFF {
-		return nil, fmt.Errorf("resulting IP is greater than 255.255.255.255")
-	}
 	return uint32ToIP(ipInt), nil
 }
 

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -84,7 +84,7 @@ func TestUtil_IsNsInSystemNamespace(t *testing.T) {
 
 	isCRInSysNs, err := IsSystemNamespace(client, ns.Namespace, nil)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("%s", err.Error())
 	}
 	if isCRInSysNs {
 		t.Fatalf("Non-system namespace identied as a system namespace")
@@ -103,7 +103,7 @@ func TestUtil_IsNsInSystemNamespace(t *testing.T) {
 
 	isCRInSysNs, err = IsSystemNamespace(client, ns.Namespace, nil)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("%s", err.Error())
 	}
 	if !isCRInSysNs {
 		t.Fatalf("System namespace not identied as a system namespace")


### PR DESCRIPTION
In order to ensure TLS 1.3 is supported. We bump Golang version to 1.23.1