### PR TITLE
Update Subnet/SubnetSet API for DHCP changes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,6 @@ github.com/vmware-tanzu/vm-operator/api v1.8.2/go.mod h1:vauVboD3sQxP+pb28TnI9wf
 github.com/vmware/govmomi v0.27.4 h1:5kY8TAkhB20lsjzrjE073eRb8+HixBI29PVMG5lxq6I=
 github.com/vmware/govmomi v0.27.4/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
-github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
-github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/vmware/vsphere-automation-sdk-go/lib v0.7.0 h1:pT+oqJ8FD5eUBQkl+e7LZwwtbwPvW5kDyyGXvt66gOM=
 github.com/vmware/vsphere-automation-sdk-go/lib v0.7.0/go.mod h1:f3+6YVZpNcK2pYyiQ94BoHWmjMj9BnYav0vNFuTiDVM=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.7.0 h1:pSBxa9Agh6bgW8Hr0A1eQxuwnxGTnuAVox8iQb023hg=
@@ -155,6 +153,8 @@ github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.0.0-20241113023437-
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.0.0-20241113023437-5938c535c194/go.mod h1:M+J1qwzF4o7sAb/2VRu/edl1HLCdC++C4SNUrgiuGlQ=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20241113023437-5938c535c194 h1:m0ZD9SXLwI4Q+nljYfmNrOpveUGud0wKefGVHkPJTW8=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20241113023437-5938c535c194/go.mod h1:ugk9I4YM62SSAox57l5NAVBCRIkPQ1RNLb3URxyTADc=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -120,7 +120,7 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 					Return([]*model.VpcSubnet{})
 				ssp.(*pkg_mock.MockSubnetServiceProvider).On("GenerateSubnetNSTags", mock.Anything)
 				vsp.(*pkg_mock.MockVPCServiceProvider).On("ListVPCInfo", mock.Anything).Return([]servicecommon.VPCResourceInfo{{}})
