### PR TITLE
[Cherry-Pick]Enhance NetworkPolicy, SecurityPolicy and LBService UTs and add license file header(#835) 

### DIFF
--- a/pkg/controllers/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controllers/networkpolicy/networkpolicy_controller_test.go
@@ -1,0 +1,569 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package networkpolicy
+
+import (
+	"context"
+	"errors"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	gomonkey "github.com/agiledragon/gomonkey/v2"
+	"github.com/golang/mock/gomock"
+	"github.com/openlyinc/pointy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	ctrcommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
+)
+
+type fakeRecorder struct{}
+
+func (recorder fakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+}
+
+func (recorder fakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+}
+
+func (recorder fakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+}
+
+type MockManager struct {
+	ctrl.Manager
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+func (m *MockManager) GetClient() client.Client {
+	return m.client
+}
+
+func (m *MockManager) GetScheme() *runtime.Scheme {
+	return m.scheme
+}
+
+func (m *MockManager) GetEventRecorderFor(name string) record.EventRecorder {
+	return nil
+}
+
+func (m *MockManager) Add(runnable manager.Runnable) error {
+	return nil
+}
+
+func (m *MockManager) Start(context.Context) error {
+	return nil
+}
+
+func fakeService() *securitypolicy.SecurityPolicyService {
+	c := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
+	cluster, _ := nsx.NewCluster(c)
+	rc, _ := cluster.NewRestConnector()
+
+	service := &securitypolicy.SecurityPolicyService{
+		Service: common.Service{
+			NSXClient: &nsx.Client{
+				QueryClient:            nil,
+				RestConnector:          rc,
+				RealizedEntitiesClient: nil,
+				ProjectInfraClient:     nil,
+				NsxConfig: &config.NSXOperatorConfig{
+					CoeConfig: &config.CoeConfig{
+						Cluster: "k8scl-one:test",
+					},
+				},
+			},
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{
+					Cluster:          "k8scl-one:test",
+					EnableVPCNetwork: true,
+				},
+				NsxConfig: &config.NsxConfig{
+					EnforcementPoint: "vmc-enforcementpoint",
+				},
+			},
+		},
+	}
+	return service
+}
+
+func createFakeNetworkPolicyReconciler(objs []client.Object) *NetworkPolicyReconciler {
+	newScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(newScheme))
+	utilruntime.Must(v1alpha1.AddToScheme(newScheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme).WithObjects(objs...).Build()
+
+	return &NetworkPolicyReconciler{
+		Client:   fakeClient,
+		Scheme:   fake.NewClientBuilder().Build().Scheme(),
+		Service:  fakeService(),
+		Recorder: fakeRecorder{},
+	}
+}
+
+func Test_setNetworkPolicyErrorAnnotation(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+
+	ctx := context.TODO()
+	info := ctrcommon.ErrorNoDFWLicense
+
+	// Create a sample NetworkPolicy without annotations
+	networkPolicy := &networkingv1.NetworkPolicy{}
+
+	// Mock the Update call with gomock for the case when info is being added
+	k8sClient.EXPECT().
+		Update(ctx, networkPolicy).
+		Return(nil)
+
+	// Call the function under test
+	setNetworkPolicyErrorAnnotation(ctx, networkPolicy, k8sClient, info)
+
+	// Check that the annotation was set correctly
+	require.NotNil(t, networkPolicy.Annotations)
+	assert.Equal(t, info, networkPolicy.Annotations[ctrcommon.NSXOperatorError])
+
+	// Call the function again with the same info; Update should not be called
+	setNetworkPolicyErrorAnnotation(ctx, networkPolicy, k8sClient, info)
+}
+
+func Test_cleanNetworkPolicyErrorAnnotation(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+
+	ctx := context.TODO()
+	info := ctrcommon.ErrorNoDFWLicense
+
+	// Test case 1: Annotation exists, should be removed
+	t.Run("Annotation exists", func(t *testing.T) {
+		networkPolicy := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					ctrcommon.NSXOperatorError: info,
+				},
+			},
+		}
+
+		// Expect Update to be called once since we are removing the annotation
+		k8sClient.EXPECT().
+			Update(ctx, networkPolicy).
+			Return(nil).
+			Times(1)
+
+		// Call the function under test
+		cleanNetworkPolicyErrorAnnotation(ctx, networkPolicy, k8sClient)
+
+		// Check that the annotation was removed
+		assert.NotContains(t, networkPolicy.Annotations, ctrcommon.NSXOperatorError)
+	})
+
+	// Test case 2: Annotation does not exist, Update should not be called
+	t.Run("Annotation does not exist", func(t *testing.T) {
+		networkPolicy := &networkingv1.NetworkPolicy{}
+
+		// Update should not be called since there's no annotation to remove
+		k8sClient.EXPECT().Update(ctx, networkPolicy).Times(0)
+
+		// Call the function under test
+		cleanNetworkPolicyErrorAnnotation(ctx, networkPolicy, k8sClient)
+	})
+}
+
+func TestNetworkPolicyReconciler_Reconcile(t *testing.T) {
+	npName := "test-np"
+	npID := "fake-np-uid"
+	ns := "default"
+
+	createNewNetworkPolicy := func(specs ...bool) *networkingv1.NetworkPolicy {
+		networkPolicyCR := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      npName,
+				Namespace: ns,
+				UID:       types.UID(npID),
+			},
+			Spec: networkingv1.NetworkPolicySpec{},
+		}
+		if len(specs) > 0 && specs[0] {
+			// Finalizers and DeletionTimestamp must be set together
+			networkPolicyCR.Finalizers = []string{"test-Finalizers"}
+			networkPolicyCR.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		}
+		return networkPolicyCR
+	}
+
+	testCases := []struct {
+		name                    string
+		req                     ctrl.Request
+		expectRes               ctrl.Result
+		expectErrStr            string
+		patches                 func(r *NetworkPolicyReconciler) *gomonkey.Patches
+		existingNetworkPolicyCR *networkingv1.NetworkPolicy
+		expectNetworkPolicyCR   *networkingv1.NetworkPolicy
+	}{
+		{
+			name: "NetworkPolicy CR not found",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: npName}},
+			patches: func(r *NetworkPolicyReconciler) *gomonkey.Patches {
+				return gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "deleteNetworkPolicyByName", func(_ *NetworkPolicyReconciler, ns, name string) error {
+					return nil
+				})
+			},
+			expectRes:               ResultNormal,
+			existingNetworkPolicyCR: nil,
+		},
+		{
+			name: "Get NetworkPolicy return other error should retry",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: npName}},
+			patches: func(r *NetworkPolicyReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.Client), "Get", func(_ client.Client, _ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return errors.New("get NetworkPolicy CR error")
+				})
+				patches.ApplyPrivateMethod(reflect.TypeOf(r), "deleteNetworkPolicyByName", func(_ *NetworkPolicyReconciler, ns, name string) error {
+					return nil
+				})
+				return patches
+			},
+			expectErrStr:            "get NetworkPolicy CR error",
+			expectRes:               ResultRequeue,
+			existingNetworkPolicyCR: nil,
+		},
+		{
+			name: "NetworkPolicy with DeletionTimestamp not zero and delete success",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: npName}},
+			patches: func(r *NetworkPolicyReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
+					return nil
+				})
+				return patches
+			},
+			expectRes:               ResultNormal,
+			existingNetworkPolicyCR: createNewNetworkPolicy(true),
+		},
+		{
+			name: "NetworkPolicy with DeletionTimestamp not zero and delete fail",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: npName}},
+			patches: func(r *NetworkPolicyReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
+					return errors.New("delete networkpolicy failed")
+				})
+				return patches
+			},
+			expectErrStr:            "delete networkpolicy failed",
+			expectRes:               ResultRequeue,
+			existingNetworkPolicyCR: createNewNetworkPolicy(true),
+		},
+		{
+			name: "NetworkPolicy with DeletionTimestamp zero and create/update success",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: npName}},
+			patches: func(r *NetworkPolicyReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}) error {
+					return nil
+				})
+				return patches
+			},
+			expectRes:               ResultNormal,
+			existingNetworkPolicyCR: createNewNetworkPolicy(),
+		},
+		{
+			name: "NetworkPolicy with DeletionTimestamp zero and create/update fail",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: npName}},
+			patches: func(r *NetworkPolicyReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}) error {
+					return errors.New("create or update networkpolicy failed")
+				})
+				return patches
+			},
+			expectErrStr:            "create or update networkpolicy failed",
+			expectRes:               ResultRequeue,
+			existingNetworkPolicyCR: createNewNetworkPolicy(),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			objs := []client.Object{}
+			if testCase.existingNetworkPolicyCR != nil {
+				objs = append(objs, testCase.existingNetworkPolicyCR)
+			}
+			reconciler := createFakeNetworkPolicyReconciler(objs)
+			ctx := context.Background()
+
+			v1alpha1.AddToScheme(reconciler.Scheme)
+			patches := testCase.patches(reconciler)
+			defer patches.Reset()
+
+			result, err := reconciler.Reconcile(ctx, testCase.req)
+			if testCase.expectErrStr != "" {
+				assert.ErrorContains(t, err, testCase.expectErrStr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, testCase.expectRes, result)
+
+			if testCase.expectNetworkPolicyCR != nil {
+				actualNetworkPolicyCR := &networkingv1.NetworkPolicy{}
+				assert.NoError(t, reconciler.Client.Get(ctx, testCase.req.NamespacedName, actualNetworkPolicyCR))
+				assert.Equal(t, testCase.expectNetworkPolicyCR.Spec, actualNetworkPolicyCR.Spec)
+			}
+		})
+	}
+}
+
+func TestNetworkPolicyReconciler_GarbageCollector(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		patches                 func(r *NetworkPolicyReconciler) *gomonkey.Patches
+		existingNetworkPolicyCR *networkingv1.NetworkPolicy
+	}{
+		{
+			name: "Delete stale NetworkPolicy success",
+			patches: func(r *NetworkPolicyReconciler) *gomonkey.Patches {
+				patch := gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "ListNetworkPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.Set[string] {
+					res := sets.New[string]("1234_ingress", "1234_isolation")
+					return res
+				})
+				patch.ApplyMethod(reflect.TypeOf(r.Service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
+					return nil
+				})
+				return patch
+			},
+		},
+		{
+			name: "Should not delete NSX corresponding SecurityPolicies when the NetworkPolicy CR exists",
+			patches: func(r *NetworkPolicyReconciler) *gomonkey.Patches {
+				// local store has same item as k8s cache
+				patch := gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "ListNetworkPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.Set[string] {
+					res := sets.New[string]("1234_allow", "1234_isolation")
+					return res
+				})
+				patch.ApplyMethod(reflect.TypeOf(r.Service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
+					assert.FailNow(t, "should not be called")
+					return nil
+				})
+				return patch
+			},
+			existingNetworkPolicyCR: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "np-1",
+					Namespace: "default",
+					UID:       types.UID("1234"),
+				},
+			},
+		},
+		{
+			name: "Delete NSX corresponding SecurityPolicies error",
+			patches: func(r *NetworkPolicyReconciler) *gomonkey.Patches {
+				patch := gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "ListNetworkPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.Set[string] {
+					res := sets.New[string]("1234_allow", "1234_isolation")
+					return res
+				})
+				patch.ApplyMethod(reflect.TypeOf(r.Service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
+					return errors.New("delete failed")
+				})
+				return patch
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			objs := []client.Object{}
+			if testCase.existingNetworkPolicyCR != nil {
+				objs = append(objs, testCase.existingNetworkPolicyCR)
+			}
+			r := createFakeNetworkPolicyReconciler(objs)
+			ctx := context.Background()
+
+			patches := testCase.patches(r)
+			defer patches.Reset()
+
+			r.CollectGarbage(ctx)
+		})
+	}
+}
+
+func TestNetworkPolicyReconciler_listNetworkPolciyCRIDs(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	r := &NetworkPolicyReconciler{
+		Client: k8sClient,
+		Scheme: nil,
+	}
+	ctx := context.Background()
+
+	// list returns an error
+	errList := errors.New("list error")
+	k8sClient.EXPECT().List(ctx, gomock.Any()).Return(errList)
+	_, err := r.listNetworkPolciyCRIDs()
+	assert.Equal(t, err, errList)
+
+	// list returns no error, but no items
+	k8sClient.EXPECT().List(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+		networkPolicyList := list.(*networkingv1.NetworkPolicyList)
+		networkPolicyList.Items = []networkingv1.NetworkPolicy{}
+		return nil
+	})
+	crIDs, err := r.listNetworkPolciyCRIDs()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, crIDs.Len())
+
+	// list returns items
+	k8sClient.EXPECT().List(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+		networkPolicyList := list.(*networkingv1.NetworkPolicyList)
+		networkPolicyList.Items = []networkingv1.NetworkPolicy{
+			{ObjectMeta: metav1.ObjectMeta{UID: "uid1"}},
+		}
+		return nil
+	})
+	crIDs, err = r.listNetworkPolciyCRIDs()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, crIDs.Len())
+	assert.True(t, crIDs.Has("uid1_allow"))
+	assert.True(t, crIDs.Has("uid1_isolation"))
+}
+
+func TestNetworkPolicyReconciler_deleteNetworkPolicyByName(t *testing.T) {
+	objs := []client.Object{}
+	r := createFakeNetworkPolicyReconciler(objs)
+
+	// listNetworkPolciyCRIDs returns an error
+	errList := errors.New("list error")
+	patch := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "listNetworkPolciyCRIDs", func(_ *NetworkPolicyReconciler) (sets.Set[string], error) {
+		return nil, errList
+	})
+	err := r.deleteNetworkPolicyByName("dummy-ns", "dummy-name")
+	assert.Equal(t, err, errList)
+
+	// listNetworkPolciyCRIDs returns items, and deletion fails
+	patch.Reset()
+	patch.ApplyPrivateMethod(reflect.TypeOf(r), "listNetworkPolciyCRIDs", func(_ *NetworkPolicyReconciler) (sets.Set[string], error) {
+		return sets.New[string]("uid1"), nil
+	})
+	patch.ApplyMethod(reflect.TypeOf(r.Service), "ListNetworkPolicyByName", func(_ *securitypolicy.SecurityPolicyService, _ string, _ string) []*model.SecurityPolicy {
+		return []*model.SecurityPolicy{
+			{
+				Id:   pointy.String("sp-id-1"),
+				Tags: []model.Tag{{Scope: pointy.String(common.TagScopeNetworkPolicyUID), Tag: pointy.String("uid1")}},
+			},
+			{
+				Id:   pointy.String("sp-id-2"),
+				Tags: []model.Tag{{Scope: pointy.String(common.TagScopeNetworkPolicyUID), Tag: pointy.String("uid2")}},
+			},
+		}
+	})
+
+	patch.ApplyMethod(reflect.TypeOf(r.Service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
+		switch sp := obj.(type) {
+		case types.UID:
+			if sp == "uid2" {
+				return errors.New("delete failed")
+			}
+		}
+		return nil
+	})
+
+	err = r.deleteNetworkPolicyByName("dummy-ns", "dummy-name")
+	assert.Error(t, err)
+	patch.Reset()
+}
+
+func TestStartNetworkPolicyController(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects().Build()
+	vpcService := &vpc.VPCService{
+		Service: common.Service{
+			Client: fakeClient,
+		},
+	}
+	commonService := common.Service{
+		Client: fakeClient,
+	}
+	mockMgr := &MockManager{scheme: runtime.NewScheme()}
+
+	exitCalled := false // Variable to check if osExit was called
+	testCases := []struct {
+		name         string
+		expectErrStr string
+		patches      func() *gomonkey.Patches
+	}{
+		// expected no error when starting the NetworkPolicy controller
+		{
+			name: "Start NetworkPolicy Controller",
+			patches: func() *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc(ctrcommon.GenericGarbageCollector, func(cancel chan bool, timeout time.Duration, f func(ctx context.Context)) {
+					return
+				})
+				patches.ApplyFunc(os.Exit, func(code int) {
+					assert.FailNow(t, "os.Exit should not be called")
+					return
+				})
+				patches.ApplyFunc(securitypolicy.GetSecurityService, func(service common.Service, vpcService common.VPCServiceProvider) *securitypolicy.SecurityPolicyService {
+					return fakeService()
+				})
+				patches.ApplyMethod(reflect.TypeOf(&ctrl.Builder{}), "Complete", func(_ *ctrl.Builder, r reconcile.Reconciler) error {
+					return nil
+				})
+				return patches
+			},
+		},
+		{
+			name:         "Start NetworkPolicy controller return error",
+			expectErrStr: "failed to setupWithManager",
+			patches: func() *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc(ctrcommon.GenericGarbageCollector, func(cancel chan bool, timeout time.Duration, f func(ctx context.Context)) {
+					return
+				})
+				patches.ApplyFunc(os.Exit, func(code int) {
+					exitCalled = true
+					return
+				})
+				patches.ApplyFunc(securitypolicy.GetSecurityService, func(service common.Service, vpcService common.VPCServiceProvider) *securitypolicy.SecurityPolicyService {
+					return fakeService()
+				})
+				patches.ApplyPrivateMethod(reflect.TypeOf(&NetworkPolicyReconciler{}), "setupWithManager", func(_ *NetworkPolicyReconciler, mgr ctrl.Manager) error {
+					return errors.New("failed to setupWithManager")
+				})
+				return patches
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			patches := testCase.patches()
+			defer patches.Reset()
+
+			StartNetworkPolicyController(mockMgr, commonService, vpcService)
+
+			if testCase.expectErrStr != "" {
+				assert.Equal(t, exitCalled, true)
+			} else {
+				assert.Equal(t, exitCalled, false)
+			}
+		})
+	}
+}

--- a/pkg/controllers/securitypolicy/namespace_handler.go
+++ b/pkg/controllers/securitypolicy/namespace_handler.go
@@ -1,4 +1,4 @@
-/* Copyright © 2022-2023 VMware, Inc. All Rights Reserved.
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0 */
 
 package securitypolicy
@@ -26,15 +26,15 @@ type EnqueueRequestForNamespace struct {
 }
 
 func (e *EnqueueRequestForNamespace) Create(_ context.Context, _ event.CreateEvent, _ workqueue.RateLimitingInterface) {
-	log.V(1).Info("namespace create event, do nothing")
+	log.V(1).Info("NameSpace create event, do nothing")
 }
 
 func (e *EnqueueRequestForNamespace) Delete(_ context.Context, _ event.DeleteEvent, _ workqueue.RateLimitingInterface) {
-	log.V(1).Info("namespace delete event, do nothing")
+	log.V(1).Info("NameSpace delete event, do nothing")
 }
 
 func (e *EnqueueRequestForNamespace) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.RateLimitingInterface) {
-	log.V(1).Info("namespace generic event, do nothing")
+	log.V(1).Info("NameSpace generic event, do nothing")
 }
 
 func (e *EnqueueRequestForNamespace) Update(_ context.Context, updateEvent event.UpdateEvent, l workqueue.RateLimitingInterface) {
@@ -43,7 +43,7 @@ func (e *EnqueueRequestForNamespace) Update(_ context.Context, updateEvent event
 		log.Error(err, "failed to fetch namespace", "namespace", obj.Name)
 		return
 	} else if isInSysNs {
-		log.V(2).Info("namespace is in system namespace, ignore it", "namespace", obj.Name)
+		log.V(2).Info("NameSpace is in system namespace, ignore it", "namespace", obj.Name)
 		return
 	}
 
@@ -62,7 +62,7 @@ func (e *EnqueueRequestForNamespace) Update(_ context.Context, updateEvent event
 		}
 	}
 	if !shouldReconcile {
-		log.Info("no pod in namespace is relevant", "namespace", obj.Name)
+		log.Info("No pod in namespace is relevant", "namespace", obj.Name)
 		return
 	}
 
@@ -79,9 +79,9 @@ var PredicateFuncsNs = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		oldObj := e.ObjectOld.(*v1.Namespace)
 		newObj := e.ObjectNew.(*v1.Namespace)
-		log.V(1).Info("receive namespace update event", "name", oldObj.Name)
+		log.V(1).Info("Receive namespace update event", "name", oldObj.Name)
 		if reflect.DeepEqual(oldObj.ObjectMeta.Labels, newObj.ObjectMeta.Labels) {
-			log.Info("label of namespace is not changed, ignore it", "name", oldObj.Name)
+			log.Info("Label of namespace is not changed, ignore it", "name", oldObj.Name)
 			return false
 		}
 		return true

--- a/pkg/controllers/securitypolicy/pod_handler.go
+++ b/pkg/controllers/securitypolicy/pod_handler.go
@@ -1,4 +1,4 @@
-/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0 */
 
 package securitypolicy
