### PR TITLE
Fix the potential race condition of InitializeSubnetService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 .DS_Store
 go.work
 go.work.sum
+.tool-versions


### PR DESCRIPTION
It is possible that an error occurs when trying to send to the already closed `fatalErrors` channel, resulting in a panic.