-				ssp.(*pkg_mock.MockSubnetServiceProvider).On("CreateOrUpdateSubnet", mock.Anything, mock.Anything, mock.Anything).Return(expectedSubnetPath, nil)
+				ssp.(*pkg_mock.MockSubnetServiceProvider).On("CreateOrUpdateSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(expectedSubnetPath, nil)
 			},
 			expectedResult: expectedSubnetPath,
 		},

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -111,9 +111,9 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	// update SubnetSet tags if labels of namespace changed
 	nsxSubnets := r.SubnetService.SubnetStore.GetByIndex(servicecommon.TagScopeSubnetSetCRUID, string(subnetsetCR.UID))
 	if len(nsxSubnets) > 0 {
+		// update SubnetSet tags if labels of namespace changed
 		tags := r.SubnetService.GenerateSubnetNSTags(subnetsetCR)
 		if tags == nil {
 			log.Error(nil, "Failed to generate SubnetSet tags", "SubnetSet", req.NamespacedName)
@@ -125,8 +125,8 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			r.StatusUpdater.UpdateFail(ctx, subnetsetCR, err, "Exceed tags limit", setSubnetSetReadyStatusFalse)
 			return ResultNormal, nil
 		}
-		if err := r.SubnetService.UpdateSubnetSetTags(subnetsetCR.Namespace, nsxSubnets, tags); err != nil {
-			r.StatusUpdater.UpdateFail(ctx, subnetsetCR, err, "Failed to update SubnetSet tags", setSubnetSetReadyStatusFalse)
+		if err := r.SubnetService.UpdateSubnetSet(subnetsetCR.Namespace, nsxSubnets, tags, string(subnetsetCR.Spec.SubnetDHCPConfig.Mode)); err != nil {
+			r.StatusUpdater.UpdateFail(ctx, subnetsetCR, err, "Failed to update SubnetSet", setSubnetSetReadyStatusFalse)
 			return ResultRequeue, nil
 		}
 	}

--- a/pkg/controllers/subnetset/subnetset_controller_test.go
+++ b/pkg/controllers/subnetset/subnetset_controller_test.go
@@ -145,8 +145,8 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
-			// return nil and not requeue when UpdateSubnetSetTags failed
-			name:         "Create a SubnetSet failed to UpdateSubnetSetTags",
+			// return nil and requeue when UpdateSubnetSet failed
+			name:         "Create a SubnetSet failed to UpdateSubnetSet",
 			expectRes:    ResultRequeue,
 			expectErrStr: "",
 			patches: func(r *SubnetSetReconciler) *gomonkey.Patches {
@@ -226,8 +226,8 @@ func TestReconcile(t *testing.T) {
 					return tags
 				})
 
-				// UpdateSubnetSetTags
-				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "UpdateSubnetSetTags", func(_ *subnet.SubnetService, ns string, vpcSubnets []*model.VpcSubnet, tags []model.Tag) error {
+				// UpdateSubnetSet
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "UpdateSubnetSet", func(_ *subnet.SubnetService, ns string, vpcSubnets []*model.VpcSubnet, tags []model.Tag, dhcpMode string) error {
 					return nil
 				})
 				return patches

--- a/pkg/nsx/services/subnet/compare.go
+++ b/pkg/nsx/services/subnet/compare.go
@@ -18,11 +18,12 @@ func (subnet *Subnet) Key() string {
 }
 
 func (subnet *Subnet) Value() data.DataValue {
-	// IPv4SubnetSize/AccessMode/IPAddresses/DHCPConfig are immutable field,
-	// Only changes of tags are considered as changed.
+	// IPv4SubnetSize/AccessMode/IPAddresses are immutable field,
+	// Changes of tags and subnetDHCPConfig are considered as changed.
 	// TODO AccessMode may also need to be compared in future.
 	s := &Subnet{
-		Tags: subnet.Tags,
+		Tags:             subnet.Tags,
+		SubnetDhcpConfig: subnet.SubnetDhcpConfig,
 	}
 	dataValue, _ := (*model.VpcSubnet)(s).GetDataValue__()
 	return dataValue

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -38,10 +38,18 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 	case *v1alpha1.SubnetPort:
 		externalAddressBinding = service.buildExternalAddressBinding(o)
 	}
-	if nsxSubnet.DhcpConfig != nil && nsxSubnet.DhcpConfig.EnableDhcp != nil && *nsxSubnet.DhcpConfig.EnableDhcp {
-		allocateAddresses = "DHCP"
+	if nsxSubnet.SubnetDhcpConfig == nil {
+		if nsxSubnet.DhcpConfig != nil && nsxSubnet.DhcpConfig.EnableDhcp != nil && *nsxSubnet.DhcpConfig.EnableDhcp {
+			allocateAddresses = "DHCP"
+		} else {
+			allocateAddresses = "BOTH"
+		}
 	} else {
-		allocateAddresses = "BOTH"
+		if nsxSubnet.SubnetDhcpConfig.Mode != nil && *nsxSubnet.SubnetDhcpConfig.Mode != v1alpha1.DHCPConfigModeDeactivated {
+			allocateAddresses = "DHCP"
+		} else {
+			allocateAddresses = "BOTH"
+		}
 	}
 	nsxSubnetPortName := service.BuildSubnetPortName(objMeta)
 	nsxSubnetPortID := service.BuildSubnetPortId(objMeta)

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -66,8 +66,8 @@ func TestBuildSubnetPort(t *testing.T) {
 				},
 			},
 			nsxSubnet: &model.VpcSubnet{
-				DhcpConfig: &model.VpcSubnetDhcpConfig{
-					EnableDhcp: common.Bool(true),
+				SubnetDhcpConfig: &model.SubnetDhcpConfig{
+					Mode: common.String(v1alpha1.DHCPConfigModeServer),
 				},
 				Path: common.String("fake_path"),
 			},
@@ -123,8 +123,8 @@ func TestBuildSubnetPort(t *testing.T) {
 				},
 			},
 			nsxSubnet: &model.VpcSubnet{
-				DhcpConfig: &model.VpcSubnetDhcpConfig{
-					EnableDhcp: common.Bool(true),
+				SubnetDhcpConfig: &model.SubnetDhcpConfig{
+					Mode: common.String(v1alpha1.DHCPConfigModeServer),
 				},
 				Path: common.String("fake_path"),
 			},

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -130,6 +130,9 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 	if (*nsxSubnet).DhcpConfig != nil && *nsxSubnet.DhcpConfig.EnableDhcp {
 		enableDHCP = true
 	}
+	if nsxSubnet.SubnetDhcpConfig != nil && nsxSubnet.SubnetDhcpConfig.Mode != nil && *nsxSubnet.SubnetDhcpConfig.Mode != v1alpha1.DHCPConfigModeDeactivated {
+		enableDHCP = true
+	}
 	nsxSubnetPortState, err := service.CheckSubnetPortState(obj, *nsxSubnet.Path, enableDHCP)
 	if err != nil {
 		log.Error(err, "check and update NSX subnet port state failed, would retry exponentially", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -193,11 +193,10 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 		},
 	}
 
-	enableDHCP := true
 	nsxSubnet := &model.VpcSubnet{
 		Path: &subnetPath,
-		DhcpConfig: &model.VpcSubnetDhcpConfig{
-			EnableDhcp: &enableDHCP,
+		SubnetDhcpConfig: &model.SubnetDhcpConfig{
+			Mode: common.String(v1alpha1.DHCPConfigModeServer),
 		},
 	}
 

--- a/test/e2e/nsx_subnet_test.go
+++ b/test/e2e/nsx_subnet_test.go
@@ -64,6 +64,8 @@ func TestSubnetSet(t *testing.T) {
 	})
 
 	t.Run("case=DefaultSubnetSet", defaultSubnetSet)
+	// TODO: Subnet test with DHCP enable required to update service profile after
+	// upgrade to new NSX which supports subnetDHCPConfig
 	t.Run("case=UserSubnetSet", UserSubnetSet)
 	t.Run("case=SharedSubnetSet", sharedSubnetSet)
 	t.Run("case=SubnetCIDR", SubnetCIDR)


### PR DESCRIPTION
The PR supports DHCP changes in NSX subnet.

Testing done:
- Create Subnet with DHCPServer/DHCPDeactivated mode and create a vm on it
- Create SubnetSet with DHCPServer/DHCPDeactivated mode and create a vm on it
- Create a Subnet with DHCPServer and create a vm on it, switch from DHCPServer to DHCPDeactivated
- Create a SubnetSet with DHCPServer and create a vm on it, switch from DHCPServer to DHCPDeactivated