@@ -94,7 +94,7 @@ func getAllPodPortNames(pods []v1.Pod) sets.Set[string] {
 var PredicateFuncsPod = predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool {
 		if p, ok := e.Object.(*v1.Pod); ok {
-			log.V(1).Info("receive pod create event", "namespace", p.Namespace, "name", p.Name)
+			log.V(1).Info("Receive pod create event", "namespace", p.Namespace, "name", p.Name)
 			return util.CheckPodHasNamedPort(*p, "create")
 		}
 		return false
@@ -102,10 +102,10 @@ var PredicateFuncsPod = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		oldObj := e.ObjectOld.(*v1.Pod)
 		newObj := e.ObjectNew.(*v1.Pod)
-		log.V(1).Info("receive pod update event", "namespace", oldObj.Namespace, "name", oldObj.Name)
+		log.V(1).Info("Receive pod update event", "namespace", oldObj.Namespace, "name", oldObj.Name)
 		// The NSX operator should handle the case when the pod phase is changed from Pending to Running.
 		if reflect.DeepEqual(oldObj.ObjectMeta.Labels, newObj.ObjectMeta.Labels) && oldObj.Status.Phase == newObj.Status.Phase {
-			log.V(1).Info("pod label and phase are not changed, ignore it", "name", oldObj.Name)
+			log.V(1).Info("POD label and phase are not changed, ignore it", "name", oldObj.Name)
 			return false
 		}
 		if util.CheckPodHasNamedPort(*newObj, "update") {
@@ -115,7 +115,7 @@ var PredicateFuncsPod = predicate.Funcs{
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {
 		if p, ok := e.Object.(*v1.Pod); ok {
-			log.V(1).Info("receive pod delete event", "namespace", p.Namespace, "name", p.Name)
+			log.V(1).Info("Receive pod delete event", "namespace", p.Namespace, "name", p.Name)
 			return util.CheckPodHasNamedPort(*p, "delete")
 		}
 		return false

--- a/pkg/controllers/securitypolicy/securitypolicy_controller_test.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller_test.go
@@ -1,4 +1,4 @@
-/* Copyright © 2021 VMware, Inc. All Rights Reserved.
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0 */
 
 package securitypolicy
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -14,28 +15,36 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gomonkey "github.com/agiledragon/gomonkey/v2"
 	"github.com/golang/mock/gomock"
+	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
-	controllerruntime "sigs.k8s.io/controller-runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/legacy/v1alpha1"
+	crdv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	ctrcommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
@@ -61,6 +70,9 @@ func fakeService() *securitypolicy.SecurityPolicyService {
 				CoeConfig: &config.CoeConfig{
 					Cluster:          "k8scl-one:test",
 					EnableVPCNetwork: false,
+				},
+				NsxConfig: &config.NsxConfig{
+					EnforcementPoint: "vmc-enforcementpoint",
 				},
 			},
 		},
@@ -155,6 +167,20 @@ func TestSecurityPolicyController_updateSecurityPolicyStatusConditions(t *testin
 	}
 }
 
+type fakeStatusWriter struct{}
+
+func (writer fakeStatusWriter) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	return nil
+}
+
+func (writer fakeStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	return nil
+}
+
+func (writer fakeStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	return nil
+}
+
 type fakeRecorder struct{}
 
 func (recorder fakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
@@ -166,8 +192,87 @@ func (recorder fakeRecorder) Eventf(object runtime.Object, eventtype, reason, me
 func (recorder fakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
 }
 
+func Test_setSecurityPolicyErrorAnnotation(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+
+	ctx := context.TODO()
+	info := ctrcommon.ErrorNoDFWLicense
+
+	// Test case with isVPCEnabled = false
+	isVPCEnabled := false
+	securityPolicy := &v1alpha1.SecurityPolicy{}
+	securityPolicy.Annotations = make(map[string]string)
+	k8sClient.EXPECT().
+		Update(ctx, gomock.AssignableToTypeOf(&v1alpha1.SecurityPolicy{})).
+		Return(nil)
+	// Call the function under test
+	setSecurityPolicyErrorAnnotation(ctx, securityPolicy, isVPCEnabled, k8sClient, info)
+	// Assert that the annotation was set correctly
+	require.NotNil(t, securityPolicy.Annotations)
+	assert.Equal(t, info, securityPolicy.Annotations[ctrcommon.NSXOperatorError])
+
+	// Test case with isVPCEnabled = true
+	isVPCEnabled = true
+	k8sClient.EXPECT().
+		Update(ctx, gomock.AssignableToTypeOf(&crdv1alpha1.SecurityPolicy{})).
+		Return(nil).AnyTimes()
+	// Call the function under test again with isVPCEnabled = true
+	setSecurityPolicyErrorAnnotation(ctx, securityPolicy, isVPCEnabled, k8sClient, info)
+	// Assert that the annotation remains the same
+	assert.Equal(t, info, securityPolicy.Annotations[ctrcommon.NSXOperatorError])
+}
+
+func Test_cleanSecurityPolicyErrorAnnotation(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+
+	ctx := context.TODO()
+	info := ctrcommon.ErrorNoDFWLicense
+
+	// Define a SecurityPolicy with an annotation
+	securityPolicy := &v1alpha1.SecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				ctrcommon.NSXOperatorError: info,
+			},
+		},
+	}
+
+	// Expected updated SecurityPolicy after annotation removal
+	expectedSecurityPolicy := &v1alpha1.SecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{}, // Annotation should be removed
+		},
+	}
+
+	// Test case with isVPCEnabled = false
+	isVPCEnabled := false
+	k8sClient.EXPECT().Update(ctx, expectedSecurityPolicy).Return(nil).Times(1)
+	// Run the function
+	cleanSecurityPolicyErrorAnnotation(ctx, securityPolicy, isVPCEnabled, k8sClient)
+	// Assertions annotation removed
+	assert.NotContains(t, securityPolicy.Annotations, ctrcommon.NSXOperatorError)
+
+	// Test case with isVPCEnabled = true
+	isVPCEnabled = true
+	k8sClient.EXPECT().
+		Update(ctx, gomock.AssignableToTypeOf(&crdv1alpha1.SecurityPolicy{})).
+		Return(nil).AnyTimes()
+	securityPolicy.Annotations[ctrcommon.NSXOperatorError] = info
+	// Assert that the annotation was set correctly
+	require.NotNil(t, securityPolicy.Annotations)
+	// Call the function under test again with isVPCEnabled = true
+	cleanSecurityPolicyErrorAnnotation(ctx, securityPolicy, isVPCEnabled, k8sClient)
+	// Assertions annotation removed
+	assert.NotContains(t, securityPolicy.Annotations, ctrcommon.NSXOperatorError)
+}
+
 func TestSecurityPolicyReconciler_Reconcile(t *testing.T) {
 	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
 	k8sClient := mock_client.NewMockClient(mockCtl)
 	service := &securitypolicy.SecurityPolicyService{
 		Service: common.Service{
@@ -189,34 +294,38 @@ func TestSecurityPolicyReconciler_Reconcile(t *testing.T) {
 		Recorder: fakeRecorder{},
 	}
 	ctx := context.Background()
-	req := controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "dummy", Name: "dummy"}}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "dummy", Name: "dummy"}}
 
-	// not found
-	errNotFound := errors.New("not found")
+	// fail to get CR
+	errFailToGet := errors.New("failed to get CR")
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errFailToGet)
+	result, retErr := r.Reconcile(ctx, req)
+	assert.Equal(t, retErr, errFailToGet)
+	assert.Equal(t, ResultRequeue, result)
+
+	// not found and deletion success
+	errNotFound := apierrors.NewNotFound(v1alpha1.Resource("SecurityPolicy"), "")
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errNotFound)
 	deleteSecurityPolicyByNamePatch := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "deleteSecurityPolicyByName", func(_ *SecurityPolicyReconciler, name, ns string) error {
 		return nil
 	})
 	defer deleteSecurityPolicyByNamePatch.Reset()
-	result, err := r.Reconcile(ctx, req)
-	assert.Equal(t, err, errNotFound)
-	assert.Equal(t, ResultRequeue, result)
+	result, retErr = r.Reconcile(ctx, req)
+	assert.Equal(t, retErr, nil)
+	assert.Equal(t, ResultNormal, result)
 
 	// NSX version check failed case
 	sp := &v1alpha1.SecurityPolicy{}
+	fakewriter := fakeStatusWriter{}
 	checkNsxVersionPatch := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, feature int) bool {
 		return false
 	})
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil)
-	updateFailPatch := gomonkey.ApplyFunc(updateFail,
-		func(r *SecurityPolicyReconciler, c context.Context, o *v1alpha1.SecurityPolicy, e *error) {
-		})
-	defer updateFailPatch.Reset()
-	result, ret := r.Reconcile(ctx, req)
-	resultRequeueAfter5mins := controllerruntime.Result{Requeue: true, RequeueAfter: 5 * time.Minute}
-	assert.Equal(t, nil, ret)
+	k8sClient.EXPECT().Status().Times(1).Return(fakewriter)
+	result, retErr = r.Reconcile(ctx, req)
+	resultRequeueAfter5mins := ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Minute}
+	assert.Equal(t, retErr, nil)
 	assert.Equal(t, resultRequeueAfter5mins, result)
-
 	checkNsxVersionPatch.Reset()
 	checkNsxVersionPatch = gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, feature int) bool {
 		return true
@@ -225,16 +334,44 @@ func TestSecurityPolicyReconciler_Reconcile(t *testing.T) {
 
 	// DeletionTimestamp.IsZero = ture, create security policy in SystemNamespace
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil)
-	err = errors.New("fetch namespace associated with security policy CR failed")
+	err := errors.New("fetch namespace associated with security policy CR failed")
 	IsSystemNamespacePatch := gomonkey.ApplyFunc(util.IsSystemNamespace, func(client client.Client, ns string, obj *v1.Namespace,
 	) (bool, error) {
 		return true, errors.New("fetch namespace associated with security policy CR failed")
 	})
-
-	result, ret = r.Reconcile(ctx, req)
-	IsSystemNamespacePatch.Reset()
-	assert.Equal(t, err, ret)
+	k8sClient.EXPECT().Status().Times(1).Return(fakewriter)
+	result, retErr = r.Reconcile(ctx, req)
+	assert.Equal(t, retErr, err)
 	assert.Equal(t, ResultRequeue, result)
+	IsSystemNamespacePatch.Reset()
+
+	// DeletionTimestamp.IsZero = ture, create security policy fail
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil)
+	IsSystemNamespacePatch = gomonkey.ApplyFunc(util.IsSystemNamespace, func(client client.Client, ns string, obj *v1.Namespace,
+	) (bool, error) {
+		return false, nil
+	})
+	err = errors.New("create or update security policy failed")
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "CreateOrUpdateSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}) error {
+		return errors.New("create or update security policy failed")
+	})
+	k8sClient.EXPECT().Status().Times(1).Return(fakewriter)
+	result, retErr = r.Reconcile(ctx, req)
+	assert.Equal(t, retErr, err)
+	assert.Equal(t, ResultRequeue, result)
+	patch.Reset()
+
+	// DeletionTimestamp.IsZero = true, Finalizers include util.SecurityPolicyFinalizerName and update success
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil)
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "CreateOrUpdateSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}) error {
+		return nil
+	})
+	k8sClient.EXPECT().Status().Times(1).Return(fakewriter)
+	result, retErr = r.Reconcile(ctx, req)
+	assert.Equal(t, retErr, nil)
+	assert.Equal(t, ResultNormal, result)
+	IsSystemNamespacePatch.Reset()
+	patch.Reset()
 
 	// DeletionTimestamp.IsZero = false, Finalizers include util.SecurityPolicyFinalizerName and update fails
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
@@ -244,20 +381,15 @@ func TestSecurityPolicyReconciler_Reconcile(t *testing.T) {
 		v1sp.Finalizers = []string{common.T1SecurityPolicyFinalizerName}
 		return nil
 	})
-
-	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, UID interface{}, isGc bool, isVPCCleanup bool) error {
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
 		assert.FailNow(t, "should not be called")
 		return nil
 	})
-
 	err = errors.New("finalizer remove failed, would retry exponentially")
 	k8sClient.EXPECT().Update(ctx, gomock.Any()).Return(err)
-	deleteFailPatch := gomonkey.ApplyFunc(deleteFail,
-		func(r *SecurityPolicyReconciler, c context.Context, o *v1alpha1.SecurityPolicy, e *error) {
-		})
-	defer deleteFailPatch.Reset()
-	result, ret = r.Reconcile(ctx, req)
-	assert.Equal(t, ret, err)
+	k8sClient.EXPECT().Status().Times(1).Return(fakewriter)
+	result, retErr = r.Reconcile(ctx, req)
+	assert.Equal(t, retErr, err)
 	assert.Equal(t, ResultRequeue, result)
 	patch.Reset()
 
@@ -268,15 +400,15 @@ func TestSecurityPolicyReconciler_Reconcile(t *testing.T) {
 		v1sp.ObjectMeta.DeletionTimestamp = &time
 		return nil
 	})
-	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, UID interface{}, isGc bool, isVPCCleanup bool) error {
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
 		return nil
 	})
-	result, ret = r.Reconcile(ctx, req)
-	assert.Equal(t, ret, nil)
+	result, retErr = r.Reconcile(ctx, req)
+	assert.Equal(t, retErr, nil)
 	assert.Equal(t, ResultNormal, result)
 	patch.Reset()
 
-	// DeletionTimestamp.IsZero = false, Finalizers include util.SecurityPolicyFinalizerName
+	// DeletionTimestamp.IsZero = false, Finalizers include util.SecurityPolicyFinalizerName and delete fail
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 		v1sp := obj.(*v1alpha1.SecurityPolicy)
 		time := metav1.Now()
@@ -284,18 +416,36 @@ func TestSecurityPolicyReconciler_Reconcile(t *testing.T) {
 		v1sp.Finalizers = []string{common.T1SecurityPolicyFinalizerName}
 		return nil
 	})
-	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, UID interface{}, isGc bool, isVPCCleanup bool) error {
+	err = errors.New("delete security policy failed")
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, UID interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
+		return errors.New("delete security policy failed")
+	})
+	k8sClient.EXPECT().Update(ctx, gomock.Any(), gomock.Any()).Return(nil)
+	k8sClient.EXPECT().Status().Times(1).Return(fakewriter)
+	result, retErr = r.Reconcile(ctx, req)
+	assert.Equal(t, retErr, err)
+	assert.Equal(t, ResultRequeue, result)
+	patch.Reset()
+
+	// DeletionTimestamp.IsZero = false, Finalizers include util.SecurityPolicyFinalizerName and delete success
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+		v1sp := obj.(*v1alpha1.SecurityPolicy)
+		time := metav1.Now()
+		v1sp.ObjectMeta.DeletionTimestamp = &time
+		v1sp.Finalizers = []string{common.T1SecurityPolicyFinalizerName}
+		return nil
+	})
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
 		return nil
 	})
 	k8sClient.EXPECT().Update(ctx, gomock.Any(), gomock.Any()).Return(nil)
-	result, ret = r.Reconcile(ctx, req)
-	assert.Equal(t, ret, nil)
+	result, retErr = r.Reconcile(ctx, req)
+	assert.Equal(t, retErr, nil)
 	assert.Equal(t, ResultNormal, result)
 	patch.Reset()
 }
 
 func TestSecurityPolicyReconciler_GarbageCollector(t *testing.T) {
-	// gc collect item "2345", local store has more item than k8s cache
 	service := &securitypolicy.SecurityPolicyService{
 		Service: common.Service{
 			NSXConfig: &config.NSXOperatorConfig{
@@ -308,19 +458,9 @@ func TestSecurityPolicyReconciler_GarbageCollector(t *testing.T) {
 			},
 		},
 	}
-	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "ListSecurityPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.Set[string] {
-		a := sets.New[string]()
-		a.Insert("1234")
-		a.Insert("2345")
-		return a
-	})
-	patch.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, UID interface{}, isGc bool, isVPCCleanup bool) error {
-		return nil
-	})
-	defer patch.Reset()
 	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
 	k8sClient := mock_client.NewMockClient(mockCtl)
-
 	r := &SecurityPolicyReconciler{
 		Client:  k8sClient,
 		Scheme:  nil,
@@ -328,7 +468,18 @@ func TestSecurityPolicyReconciler_GarbageCollector(t *testing.T) {
 	}
 	ctx := context.Background()
 	policyList := &v1alpha1.SecurityPolicyList{}
-	k8sClient.EXPECT().List(gomock.Any(), policyList).Return(nil).Do(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+
+	// gc collect item "2345", local store has more item than k8s cache
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
+		return nil
+	})
+	patch.ApplyMethod(reflect.TypeOf(service), "ListSecurityPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.Set[string] {
+		a := sets.New[string]()
+		a.Insert("1234")
+		a.Insert("2345")
+		return a
+	})
+	k8sClient.EXPECT().List(ctx, policyList).Return(nil).Do(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 		a := list.(*v1alpha1.SecurityPolicyList)
 		a.Items = append(a.Items, v1alpha1.SecurityPolicy{})
 		a.Items[0].ObjectMeta = metav1.ObjectMeta{}
@@ -339,12 +490,12 @@ func TestSecurityPolicyReconciler_GarbageCollector(t *testing.T) {
 
 	// local store has same item as k8s cache
 	patch.Reset()
-	patch.ApplyMethod(reflect.TypeOf(service), "ListSecurityPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.Set[string] {
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "ListSecurityPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.Set[string] {
 		a := sets.New[string]()
 		a.Insert("1234")
 		return a
 	})
-	patch.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, UID interface{}, isVPCCleanupOrGC bool) error {
+	patch.ApplyMethod(reflect.TypeOf(r.Service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
 		assert.FailNow(t, "should not be called")
 		return nil
 	})
@@ -359,41 +510,17 @@ func TestSecurityPolicyReconciler_GarbageCollector(t *testing.T) {
 
 	// local store has no item
 	patch.Reset()
-	patch.ApplyMethod(reflect.TypeOf(service), "ListSecurityPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.Set[string] {
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "ListSecurityPolicyID", func(_ *securitypolicy.SecurityPolicyService) sets.Set[string] {
 		a := sets.New[string]()
 		return a
 	})
-	patch.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, UID interface{}, isGc bool, isVPCCleanup bool) error {
+	patch.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
 		assert.FailNow(t, "should not be called")
 		return nil
 	})
 	k8sClient.EXPECT().List(ctx, policyList).Return(nil).Times(0)
 	r.CollectGarbage(ctx)
