### PR TITLE
Move services_mock.go to pkg/mock

### DIFF
--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	pkg_mock "github.com/vmware-tanzu/nsx-operator/pkg/mock"
 	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
@@ -83,7 +84,7 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 		{
 			name: "AvailableSubnet",
 			prepareFunc: func(t *testing.T, vsp servicecommon.VPCServiceProvider, ssp servicecommon.SubnetServiceProvider, spsp servicecommon.SubnetPortServiceProvider) {
-				ssp.(*servicecommon.MockSubnetServiceProvider).On("GetSubnetsByIndex", mock.Anything, mock.Anything).
+				ssp.(*pkg_mock.MockSubnetServiceProvider).On("GetSubnetsByIndex", mock.Anything, mock.Anything).
 					Return([]*model.VpcSubnet{
 						{
 							Id:             servicecommon.String("id-1"),
@@ -92,37 +93,37 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 							IpAddresses:    []string{"10.0.0.1/28"},
 						},
 					})
-				spsp.(*servicecommon.MockSubnetPortServiceProvider).On("GetPortsOfSubnet", mock.Anything).Return([]*model.VpcSubnetPort{})
+				spsp.(*pkg_mock.MockSubnetPortServiceProvider).On("GetPortsOfSubnet", mock.Anything).Return([]*model.VpcSubnetPort{})
 			},
 			expectedResult: expectedSubnetPath,
 		},
 		{
 			name: "ListVPCFailure",
 			prepareFunc: func(t *testing.T, vsp servicecommon.VPCServiceProvider, ssp servicecommon.SubnetServiceProvider, spsp servicecommon.SubnetPortServiceProvider) {
-				ssp.(*servicecommon.MockSubnetServiceProvider).On("GetSubnetsByIndex", mock.Anything, mock.Anything).
+				ssp.(*pkg_mock.MockSubnetServiceProvider).On("GetSubnetsByIndex", mock.Anything, mock.Anything).
 					Return([]*model.VpcSubnet{})
-				ssp.(*servicecommon.MockSubnetServiceProvider).On("GenerateSubnetNSTags", mock.Anything)
-				vsp.(*servicecommon.MockVPCServiceProvider).On("ListVPCInfo", mock.Anything).Return([]servicecommon.VPCResourceInfo{})
+				ssp.(*pkg_mock.MockSubnetServiceProvider).On("GenerateSubnetNSTags", mock.Anything)
+				vsp.(*pkg_mock.MockVPCServiceProvider).On("ListVPCInfo", mock.Anything).Return([]servicecommon.VPCResourceInfo{})
 			},
 			expectedErr: "no VPC found",
 		},
 		{
 			name: "CreateSubnet",
 			prepareFunc: func(t *testing.T, vsp servicecommon.VPCServiceProvider, ssp servicecommon.SubnetServiceProvider, spsp servicecommon.SubnetPortServiceProvider) {
-				ssp.(*servicecommon.MockSubnetServiceProvider).On("GetSubnetsByIndex", mock.Anything, mock.Anything).
+				ssp.(*pkg_mock.MockSubnetServiceProvider).On("GetSubnetsByIndex", mock.Anything, mock.Anything).
 					Return([]*model.VpcSubnet{})
-				ssp.(*servicecommon.MockSubnetServiceProvider).On("GenerateSubnetNSTags", mock.Anything)
-				vsp.(*servicecommon.MockVPCServiceProvider).On("ListVPCInfo", mock.Anything).Return([]servicecommon.VPCResourceInfo{{}})
-				ssp.(*servicecommon.MockSubnetServiceProvider).On("CreateOrUpdateSubnet", mock.Anything, mock.Anything, mock.Anything).Return(expectedSubnetPath, nil)
+				ssp.(*pkg_mock.MockSubnetServiceProvider).On("GenerateSubnetNSTags", mock.Anything)
+				vsp.(*pkg_mock.MockVPCServiceProvider).On("ListVPCInfo", mock.Anything).Return([]servicecommon.VPCResourceInfo{{}})
+				ssp.(*pkg_mock.MockSubnetServiceProvider).On("CreateOrUpdateSubnet", mock.Anything, mock.Anything, mock.Anything).Return(expectedSubnetPath, nil)
 			},
 			expectedResult: expectedSubnetPath,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vps := &servicecommon.MockVPCServiceProvider{}
-			ssp := &servicecommon.MockSubnetServiceProvider{}
-			spsp := &servicecommon.MockSubnetPortServiceProvider{}
+			vps := &pkg_mock.MockVPCServiceProvider{}
+			ssp := &pkg_mock.MockSubnetServiceProvider{}
+			spsp := &pkg_mock.MockSubnetPortServiceProvider{}
 			tt.prepareFunc(t, vps, ssp, spsp)
 			subnetPath, err := AllocateSubnetFromSubnetSet(&v1alpha1.SubnetSet{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/namespace/namespace_controller_test.go
+++ b/pkg/controllers/namespace/namespace_controller_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	pkg_mock "github.com/vmware-tanzu/nsx-operator/pkg/mock"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
@@ -120,16 +121,16 @@ func TestInsertNamespaceNetworkconfigBinding(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r.VPCService = &common.MockVPCServiceProvider{}
+			r.VPCService = &pkg_mock.MockVPCServiceProvider{}
 			patch := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "getDefaultNetworkConfigName", func(_ *NamespaceReconciler, ns string, anno map[string]string) (string, error) {
 				return tt.ncName, tt.err
 			})
-			r.VPCService.(*common.MockVPCServiceProvider).On("RegisterNamespaceNetworkconfigBinding", mock.Anything, mock.Anything).Return(nil)
+			r.VPCService.(*pkg_mock.MockVPCServiceProvider).On("RegisterNamespaceNetworkconfigBinding", mock.Anything, mock.Anything).Return(nil)
 			err := r.insertNamespaceNetworkconfigBinding(tt.ns, tt.annos)
 			if err != nil {
-				r.VPCService.(*common.MockVPCServiceProvider).AssertNotCalled(t, "RegisterNamespaceNetworkconfigBinding")
+				r.VPCService.(*pkg_mock.MockVPCServiceProvider).AssertNotCalled(t, "RegisterNamespaceNetworkconfigBinding")
 			} else {
-				r.VPCService.(*common.MockVPCServiceProvider).AssertCalled(t, "RegisterNamespaceNetworkconfigBinding", tt.ns, tt.expectName)
+				r.VPCService.(*pkg_mock.MockVPCServiceProvider).AssertCalled(t, "RegisterNamespaceNetworkconfigBinding", tt.ns, tt.expectName)
 			}
 			patch.Reset()
 		})

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -1,9 +1,11 @@
-package common
+package mock
 
 import (
 	"github.com/stretchr/testify/mock"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
 type MockVPCServiceProvider struct {
@@ -14,7 +16,7 @@ func (m *MockVPCServiceProvider) GetNamespacesByNetworkconfigName(nc string) []s
 	return nil
 }
 
-func (m *MockVPCServiceProvider) RegisterVPCNetworkConfig(ncCRName string, info VPCNetworkConfigInfo) {
+func (m *MockVPCServiceProvider) RegisterVPCNetworkConfig(ncCRName string, info common.VPCNetworkConfigInfo) {
 }
 
 func (m *MockVPCServiceProvider) RegisterNamespaceNetworkconfigBinding(ns string, ncCRName string) {
@@ -25,29 +27,29 @@ func (m *MockVPCServiceProvider) UnRegisterNamespaceNetworkconfigBinding(ns stri
 	m.Called(ns)
 }
 
-func (m *MockVPCServiceProvider) GetVPCNetworkConfig(ncCRName string) (VPCNetworkConfigInfo, bool) {
+func (m *MockVPCServiceProvider) GetVPCNetworkConfig(ncCRName string) (common.VPCNetworkConfigInfo, bool) {
 	m.Called(ncCRName)
-	return VPCNetworkConfigInfo{}, false
+	return common.VPCNetworkConfigInfo{}, false
 }
 
-func (m *MockVPCServiceProvider) ValidateNetworkConfig(nc VPCNetworkConfigInfo) bool {
+func (m *MockVPCServiceProvider) ValidateNetworkConfig(nc common.VPCNetworkConfigInfo) bool {
 	m.Called(nc)
 	return true
 }
 
-func (m *MockVPCServiceProvider) GetVPCNetworkConfigByNamespace(ns string) *VPCNetworkConfigInfo {
+func (m *MockVPCServiceProvider) GetVPCNetworkConfigByNamespace(ns string) *common.VPCNetworkConfigInfo {
 	m.Called()
 	return nil
 }
 
-func (m *MockVPCServiceProvider) GetDefaultNetworkConfig() (bool, *VPCNetworkConfigInfo) {
+func (m *MockVPCServiceProvider) GetDefaultNetworkConfig() (bool, *common.VPCNetworkConfigInfo) {
 	m.Called()
 	return false, nil
 }
 
-func (m *MockVPCServiceProvider) ListVPCInfo(ns string) []VPCResourceInfo {
+func (m *MockVPCServiceProvider) ListVPCInfo(ns string) []common.VPCResourceInfo {
 	arg := m.Called(ns)
-	return arg.Get(0).([]VPCResourceInfo)
+	return arg.Get(0).([]common.VPCResourceInfo)
 }
 
 type MockSubnetServiceProvider struct {
@@ -67,7 +69,7 @@ func (m *MockSubnetServiceProvider) GetSubnetsByIndex(key, value string) []*mode
 	return arg.Get(0).([]*model.VpcSubnet)
 }
 
-func (m *MockSubnetServiceProvider) CreateOrUpdateSubnet(obj client.Object, vpcInfo VPCResourceInfo, tags []model.Tag) (string, error) {
+func (m *MockSubnetServiceProvider) CreateOrUpdateSubnet(obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (string, error) {
 	arg := m.Called(obj, vpcInfo, tags)
 	return arg.Get(0).(string), arg.Error(1)
 }

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/legacy/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	"github.com/vmware-tanzu/nsx-operator/pkg/mock"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
@@ -168,7 +169,7 @@ func TestBuildSecurityPolicyForVPC(t *testing.T) {
 
 	fakeService := fakeSecurityPolicyService()
 	fakeService.NSXConfig.EnableVPCNetwork = true
-	mockVPCService := common.MockVPCServiceProvider{}
+	mockVPCService := mock.MockVPCServiceProvider{}
 	fakeService.vpcService = &mockVPCService
 
 	// For VPC mode

--- a/pkg/nsx/services/securitypolicy/expand_test.go
+++ b/pkg/nsx/services/securitypolicy/expand_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/legacy/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	pkg_mock "github.com/vmware-tanzu/nsx-operator/pkg/mock"
 	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
@@ -346,7 +347,7 @@ func TestExpandRule(t *testing.T) {
 		},
 	).AnyTimes()
 
-	mockVPCService := common.MockVPCServiceProvider{}
+	mockVPCService := pkg_mock.MockVPCServiceProvider{}
 	mockVPCService.On("ListVPCInfo", mock.Anything).Return([]common.VPCResourceInfo{{
 		OrgID:     "default",
 		ProjectID: "pro1",

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/legacy/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	"github.com/vmware-tanzu/nsx-operator/pkg/mock"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
@@ -1070,7 +1071,7 @@ func TestCreateOrUpdateSecurityPolicy(t *testing.T) {
 
 	fakeService := fakeSecurityPolicyService()
 	fakeService.NSXConfig.EnableVPCNetwork = true
-	mockVPCService := common.MockVPCServiceProvider{}
+	mockVPCService := mock.MockVPCServiceProvider{}
 	fakeService.vpcService = &mockVPCService
 
 	podSelectorRule0IDPort000 := fakeService.buildExpandedRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy, nil)
@@ -1220,7 +1221,7 @@ func TestGetFinalSecurityPolicyResouce(t *testing.T) {
 	VPCInfo[0].VPCID = "vpc1"
 
 	fakeService := fakeSecurityPolicyService()
-	mockVPCService := common.MockVPCServiceProvider{}
+	mockVPCService := mock.MockVPCServiceProvider{}
 	fakeService.vpcService = &mockVPCService
 
 	type args struct {
@@ -1355,7 +1356,7 @@ func TestConvertNetworkPolicyToInternalSecurityPolicies(t *testing.T) {
 
 	fakeService := fakeSecurityPolicyService()
 	fakeService.NSXConfig.EnableVPCNetwork = true
-	mockVPCService := common.MockVPCServiceProvider{}
+	mockVPCService := mock.MockVPCServiceProvider{}
 	fakeService.vpcService = &mockVPCService
 
 	tests := []struct {
@@ -1448,7 +1449,7 @@ func TestGetFinalSecurityPolicyResouceFromNetworkPolicy(t *testing.T) {
 
 	fakeService := fakeSecurityPolicyService()
 	fakeService.NSXConfig.EnableVPCNetwork = true
-	mockVPCService := common.MockVPCServiceProvider{}
+	mockVPCService := mock.MockVPCServiceProvider{}
 	fakeService.vpcService = &mockVPCService
 
 	destinationPorts := data.NewListValue()

--- a/pkg/nsx/services/staticroute/staticroute_test.go
+++ b/pkg/nsx/services/staticroute/staticroute_test.go
@@ -338,10 +338,11 @@ func TestStaticRouteService_Cleanup(t *testing.T) {
 		Path: &staticRoutePath2,
 	}
 
-	service.StaticRouteStore.Add(staticRoute1)
-	service.StaticRouteStore.Add(staticRoute2)
-
 	t.Run("Successful cleanup", func(t *testing.T) {
+		service.StaticRouteStore.Add(staticRoute1)
+		service.StaticRouteStore.Add(staticRoute2)
+		mockStaticRouteclient = mocks.NewMockStaticRoutesClient(mockController)
+		service.NSXClient.StaticRouteClient = mockStaticRouteclient
 		mockStaticRouteclient.EXPECT().Delete("org1", "project1", "vpc1", "staticroute1").Return(nil).Times(1)
 		mockStaticRouteclient.EXPECT().Delete("org2", "project2", "vpc2", "staticroute2").Return(nil).Times(1)
 
@@ -361,7 +362,8 @@ func TestStaticRouteService_Cleanup(t *testing.T) {
 
 	t.Run("Delete static route error", func(t *testing.T) {
 		service.StaticRouteStore.Add(staticRoute1)
-		service.StaticRouteStore.Add(staticRoute2)
+		mockStaticRouteclient = mocks.NewMockStaticRoutesClient(mockController)
+		service.NSXClient.StaticRouteClient = mockStaticRouteclient
 
 		mockStaticRouteclient.EXPECT().Delete("org1", "project1", "vpc1", "staticroute1").Return(fmt.Errorf("delete error")).Times(1)
 


### PR DESCRIPTION
UT will exclude dir which name including mock. servcies_mock.go is a mock file and should'nt be included in UT.
Move servcies_mock.go to pkg/mock will increase the UT rate.

Reset the mockStaticRouteclient before use each time so the status will be reset to avoid random fail
else mockStaticRouteclient.EXPECT may return unexpected error