-}
-
-func TestSecurityPolicyReconciler_Start(t *testing.T) {
-	mockCtl := gomock.NewController(t)
-	k8sClient := mock_client.NewMockClient(mockCtl)
-	service := &securitypolicy.SecurityPolicyService{
-		Service: common.Service{
-			NSXConfig: &config.NSXOperatorConfig{
-				NsxConfig: &config.NsxConfig{
-					EnforcementPoint: "vmc-enforcementpoint",
-				},
-				CoeConfig: &config.CoeConfig{
-					EnableVPCNetwork: false,
-				},
-			},
-		},
-	}
-	mgr, _ := controllerruntime.NewManager(&rest.Config{}, manager.Options{})
-	r := &SecurityPolicyReconciler{
-		Client:  k8sClient,
-		Scheme:  nil,
-		Service: service,
-	}
-	err := r.Start(mgr)
-	assert.NotEqual(t, err, nil)
+	patch.Reset()
 }
 
 func TestReconcileSecurityPolicy(t *testing.T) {
@@ -452,6 +579,7 @@ func TestReconcileSecurityPolicy(t *testing.T) {
 	}
 
 	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
 	k8sClient := mock_client.NewMockClient(mockCtl)
 	ctx := context.Background()
 	policyList := &v1alpha1.SecurityPolicyList{}
@@ -482,6 +610,373 @@ func TestReconcileSecurityPolicy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.wantErr(t, reconcileSecurityPolicy(r, tt.args.client, tt.args.pods, tt.args.q),
 				fmt.Sprintf("reconcileSecurityPolicy(%v, %v, %v)", tt.args.client, tt.args.pods, tt.args.q))
+		})
+	}
+}
+
+func TestSecurityPolicyReconciler_listSecurityPolciyCRIDsForVPC(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	service := &securitypolicy.SecurityPolicyService{
+		Service: common.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{
+					EnableVPCNetwork: true,
+				},
+				NsxConfig: &config.NsxConfig{
+					EnforcementPoint: "vmc-enforcementpoint",
+				},
+			},
+		},
+	}
+	r := &SecurityPolicyReconciler{
+		Client:   k8sClient,
+		Scheme:   nil,
+		Service:  service,
+		Recorder: fakeRecorder{},
+	}
+	ctx := context.Background()
+
+	// list returns an error
+	errList := errors.New("list error")
+	k8sClient.EXPECT().List(ctx, gomock.Any()).Return(errList)
+	_, err := r.listSecurityPolciyCRIDs()
+	assert.Equal(t, err, errList)
+
+	// list returns no error, but no items
+	k8sClient.EXPECT().List(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+		networkPolicyList := list.(*crdv1alpha1.SecurityPolicyList)
+		networkPolicyList.Items = []crdv1alpha1.SecurityPolicy{}
+		return nil
+	})
+	crIDs, err := r.listSecurityPolciyCRIDs()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, crIDs.Len())
+
+	// list returns items
+	k8sClient.EXPECT().List(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+		networkPolicyList := list.(*crdv1alpha1.SecurityPolicyList)
+		networkPolicyList.Items = []crdv1alpha1.SecurityPolicy{
+			{ObjectMeta: metav1.ObjectMeta{UID: "uid1"}},
+			{ObjectMeta: metav1.ObjectMeta{UID: "uid2"}},
+		}
+		return nil
+	})
+	crIDs, err = r.listSecurityPolciyCRIDs()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, crIDs.Len())
+	assert.True(t, crIDs.Has("uid1"))
+	assert.True(t, crIDs.Has("uid2"))
+}
+
+func TestSecurityPolicyReconciler_deleteSecuritypolicyByName(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	service := &securitypolicy.SecurityPolicyService{
+		Service: common.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{
+					EnableVPCNetwork: false,
+				},
+				NsxConfig: &config.NsxConfig{
+					EnforcementPoint: "vmc-enforcementpoint",
+				},
+			},
+		},
+	}
+	r := &SecurityPolicyReconciler{
+		Client:   k8sClient,
+		Scheme:   nil,
+		Service:  service,
+		Recorder: fakeRecorder{},
+	}
+
+	// listSecurityPolciyCRIDs returns an error
+	errList := errors.New("list error")
+	patch := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "listSecurityPolciyCRIDs", func(_ *SecurityPolicyReconciler) (sets.Set[string], error) {
+		return nil, errList
+	})
+	err := r.deleteSecurityPolicyByName("dummy-ns", "dummy-name")
+	assert.Equal(t, err, errList)
+
+	// listSecurityPolciyCRIDs returns items, and deletion fails
+	patch.Reset()
+	patch.ApplyPrivateMethod(reflect.TypeOf(r), "listSecurityPolciyCRIDs", func(_ *SecurityPolicyReconciler) (sets.Set[string], error) {
+		return sets.New[string]("uid1"), nil
+	})
+	patch.ApplyMethod(reflect.TypeOf(service), "ListSecurityPolicyByName", func(_ *securitypolicy.SecurityPolicyService, _ string, _ string) []*model.SecurityPolicy {
+		return []*model.SecurityPolicy{
+			{
+				Id:   pointy.String("sp-id-1"),
+				Tags: []model.Tag{{Scope: pointy.String(common.TagValueScopeSecurityPolicyUID), Tag: pointy.String("uid1")}},
+			},
+			{
+				Id:   pointy.String("sp-id-2"),
+				Tags: []model.Tag{{Scope: pointy.String(common.TagValueScopeSecurityPolicyUID), Tag: pointy.String("uid2")}},
+			},
+		}
+	})
+
+	patch.ApplyMethod(reflect.TypeOf(service), "DeleteSecurityPolicy", func(_ *securitypolicy.SecurityPolicyService, obj interface{}, isGc bool, isVPCCleanup bool, createdFor string) error {
+		switch sp := obj.(type) {
+		case types.UID:
+			if sp == "uid2" {
+				return errors.New("delete failed")
+			}
+		}
+		return nil
+	})
+
+	err = r.deleteSecurityPolicyByName("dummy-ns", "dummy-name")
+	assert.Error(t, err)
+	patch.Reset()
+}
+
+func TestSecurityPolicyReconcilerForVPC_Reconcile(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	service := &securitypolicy.SecurityPolicyService{
+		Service: common.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{
+					EnableVPCNetwork: true,
+				},
+				NsxConfig: &config.NsxConfig{
+					EnforcementPoint: "vmc-enforcementpoint",
+				},
+			},
+		},
+	}
+	r := &SecurityPolicyReconciler{
+		Client:   k8sClient,
+		Scheme:   nil,
+		Service:  service,
+		Recorder: fakeRecorder{},
+	}
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "dummy", Name: "dummy"}}
+
+	// fail to get CR
+	errFailToGet := errors.New("failed to get CR")
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errFailToGet)
+	result, retErr := r.Reconcile(ctx, req)
+	assert.Equal(t, retErr, errFailToGet)
+	assert.Equal(t, ResultRequeue, result)
+
+	// not found and deletion failed
+	errNotFound := apierrors.NewNotFound(crdv1alpha1.Resource("SecurityPolicy"), "")
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errNotFound)
+	err := errors.New("delete security policy failed")
+	deleteSecurityPolicyByNamePatch := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "deleteSecurityPolicyByName", func(_ *SecurityPolicyReconciler, name, ns string) error {
+		return errors.New("delete security policy failed")
+	})
+	result, retErr = r.Reconcile(ctx, req)
+	assert.Equal(t, retErr, err)
+	assert.Equal(t, ResultRequeue, result)
+
+	// not found and deletion success
+	deleteSecurityPolicyByNamePatch.Reset()
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errNotFound)
+	deleteSecurityPolicyByNamePatch = gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "deleteSecurityPolicyByName", func(_ *SecurityPolicyReconciler, name, ns string) error {
+		return nil
+	})
+	defer deleteSecurityPolicyByNamePatch.Reset()
+	result, retErr = r.Reconcile(ctx, req)
+	assert.Equal(t, retErr, nil)
+	assert.Equal(t, ResultNormal, result)
+
+	// NSX version check failed case
+	sp := &crdv1alpha1.SecurityPolicy{}
+	fakewriter := fakeStatusWriter{}
+	checkNsxVersionPatch := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, feature int) bool {
+		return false
+	})
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil)
+	k8sClient.EXPECT().Status().Times(1).Return(fakewriter)
+	result, retErr = r.Reconcile(ctx, req)
+	resultRequeueAfter5mins := ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Minute}
+	assert.Equal(t, retErr, nil)
+	assert.Equal(t, resultRequeueAfter5mins, result)
+	checkNsxVersionPatch.Reset()
+	checkNsxVersionPatch = gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, feature int) bool {
+		return true
+	})
+	defer checkNsxVersionPatch.Reset()
+}
+
+func TestReconcileSecurityPolicyForVPC(t *testing.T) {
+	rule := crdv1alpha1.SecurityPolicyRule{
+		Name: "rule-with-pod-selector",
+		AppliedTo: []crdv1alpha1.SecurityPolicyTarget{
+			{},
+		},
+		Sources: []crdv1alpha1.SecurityPolicyPeer{
+			{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"pod_selector_1": "pod_value_1"},
+				},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"ns1": "spA"},
+				},
+			},
+		},
+		Ports: []crdv1alpha1.SecurityPolicyPort{
+			{
+				Protocol: v1.ProtocolUDP,
+				Port:     intstr.IntOrString{Type: intstr.String, StrVal: "named-port"},
+			},
+		},
+	}
+	spList := &crdv1alpha1.SecurityPolicyList{
+		Items: []crdv1alpha1.SecurityPolicy{
+			{
+				Spec: crdv1alpha1.SecurityPolicySpec{
+					Rules: []crdv1alpha1.SecurityPolicyRule{
+						rule,
+					},
+				},
+			},
+		},
+	}
+	pods := []v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod-1",
+				Namespace: "spA",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "test-container-1",
+						Ports: []v1.ContainerPort{
+							{
+								Name: "named-port",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	ctx := context.Background()
+	policyList := &crdv1alpha1.SecurityPolicyList{}
+	k8sClient.EXPECT().List(ctx, policyList).Return(nil).Do(func(_ context.Context, list client.ObjectList,
+		_ ...client.ListOption,
+	) error {
+		a := list.(*crdv1alpha1.SecurityPolicyList)
+		a.Items = spList.Items
+		return nil
+	})
+
+	r := NewFakeSecurityPolicyReconciler()
+	// Enable VPC network
+	r.Service.NSXConfig.EnableVPCNetwork = true
+	mockQueue := mock_client.NewMockInterface(mockCtl)
+
+	type args struct {
+		client client.Client
+		pods   []v1.Pod
+		q      workqueue.RateLimitingInterface
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{"1", args{k8sClient, pods, mockQueue}, assert.NoError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.wantErr(t, reconcileSecurityPolicy(r, tt.args.client, tt.args.pods, tt.args.q),
+				fmt.Sprintf("reconcileSecurityPolicy(%v, %v, %v)", tt.args.client, tt.args.pods, tt.args.q))
+		})
+	}
+}
+
+func TestStartSecurityPolicyController(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects().Build()
+	vpcService := &vpc.VPCService{
+		Service: common.Service{
+			Client: fakeClient,
+		},
+	}
+	commonService := common.Service{
+		Client: fakeClient,
+	}
+	mgr, _ := ctrl.NewManager(&rest.Config{}, manager.Options{})
+
+	exitCalled := false // Variable to check if osExit was called
+	testCases := []struct {
+		name         string
+		expectErrStr string
+		patches      func() *gomonkey.Patches
+	}{
+		// expected no error when starting the SecurityPolicy controller
+		{
+			name: "Start SecurityPolicy Controller",
+			patches: func() *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc(ctrcommon.GenericGarbageCollector, func(cancel chan bool, timeout time.Duration, f func(ctx context.Context)) {
+					return
+				})
+				patches.ApplyFunc(os.Exit, func(code int) {
+					assert.FailNow(t, "os.Exit should not be called")
+					return
+				})
+				patches.ApplyFunc(securitypolicy.GetSecurityService, func(service common.Service, vpcService common.VPCServiceProvider) *securitypolicy.SecurityPolicyService {
+					return fakeService()
+				})
+				patches.ApplyMethod(reflect.TypeOf(&ctrl.Builder{}), "Complete", func(_ *ctrl.Builder, r reconcile.Reconciler) error {
+					return nil
+				})
+				return patches
+			},
+		},
+		{
+			name:         "Start SecurityPolicy controller return error",
+			expectErrStr: "failed to setupWithManager",
+			patches: func() *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc(ctrcommon.GenericGarbageCollector, func(cancel chan bool, timeout time.Duration, f func(ctx context.Context)) {
+					return
+				})
+				patches.ApplyFunc(os.Exit, func(code int) {
+					exitCalled = true
+					return
+				})
+				patches.ApplyFunc(securitypolicy.GetSecurityService, func(service common.Service, vpcService common.VPCServiceProvider) *securitypolicy.SecurityPolicyService {
+					return fakeService()
+				})
+				patches.ApplyPrivateMethod(reflect.TypeOf(&SecurityPolicyReconciler{}), "setupWithManager", func(_ *SecurityPolicyReconciler, mgr ctrl.Manager) error {
+					return errors.New("failed to setupWithManager")
+				})
+				return patches
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			patches := testCase.patches()
+			defer patches.Reset()
+
+			StartSecurityPolicyController(mgr, commonService, vpcService)
+
+			if testCase.expectErrStr != "" {
+				assert.Equal(t, exitCalled, true)
+			} else {
+				assert.Equal(t, exitCalled, false)
+			}
 		})
 	}
 }

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -1,3 +1,6 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
 package securitypolicy
 
 import (
@@ -21,7 +24,7 @@ import (
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
-func TestBuildSecurityPolicy(t *testing.T) {
+func Test_BuildSecurityPolicyForT1(t *testing.T) {
 	destinationPorts := data.NewListValue()
 	destinationPorts.Add(data.NewStringValue("53"))
 	serviceEntry := data.NewStructValue(
@@ -161,7 +164,7 @@ func TestBuildSecurityPolicy(t *testing.T) {
 	}
 }
 
-func TestBuildSecurityPolicyForVPC(t *testing.T) {
+func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 	VPCInfo := make([]common.VPCResourceInfo, 1)
 	VPCInfo[0].OrgID = "default"
 	VPCInfo[0].ProjectID = "projectQuality"
@@ -199,7 +202,6 @@ func TestBuildSecurityPolicyForVPC(t *testing.T) {
 		func(s *SecurityPolicyService, ns string) types.UID {
 			return types.UID(tagValueNSUID)
 		})
-
 	defer patches.Reset()
 
 	podSelectorRule0Name00 := "rule-with-pod-ns-selector_ingress_allow"
@@ -320,7 +322,7 @@ func TestBuildSecurityPolicyForVPC(t *testing.T) {
 	}
 }
 
-func TestBuildPolicyGroup(t *testing.T) {
+func Test_BuildPolicyGroup(t *testing.T) {
 	tests := []struct {
 		name                    string
 		inputPolicy             *v1alpha1.SecurityPolicy
@@ -352,11 +354,11 @@ func TestBuildPolicyGroup(t *testing.T) {
 	}
 }
 
-func TestBuildTargetTags(t *testing.T) {
+func Test_BuildTargetTags(t *testing.T) {
 	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyCRName
 	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyCRUID
 
-	ruleTagID0 := service.buildRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy)
+	ruleTagID0 := service.buildRuleID(&spWithPodSelector, 0)
 	tests := []struct {
 		name         string
 		inputPolicy  *v1alpha1.SecurityPolicy
@@ -438,8 +440,8 @@ func TestBuildTargetTags(t *testing.T) {
 	}
 }
 
-func TestBuildPeerTags(t *testing.T) {
-	ruleTagID0 := service.buildRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy)
+func Test_BuildPeerTags(t *testing.T) {
+	ruleTagID0 := service.buildRuleID(&spWithPodSelector, 0)
 	tests := []struct {
 		name         string
 		inputPolicy  *v1alpha1.SecurityPolicy
@@ -503,7 +505,7 @@ func TestBuildPeerTags(t *testing.T) {
 	}
 }
 
-func TestMergeSelectorMatchExpression(t *testing.T) {
+func Test_MergeSelectorMatchExpression(t *testing.T) {
 	matchExpressions := []v1.LabelSelectorRequirement{
 		{
 			Key:      "k1",
@@ -557,7 +559,7 @@ func TestMergeSelectorMatchExpression(t *testing.T) {
 	assert.Equal(t, 2, len((*mergedMatchExpressions)[1].Values))
 }
 
-func TestUpdateExpressionsMatchExpression(t *testing.T) {
+func Test_UpdateExpressionsMatchExpression(t *testing.T) {
 	group := model.Group{}
 	expressions := service.buildGroupExpression(&group.Expression)
 	memberType := "SegmentPort"
@@ -603,7 +605,7 @@ func TestUpdateExpressionsMatchExpression(t *testing.T) {
 	assert.NotEqual(t, nil, err)
 }
 
-func TestValidateSelectorExpressions(t *testing.T) {
+func Test_ValidateSelectorExpressions(t *testing.T) {
 	matchLabelsCount := 2
 	matchExpressionsCount := 3
 	opInValueCount := 0
@@ -639,7 +641,7 @@ func TestValidateSelectorExpressions(t *testing.T) {
 	assert.NotEqual(t, nil, err)
 }
 
-func TestValidateSelectorOpIn(t *testing.T) {
+func Test_ValidateSelectorOpIn(t *testing.T) {
 	var matchLabels map[string]string
 	matchExpressions := []v1.LabelSelectorRequirement{
 		{
@@ -709,7 +711,7 @@ func TestValidateSelectorOpIn(t *testing.T) {
 	assert.Equal(t, 5, opInValueCount)
 }
 
-func TestValidateNsSelectorOpNotIn(t *testing.T) {
+func Test_ValidateNsSelectorOpNotIn(t *testing.T) {
 	matchExpressions := []v1.LabelSelectorRequirement{
 		{
 			Key:      "k1",
@@ -739,7 +741,7 @@ func TestValidateNsSelectorOpNotIn(t *testing.T) {
 	assert.NotEqual(t, nil, err)
 }
 
-func TestUpdateMixedExpressionsMatchExpression(t *testing.T) {
+func Test_UpdateMixedExpressionsMatchExpression(t *testing.T) {
 	group := model.Group{}
 	expressions := service.buildGroupExpression(&group.Expression)
 	nsMatchLabels := map[string]string{"ns_selector_1": "ns_1"}
@@ -943,7 +945,7 @@ var securityPolicyWithOneNamedPort = v1alpha1.SecurityPolicy{
 	},
 }
 
-func TestBuildRulePortsString(t *testing.T) {
+func Test_BuildRulePortsString(t *testing.T) {
 	tests := []struct {
 		name                    string
 		inputPorts              []v1alpha1.SecurityPolicyPort
@@ -998,7 +1000,7 @@ func TestBuildRulePortsString(t *testing.T) {
 	}
 }
 
-func TestBuildRulePortsNumberString(t *testing.T) {
+func Test_BuildRulePortsNumberString(t *testing.T) {
 	tests := []struct {
 		name                    string
 		inputPorts              []v1alpha1.SecurityPolicyPort
@@ -1053,7 +1055,7 @@ func TestBuildRulePortsNumberString(t *testing.T) {
 	}
 }
 
-func TestBuildRuleDisplayName(t *testing.T) {
+func Test_BuildRuleDisplayName(t *testing.T) {
 	tests := []struct {
 		name                    string
 		inputSecurityPolicy     *v1alpha1.SecurityPolicy
@@ -1118,7 +1120,7 @@ func TestBuildRuleDisplayName(t *testing.T) {
 	}
 }
 
-func TestBuildExpandedRuleID(t *testing.T) {
+func Test_BuildExpandedRuleID(t *testing.T) {
 	svc := &SecurityPolicyService{
 		Service: common.Service{
 			NSXConfig: &config.NSXOperatorConfig{
@@ -1200,7 +1202,7 @@ func TestBuildExpandedRuleID(t *testing.T) {
 	}
 }
 
-func TestBuildSecurityPolicyName(t *testing.T) {
+func Test_BuildSecurityPolicyName(t *testing.T) {
 	svc := &SecurityPolicyService{
 		Service: common.Service{
 			NSXConfig: &config.NSXOperatorConfig{
@@ -1287,7 +1289,7 @@ func TestBuildSecurityPolicyName(t *testing.T) {
 	}
 }
 
-func TestBuildGroupName(t *testing.T) {
+func Test_BuildGroupName(t *testing.T) {
 	svc := &SecurityPolicyService{
 		Service: common.Service{
 			NSXConfig: &config.NSXOperatorConfig{
@@ -1378,7 +1380,6 @@ func TestBuildGroupName(t *testing.T) {
 	})
 
 	t.Run("build applied group name", func(t *testing.T) {
-		createdFor := common.ResourceTypeSecurityPolicy
 		for _, tc := range []struct {
 			name      string
 			ruleIdx   int
@@ -1433,7 +1434,7 @@ func TestBuildGroupName(t *testing.T) {
 				svc.NSXConfig.EnableVPCNetwork = tc.enableVPC
 				dispName := svc.buildAppliedGroupName(obj, tc.ruleIdx)
 				assert.Equal(t, dispName, tc.expName)
-				id := svc.buildAppliedGroupID(obj, tc.ruleIdx, createdFor)
+				id := svc.buildAppliedGroupID(obj, tc.ruleIdx)
 				assert.Equal(t, tc.expId, id)
 			})
 		}

--- a/pkg/nsx/services/securitypolicy/compare.go
+++ b/pkg/nsx/services/securitypolicy/compare.go
@@ -1,3 +1,6 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
 package securitypolicy
 
 import (

--- a/pkg/nsx/services/securitypolicy/compare_test.go
+++ b/pkg/nsx/services/securitypolicy/compare_test.go
@@ -1,3 +1,6 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
 package securitypolicy
 
 import (
@@ -9,7 +12,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
-func TestGroupsEqual(t *testing.T) {
+func Test_GroupsEqual(t *testing.T) {
 	spNewGroupID := "spNewGroupID"
 	tests := []struct {
 		name            string
@@ -84,7 +87,7 @@ func TestGroupsEqual(t *testing.T) {
 	}
 }
 
-func TestRulesEqual(t *testing.T) {
+func Test_RulesEqual(t *testing.T) {
 	tests := []struct {
 		name            string
 		inputRule1      []model.Rule
@@ -158,7 +161,7 @@ func TestRulesEqual(t *testing.T) {
 	}
 }
 
-func TestSecurityPolicyEqual(t *testing.T) {
+func Test_SecurityPolicyEqual(t *testing.T) {
 	tests := []struct {
 		name            string
 		inputPolicy1    *model.SecurityPolicy

--- a/pkg/nsx/services/securitypolicy/convert.go
+++ b/pkg/nsx/services/securitypolicy/convert.go
@@ -1,3 +1,6 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
 package securitypolicy
 
 import (

--- a/pkg/nsx/services/securitypolicy/convert_test.go
+++ b/pkg/nsx/services/securitypolicy/convert_test.go
@@ -1,0 +1,54 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package securitypolicy
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/legacy/v1alpha1"
+	crdv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+)
+
+func Test_T1ToVPC(t *testing.T) {
+	// Initialize input SecurityPolicy
+	input := &v1alpha1.SecurityPolicy{
+		Spec: v1alpha1.SecurityPolicySpec{
+			Rules: []v1alpha1.SecurityPolicyRule{
+				{
+					Name: "ingress_isolation",
+				},
+			},
+		},
+	}
+
+	output := T1ToVPC(input)
+
+	// Verify the output
+	assert.Equal(t, "crd.nsx.vmware.com/v1alpha1", output.APIVersion, "APIVersion should be set correctly")
+	assert.Equal(t, (*crdv1alpha1.SecurityPolicy)(unsafe.Pointer(input)), output, "Conversion should produce the correct type")
+	assert.Equal(t, input.Spec.Rules[0].Name, output.Spec.Rules[0].Name, "Field values should match after conversion")
+}
+
+func Test_VPCToT1(t *testing.T) {
+	// Initialize input SecurityPolicy
+	input := &crdv1alpha1.SecurityPolicy{
+		Spec: crdv1alpha1.SecurityPolicySpec{
+			Rules: []crdv1alpha1.SecurityPolicyRule{
+				{
+					Name: "egress_isolation",
+				},
+			},
+		},
+	}
+
+	output := VPCToT1(input)
+
+	// Verify the output
+	assert.Equal(t, "nsx.vmware.com/v1alpha1", output.APIVersion, "APIVersion should be set correctly")
+	assert.Equal(t, (*v1alpha1.SecurityPolicy)(unsafe.Pointer(input)), output, "Conversion should produce the correct type")
+	assert.Equal(t, input.Spec.Rules[0].Name, output.Spec.Rules[0].Name, "Field values should match after conversion")
+}

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -1,3 +1,6 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
 package securitypolicy
 
 import (
@@ -8,13 +11,14 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/legacy/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
@@ -195,7 +199,7 @@ func (s *SecurityPolicyService) setUpStore(indexScope string) {
 
 func (service *SecurityPolicyService) CreateOrUpdateSecurityPolicy(obj interface{}) error {
 	if !nsxutil.IsLicensed(nsxutil.FeatureDFW) {
-		log.Info("no DFW license, skip creating SecurityPolicy.")
+		log.Info("No DFW license, skip creating SecurityPolicy.")
 		return nsxutil.RestrictionError{Desc: "no DFW license"}
 	}
 	var err error
@@ -355,7 +359,7 @@ func (service *SecurityPolicyService) convertNetworkPolicyToInternalSecurityPoli
 	}
 
 	securityPolicies = append(securityPolicies, spAllow, spIsolation)
-	log.V(1).Info("converted network policy to security policies", "securityPolicies", securityPolicies)
+	log.V(1).Info("Converted network policy to security policies", "securityPolicies", securityPolicies)
 	return securityPolicies, nil
 }
 
@@ -457,7 +461,7 @@ func (service *SecurityPolicyService) getFinalSecurityPolicyResource(obj *v1alph
 	}
 
 	if len(nsxSecurityPolicy.Scope) == 0 {
-		log.Info("securityPolicy has empty policy-level appliedTo")
+		log.Info("SecurityPolicy has empty policy-level appliedTo field")
 	}
 	indexScope := common.TagValueScopeSecurityPolicyUID
 	if createdFor == common.ResourceTypeNetworkPolicy {
@@ -503,7 +507,7 @@ func (service *SecurityPolicyService) createOrUpdateSecurityPolicy(obj *v1alpha1
 	finalRules := finalSecurityPolicy.Rules
 
 	if !isChanged && len(finalSecurityPolicy.Rules) == 0 && len(finalGroups) == 0 {
-		log.Info("securityPolicy, rules, groups are not changed, skip updating them", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
+		log.Info("SecurityPolicy, rules, groups are not changed, skip updating them", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
 		return nil
 	}
 
@@ -546,7 +550,7 @@ func (service *SecurityPolicyService) createOrUpdateSecurityPolicy(obj *v1alpha1
 		log.Error(err, "failed to apply store", "nsxGroups", finalGroups)
 		return err
 	}
-	log.Info("successfully created or updated NSX SecurityPolicy", "nsxSecurityPolicy", finalGetNSXSecurityPolicy)
+	log.Info("Successfully created or updated NSX SecurityPolicy", "nsxSecurityPolicy", finalGetNSXSecurityPolicy)
 	return nil
 }
 
@@ -573,7 +577,7 @@ func (service *SecurityPolicyService) createOrUpdateVPCSecurityPolicy(obj *v1alp
 	finalRules := finalSecurityPolicy.Rules
 
 	if !isChanged && len(finalSecurityPolicy.Rules) == 0 && len(finalGroups) == 0 && len(finalShares) == 0 {
-		log.Info("securityPolicy, rules, groups and shares are not changed, skip updating them", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
+		log.Info("SecurityPolicy, rules, groups and shares are not changed, skip updating them", "nsxSecurityPolicyId", finalSecurityPolicy.Id)
 		return nil
 	}
 	if !isDefaultProject {
@@ -594,7 +598,7 @@ func (service *SecurityPolicyService) createOrUpdateVPCSecurityPolicy(obj *v1alp
 		return err
 	}
 
-	log.Info("successfully created or updated NSX SecurityPolicy in VPC", "nsxSecurityPolicy", finalGetNSXSecurityPolicy)
+	log.Info("Successfully created or updated NSX SecurityPolicy in VPC", "nsxSecurityPolicy", finalGetNSXSecurityPolicy)
 	return nil
 }
 
@@ -689,7 +693,7 @@ func (service *SecurityPolicyService) deleteSecurityPolicy(sp types.UID) error {
 		return err
 	}
 
-	log.Info("successfully deleted NSX SecurityPolicy", "nsxSecurityPolicy", finalSecurityPolicyCopy)
+	log.Info("Successfully deleted NSX SecurityPolicy", "nsxSecurityPolicy", finalSecurityPolicyCopy)
 	return nil
 }
 
@@ -790,7 +794,7 @@ func (service *SecurityPolicyService) deleteVPCSecurityPolicy(sp types.UID, isGC
 		return err
 	}
 
-	log.Info("successfully deleted NSX SecurityPolicy in VPC", "nsxSecurityPolicy", finalSecurityPolicyCopy)
+	log.Info("Successfully deleted NSX SecurityPolicy in VPC", "nsxSecurityPolicy", finalSecurityPolicyCopy)
 	return nil
 }
 
@@ -825,7 +829,7 @@ func (service *SecurityPolicyService) createOrUpdateGroups(obj *v1alpha1.Securit
 	if err != nil {
 		return err
 	}
-	log.Info("successfully create or update groups", "nsxGroups", finalGroups)
+	log.Info("Successfully create or update groups", "nsxGroups", finalGroups)
 	return nil
 }
 
@@ -867,7 +871,7 @@ func (service *SecurityPolicyService) getUpdateShares(existingShares []*model.Sh
 
 func (service *SecurityPolicyService) markDeleteGroups(existingGroups []*model.Group, deleteGroups *[]model.Group, sp types.UID) {
 	if len(existingGroups) == 0 {
-		log.Info("did not get groups with SecurityPolicy index", "securityPolicyUID", string(sp))
+		log.Info("Did not get groups with SecurityPolicy index", "securityPolicyUID", string(sp))
 		return
 	}
 	for _, group := range existingGroups {
@@ -880,7 +884,7 @@ func (service *SecurityPolicyService) markDeleteGroups(existingGroups []*model.G
 
 func (service *SecurityPolicyService) markDeleteRules(existingRules []*model.Rule, deleteRules *[]model.Rule, sp types.UID) {
 	if len(existingRules) == 0 {
-		log.Info("did not get rules with SecurityPolicy index", "securityPolicyUID", string(sp))
+		log.Info("Did not get rules with SecurityPolicy index", "securityPolicyUID", string(sp))
 		return
 	}
 	for _, rule := range existingRules {
@@ -893,7 +897,7 @@ func (service *SecurityPolicyService) markDeleteRules(existingRules []*model.Rul
 
 func (service *SecurityPolicyService) markDeleteShares(existingShares []*model.Share, deleteShares *[]model.Share, sp types.UID) {
 	if len(existingShares) == 0 {
-		log.Info("did not get shares with SecurityPolicy index", "securityPolicyUID", string(sp))
+		log.Info("Did not get shares with SecurityPolicy index", "securityPolicyUID", string(sp))
 		return
 	}
 	for _, share := range existingShares {
@@ -1132,7 +1136,7 @@ func (service *SecurityPolicyService) ListNetworkPolicyByName(ns, name string) [
 func (service *SecurityPolicyService) Cleanup(ctx context.Context) error {
 	// Delete all the security policies in store
 	uids := service.ListSecurityPolicyID()
-	log.Info("cleaning up security policies created for CR", "count", len(uids))
+	log.Info("Cleaning up security policies created for SecurityPolicy CR", "count", len(uids))
 	for uid := range uids {
 		select {
 		case <-ctx.Done():
@@ -1147,7 +1151,7 @@ func (service *SecurityPolicyService) Cleanup(ctx context.Context) error {
 
 	// Delete all the security policies created for network policy in store
 	uids = service.ListNetworkPolicyID()
-	log.Info("cleaning up security policies created for network policy", "count", len(uids))
+	log.Info("Cleaning up security policies created for network policy", "count", len(uids))
 	for uid := range uids {
 		select {
 		case <-ctx.Done():

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -1,15 +1,18 @@
-/* Copyright © 2021 VMware, Inc. All Rights Reserved.
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
    SPDX-License-Identifier: Apache-2.0 */
 
 package securitypolicy
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
+	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
@@ -24,6 +27,8 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	"github.com/vmware-tanzu/nsx-operator/pkg/mock"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 var (
@@ -37,13 +42,14 @@ var (
 	tagScopeCluster              = common.TagScopeCluster
 	tagScopeNamespace            = common.TagScopeNamespace
 	tagScopeNamespaceUID         = common.TagScopeNamespaceUID
-	tagScopeSecurityPolicyCRName = common.TagValueScopeSecurityPolicyName
-	tagScopeSecurityPolicyCRUID  = common.TagValueScopeSecurityPolicyUID
+	tagScopeSecurityPolicyCRName = common.TagScopeSecurityPolicyCRName
+	tagScopeSecurityPolicyCRUID  = common.TagScopeSecurityPolicyCRUID
 	tagScopeSecurityPolicyName   = common.TagScopeSecurityPolicyName
 	tagScopeSecurityPolicyUID    = common.TagScopeSecurityPolicyUID
 	tagScopeRuleID               = common.TagScopeRuleID
 	tagScopeSelectorHash         = common.TagScopeSelectorHash
 	spName                       = "spA"
+	spName1                      = "spB"
 	spGroupName                  = "spA_scope"
 	spID                         = "sp_uidA"
 	spID2                        = "sp_uidB"
@@ -255,33 +261,6 @@ var (
 		},
 	}
 
-	basicTagsForSpWithVMSelector = []model.Tag{
-		{
-			Scope: &tagScopeCluster,
-			Tag:   &clusterName,
-		},
-		{
-			Scope: &tagScopeVersion,
-			Tag:   &tagValueVersion,
-		},
-		{
-			Scope: &tagScopeNamespace,
-			Tag:   &tagValueNS,
-		},
-		{
-			Scope: &tagScopeNamespaceUID,
-			Tag:   &tagValueNSUID,
-		},
-		{
-			Scope: &tagScopeSecurityPolicyCRName,
-			Tag:   String(spWithVMSelector.Name),
-		},
-		{
-			Scope: &tagScopeSecurityPolicyCRUID,
-			Tag:   String(string(spWithVMSelector.UID)),
-		},
-	}
-
 	basicTags = []model.Tag{
 		{
 			Scope: &tagScopeCluster,
@@ -336,6 +315,33 @@ var (
 		},
 	}
 
+	basicTagsForSpWithVMSelector = []model.Tag{
+		{
+			Scope: &tagScopeCluster,
+			Tag:   &clusterName,
+		},
+		{
+			Scope: &tagScopeVersion,
+			Tag:   &tagValueVersion,
+		},
+		{
+			Scope: &tagScopeNamespace,
+			Tag:   &tagValueNS,
+		},
+		{
+			Scope: &tagScopeNamespaceUID,
+			Tag:   &tagValueNSUID,
+		},
+		{
+			Scope: &tagScopeSecurityPolicyCRName,
+			Tag:   String(spWithVMSelector.Name),
+		},
+		{
+			Scope: &tagScopeSecurityPolicyCRUID,
+			Tag:   String(string(spWithVMSelector.UID)),
+		},
+	}
+
 	vpcBasicTagsForSpWithVMSelector = []model.Tag{
 		{
 			Scope: &tagScopeCluster,
@@ -374,6 +380,7 @@ var (
 		Spec: networkingv1.NetworkPolicySpec{
 			PolicyTypes: []networkingv1.PolicyType{
 				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
 			},
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -406,6 +413,37 @@ var (
 							}(),
 							Port: &intstr.IntOrString{
 								IntVal: 6001,
+							},
+						},
+					},
+				},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "mysql",
+								},
+							},
+						},
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"ns-name": "ns-2",
+								},
+							},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: func() *corev1.Protocol {
+								proto := corev1.ProtocolTCP
+								return &proto
+							}(),
+							Port: &intstr.IntOrString{
+								IntVal: 3366,
 							},
 						},
 					},
@@ -469,14 +507,55 @@ var (
 	}
 )
 
-func TestListSecurityPolicyID(t *testing.T) {
+func Test_GetSecurityService(t *testing.T) {
+	fakeService := fakeSecurityPolicyService()
+	fakeService.NSXConfig.EnableVPCNetwork = true
+	commonService := fakeService.Service
+
+	vpcService := &vpc.VPCService{}
+
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(&commonService), "InitializeResourceStore", func(_ *common.Service, wg *sync.WaitGroup,
+		fatalErrors chan error, resourceTypeValue string, tags []model.Tag, store common.Store,
+	) {
+		wg.Done()
+		return
+	})
+	defer patch.Reset()
+
+	spSvc := GetSecurityService(commonService, vpcService)
+	assert.Equal(t, clusterName, spSvc.NSXConfig.CoeConfig.Cluster)
+	assert.Equal(t, true, spSvc.NSXConfig.EnableVPCNetwork)
+}
+
+func Test_InitializeSecurityPolicy(t *testing.T) {
+	fakeService := fakeSecurityPolicyService()
+	fakeService.NSXConfig.EnableVPCNetwork = true
+	commonService := fakeService.Service
+
+	vpcService := &vpc.VPCService{}
+
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(&commonService), "InitializeResourceStore", func(_ *common.Service, wg *sync.WaitGroup,
+		fatalErrors chan error, resourceTypeValue string, tags []model.Tag, store common.Store,
+	) {
+		wg.Done()
+		return
+	})
+	defer patch.Reset()
+
+	_, err := InitializeSecurityPolicy(commonService, vpcService)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func Test_ListSecurityPolicyID(t *testing.T) {
 	service := &SecurityPolicyService{
 		Service: common.Service{NSXClient: nil},
 	}
 	service.setUpStore(common.TagValueScopeSecurityPolicyUID)
 
 	group := model.Group{}
-	scope := "nsx-op/security_policy_cr_uid"
+	scope := common.TagValueScopeSecurityPolicyUID
 	uuid := "111111111"
 	id := "1234"
 	group.Id = &id
@@ -558,7 +637,90 @@ func TestListSecurityPolicyID(t *testing.T) {
 	}
 }
 
-func TestGetUpdateRules(t *testing.T) {
+func Test_createOrUpdateGroups(t *testing.T) {
+	VPCInfo := make([]common.VPCResourceInfo, 1)
+	VPCInfo[0].OrgID = "default"
+	VPCInfo[0].ProjectID = "projectQuality"
+	VPCInfo[0].VPCID = "vpc1"
+
+	mId, mTag, mScope := "spA_uidA_scope", "uidA", tagScopeSecurityPolicyUID
+	markDelete := true
+
+	g1 := model.Group{
+		Id:              &mId,
+		Tags:            []model.Tag{{Tag: &mTag, Scope: &mScope}},
+		MarkedForDelete: &markDelete,
+	}
+
+	type args struct {
+		spObj      *v1alpha1.SecurityPolicy
+		createdFor string
+	}
+	tests := []struct {
+		name                string
+		prepareFunc         func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		args                args
+		inputGroups         []*model.Group
+		wantErr             bool
+		wantGroupStoreCount int
+	}{
+		{
+			name: "success createOrUpdateGroups for VPC",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVPCInfo",
+					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
+						return &VPCInfo[0], nil
+					})
+
+				patches.ApplyMethodSeq(s.NSXClient.VpcGroupClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+
+				return patches
+			},
+			args: args{
+				spObj:      &spWithPodSelector,
+				createdFor: common.ResourceTypeSecurityPolicy,
+			},
+			inputGroups: []*model.Group{
+				&g1,
+			},
+			wantErr:             false,
+			wantGroupStoreCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
+			fakeService := fakeSecurityPolicyService()
+			fakeService.NSXConfig.EnableVPCNetwork = true
+			mockVPCService := mock.MockVPCServiceProvider{}
+			fakeService.vpcService = &mockVPCService
+
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			patches := tt.prepareFunc(t, fakeService)
+			defer patches.Reset()
+
+			if err := fakeService.createOrUpdateGroups(tt.args.spObj, tt.inputGroups); (err != nil) != tt.wantErr {
+				t.Errorf("createOrUpdateGroups error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
+			existingGroups := fakeService.groupStore.GetByIndex(tt.args.createdFor, string(tt.args.spObj.UID))
+
+			for _, group := range existingGroups {
+				assert.Equal(t, nil, *(*group).MarkedForDelete)
+			}
+		})
+	}
+}
+
+func Test_GetUpdateRules(t *testing.T) {
 	r1 := model.Rule{
 		DisplayName:       String("nsxrule1"),
 		Id:                String("nsxrule_1"),
@@ -627,8 +789,8 @@ func TestGetUpdateRules(t *testing.T) {
 	}
 }
 
-func TestGetUpdateGroups(t *testing.T) {
-	mId, mTag, mTag2, mScope := "11111", "11111", "22222", "nsx-op/security_policy_cr_uid"
+func Test_GetUpdateGroups(t *testing.T) {
+	mId, mTag, mTag2, mScope := "11111", "11111", "22222", tagScopeSecurityPolicyUID
 	markDelete := true
 
 	g1 := model.Group{
@@ -695,8 +857,8 @@ func TestGetUpdateGroups(t *testing.T) {
 	}
 }
 
-func TestGetUpdateShares(t *testing.T) {
-	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_cr_uid"
+func Test_GetUpdateShares(t *testing.T) {
+	mId, mTag, mScope := "11111", "11111", tagScopeSecurityPolicyUID
 
 	s1 := model.Share{
 		Id:         &mId,
@@ -762,7 +924,7 @@ func TestGetUpdateShares(t *testing.T) {
 	}
 }
 
-func TestListMarkDeleteRules(t *testing.T) {
+func Test_MarkDeleteRules(t *testing.T) {
 	var sp types.UID
 	sp = "sp_test"
 	markNoDelete := false
@@ -805,7 +967,7 @@ func TestListMarkDeleteRules(t *testing.T) {
 	}
 }
 
-func TestListMarkDeleteGroups(t *testing.T) {
+func Test_MarkDeleteGroups(t *testing.T) {
 	var sp types.UID
 	sp = "sp_test"
 	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_cr_uid"
@@ -842,7 +1004,7 @@ func TestListMarkDeleteGroups(t *testing.T) {
 	}
 }
 
-func TestListMarkDeleteShares(t *testing.T) {
+func Test_MarkDeleteShares(t *testing.T) {
 	var sp types.UID
 	sp = "sp_test"
 	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_cr_uid"
@@ -880,8 +1042,8 @@ func TestListMarkDeleteShares(t *testing.T) {
 	}
 }
 
-func TestDleleteVPCSecurityPolicy(t *testing.T) {
-	vpcPath := "/orgs/default/projects/projectQuality/vpcs/vpc1"
+func Test_DeleteVPCSecurityPolicy(t *testing.T) {
+	spPath := "/orgs/default/projects/projectQuality/vpcs/vpc1"
 
 	type args struct {
 		uid        types.UID
@@ -898,12 +1060,14 @@ func TestDleleteVPCSecurityPolicy(t *testing.T) {
 		wantGroupStoreCount          int
 		wantProjectGroupStoreCount   int
 		wantProjectShareStoreCount   int
+		wantInfraGroupStoreCount     int
+		wantInfraShareStoreCount     int
 	}{
 		{
-			name: "successDeleteVPCSecurityPolicy",
+			name: "success DeleteSecurityPolicy for VPC",
 			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
-				mGId := "sp_uidA_0_scope"
-				mTag, mScope := tagValuePolicyCRUID, tagScopeSecurityPolicyCRUID
+				mGId := "spA_uidA_scope"
+				mTag, mScope := tagValuePolicyCRUID, tagScopeSecurityPolicyUID
 				g := make([]model.Group, 0)
 				g1 := &g
 				scopeGroup := model.Group{
@@ -913,7 +1077,7 @@ func TestDleleteVPCSecurityPolicy(t *testing.T) {
 				*g1 = append(*g1, scopeGroup)
 				assert.NoError(t, s.groupStore.Apply(g1))
 
-				mProjGId := "sp_uidA_1_src"
+				mProjGId := "spA_uidA_2c822e90_src"
 				g = make([]model.Group, 0)
 				g2 := &g
 				projectGroup := model.Group{
@@ -923,7 +1087,7 @@ func TestDleleteVPCSecurityPolicy(t *testing.T) {
 				*g2 = append(*g2, projectGroup)
 				assert.NoError(t, s.projectGroupStore.Apply(g2))
 
-				mSId := "share-projectQuality-group-sp_uidA_1_src"
+				mSId := "share_projectQuality_group_spA_uidA_2c822e90_src"
 				sh := make([]model.Share, 0)
 				s1 := &sh
 				projectShare := model.Share{
@@ -946,8 +1110,312 @@ func TestDleleteVPCSecurityPolicy(t *testing.T) {
 			},
 			inputPolicy: &model.SecurityPolicy{
 				DisplayName:    &spName,
-				Id:             &tagValuePolicyCRUID,
-				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/sp_uidA_scope"},
+				Id:             common.String("spA_uidA"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules: []model.Rule{
+					{
+						DisplayName:       &ruleNameWithPodSelector00,
+						Id:                &ruleID0,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"ANY"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              vpcBasicTags,
+					},
+					{
+						DisplayName:       &ruleNameWithNsSelector00,
+						Id:                &ruleID1,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq1,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA_uidA_2c822e90_src"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              vpcBasicTags,
+					},
+				},
+				Tags: vpcBasicTags,
+				Path: &spPath,
+			},
+			wantErr:                      false,
+			wantSecurityPolicyStoreCount: 0,
+			wantRuleStoreCount:           0,
+			wantGroupStoreCount:          0,
+			wantProjectGroupStoreCount:   0,
+			wantProjectShareStoreCount:   0,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
+			fakeService := fakeSecurityPolicyService()
+			fakeService.NSXConfig.EnableVPCNetwork = true
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			assert.NoError(t, fakeService.securityPolicyStore.Apply(tt.inputPolicy))
+			assert.NoError(t, fakeService.ruleStore.Apply(&tt.inputPolicy.Rules))
+
+			patches := tt.prepareFunc(t, fakeService)
+			defer patches.Reset()
+
+			if err := fakeService.DeleteSecurityPolicy(tt.args.uid, false, false, tt.args.createdFor); (err != nil) != tt.wantErr {
+				t.Errorf("deleteVPCSecurityPolicy error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.wantSecurityPolicyStoreCount, len(fakeService.securityPolicyStore.ListKeys()))
+			assert.Equal(t, tt.wantRuleStoreCount, len(fakeService.ruleStore.ListKeys()))
+			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectGroupStoreCount, len(fakeService.projectGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.projectShareStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraGroupStoreCount, len(fakeService.infraGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraShareStoreCount, len(fakeService.infraShareStore.ListKeys()))
+		})
+	}
+}
+
+func Test_DeleteVPCSecurityPolicyForNetworkPolicy(t *testing.T) {
+	spPath := "/orgs/default/projects/projectQuality/vpcs/vpc1"
+
+	VPCInfo := make([]common.VPCResourceInfo, 1)
+	VPCInfo[0].OrgID = "default"
+	VPCInfo[0].ProjectID = "projectQuality"
+	VPCInfo[0].VPCID = "vpc1"
+
+	ingressServiceEntry := getRuleServiceEntries(6001, 0, "TCP")
+	egressServiceEntry := getRuleServiceEntries(3366, 0, "TCP")
+
+	tests := []struct {
+		name                           string
+		prepareFunc                    func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		npObj                          *networkingv1.NetworkPolicy
+		expAllowPolicy                 *model.SecurityPolicy
+		expIsolationPolicy             *model.SecurityPolicy
+		wantSPStoreCountBeforeDelete   int
+		wantRuleStoreCountBeforeDelete int
+		wantErr                        bool
+		wantSPStoreCount               int
+		wantRuleStoreCount             int
+		wantGroupStoreCount            int
+		wantProjectGroupStoreCount     int
+		wantProjectShareStoreCount     int
+		wantInfraGroupStoreCount       int
+		wantInfraShareStoreCount       int
+	}{
+		{
+			name:  "success DeleteSecurityPolicy From NetworkPolicy",
+			npObj: &npWithNsSelecotr,
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVPCInfo",
+					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
+						return &VPCInfo[0], nil
+					})
+
+				patches.ApplyFuncSeq(nsxutil.IsLicensed, []gomonkey.OutputCell{{
+					Values: gomonkey.Params{true},
+					Times:  1,
+				}})
+
+				patches.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  2,
+				}})
+
+				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+					func(s *SecurityPolicyService, ns string) types.UID {
+						return types.UID(tagValueNSUID)
+					})
+
+				return patches
+			},
+			expAllowPolicy: &model.SecurityPolicy{
+				DisplayName:    common.String("np-app-access"),
+				Id:             common.String("np-app-access_uidNP_allow"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/np-app-access_uidNP_allow_scope"},
+				SequenceNumber: Int64(int64(common.PriorityNetworkPolicyAllowRule)),
+				Rules: []model.Rule{
+					{
+						DisplayName:       common.String("TCP.6001_ingress_allow"),
+						Id:                common.String("np-app-access_uidNP_allow_6c2a026c_6001"),
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access_uidNP_allow_6c2a026c_src"},
+						Action:            &nsxRuleActionAllow,
+						ServiceEntries:    []*data.StructValue{ingressServiceEntry},
+						Tags:              npAllowBasicTags,
+					},
+					{
+						DisplayName:       common.String("TCP.3366_egress_allow"),
+						Id:                common.String("np-app-access_uidNP_allow_025d37a6_3366"),
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access_uidNP_allow_025d37a6_dst"},
+						Direction:         &nsxRuleDirectionOut,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq1,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"ANY"},
+						Action:            &nsxRuleActionAllow,
+						ServiceEntries:    []*data.StructValue{egressServiceEntry},
+						Tags:              npAllowBasicTags,
+					},
+				},
+				Tags: npAllowBasicTags,
+				Path: &spPath,
+			},
+			expIsolationPolicy: &model.SecurityPolicy{
+				DisplayName:    common.String("np-app-access"),
+				Id:             common.String("np-app-access_uidNP_isolation"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/np-app-access_uidNP_isolation_scope"},
+				SequenceNumber: Int64(int64(common.PriorityNetworkPolicyIsolationRule)),
+				Rules: []model.Rule{
+					{
+						DisplayName:       common.String("ingress_isolation"),
+						Id:                common.String("np-app-access_uidNP_isolation_114fed10_all"),
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/np-app-access_uidNP_isolation_scope"},
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"ANY"},
+						Action:            &nsxRuleActionDrop,
+						Tags:              npIsolationBasicTags,
+					},
+					{
+						DisplayName:       common.String("egress_isolation"),
+						Id:                common.String("np-app-access_uidNP_isolation_8cae63ab_all"),
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionOut,
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/np-app-access_uidNP_isolation_scope"},
+						SequenceNumber:    &seq1,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"ANY"},
+						Action:            &nsxRuleActionDrop,
+						Tags:              npIsolationBasicTags,
+					},
+				},
+				Tags: npIsolationBasicTags,
+				Path: &spPath,
+			},
+			wantSPStoreCountBeforeDelete:   2,
+			wantRuleStoreCountBeforeDelete: 4,
+			wantErr:                        false,
+			wantSPStoreCount:               0,
+			wantRuleStoreCount:             0,
+			wantGroupStoreCount:            0,
+			wantProjectGroupStoreCount:     0,
+			wantProjectShareStoreCount:     0,
+			wantInfraGroupStoreCount:       0,
+			wantInfraShareStoreCount:       0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
+			fakeService := fakeSecurityPolicyService()
+			fakeService.NSXConfig.EnableVPCNetwork = true
+			mockVPCService := mock.MockVPCServiceProvider{}
+			fakeService.vpcService = &mockVPCService
+
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			patches := tt.prepareFunc(t, fakeService)
+			defer patches.Reset()
+
+			assert.NoError(t, fakeService.securityPolicyStore.Apply(tt.expAllowPolicy))
+			assert.NoError(t, fakeService.securityPolicyStore.Apply(tt.expIsolationPolicy))
+			assert.NoError(t, fakeService.ruleStore.Apply(&tt.expAllowPolicy.Rules))
+			assert.NoError(t, fakeService.ruleStore.Apply(&tt.expIsolationPolicy.Rules))
+
+			assert.Equal(t, tt.wantSPStoreCountBeforeDelete, len(fakeService.securityPolicyStore.ListKeys()))
+			assert.Equal(t, tt.wantRuleStoreCountBeforeDelete, len(fakeService.ruleStore.ListKeys()))
+
+			if err := fakeService.DeleteSecurityPolicy(tt.npObj, false, false, common.ResourceTypeNetworkPolicy); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteSecurityPolicy error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.Equal(t, tt.wantSPStoreCount, len(fakeService.securityPolicyStore.ListKeys()))
+			assert.Equal(t, tt.wantRuleStoreCount, len(fakeService.ruleStore.ListKeys()))
+			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectGroupStoreCount, len(fakeService.projectGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.projectShareStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraGroupStoreCount, len(fakeService.infraGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraShareStoreCount, len(fakeService.infraShareStore.ListKeys()))
+		})
+	}
+}
+
+func Test_deleteSecurityPolicy(t *testing.T) {
+	spPath := "/infra/domains/k8scl-one/"
+
+	type args struct {
+		uid        types.UID
+		createdFor string
+	}
+	tests := []struct {
+		name                         string
+		prepareFunc                  func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		args                         args
+		inputPolicy                  *model.SecurityPolicy
+		wantErr                      bool
+		wantSecurityPolicyStoreCount int
+		wantRuleStoreCount           int
+		wantGroupStoreCount          int
+		wantProjectGroupStoreCount   int
+		wantProjectShareStoreCount   int
+		wantInfraGroupStoreCount     int
+		wantInfraShareStoreCount     int
+	}{
+		{
+			name: "success deleteT1SecurityPolicy",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				mGId := "sp_uidA_scope"
+				mTag, mScope := tagValuePolicyCRUID, tagScopeSecurityPolicyCRUID
+				g := make([]model.Group, 0)
+				g1 := &g
+				scopeGroup := model.Group{
+					Id:   &mGId,
+					Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+				}
+				*g1 = append(*g1, scopeGroup)
+				assert.NoError(t, s.groupStore.Apply(g1))
+
+				msrcGId := "sp_uidA_1_src"
+				g = make([]model.Group, 0)
+				g2 := &g
+				srcGroup := model.Group{
+					Id:   &msrcGId,
+					Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+				}
+				*g2 = append(*g2, srcGroup)
+				assert.NoError(t, s.groupStore.Apply(g2))
+
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.InfraClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				uid:        types.UID(tagValuePolicyCRUID),
+			},
+			inputPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             common.String("sp_uidA"),
+				Scope:          []string{"/infra/domains/k8scl-one/groups/sp_uidA_scope"},
 				SequenceNumber: &seq0,
 				Rules: []model.Rule{
 					{
@@ -970,13 +1438,13 @@ func TestDleleteVPCSecurityPolicy(t *testing.T) {
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/sp_uidA_1_src"},
+						SourceGroups:      []string{"/infra/domains/k8scl-one/groups/groups/sp_uidA_1_src"},
 						Action:            &nsxRuleActionAllow,
 						Tags:              basicTags,
 					},
 				},
 				Tags: basicTags,
-				Path: &vpcPath,
+				Path: &spPath,
 			},
 			wantErr:                      false,
 			wantSecurityPolicyStoreCount: 0,
@@ -984,12 +1452,209 @@ func TestDleleteVPCSecurityPolicy(t *testing.T) {
 			wantGroupStoreCount:          0,
 			wantProjectGroupStoreCount:   0,
 			wantProjectShareStoreCount:   0,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
 		},
 		{
-			name: "errorDeleteVPCSecurityPolicy",
+			name: "error deleteT1SecurityPolicy",
 			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
-				mGId := "sp_uidA_0_scope"
+				mGId := "sp_uidA_scope"
 				mTag, mScope := tagValuePolicyCRUID, tagScopeSecurityPolicyCRUID
+				g := make([]model.Group, 0)
+				g1 := &g
+				scopeGroup := model.Group{
+					Id:   &mGId,
+					Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+				}
+				*g1 = append(*g1, scopeGroup)
+				assert.NoError(t, s.groupStore.Apply(g1))
+
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.InfraClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{fmt.Errorf("mock error")},
+					Times:  1,
+				}})
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				uid:        types.UID(tagValuePolicyCRUID),
+			},
+			inputPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             common.String("sp_uidA"),
+				Scope:          []string{"/infra/domains/k8scl-one/groups/groups/sp_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules: []model.Rule{
+					{
+						DisplayName:       &ruleNameWithPodSelector00,
+						Id:                &ruleID0,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"ANY"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              basicTags,
+					},
+				},
+				Tags: basicTags,
+				Path: &spPath,
+			},
+			wantErr:                      true,
+			wantSecurityPolicyStoreCount: 1,
+			wantRuleStoreCount:           1,
+			wantGroupStoreCount:          1,
+			wantProjectGroupStoreCount:   0,
+			wantProjectShareStoreCount:   0,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyCRName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyCRUID
+
+			fakeService := fakeSecurityPolicyService()
+			fakeService.NSXConfig.EnableVPCNetwork = false
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			assert.NoError(t, fakeService.securityPolicyStore.Apply(tt.inputPolicy))
+			assert.NoError(t, fakeService.ruleStore.Apply(&tt.inputPolicy.Rules))
+
+			patches := tt.prepareFunc(t, fakeService)
+			defer patches.Reset()
+
+			if err := fakeService.deleteSecurityPolicy(tt.args.uid); (err != nil) != tt.wantErr {
+				t.Errorf("deleteSecurityPolicy error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.wantSecurityPolicyStoreCount, len(fakeService.securityPolicyStore.ListKeys()))
+			assert.Equal(t, tt.wantRuleStoreCount, len(fakeService.ruleStore.ListKeys()))
+			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectGroupStoreCount, len(fakeService.projectGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.projectShareStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraGroupStoreCount, len(fakeService.infraGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraShareStoreCount, len(fakeService.infraShareStore.ListKeys()))
+		})
+	}
+}
+
+func Test_deleteVPCSecurityPolicy(t *testing.T) {
+	spPath := "/orgs/default/projects/projectQuality/vpcs/vpc1"
+
+	type args struct {
+		uid        types.UID
+		createdFor string
+	}
+	tests := []struct {
+		name                         string
+		prepareFunc                  func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		args                         args
+		inputPolicy                  *model.SecurityPolicy
+		wantErr                      bool
+		wantSecurityPolicyStoreCount int
+		wantRuleStoreCount           int
+		wantGroupStoreCount          int
+		wantProjectGroupStoreCount   int
+		wantProjectShareStoreCount   int
+		wantInfraGroupStoreCount     int
+		wantInfraShareStoreCount     int
+	}{
+		{
+			name: "success deleteVPCSecurityPolicy",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				mGId := "spA_uidA_scope"
+				mTag, mScope := tagValuePolicyCRUID, tagScopeSecurityPolicyUID
+				g := make([]model.Group, 0)
+				g1 := &g
+				scopeGroup := model.Group{
+					Id:   &mGId,
+					Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+				}
+				*g1 = append(*g1, scopeGroup)
+				assert.NoError(t, s.groupStore.Apply(g1))
+
+				mProjGId := "spA_uidA_2c822e90_src"
+				g = make([]model.Group, 0)
+				g2 := &g
+				projectGroup := model.Group{
+					Id:   &mProjGId,
+					Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+				}
+				*g2 = append(*g2, projectGroup)
+				assert.NoError(t, s.projectGroupStore.Apply(g2))
+
+				mSId := "share_projectQuality_group_spA_uidA_2c822e90_src"
+				sh := make([]model.Share, 0)
+				s1 := &sh
+				projectShare := model.Share{
+					Id:         &mSId,
+					Tags:       []model.Tag{{Tag: &mTag, Scope: &mScope}},
+					SharedWith: []string{"/org/default/project/projectQuality/vpcs/vpc1"},
+				}
+				*s1 = append(*s1, projectShare)
+				assert.NoError(t, s.projectShareStore.Apply(s1))
+
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				uid:        types.UID(tagValuePolicyCRUID),
+			},
+			inputPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             common.String("spA_uidA"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules: []model.Rule{
+					{
+						DisplayName:       &ruleNameWithPodSelector00,
+						Id:                &ruleID0,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"ANY"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              vpcBasicTags,
+					},
+					{
+						DisplayName:       &ruleNameWithNsSelector00,
+						Id:                &ruleID1,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq1,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA_uidA_2c822e90_src"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              vpcBasicTags,
+					},
+				},
+				Tags: vpcBasicTags,
+				Path: &spPath,
+			},
+			wantErr:                      false,
+			wantSecurityPolicyStoreCount: 0,
+			wantRuleStoreCount:           0,
+			wantGroupStoreCount:          0,
+			wantProjectGroupStoreCount:   0,
+			wantProjectShareStoreCount:   0,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
+		},
+		{
+			name: "error deleteVPCSecurityPolicy",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				mGId := "sp_uidA_2c822e99_scope"
+				mTag, mScope := tagValuePolicyCRUID, tagScopeSecurityPolicyUID
 				g := make([]model.Group, 0)
 				g1 := &g
 				scopeGroup := model.Group{
@@ -1011,8 +1676,8 @@ func TestDleleteVPCSecurityPolicy(t *testing.T) {
 			},
 			inputPolicy: &model.SecurityPolicy{
 				DisplayName:    &spName,
-				Id:             &tagValuePolicyCRUID,
-				Scope:          []string{"/orgs/default/projects/default/vpcs/vpc1/groups/sp_uidA_scope"},
+				Id:             common.String("spA_uidA"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA_uidA_scope"},
 				SequenceNumber: &seq0,
 				Rules: []model.Rule{
 					{
@@ -1025,11 +1690,11 @@ func TestDleleteVPCSecurityPolicy(t *testing.T) {
 						Services:          []string{"ANY"},
 						SourceGroups:      []string{"ANY"},
 						Action:            &nsxRuleActionAllow,
-						Tags:              basicTags,
+						Tags:              vpcBasicTags,
 					},
 				},
-				Tags: basicTags,
-				Path: &vpcPath,
+				Tags: vpcBasicTags,
+				Path: &spPath,
 			},
 			wantErr:                      true,
 			wantSecurityPolicyStoreCount: 1,
@@ -1037,12 +1702,18 @@ func TestDleleteVPCSecurityPolicy(t *testing.T) {
 			wantGroupStoreCount:          1,
 			wantProjectGroupStoreCount:   0,
 			wantProjectShareStoreCount:   0,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
 			fakeService := fakeSecurityPolicyService()
+			fakeService.NSXConfig.EnableVPCNetwork = true
 			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
 
 			assert.NoError(t, fakeService.securityPolicyStore.Apply(tt.inputPolicy))
@@ -1059,20 +1730,445 @@ func TestDleleteVPCSecurityPolicy(t *testing.T) {
 			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
 			assert.Equal(t, tt.wantProjectGroupStoreCount, len(fakeService.projectGroupStore.ListKeys()))
 			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.projectShareStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraGroupStoreCount, len(fakeService.infraGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraShareStoreCount, len(fakeService.infraShareStore.ListKeys()))
 		})
 	}
 }
 
-func TestCreateOrUpdateSecurityPolicy(t *testing.T) {
+func Test_deleteVPCSecurityPolicyInDefaultProject(t *testing.T) {
+	spPath := "/orgs/default/projects/default/vpcs/vpc1"
+
+	type args struct {
+		uid        types.UID
+		createdFor string
+	}
+	tests := []struct {
+		name                         string
+		prepareFunc                  func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		args                         args
+		inputPolicy                  *model.SecurityPolicy
+		wantErr                      bool
+		wantSecurityPolicyStoreCount int
+		wantRuleStoreCount           int
+		wantGroupStoreCount          int
+		wantProjectGroupStoreCount   int
+		wantProjectShareStoreCount   int
+		wantInfraGroupStoreCount     int
+		wantInfraShareStoreCount     int
+	}{
+		{
+			name: "success deleteVPCSecurityPolicy in default project",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				mGId := "spA_uidA_scope"
+				mTag, mScope := tagValuePolicyCRUID, tagScopeSecurityPolicyUID
+				g := make([]model.Group, 0)
+				g1 := &g
+				scopeGroup := model.Group{
+					Id:   &mGId,
+					Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+				}
+				*g1 = append(*g1, scopeGroup)
+				assert.NoError(t, s.groupStore.Apply(g1))
+
+				mInfraGId := "spA_uidA_2c822e90_src"
+				g = make([]model.Group, 0)
+				g2 := &g
+				infraGroup := model.Group{
+					Id:   &mInfraGId,
+					Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+				}
+				*g2 = append(*g2, infraGroup)
+				assert.NoError(t, s.infraGroupStore.Apply(g2))
+
+				mSId := "share_default_group_spA_uidA_2c822e90_src"
+				sh := make([]model.Share, 0)
+				s1 := &sh
+				infraShare := model.Share{
+					Id:         &mSId,
+					Tags:       []model.Tag{{Tag: &mTag, Scope: &mScope}},
+					SharedWith: []string{"/org/default/project/default"},
+				}
+				*s1 = append(*s1, infraShare)
+				assert.NoError(t, s.infraShareStore.Apply(s1))
+
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(s.NSXClient.InfraClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				uid:        types.UID(tagValuePolicyCRUID),
+			},
+			inputPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             common.String("spA_uidA"),
+				Scope:          []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spA_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules: []model.Rule{
+					{
+						DisplayName:       &ruleNameWithPodSelector00,
+						Id:                &ruleID0,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"ANY"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              vpcBasicTags,
+					},
+					{
+						DisplayName:       &ruleNameWithNsSelector00,
+						Id:                &ruleID1,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq1,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"/infra/domains/default/groups/spA_uidA_2c822e90_src"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              vpcBasicTags,
+					},
+				},
+				Tags: vpcBasicTags,
+				Path: &spPath,
+			},
+			wantErr:                      false,
+			wantSecurityPolicyStoreCount: 0,
+			wantRuleStoreCount:           0,
+			wantGroupStoreCount:          0,
+			wantProjectGroupStoreCount:   0,
+			wantProjectShareStoreCount:   0,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
+		},
+		{
+			name: "error deleteVPCSecurityPolicy in default project",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				mGId := "sp_uidA_2c822e99_scope"
+				mTag, mScope := tagValuePolicyCRUID, tagScopeSecurityPolicyUID
+				g := make([]model.Group, 0)
+				g1 := &g
+				scopeGroup := model.Group{
+					Id:   &mGId,
+					Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+				}
+				*g1 = append(*g1, scopeGroup)
+				assert.NoError(t, s.groupStore.Apply(g1))
+
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{fmt.Errorf("mock error")},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(s.NSXClient.InfraClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				uid:        types.UID(tagValuePolicyCRUID),
+			},
+			inputPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             common.String("spA_uidA"),
+				Scope:          []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spA_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules: []model.Rule{
+					{
+						DisplayName:       &ruleNameWithPodSelector00,
+						Id:                &ruleID0,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"ANY"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              vpcBasicTags,
+					},
+				},
+				Tags: vpcBasicTags,
+				Path: &spPath,
+			},
+			wantErr:                      true,
+			wantSecurityPolicyStoreCount: 1,
+			wantRuleStoreCount:           1,
+			wantGroupStoreCount:          1,
+			wantProjectGroupStoreCount:   0,
+			wantProjectShareStoreCount:   0,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
+			fakeService := fakeSecurityPolicyService()
+			fakeService.NSXConfig.EnableVPCNetwork = true
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			assert.NoError(t, fakeService.securityPolicyStore.Apply(tt.inputPolicy))
+			assert.NoError(t, fakeService.ruleStore.Apply(&tt.inputPolicy.Rules))
+
+			patches := tt.prepareFunc(t, fakeService)
+			defer patches.Reset()
+
+			if err := fakeService.deleteVPCSecurityPolicy(tt.args.uid, false, tt.args.createdFor); (err != nil) != tt.wantErr {
+				t.Errorf("deleteVPCSecurityPolicy error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.wantSecurityPolicyStoreCount, len(fakeService.securityPolicyStore.ListKeys()))
+			assert.Equal(t, tt.wantRuleStoreCount, len(fakeService.ruleStore.ListKeys()))
+			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectGroupStoreCount, len(fakeService.projectGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.projectShareStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraGroupStoreCount, len(fakeService.infraGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraShareStoreCount, len(fakeService.infraShareStore.ListKeys()))
+		})
+	}
+}
+
+func Test_CreateOrUpdateSecurityPolicy(t *testing.T) {
 	VPCInfo := make([]common.VPCResourceInfo, 1)
 	VPCInfo[0].OrgID = "default"
 	VPCInfo[0].ProjectID = "projectQuality"
 	VPCInfo[0].VPCID = "vpc1"
 
+	type args struct {
+		spObj      *v1alpha1.SecurityPolicy
+		createdFor string
+	}
+	tests := []struct {
+		name                         string
+		prepareFunc                  func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		args                         args
+		expectedPolicy               *model.SecurityPolicy
+		wantErr                      bool
+		wantSecurityPolicyStoreCount int
+		wantRuleStoreCount           int
+		wantGroupStoreCount          int
+		wantProjectGroupStoreCount   int
+		wantProjectShareStoreCount   int
+		wantInfraGroupStoreCount     int
+		wantInfraShareStoreCount     int
+	}{
+		{
+			name: "success CreateUpdateSecurityPolicy for VPC",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVPCInfo",
+					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
+						return &VPCInfo[0], nil
+					})
+
+				patches.ApplyFuncSeq(nsxutil.IsLicensed, []gomonkey.OutputCell{{
+					Values: gomonkey.Params{true},
+					Times:  1,
+				}})
+
+				patches.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+
+				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+					func(s *SecurityPolicyService, ns string) types.UID {
+						return types.UID(tagValueNSUID)
+					})
+
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				spObj:      &spWithPodSelector,
+			},
+			expectedPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             &spID,
+				SequenceNumber: &seq0,
+				Rules:          []model.Rule{},
+				Tags:           vpcBasicTags,
+			},
+			wantErr:                      false,
+			wantSecurityPolicyStoreCount: 1,
+			wantRuleStoreCount:           2,
+			wantGroupStoreCount:          2,
+			wantProjectGroupStoreCount:   2,
+			wantProjectShareStoreCount:   2,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
+			fakeService := fakeSecurityPolicyService()
+			fakeService.NSXConfig.EnableVPCNetwork = true
+			mockVPCService := mock.MockVPCServiceProvider{}
+			fakeService.vpcService = &mockVPCService
+
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			patches := tt.prepareFunc(t, fakeService)
+			patches.ApplyMethodSeq(fakeService.NSXClient.VPCSecurityClient, "Get", []gomonkey.OutputCell{{
+				Values: gomonkey.Params{*(tt.expectedPolicy), nil},
+				Times:  1,
+			}})
+			defer patches.Reset()
+
+			if err := fakeService.CreateOrUpdateSecurityPolicy(tt.args.spObj); (err != nil) != tt.wantErr {
+				t.Errorf("CreateOrUpdateSecurityPolicy error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.Equal(t, tt.wantSecurityPolicyStoreCount, len(fakeService.securityPolicyStore.ListKeys()))
+			assert.Equal(t, tt.wantRuleStoreCount, len(fakeService.ruleStore.ListKeys()))
+			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectGroupStoreCount, len(fakeService.projectGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.projectShareStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraGroupStoreCount, len(fakeService.infraGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraShareStoreCount, len(fakeService.infraShareStore.ListKeys()))
+		})
+	}
+}
+
+func Test_CreateOrUpdateSecurityPolicyFromNetworkPolicy(t *testing.T) {
+	VPCInfo := make([]common.VPCResourceInfo, 1)
+	VPCInfo[0].OrgID = "default"
+	VPCInfo[0].ProjectID = "projectQuality"
+	VPCInfo[0].VPCID = "vpc1"
+
+	tests := []struct {
+		name                           string
+		prepareFunc                    func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		npObj                          *networkingv1.NetworkPolicy
+		expAllowPolicy                 *model.SecurityPolicy
+		expIsolationPolicy             *model.SecurityPolicy
+		wantSPStoreCountBeforeCreate   int
+		wantRuleStoreCountBeforeCreate int
+		wantErr                        bool
+		wantSPStoreCount               int
+		wantRuleStoreCount             int
+		wantGroupStoreCount            int
+		wantProjectGroupStoreCount     int
+		wantProjectShareStoreCount     int
+		wantInfraGroupStoreCount       int
+		wantInfraShareStoreCount       int
+	}{
+		{
+			name:  "success CreateUpdateSecurityPolicy From NetworkPolicy",
+			npObj: &npWithNsSelecotr,
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVPCInfo",
+					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
+						return &VPCInfo[0], nil
+					})
+
+				patches.ApplyFuncSeq(nsxutil.IsLicensed, []gomonkey.OutputCell{{
+					Values: gomonkey.Params{true},
+					Times:  1,
+				}})
+
+				patches.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  2,
+				}})
+
+				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+					func(s *SecurityPolicyService, ns string) types.UID {
+						return types.UID(tagValueNSUID)
+					})
+
+				return patches
+			},
+			expAllowPolicy: &model.SecurityPolicy{
+				DisplayName:    common.String("np-app-access"),
+				Id:             common.String("np-app-access_uidNP_allow"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/np-app-access_uidNP_allow_scope"},
+				SequenceNumber: Int64(int64(common.PriorityNetworkPolicyAllowRule)),
+				Rules:          []model.Rule{},
+				Tags:           npAllowBasicTags,
+			},
+			expIsolationPolicy: &model.SecurityPolicy{
+				DisplayName:    common.String("np-app-access"),
+				Id:             common.String("np-app-access_uidNP_isolation"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/np-app-access_uidNP_isolation_scope"},
+				SequenceNumber: Int64(int64(common.PriorityNetworkPolicyIsolationRule)),
+				Rules:          []model.Rule{},
+				Tags:           npIsolationBasicTags,
+			},
+			wantErr:                        false,
+			wantSPStoreCountBeforeCreate:   0,
+			wantRuleStoreCountBeforeCreate: 0,
+			wantSPStoreCount:               2,
+			wantRuleStoreCount:             4,
+			wantGroupStoreCount:            2,
+			wantProjectGroupStoreCount:     2,
+			wantProjectShareStoreCount:     2,
+			wantInfraGroupStoreCount:       0,
+			wantInfraShareStoreCount:       0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
+			fakeService := fakeSecurityPolicyService()
+			fakeService.NSXConfig.EnableVPCNetwork = true
+			mockVPCService := mock.MockVPCServiceProvider{}
+			fakeService.vpcService = &mockVPCService
+
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			patches := tt.prepareFunc(t, fakeService)
+			patches.ApplyMethodSeq(fakeService.NSXClient.VPCSecurityClient, "Get", []gomonkey.OutputCell{
+				{
+					Values: gomonkey.Params{*(tt.expAllowPolicy), nil},
+					Times:  1, // First call returns expAllowPolicy
+				},
+				{
+					Values: gomonkey.Params{*(tt.expIsolationPolicy), nil},
+					Times:  1, // Second call returns expIsolationPolicy
+				},
+			})
+			defer patches.Reset()
+
+			assert.Equal(t, tt.wantSPStoreCountBeforeCreate, len(fakeService.securityPolicyStore.ListKeys()))
+			assert.Equal(t, tt.wantRuleStoreCountBeforeCreate, len(fakeService.ruleStore.ListKeys()))
+
+			if err := fakeService.CreateOrUpdateSecurityPolicy(tt.npObj); (err != nil) != tt.wantErr {
+				t.Errorf("CreateOrUpdateSecurityPolicy error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.Equal(t, tt.wantSPStoreCount, len(fakeService.securityPolicyStore.ListKeys()))
+			assert.Equal(t, tt.wantRuleStoreCount, len(fakeService.ruleStore.ListKeys()))
+			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectGroupStoreCount, len(fakeService.projectGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.projectShareStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraGroupStoreCount, len(fakeService.infraGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraShareStoreCount, len(fakeService.infraShareStore.ListKeys()))
+		})
+	}
+}
+
+func Test_createOrUpdateSecurityPolicy(t *testing.T) {
 	fakeService := fakeSecurityPolicyService()
-	fakeService.NSXConfig.EnableVPCNetwork = true
-	mockVPCService := mock.MockVPCServiceProvider{}
-	fakeService.vpcService = &mockVPCService
+	fakeService.NSXConfig.EnableVPCNetwork = false
 
 	podSelectorRule0IDPort000 := fakeService.buildExpandedRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy, nil)
 	podSelectorRule1IDPort000 := fakeService.buildExpandedRuleID(&spWithPodSelector, 1, common.ResourceTypeSecurityPolicy, nil)
@@ -1095,16 +2191,13 @@ func TestCreateOrUpdateSecurityPolicy(t *testing.T) {
 		wantGroupStoreCount          int
 		wantProjectGroupStoreCount   int
 		wantProjectShareStoreCount   int
+		wantInfraGroupStoreCount     int
+		wantInfraShareStoreCount     int
 	}{
 		{
-			name: "successCreateUpdateVPCSecurityPolicy",
+			name: "success createUpdateT1SecurityPolicy",
 			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
-				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVPCInfo",
-					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
-						return &VPCInfo[0], nil
-					})
-
-				patches.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.InfraClient, "Patch", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{nil},
 					Times:  1,
 				}})
@@ -1152,12 +2245,170 @@ func TestCreateOrUpdateSecurityPolicy(t *testing.T) {
 			wantErr:                      false,
 			wantSecurityPolicyStoreCount: 1,
 			wantRuleStoreCount:           2,
+			wantGroupStoreCount:          4,
+			wantProjectGroupStoreCount:   0,
+			wantProjectShareStoreCount:   0,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
+		},
+		{
+			name: "error createUpdateT1SecurityPolicy",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.InfraClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{fmt.Errorf("mock error")},
+					Times:  1,
+				}})
+				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+					func(s *SecurityPolicyService, ns string) types.UID {
+						return types.UID(tagValueNSUID)
+					})
+
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				spObj:      &spWithPodSelector,
+			},
+			expectedPolicy:               &model.SecurityPolicy{},
+			wantErr:                      true,
+			wantSecurityPolicyStoreCount: 0,
+			wantRuleStoreCount:           0,
+			wantGroupStoreCount:          0,
+			wantProjectGroupStoreCount:   0,
+			wantProjectShareStoreCount:   0,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyCRName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyCRUID
+
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			patches := tt.prepareFunc(t, fakeService)
+			patches.ApplyMethodSeq(fakeService.NSXClient.SecurityClient, "Get", []gomonkey.OutputCell{{
+				Values: gomonkey.Params{*(tt.expectedPolicy), nil},
+				Times:  1,
+			}})
+			defer patches.Reset()
+
+			if err := fakeService.createOrUpdateSecurityPolicy(tt.args.spObj, tt.args.createdFor); (err != nil) != tt.wantErr {
+				t.Errorf("createOrUpdateSecurityPolicy error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.Equal(t, tt.wantSecurityPolicyStoreCount, len(fakeService.securityPolicyStore.ListKeys()))
+			assert.Equal(t, tt.wantRuleStoreCount, len(fakeService.ruleStore.ListKeys()))
+			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectGroupStoreCount, len(fakeService.projectGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.projectShareStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraGroupStoreCount, len(fakeService.infraGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraShareStoreCount, len(fakeService.infraShareStore.ListKeys()))
+		})
+	}
+}
+
+func Test_createOrUpdateVPCSecurityPolicy(t *testing.T) {
+	VPCInfo := make([]common.VPCResourceInfo, 1)
+	VPCInfo[0].OrgID = "default"
+	VPCInfo[0].ProjectID = "projectQuality"
+	VPCInfo[0].VPCID = "vpc1"
+
+	fakeService := fakeSecurityPolicyService()
+	fakeService.NSXConfig.EnableVPCNetwork = true
+	mockVPCService := mock.MockVPCServiceProvider{}
+	fakeService.vpcService = &mockVPCService
+
+	podSelectorRule0IDPort000 := fakeService.buildExpandedRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy, nil)
+	podSelectorRule1IDPort000 := fakeService.buildExpandedRuleID(&spWithPodSelector, 1, common.ResourceTypeSecurityPolicy, nil)
+
+	podSelectorRule0Name00, _ := fakeService.buildRuleDisplayName(&spWithPodSelector.Spec.Rules[0], common.ResourceTypeSecurityPolicy, nil)
+	podSelectorRule1Name00, _ := fakeService.buildRuleDisplayName(&spWithPodSelector.Spec.Rules[1], common.ResourceTypeSecurityPolicy, nil)
+
+	type args struct {
+		spObj      *v1alpha1.SecurityPolicy
+		createdFor string
+	}
+	tests := []struct {
+		name                         string
+		prepareFunc                  func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		args                         args
+		expectedPolicy               *model.SecurityPolicy
+		wantErr                      bool
+		wantSecurityPolicyStoreCount int
+		wantRuleStoreCount           int
+		wantGroupStoreCount          int
+		wantProjectGroupStoreCount   int
+		wantProjectShareStoreCount   int
+		wantInfraGroupStoreCount     int
+		wantInfraShareStoreCount     int
+	}{
+		{
+			name: "success createUpdateVPCSecurityPolicy",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVPCInfo",
+					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
+						return &VPCInfo[0], nil
+					})
+
+				patches.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+
+				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+					func(s *SecurityPolicyService, ns string) types.UID {
+						return types.UID(tagValueNSUID)
+					})
+
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				spObj:      &spWithPodSelector,
+			},
+			expectedPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             &spID,
+				SequenceNumber: &seq0,
+				Rules: []model.Rule{
+					{
+						DisplayName:       &podSelectorRule0Name00,
+						Id:                &podSelectorRule0IDPort000,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              vpcBasicTags,
+					},
+					{
+						DisplayName:       &podSelectorRule1Name00,
+						Id:                &podSelectorRule1IDPort000,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq1,
+						Services:          []string{"ANY"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              vpcBasicTags,
+					},
+				},
+				Tags: vpcBasicTags,
+			},
+			wantErr:                      false,
+			wantSecurityPolicyStoreCount: 1,
+			wantRuleStoreCount:           2,
 			wantGroupStoreCount:          2,
 			wantProjectGroupStoreCount:   2,
 			wantProjectShareStoreCount:   2,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
 		},
 		{
-			name: "errorCreateUpdateVPCSecurityPolicy",
+			name: "error createUpdateVPCSecurityPolicy",
 			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
 				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVPCInfo",
 					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
@@ -1187,11 +2438,16 @@ func TestCreateOrUpdateSecurityPolicy(t *testing.T) {
 			wantGroupStoreCount:          0,
 			wantProjectGroupStoreCount:   0,
 			wantProjectShareStoreCount:   0,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
 			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
 
 			patches := tt.prepareFunc(t, fakeService)
@@ -1210,19 +2466,186 @@ func TestCreateOrUpdateSecurityPolicy(t *testing.T) {
 			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
 			assert.Equal(t, tt.wantProjectGroupStoreCount, len(fakeService.projectGroupStore.ListKeys()))
 			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.projectShareStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraGroupStoreCount, len(fakeService.infraGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraShareStoreCount, len(fakeService.infraShareStore.ListKeys()))
 		})
 	}
 }
 
-func TestGetFinalSecurityPolicyResouce(t *testing.T) {
+func Test_createOrUpdateVPCSecurityPolicyInDefaultProject(t *testing.T) {
 	VPCInfo := make([]common.VPCResourceInfo, 1)
 	VPCInfo[0].OrgID = "default"
-	VPCInfo[0].ProjectID = "projectQuality"
+	VPCInfo[0].ProjectID = "default"
 	VPCInfo[0].VPCID = "vpc1"
 
 	fakeService := fakeSecurityPolicyService()
+	fakeService.NSXConfig.EnableVPCNetwork = true
 	mockVPCService := mock.MockVPCServiceProvider{}
 	fakeService.vpcService = &mockVPCService
+
+	podSelectorRule0IDPort000 := fakeService.buildExpandedRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy, nil)
+	podSelectorRule1IDPort000 := fakeService.buildExpandedRuleID(&spWithPodSelector, 1, common.ResourceTypeSecurityPolicy, nil)
+
+	podSelectorRule0Name00, _ := fakeService.buildRuleDisplayName(&spWithPodSelector.Spec.Rules[0], common.ResourceTypeSecurityPolicy, nil)
+	podSelectorRule1Name00, _ := fakeService.buildRuleDisplayName(&spWithPodSelector.Spec.Rules[1], common.ResourceTypeSecurityPolicy, nil)
+
+	type args struct {
+		spObj      *v1alpha1.SecurityPolicy
+		createdFor string
+	}
+	tests := []struct {
+		name                         string
+		prepareFunc                  func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		args                         args
+		expectedPolicy               *model.SecurityPolicy
+		wantErr                      bool
+		wantSecurityPolicyStoreCount int
+		wantRuleStoreCount           int
+		wantGroupStoreCount          int
+		wantProjectGroupStoreCount   int
+		wantProjectShareStoreCount   int
+		wantInfraGroupStoreCount     int
+		wantInfraShareStoreCount     int
+	}{
+		{
+			name: "success createUpdateVPCSecurityPolicy in default project",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVPCInfo",
+					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
+						return &VPCInfo[0], nil
+					})
+
+				patches.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+
+				patches.ApplyMethodSeq(s.NSXClient.InfraClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+
+				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+					func(s *SecurityPolicyService, ns string) types.UID {
+						return types.UID(tagValueNSUID)
+					})
+
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				spObj:      &spWithPodSelector,
+			},
+			expectedPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             &spID,
+				SequenceNumber: &seq0,
+				Rules: []model.Rule{
+					{
+						DisplayName:       &podSelectorRule0Name00,
+						Id:                &podSelectorRule0IDPort000,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              vpcBasicTags,
+					},
+					{
+						DisplayName:       &podSelectorRule1Name00,
+						Id:                &podSelectorRule1IDPort000,
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq1,
+						Services:          []string{"ANY"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              vpcBasicTags,
+					},
+				},
+				Tags: vpcBasicTags,
+			},
+			wantErr:                      false,
+			wantSecurityPolicyStoreCount: 1,
+			wantRuleStoreCount:           2,
+			wantGroupStoreCount:          2,
+			wantProjectGroupStoreCount:   0,
+			wantProjectShareStoreCount:   0,
+			wantInfraGroupStoreCount:     2,
+			wantInfraShareStoreCount:     2,
+		},
+		{
+			name: "error createUpdateVPCSecurityPolicy in default project",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVPCInfo",
+					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
+						return &VPCInfo[0], nil
+					})
+
+				patches.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{fmt.Errorf("mock error")},
+					Times:  1,
+				}})
+
+				patches.ApplyMethodSeq(s.NSXClient.InfraClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+
+				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+					func(s *SecurityPolicyService, ns string) types.UID {
+						return types.UID(tagValueNSUID)
+					})
+
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				spObj:      &spWithPodSelector,
+			},
+			expectedPolicy:               &model.SecurityPolicy{},
+			wantErr:                      true,
+			wantSecurityPolicyStoreCount: 0,
+			wantRuleStoreCount:           0,
+			wantGroupStoreCount:          0,
+			wantProjectGroupStoreCount:   0,
+			wantProjectShareStoreCount:   0,
+			wantInfraGroupStoreCount:     0,
+			wantInfraShareStoreCount:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			patches := tt.prepareFunc(t, fakeService)
+			patches.ApplyMethodSeq(fakeService.NSXClient.VPCSecurityClient, "Get", []gomonkey.OutputCell{{
+				Values: gomonkey.Params{*(tt.expectedPolicy), nil},
+				Times:  1,
+			}})
+			defer patches.Reset()
+
+			if err := fakeService.createOrUpdateVPCSecurityPolicy(tt.args.spObj, tt.args.createdFor); (err != nil) != tt.wantErr {
+				t.Errorf("createOrUpdateVPCSecurityPolicy error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.Equal(t, tt.wantSecurityPolicyStoreCount, len(fakeService.securityPolicyStore.ListKeys()))
+			assert.Equal(t, tt.wantRuleStoreCount, len(fakeService.ruleStore.ListKeys()))
+			assert.Equal(t, tt.wantGroupStoreCount, len(fakeService.groupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectGroupStoreCount, len(fakeService.projectGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.projectShareStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraGroupStoreCount, len(fakeService.infraGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraShareStoreCount, len(fakeService.infraShareStore.ListKeys()))
+		})
+	}
+}
+
+func Test_GetFinalSecurityPolicyResourceForT1(t *testing.T) {
+	fakeService := fakeSecurityPolicyService()
 
 	type args struct {
 		spObj      *v1alpha1.SecurityPolicy
@@ -1241,52 +2664,11 @@ func TestGetFinalSecurityPolicyResouce(t *testing.T) {
 		wantShareGroupStoreCount  int
 	}{
 		{
-			name: "getFinalSecurityPolicyResouceForVPCMode",
-			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
-				s.NSXConfig.EnableVPCNetwork = true
-
-				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVPCInfo",
-					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
-						return &VPCInfo[0], nil
-					})
-
-				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
-					func(s *SecurityPolicyService, ns string) types.UID {
-						return types.UID(tagValueNSUID)
-					})
-
-				return patches
-			},
-			args: args{
-				createdFor: common.ResourceTypeSecurityPolicy,
-				spObj:      &spWithPodSelector,
-			},
-			expectedPolicy: &model.SecurityPolicy{
-				DisplayName:    common.String("spA"),
-				Id:             common.String("spA_uidA"),
-				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA_uidA_scope"},
-				SequenceNumber: &seq0,
-				Rules:          []model.Rule{},
-				Tags:           basicTags,
-			},
-			wantErr:                   false,
-			wantSecurityPolicyChanged: true,
-			wantRuleStoreCount:        2,
-			wantGroupStoreCount:       2,
-			wantShareStoreCount:       2,
-			wantShareGroupStoreCount:  2,
-		},
-		{
-			name: "getFinalSecurityPolicyResouceForT1",
+			name: "GetFinalSecurityPolicyResourceForT1",
 			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
 				s.NSXConfig.EnableVPCNetwork = false
 
-				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVPCInfo",
-					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
-						return &VPCInfo[0], nil
-					})
-
-				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
 					func(s *SecurityPolicyService, ns string) types.UID {
 						return types.UID(tagValueNSUID)
 					})
@@ -1316,6 +2698,9 @@ func TestGetFinalSecurityPolicyResouce(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyCRName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyCRUID
+
 			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
 
 			patches := tt.prepareFunc(t, fakeService)
@@ -1329,7 +2714,7 @@ func TestGetFinalSecurityPolicyResouce(t *testing.T) {
 			var err error
 
 			if finalSecurityPolicy, finalGroups, finalShares, finalShareGroups, isChanged, err = fakeService.getFinalSecurityPolicyResource(tt.args.spObj, tt.args.createdFor, false); (err != nil) != tt.wantErr {
-				t.Errorf("getFinalSecurityPolicyResouce error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("getFinalSecurityPolicyResource error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			assert.Equal(t, *tt.expectedPolicy.Id, *finalSecurityPolicy.Id)
@@ -1348,7 +2733,140 @@ func TestGetFinalSecurityPolicyResouce(t *testing.T) {
 	}
 }
 
-func TestConvertNetworkPolicyToInternalSecurityPolicies(t *testing.T) {
+func Test_GetFinalSecurityPolicyResourceForVPC(t *testing.T) {
+	VPCInfo := make([]common.VPCResourceInfo, 1)
+	VPCInfo[0].OrgID = "default"
+	VPCInfo[0].ProjectID = "projectQuality"
+	VPCInfo[0].VPCID = "vpc1"
+
+	fakeService := fakeSecurityPolicyService()
+	mockVPCService := mock.MockVPCServiceProvider{}
+	fakeService.vpcService = &mockVPCService
+
+	serviceEntry := getRuleServiceEntries(53, 0, "UDP")
+
+	type args struct {
+		spObj      *v1alpha1.SecurityPolicy
+		createdFor string
+	}
+	tests := []struct {
+		name                      string
+		prepareFunc               func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		args                      args
+		expectedPolicy            *model.SecurityPolicy
+		wantErr                   bool
+		wantSecurityPolicyChanged bool
+		wantRuleStoreCount        int
+		wantGroupStoreCount       int
+		wantShareStoreCount       int
+		wantShareGroupStoreCount  int
+	}{
+		{
+			name: "GetFinalSecurityPolicyResourceForVPCMode",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				s.NSXConfig.EnableVPCNetwork = true
+
+				common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+				common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(s), "getVPCInfo",
+					func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
+						return &VPCInfo[0], nil
+					})
+
+				patches.ApplyPrivateMethod(reflect.TypeOf(s), "getNamespaceUID",
+					func(s *SecurityPolicyService, ns string) types.UID {
+						return types.UID(tagValueNSUID)
+					})
+
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				spObj:      &spWithPodSelector,
+			},
+			expectedPolicy: &model.SecurityPolicy{
+				DisplayName:    common.String("spA"),
+				Id:             common.String("spA_uidA"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules: []model.Rule{
+					{
+						DisplayName:       common.String("rule-with-pod-ns-selector_ingress_allow"),
+						Id:                common.String("spA_uidA_2c822e90_all"),
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA_uidA_2c822e90_scope"},
+						SequenceNumber:    &seq0,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA_uidA_2c822e90_src"},
+						Action:            &nsxRuleActionAllow,
+						Tags:              vpcBasicTags,
+					},
+					{
+						DisplayName:       common.String("rule-with-ns-selector_ingress_allow"),
+						Id:                common.String("spA_uidA_2a4595d0_53"),
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionIn,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq1,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA_uidA_2a4595d0_src"},
+						Action:            &nsxRuleActionAllow,
+						ServiceEntries:    []*data.StructValue{serviceEntry},
+						Tags:              vpcBasicTags,
+					},
+				},
+				Tags: vpcBasicTags,
+			},
+			wantErr:                   false,
+			wantSecurityPolicyChanged: true,
+			wantRuleStoreCount:        2,
+			wantGroupStoreCount:       2,
+			wantShareStoreCount:       2,
+			wantShareGroupStoreCount:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			patches := tt.prepareFunc(t, fakeService)
+			defer patches.Reset()
+
+			var finalSecurityPolicy *model.SecurityPolicy
+			var finalGroups []model.Group
+			var finalShares []model.Share
+			var finalShareGroups []model.Group
+			var isChanged bool
+			var err error
+
+			if finalSecurityPolicy, finalGroups, finalShares, finalShareGroups, isChanged, err = fakeService.getFinalSecurityPolicyResource(tt.args.spObj, tt.args.createdFor, false); (err != nil) != tt.wantErr {
+				t.Errorf("getFinalSecurityPolicyResource error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.Equal(t, *tt.expectedPolicy.Id, *finalSecurityPolicy.Id)
+			assert.Equal(t, tt.expectedPolicy.Scope[0], finalSecurityPolicy.Scope[0])
+			assert.Equal(t, true, isChanged)
+			assert.Equal(t, tt.wantGroupStoreCount, len(finalGroups))
+			assert.Equal(t, tt.wantRuleStoreCount, len(finalSecurityPolicy.Rules))
+
+			if fakeService.NSXConfig.EnableVPCNetwork {
+				assert.Equal(t, tt.wantShareStoreCount, len(finalShares))
+				assert.Equal(t, tt.wantShareGroupStoreCount, len(finalShareGroups))
+			} else {
+				assert.Equal(t, ([]model.Share)(nil), finalShares)
+			}
+			assert.ElementsMatch(t, tt.expectedPolicy.Rules, finalSecurityPolicy.Rules)
+		})
+	}
+}
+
+func Test_ConvertNetworkPolicyToInternalSecurityPolicies(t *testing.T) {
 	VPCInfo := make([]common.VPCResourceInfo, 1)
 	VPCInfo[0].OrgID = "default"
 	VPCInfo[0].ProjectID = "projectQuality"
@@ -1361,13 +2879,13 @@ func TestConvertNetworkPolicyToInternalSecurityPolicies(t *testing.T) {
 
 	tests := []struct {
 		name                      string
-		inputPolicy               *networkingv1.NetworkPolicy
+		npObj                     *networkingv1.NetworkPolicy
 		expPolicyAllowSection     *v1alpha1.SecurityPolicy
 		expPolicyIsolationSection *v1alpha1.SecurityPolicy
 	}{
 		{
-			name:        "Convert NetworkPolicy",
-			inputPolicy: &npWithNsSelecotr,
+			name:  "Convert NetworkPolicy",
+			npObj: &npWithNsSelecotr,
 			expPolicyAllowSection: &v1alpha1.SecurityPolicy{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "np-app-access", UID: "uidNP_allow"},
 				Spec: v1alpha1.SecurityPolicySpec{
@@ -1404,6 +2922,31 @@ func TestConvertNetworkPolicyToInternalSecurityPolicies(t *testing.T) {
 								},
 							},
 						},
+						{
+							Action:    &allowAction,
+							Direction: &directionOut,
+							Destinations: []v1alpha1.SecurityPolicyPeer{
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"app": "mysql"},
+									},
+								},
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{},
+									},
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"ns-name": "ns-2"},
+									},
+								},
+							},
+							Ports: []v1alpha1.SecurityPolicyPort{
+								{
+									Protocol: corev1.ProtocolTCP,
+									Port:     intstr.IntOrString{Type: intstr.Int, IntVal: 3366},
+								},
+							},
+						},
 					},
 					Priority: common.PriorityNetworkPolicyAllowRule,
 				},
@@ -1424,6 +2967,11 @@ func TestConvertNetworkPolicyToInternalSecurityPolicies(t *testing.T) {
 							Direction: &directionIn,
 							Name:      "ingress_isolation",
 						},
+						{
+							Action:    &allowDrop,
+							Direction: &directionOut,
+							Name:      "egress_isolation",
+						},
 					},
 					Priority: common.PriorityNetworkPolicyIsolationRule,
 				},
@@ -1433,15 +2981,16 @@ func TestConvertNetworkPolicyToInternalSecurityPolicies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			observedPolicy, err := fakeService.convertNetworkPolicyToInternalSecurityPolicies(tt.inputPolicy)
+			observedPolicy, err := fakeService.convertNetworkPolicyToInternalSecurityPolicies(tt.npObj)
 			assert.Equal(t, nil, err)
+			assert.Equal(t, 2, len(observedPolicy))
 			assert.Equal(t, tt.expPolicyAllowSection, observedPolicy[0])
 			assert.Equal(t, tt.expPolicyIsolationSection, observedPolicy[1])
 		})
 	}
 }
 
-func TestGetFinalSecurityPolicyResouceFromNetworkPolicy(t *testing.T) {
+func Test_GetFinalSecurityPolicyResourceFromNetworkPolicy(t *testing.T) {
 	VPCInfo := make([]common.VPCResourceInfo, 1)
 	VPCInfo[0].OrgID = "default"
 	VPCInfo[0].ProjectID = "projectQuality"
@@ -1452,19 +3001,8 @@ func TestGetFinalSecurityPolicyResouceFromNetworkPolicy(t *testing.T) {
 	mockVPCService := mock.MockVPCServiceProvider{}
 	fakeService.vpcService = &mockVPCService
 
-	destinationPorts := data.NewListValue()
-	destinationPorts.Add(data.NewStringValue("6001"))
-	serviceEntry := data.NewStructValue(
-		"",
-		map[string]data.DataValue{
-			"source_ports":      data.NewListValue(),
-			"destination_ports": destinationPorts,
-			"l4_protocol":       data.NewStringValue("TCP"),
-			"resource_type":     data.NewStringValue("L4PortSetServiceEntry"),
-			"marked_for_delete": data.NewBooleanValue(false),
-			"overridden":        data.NewBooleanValue(false),
-		},
-	)
+	ingressServiceEntry := getRuleServiceEntries(6001, 0, "TCP")
+	egressServiceEntry := getRuleServiceEntries(3366, 0, "TCP")
 
 	patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(fakeService), "getVPCInfo",
 		func(s *SecurityPolicyService, spNameSpace string) (*common.VPCResourceInfo, error) {
@@ -1475,18 +3013,27 @@ func TestGetFinalSecurityPolicyResouceFromNetworkPolicy(t *testing.T) {
 		func(s *SecurityPolicyService, ns string) types.UID {
 			return types.UID(tagValueNSUID)
 		})
-
 	defer patches.Reset()
 
 	tests := []struct {
-		name               string
-		inputPolicy        *networkingv1.NetworkPolicy
-		expAllowPolicy     *model.SecurityPolicy
-		expIsolationPolicy *model.SecurityPolicy
+		name                                    string
+		npObj                                   *networkingv1.NetworkPolicy
+		expAllowPolicy                          *model.SecurityPolicy
+		expIsolationPolicy                      *model.SecurityPolicy
+		wantErr                                 bool
+		wantSecurityPolicyChanged               bool
+		wantSecurityPolicyStoreCount            int
+		wantRuleStoreCount                      int
+		wantAllowPolicyGroupStoreCount          int
+		wantIsolationPolicyGroupStoreCount      int
+		wantAllowPolicyShareStoreCount          int
+		wantAllowPolicyShareGroupStoreCount     int
+		wantIsolationPolicyShareStoreCount      int
+		wantIsolationPolicyShareGroupStoreCount int
 	}{
 		{
-			name:        "Get SecurityPolicy from NetworkPolicy",
-			inputPolicy: &npWithNsSelecotr,
+			name:  "Get SecurityPolicy from NetworkPolicy",
+			npObj: &npWithNsSelecotr,
 			expAllowPolicy: &model.SecurityPolicy{
 				DisplayName:    common.String("np-app-access"),
 				Id:             common.String("np-app-access_uidNP_allow"),
@@ -1503,7 +3050,20 @@ func TestGetFinalSecurityPolicyResouceFromNetworkPolicy(t *testing.T) {
 						Services:          []string{"ANY"},
 						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access_uidNP_allow_6c2a026c_src"},
 						Action:            &nsxRuleActionAllow,
-						ServiceEntries:    []*data.StructValue{serviceEntry},
+						ServiceEntries:    []*data.StructValue{ingressServiceEntry},
+						Tags:              npAllowBasicTags,
+					},
+					{
+						DisplayName:       common.String("TCP.3366_egress_allow"),
+						Id:                common.String("np-app-access_uidNP_allow_025d37a6_3366"),
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access_uidNP_allow_025d37a6_dst"},
+						Direction:         &nsxRuleDirectionOut,
+						Scope:             []string{"ANY"},
+						SequenceNumber:    &seq1,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"ANY"},
+						Action:            &nsxRuleActionAllow,
+						ServiceEntries:    []*data.StructValue{egressServiceEntry},
 						Tags:              npAllowBasicTags,
 					},
 				},
@@ -1527,28 +3087,439 @@ func TestGetFinalSecurityPolicyResouceFromNetworkPolicy(t *testing.T) {
 						Action:            &nsxRuleActionDrop,
 						Tags:              npIsolationBasicTags,
 					},
+					{
+						DisplayName:       common.String("egress_isolation"),
+						Id:                common.String("np-app-access_uidNP_isolation_8cae63ab_all"),
+						DestinationGroups: []string{"ANY"},
+						Direction:         &nsxRuleDirectionOut,
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/np-app-access_uidNP_isolation_scope"},
+						SequenceNumber:    &seq1,
+						Services:          []string{"ANY"},
+						SourceGroups:      []string{"ANY"},
+						Action:            &nsxRuleActionDrop,
+						Tags:              npIsolationBasicTags,
+					},
 				},
 				Tags: npIsolationBasicTags,
 			},
+			wantErr:                                 false,
+			wantSecurityPolicyChanged:               true,
+			wantRuleStoreCount:                      2,
+			wantAllowPolicyGroupStoreCount:          1,
+			wantIsolationPolicyGroupStoreCount:      1,
+			wantAllowPolicyShareStoreCount:          2,
+			wantAllowPolicyShareGroupStoreCount:     2,
+			wantIsolationPolicyShareStoreCount:      0,
+			wantIsolationPolicyShareGroupStoreCount: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeService.setUpStore(common.TagScopeSecurityPolicyUID)
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
 
-			convertSecurityPolicy, err := fakeService.convertNetworkPolicyToInternalSecurityPolicies(tt.inputPolicy)
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+			var finalAllowSecurityPolicy *model.SecurityPolicy
+			var finalIsolationSecurityPolicy *model.SecurityPolicy
+			var finalGroups []model.Group
+			var finalShares []model.Share
+			var finalShareGroups []model.Group
+			var isChanged bool
+
+			convertSecurityPolicy, err := fakeService.convertNetworkPolicyToInternalSecurityPolicies(tt.npObj)
 			assert.Equal(t, nil, err)
 
-			finalAllowSecurityPolicy, _, _, _, _, err := fakeService.getFinalSecurityPolicyResource(convertSecurityPolicy[0], common.ResourceTypeNetworkPolicy, false)
-			assert.Equal(t, nil, err)
+			if finalAllowSecurityPolicy, finalGroups, finalShares, finalShareGroups, isChanged, err = fakeService.getFinalSecurityPolicyResource(convertSecurityPolicy[0], common.ResourceTypeNetworkPolicy, false); (err != nil) != tt.wantErr {
+				t.Errorf("getFinalSecurityPolicyResource error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, *tt.expAllowPolicy.Id, *finalAllowSecurityPolicy.Id)
+			assert.Equal(t, tt.expAllowPolicy.Scope[0], finalAllowSecurityPolicy.Scope[0])
+			assert.Equal(t, true, isChanged)
+			assert.Equal(t, tt.wantRuleStoreCount, len(finalAllowSecurityPolicy.Rules))
+			assert.Equal(t, tt.wantAllowPolicyGroupStoreCount, len(finalGroups))
+			assert.Equal(t, tt.wantAllowPolicyShareStoreCount, len(finalShares))
+			assert.Equal(t, tt.wantAllowPolicyShareGroupStoreCount, len(finalShareGroups))
+			assert.ElementsMatch(t, tt.expAllowPolicy.Rules, finalAllowSecurityPolicy.Rules)
 
-			assert.Equal(t, tt.expAllowPolicy, finalAllowSecurityPolicy)
+			if finalIsolationSecurityPolicy, finalGroups, finalShares, finalShareGroups, isChanged, err = fakeService.getFinalSecurityPolicyResource(convertSecurityPolicy[1], common.ResourceTypeNetworkPolicy, false); (err != nil) != tt.wantErr {
+				t.Errorf("getFinalSecurityPolicyResource error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, *tt.expIsolationPolicy.Id, *finalIsolationSecurityPolicy.Id)
+			assert.Equal(t, tt.expIsolationPolicy.Scope[0], finalIsolationSecurityPolicy.Scope[0])
+			assert.Equal(t, true, isChanged)
+			assert.Equal(t, tt.wantRuleStoreCount, len(finalIsolationSecurityPolicy.Rules))
+			assert.Equal(t, tt.wantIsolationPolicyGroupStoreCount, len(finalGroups))
+			assert.Equal(t, tt.wantIsolationPolicyShareStoreCount, len(finalShares))
+			assert.Equal(t, tt.wantIsolationPolicyShareGroupStoreCount, len(finalShareGroups))
+			assert.ElementsMatch(t, tt.expIsolationPolicy.Rules, finalIsolationSecurityPolicy.Rules)
+		})
+	}
+}
 
-			finalIsolationSecurityPolicy, _, _, _, _, err := fakeService.getFinalSecurityPolicyResource(convertSecurityPolicy[1], common.ResourceTypeNetworkPolicy, false)
-			assert.Equal(t, nil, err)
+func Test_ListSecurityPolicyByName(t *testing.T) {
+	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+	fakeService := fakeSecurityPolicyService()
+	fakeService.NSXConfig.EnableVPCNetwork = true
 
-			assert.Equal(t, tt.expIsolationPolicy, finalIsolationSecurityPolicy)
+	fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+	sp1 := &model.SecurityPolicy{
+		DisplayName: &spName,
+		Id:          common.String(spID),
+		Tags: []model.Tag{
+			{Scope: pointy.String(common.TagValueScopeSecurityPolicyName), Tag: pointy.String("sp1")},
+			{Scope: pointy.String(common.TagValueScopeSecurityPolicyUID), Tag: pointy.String("uid1")},
+			{Scope: pointy.String(common.TagScopeNamespace), Tag: pointy.String("namespace1")},
+		},
+	}
+
+	sp2 := &model.SecurityPolicy{
+		DisplayName: &spName1,
+		Id:          common.String(spID2),
+		Tags: []model.Tag{
+			{Scope: pointy.String(common.TagValueScopeSecurityPolicyName), Tag: pointy.String("sp2")},
+			{Scope: pointy.String(common.TagValueScopeSecurityPolicyUID), Tag: pointy.String("uid2")},
+			{Scope: pointy.String(common.TagScopeNamespace), Tag: pointy.String("namespace1")},
+		},
+	}
+
+	fakeService.securityPolicyStore.Apply(sp1)
+	fakeService.securityPolicyStore.Apply(sp2)
+
+	// Test case: List SecurityPolicy by name
+	result := fakeService.ListSecurityPolicyByName("namespace1", "sp1")
+	assert.Len(t, result, 1)
+	name := nsxutil.FindTag(result[0].Tags, common.TagValueScopeSecurityPolicyName)
+	assert.Equal(t, "sp1", name)
+
+	// Test case: No SecurityPolicy found
+	result = fakeService.ListSecurityPolicyByName("namespace1", "nonexistent")
+	assert.Len(t, result, 0)
+}
+
+func Test_ListNetworkPolicyByName(t *testing.T) {
+	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+	fakeService := fakeSecurityPolicyService()
+	fakeService.NSXConfig.EnableVPCNetwork = true
+
+	fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+	sp1 := &model.SecurityPolicy{
+		DisplayName: &spName,
+		Id:          common.String(spID),
+		Tags: []model.Tag{
+			{Scope: pointy.String(common.TagScopeNetworkPolicyName), Tag: pointy.String("np1")},
+			{Scope: pointy.String(common.TagScopeNetworkPolicyUID), Tag: pointy.String("uid1_allow")},
+			{Scope: pointy.String(common.TagScopeNamespace), Tag: pointy.String("namespace1")},
+		},
+	}
+
+	sp2 := &model.SecurityPolicy{
+		DisplayName: &spName1,
+		Id:          common.String(spID2),
+		Tags: []model.Tag{
+			{Scope: pointy.String(common.TagScopeNetworkPolicyName), Tag: pointy.String("np1")},
+			{Scope: pointy.String(common.TagScopeNetworkPolicyUID), Tag: pointy.String("uid1_isolation")},
+			{Scope: pointy.String(common.TagScopeNamespace), Tag: pointy.String("namespace1")},
+		},
+	}
+
+	fakeService.securityPolicyStore.Apply(sp1)
+	fakeService.securityPolicyStore.Apply(sp2)
+
+	// Test case: List NetworkPolicy by name
+	result := fakeService.ListNetworkPolicyByName("namespace1", "np1")
+	assert.Len(t, result, 2)
+	name := nsxutil.FindTag(result[0].Tags, common.TagScopeNetworkPolicyName)
+	assert.Equal(t, "np1", name)
+	name = nsxutil.FindTag(result[1].Tags, common.TagScopeNetworkPolicyName)
+	assert.Equal(t, "np1", name)
+
+	// Test case: No NetworkPolicy found
+	result = fakeService.ListNetworkPolicyByName("namespace1", "nonexistent")
+	assert.Len(t, result, 0)
+}
+
+func Test_Cleanup(t *testing.T) {
+	spPath := "/orgs/default/projects/projectQuality/vpcs/vpc1"
+
+	tests := []struct {
+		name                         string
+		prepareFunc                  func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		inputPolicy                  *model.SecurityPolicy
+		wantErr                      bool
+		wantSecurityPolicyStoreCount int
+	}{
+		{
+			name: "success Cleanup",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				return patches
+			},
+			inputPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             common.String("spA_uidA"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules:          []model.Rule{},
+				Tags:           vpcBasicTags,
+				Path:           &spPath,
+			},
+			wantErr:                      false,
+			wantSecurityPolicyStoreCount: 0,
+		},
+		{
+			name: "error Cleanup",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				return patches
+			},
+			inputPolicy: &model.SecurityPolicy{
+				DisplayName:    &spName,
+				Id:             common.String("spA_uidA"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA_uidA_scope"},
+				SequenceNumber: &seq0,
+				Rules:          []model.Rule{},
+				Tags:           vpcBasicTags,
+				Path:           &spPath,
+			},
+			wantErr:                      true,
+			wantSecurityPolicyStoreCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
+			fakeService := fakeSecurityPolicyService()
+			fakeService.NSXConfig.EnableVPCNetwork = true
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			assert.NoError(t, fakeService.securityPolicyStore.Apply(tt.inputPolicy))
+
+			patches := tt.prepareFunc(t, fakeService)
+			defer patches.Reset()
+			ctx := context.Background()
+
+			if tt.name == "error Cleanup" {
+				ctx, cancel := context.WithCancel(ctx)
+				cancel()
+				if err := fakeService.Cleanup(ctx); (err != nil) != tt.wantErr {
+					t.Errorf("Cleanup error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+
+			if tt.name == "success Cleanup" {
+				if err := fakeService.Cleanup(ctx); (err != nil) != tt.wantErr {
+					t.Errorf("Cleanup error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+
+			assert.Equal(t, tt.wantSecurityPolicyStoreCount, len(fakeService.securityPolicyStore.ListKeys()))
+		})
+	}
+}
+
+func Test_Cleanup_ForNetworkPolicy(t *testing.T) {
+	spPath := "/orgs/default/projects/projectQuality/vpcs/vpc1"
+
+	tests := []struct {
+		name                         string
+		prepareFunc                  func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		expAllowPolicy               *model.SecurityPolicy
+		expIsolationPolicy           *model.SecurityPolicy
+		wantErr                      bool
+		wantSecurityPolicyStoreCount int
+	}{
+		{
+			name: "success Cleanup for NetworkPolicy",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.OrgRootClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  2,
+				}})
+				return patches
+			},
+			expAllowPolicy: &model.SecurityPolicy{
+				DisplayName:    common.String("np-app-access"),
+				Id:             common.String("np-app-access_uidNP_allow"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/np-app-access_uidNP_allow_scope"},
+				SequenceNumber: Int64(int64(common.PriorityNetworkPolicyAllowRule)),
+				Rules:          []model.Rule{},
+				Tags:           npAllowBasicTags,
+				Path:           &spPath,
+			},
+			expIsolationPolicy: &model.SecurityPolicy{
+				DisplayName:    common.String("np-app-access"),
+				Id:             common.String("np-app-access_uidNP_isolation"),
+				Scope:          []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/np-app-access_uidNP_isolation_scope"},
+				SequenceNumber: Int64(int64(common.PriorityNetworkPolicyIsolationRule)),
+				Rules:          []model.Rule{},
+				Tags:           npIsolationBasicTags,
+				Path:           &spPath,
+			},
+			wantErr:                      false,
+			wantSecurityPolicyStoreCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
+			fakeService := fakeSecurityPolicyService()
+			fakeService.NSXConfig.EnableVPCNetwork = true
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			assert.NoError(t, fakeService.securityPolicyStore.Apply(tt.expAllowPolicy))
+			assert.NoError(t, fakeService.securityPolicyStore.Apply(tt.expIsolationPolicy))
+			assert.Equal(t, 2, len(fakeService.securityPolicyStore.ListKeys()))
+
+			patches := tt.prepareFunc(t, fakeService)
+			defer patches.Reset()
+			ctx := context.Background()
+
+			if err := fakeService.Cleanup(ctx); (err != nil) != tt.wantErr {
+				t.Errorf("Cleanup error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.Equal(t, tt.wantSecurityPolicyStoreCount, len(fakeService.securityPolicyStore.ListKeys()))
+		})
+	}
+}
+
+func Test_gcInfraSharesGroups(t *testing.T) {
+	markNoDelete := false
+
+	type args struct {
+		uid        types.UID
+		createdFor string
+	}
+	tests := []struct {
+		name                     string
+		prepareFunc              func(*testing.T, *SecurityPolicyService) *gomonkey.Patches
+		args                     args
+		inputPolicy              *model.SecurityPolicy
+		wantErr                  bool
+		wantInfraGroupStoreCount int
+		wantInfraShareStoreCount int
+	}{
+		{
+			name: "success gcInfraSharesGroups",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				mProjGId := "spA_uidA_2c822e90_src"
+				mTag, mScope := tagValuePolicyCRUID, tagScopeSecurityPolicyUID
+				g := make([]model.Group, 0)
+				g1 := &g
+				infraGroup := model.Group{
+					Id:              &mProjGId,
+					Tags:            []model.Tag{{Tag: &mTag, Scope: &mScope}},
+					MarkedForDelete: &markNoDelete,
+				}
+				*g1 = append(*g1, infraGroup)
+				assert.NoError(t, s.infraGroupStore.Apply(g1))
+
+				mSId := "share_default_group_spA_uidA_2c822e90_src"
+				sh := make([]model.Share, 0)
+				s1 := &sh
+				infraShare := model.Share{
+					Id:              &mSId,
+					Tags:            []model.Tag{{Tag: &mTag, Scope: &mScope}},
+					SharedWith:      []string{"/org/default/project/default"},
+					MarkedForDelete: &markNoDelete,
+				}
+				*s1 = append(*s1, infraShare)
+				assert.NoError(t, s.infraShareStore.Apply(s1))
+
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.InfraClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{nil},
+					Times:  1,
+				}})
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				uid:        types.UID(tagValuePolicyCRUID),
+			},
+			wantErr:                  false,
+			wantInfraGroupStoreCount: 1,
+			wantInfraShareStoreCount: 1,
+		},
+		{
+			name: "error gcInfraSharesGroups",
+			prepareFunc: func(t *testing.T, s *SecurityPolicyService) *gomonkey.Patches {
+				mProjGId := "spA_uidA_2c822e90_src"
+				mTag, mScope := tagValuePolicyCRUID, tagScopeSecurityPolicyUID
+				g := make([]model.Group, 0)
+				g1 := &g
+				infraGroup := model.Group{
+					Id:              &mProjGId,
+					Tags:            []model.Tag{{Tag: &mTag, Scope: &mScope}},
+					MarkedForDelete: &markNoDelete,
+				}
+				*g1 = append(*g1, infraGroup)
+				assert.NoError(t, s.infraGroupStore.Apply(g1))
+
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.InfraClient, "Patch", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{fmt.Errorf("mock error")},
+					Times:  1,
+				}})
+				return patches
+			},
+			args: args{
+				createdFor: common.ResourceTypeSecurityPolicy,
+				uid:        types.UID(tagValuePolicyCRUID),
+			},
+			wantErr:                  true,
+			wantInfraGroupStoreCount: 1,
+			wantInfraShareStoreCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
+			fakeService := fakeSecurityPolicyService()
+			fakeService.NSXConfig.EnableVPCNetwork = true
+			fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID)
+
+			patches := tt.prepareFunc(t, fakeService)
+			defer patches.Reset()
+
+			if err := fakeService.gcInfraSharesGroups(tt.args.uid, tt.args.createdFor); (err != nil) != tt.wantErr {
+				t.Errorf("gcInfraSharesGroups error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.Equal(t, tt.wantInfraGroupStoreCount, len(fakeService.infraGroupStore.ListKeys()))
+			assert.Equal(t, tt.wantInfraShareStoreCount, len(fakeService.infraShareStore.ListKeys()))
+
+			existingGroups := fakeService.infraGroupStore.GetByIndex(tt.args.createdFor, string(tt.args.uid))
+			for _, group := range existingGroups {
+				if tt.name == "error gcInfraSharesGroups" {
+					assert.Equal(t, false, *(*group).MarkedForDelete)
+				} else {
+					assert.Equal(t, true, *(*group).MarkedForDelete)
+				}
+			}
+
+			existingShares := fakeService.infraShareStore.GetByIndex(tt.args.createdFor, string(tt.args.uid))
+			for _, share := range existingShares {
+				assert.Equal(t, true, *(*share).MarkedForDelete)
+			}
 		})
 	}
 }

--- a/pkg/nsx/services/securitypolicy/parse.go
+++ b/pkg/nsx/services/securitypolicy/parse.go
@@ -1,3 +1,6 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
 package securitypolicy
 
 import (

--- a/pkg/nsx/services/securitypolicy/parse_test.go
+++ b/pkg/nsx/services/securitypolicy/parse_test.go
@@ -1,3 +1,6 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
 package securitypolicy
 
 import (
@@ -6,6 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetCluster(t *testing.T) {
+func Test_GetCluster(t *testing.T) {
 	assert.Equal(t, "k8scl-one", getCluster(service))
 }

--- a/pkg/nsx/services/securitypolicy/store.go
+++ b/pkg/nsx/services/securitypolicy/store.go
@@ -1,3 +1,6 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
 package securitypolicy
 
 import (
@@ -122,13 +125,13 @@ func (securityPolicyStore *SecurityPolicyStore) Apply(i interface{}) error {
 	sp := i.(*model.SecurityPolicy)
 	if sp.MarkedForDelete != nil && *sp.MarkedForDelete {
 		err := securityPolicyStore.Delete(sp)
-		log.V(1).Info("delete security policy from store", "securitypolicy", sp)
+		log.V(1).Info("Delete security policy from store", "securitypolicy", sp)
 		if err != nil {
 			return err
 		}
 	} else {
 		err := securityPolicyStore.Add(sp)
-		log.V(1).Info("add security policy to store", "securitypolicy", sp)
+		log.V(1).Info("Add security policy to store", "securitypolicy", sp)
 		if err != nil {
 			return err
 		}
@@ -160,13 +163,13 @@ func (ruleStore *RuleStore) Apply(i interface{}) error {
 		tempRule := rule
 		if rule.MarkedForDelete != nil && *rule.MarkedForDelete {
 			err := ruleStore.Delete(&tempRule)
-			log.V(1).Info("delete rule from store", "rule", tempRule)
+			log.V(1).Info("Delete rule from store", "rule", tempRule)
 			if err != nil {
 				return err
 			}
 		} else {
 			err := ruleStore.Add(&tempRule)
-			log.V(1).Info("add rule to store", "rule", tempRule)
+			log.V(1).Info("Add rule to store", "rule", tempRule)
 			if err != nil {
 				return err
 			}
@@ -190,13 +193,13 @@ func (groupStore *GroupStore) Apply(i interface{}) error {
 		tempGroup := group
 		if group.MarkedForDelete != nil && *group.MarkedForDelete {
 			err := groupStore.Delete(&tempGroup)
-			log.V(1).Info("delete group from store", "group", tempGroup)
+			log.V(1).Info("Delete group from store", "group", tempGroup)
 			if err != nil {
 				return err
 			}
 		} else {
 			err := groupStore.Add(&tempGroup)
-			log.V(1).Info("add group to store", "group", tempGroup)
+			log.V(1).Info("Add group to store", "group", tempGroup)
 			if err != nil {
 				return err
 			}
@@ -220,28 +223,19 @@ func (shareStore *ShareStore) Apply(i interface{}) error {
 		tempShare := share
 		if share.MarkedForDelete != nil && *share.MarkedForDelete {
 			err := shareStore.Delete(&tempShare)
-			log.V(1).Info("delete share from store", "share", tempShare)
+			log.V(1).Info("Delete share from store", "share", tempShare)
 			if err != nil {
 				return err
 			}
 		} else {
 			err := shareStore.Add(&tempShare)
-			log.V(1).Info("add share to store", "share", tempShare)
+			log.V(1).Info("Add share to store", "share", tempShare)
 			if err != nil {
 				return err
 			}
 		}
 	}
 	return nil
-}
-
-func (shareStore *ShareStore) GetByKey(key string) *model.Share {
-	var share *model.Share
-	obj := shareStore.ResourceStore.GetByKey(key)
-	if obj != nil {
-		share = obj.(*model.Share)
-	}
-	return share
 }
 
 func (shareStore *ShareStore) GetByIndex(key string, value string) []*model.Share {

--- a/pkg/nsx/services/securitypolicy/store_test.go
+++ b/pkg/nsx/services/securitypolicy/store_test.go
@@ -1,3 +1,6 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
 package securitypolicy
 
 import (
@@ -19,8 +22,8 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
-func Test_indexBySecurityPolicyCRUID(t *testing.T) {
-	mId, mTag, mScope := "11111", "11111", "nsx-op/security_policy_cr_uid"
+func Test_indexBySecurityPolicyUIDForT1(t *testing.T) {
+	mId, mTag, mScope := "11111", "11111", common.TagScopeSecurityPolicyCRUID
 	m := &model.Group{
 		Id:   &mId,
 		Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
@@ -33,6 +36,46 @@ func Test_indexBySecurityPolicyCRUID(t *testing.T) {
 		Id:   &mId,
 		Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
 	}
+	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyCRName
+	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyCRUID
+
+	t.Run("1", func(t *testing.T) {
+		got, _ := indexBySecurityPolicyUID(s)
+		if !reflect.DeepEqual(got, []string{"11111"}) {
+			t.Errorf("indexBySecurityPolicyUID() = %v, want %v", got, model.Tag{Tag: &mTag, Scope: &mScope})
+		}
+	})
+	t.Run("2", func(t *testing.T) {
+		got, _ := indexBySecurityPolicyUID(m)
+		if !reflect.DeepEqual(got, []string{"11111"}) {
+			t.Errorf("indexBySecurityPolicyUID() = %v, want %v", got, model.Tag{Tag: &mTag, Scope: &mScope})
+		}
+	})
+	t.Run("3", func(t *testing.T) {
+		got, _ := indexBySecurityPolicyUID(r)
+		if !reflect.DeepEqual(got, []string{"11111"}) {
+			t.Errorf("indexBySecurityPolicyUID() = %v, want %v", got, model.Tag{Tag: &mTag, Scope: &mScope})
+		}
+	})
+}
+
+func Test_indexBySecurityPolicyUIDForVPC(t *testing.T) {
+	mId, mTag, mScope := "11111", "11111", common.TagScopeSecurityPolicyUID
+	m := &model.Group{
+		Id:   &mId,
+		Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+	}
+	s := &model.SecurityPolicy{
+		Id:   &mId,
+		Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+	}
+	r := &model.Rule{
+		Id:   &mId,
+		Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
+	}
+	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
+	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
+
 	t.Run("1", func(t *testing.T) {
 		got, _ := indexBySecurityPolicyUID(s)
 		if !reflect.DeepEqual(got, []string{"11111"}) {
@@ -257,7 +300,7 @@ func Test_InitializeSecurityPolicyStore(t *testing.T) {
 	assert.Equal(t, []string{"11111"}, securityPolicyStore.ListKeys())
 }
 
-func TestSecurityPolicyStore_Apply(t *testing.T) {
+func Test_SecurityPolicyStore_Apply(t *testing.T) {
 	securityPolicyCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID})
 	resourceStore := common.ResourceStore{
 		Indexer:     securityPolicyCacheIndexer,
@@ -281,7 +324,7 @@ func TestSecurityPolicyStore_Apply(t *testing.T) {
 	}
 }
 
-func TestRuleStore_Apply(t *testing.T) {
+func Test_RuleStore_Apply(t *testing.T) {
 	ruleCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID})
 	resourceStore := common.ResourceStore{
 		Indexer:     ruleCacheIndexer,
@@ -337,7 +380,7 @@ func TestRuleStore_Apply(t *testing.T) {
 	}
 }
 
-func TestGroupStore_Apply(t *testing.T) {
+func Test_GroupStore_Apply(t *testing.T) {
 	groupCacheIndexer := cache.NewIndexer(keyFunc, cache.Indexers{common.TagValueScopeSecurityPolicyUID: indexBySecurityPolicyUID})
 	resourceStore := common.ResourceStore{
 		Indexer:     groupCacheIndexer,

--- a/pkg/nsx/services/securitypolicy/wrap.go
+++ b/pkg/nsx/services/securitypolicy/wrap.go
@@ -1,3 +1,6 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
 package securitypolicy
 
 import (

--- a/pkg/nsx/services/securitypolicy/wrap_test.go
+++ b/pkg/nsx/services/securitypolicy/wrap_test.go
@@ -1,3 +1,6 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
 package securitypolicy
 
 import (
@@ -20,6 +23,7 @@ type (
 	fakeOrgClient         struct{}
 	fakeSecurityClient    struct{}
 	fakeVPCSecurityClient struct{}
+	fakeVPCGroupClient    struct{}
 )
 
 func (_ *fakeQueryClient) List(_ string, _ *string, _ *string, _ *int64, _ *bool, _ *string) (model.SearchResponse, error) {
@@ -107,6 +111,26 @@ func (f fakeVPCSecurityClient) Update(orgIDParam string, projectIDParam string, 
 	return model.SecurityPolicy{}, nil
 }
 
+func (f fakeVPCGroupClient) Delete(orgIdParam string, projectIdParam string, vpcIdParam string, groupIdParam string) error {
+	return nil
+}
+
+func (f fakeVPCGroupClient) Get(orgIdParam string, projectIdParam string, vpcIdParam string, groupIdParam string) (model.Group, error) {
+	return model.Group{}, nil
+}
+
+func (f fakeVPCGroupClient) List(orgIdParam string, projectIdParam string, vpcIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, memberTypesParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.GroupListResult, error) {
+	return model.GroupListResult{}, nil
+}
+
+func (f fakeVPCGroupClient) Patch(orgIdParam string, projectIdParam string, vpcIdParam string, groupIdParam string, groupParam model.Group) error {
+	return nil
+}
+
+func (f fakeVPCGroupClient) Update(orgIdParam string, projectIdParam string, vpcIdParam string, groupIdParam string, groupParam model.Group) (model.Group, error) {
+	return model.Group{}, nil
+}
+
 func fakeSecurityPolicyService() *SecurityPolicyService {
 	c := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{})
 	cluster, _ := nsx.NewCluster(c)
@@ -119,6 +143,7 @@ func fakeSecurityPolicyService() *SecurityPolicyService {
 				SecurityClient:    &fakeSecurityClient{},
 				OrgRootClient:     &fakeOrgClient{},
 				VPCSecurityClient: &fakeVPCSecurityClient{},
+				VpcGroupClient:    &fakeVPCGroupClient{},
 				RestConnector:     rc,
 				NsxConfig: &config.NSXOperatorConfig{
 					CoeConfig: &config.CoeConfig{


### PR DESCRIPTION
Cherry-Pick PR: https://github.com/vmware-tanzu/nsx-operator/pull/835

This patch is to
1. Add more UTS for NetworkPolicy, SecurityPolicy and LBService controller.
2. Add more UTS for SecurityPolicy service.
3. Add license file header.
4. Change log info format.