### PR TITLE
Fix checking realized state error

### DIFF
--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -16,14 +16,15 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/trust_management"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/trust_management/principal_identities"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra"
+
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/domains"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/domains/security_policies"
+	infra_realized "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/shares"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcement_points"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects"
 	project_infra "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/infra"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/infra/realized_state"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/transit_gateways"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/vpcs"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/vpcs/nat"
@@ -64,7 +65,7 @@ type Client struct {
 	ClusterControlPlanesClient enforcement_points.ClusterControlPlanesClient
 	HostTransPortNodesClient   enforcement_points.HostTransportNodesClient
 	SubnetStatusClient         subnets.StatusClient
-	RealizedEntitiesClient     realized_state.RealizedEntitiesClient
+	RealizedEntitiesClient     infra_realized.RealizedEntitiesClient
 	MPQueryClient              mpsearch.QueryClient
 	CertificatesClient         trust_management.CertificatesClient
 	PrincipalIdentitiesClient  trust_management.PrincipalIdentitiesClient
@@ -87,7 +88,6 @@ type Client struct {
 	IPPoolClient                   subnets.IpPoolsClient
 	IPAllocationClient             ip_pools.IpAllocationsClient
 	SubnetsClient                  vpcs.SubnetsClient
-	RealizedStateClient            realized_state.RealizedEntitiesClient
 	IPAddressAllocationClient      vpcs.IpAddressAllocationsClient
 	VPCLBSClient                   vpcs.VpcLbsClient
 	VpcLbVirtualServersClient      vpcs.VpcLbVirtualServersClient
@@ -161,7 +161,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 
 	clusterControlPlanesClient := enforcement_points.NewClusterControlPlanesClient(restConnector(cluster))
 	hostTransportNodesClient := enforcement_points.NewHostTransportNodesClient(restConnector(cluster))
-	realizedEntitiesClient := realized_state.NewRealizedEntitiesClient(restConnector(cluster))
+	realizedEntitiesClient := infra_realized.NewRealizedEntitiesClient(restConnector(cluster))
 	mpQueryClient := mpsearch.NewQueryClient(restConnector(cluster))
 	certificatesClient := trust_management.NewCertificatesClient(restConnector(cluster))
 	principalIdentitiesClient := trust_management.NewPrincipalIdentitiesClient(restConnector(cluster))
@@ -182,7 +182,6 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 	ipAllocationClient := ip_pools.NewIpAllocationsClient(restConnector(cluster))
 	subnetsClient := vpcs.NewSubnetsClient(restConnector(cluster))
 	subnetStatusClient := subnets.NewStatusClient(restConnector(cluster))
-	realizedStateClient := realized_state.NewRealizedEntitiesClient(restConnector(cluster))
 	ipAddressAllocationClient := vpcs.NewIpAddressAllocationsClient(restConnector(cluster))
 	vpcLBSClient := vpcs.NewVpcLbsClient(restConnector(cluster))
 	vpcLbVirtualServersClient := vpcs.NewVpcLbVirtualServersClient(restConnector(cluster))
@@ -243,7 +242,6 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 		IPPoolClient:                   ipPoolClient,
 		IPAllocationClient:             ipAllocationClient,
 		SubnetsClient:                  subnetsClient,
-		RealizedStateClient:            realizedStateClient,
 		IPAddressAllocationClient:      ipAddressAllocationClient,
 		TransitGatewayClient:           transitGatewayClient,
 		TransitGatewayAttachmentClient: transitGatewayAttachmentClient,

--- a/pkg/nsx/services/realizestate/realize_state.go
+++ b/pkg/nsx/services/realizestate/realize_state.go
@@ -45,15 +45,11 @@ func IsRealizeStateError(err error) bool {
 // backoff defines the maximum retries and the wait interval between two retries.
 func (service *RealizeStateService) CheckRealizeState(backoff wait.Backoff, intentPath, entityType string) error {
 	// TODO， ask NSX if there were multiple realize states could we check only the latest one?
-	vpcInfo, err := common.ParseVPCResourcePath(intentPath)
-	if err != nil {
-		return err
-	}
 	return retry.OnError(backoff, func(err error) bool {
 		// Won't retry when realized state is `ERROR`.
 		return !IsRealizeStateError(err)
 	}, func() error {
-		results, err := service.NSXClient.RealizedEntitiesClient.List(vpcInfo.OrgID, vpcInfo.ProjectID, intentPath, nil)
+		results, err := service.NSXClient.RealizedEntitiesClient.List(intentPath, nil)
 		err = nsxutil.TransNSXApiError(err)
 		if err != nil {
 			return err

--- a/pkg/nsx/services/subnet/subnet_test.go
+++ b/pkg/nsx/services/subnet/subnet_test.go
@@ -138,7 +138,7 @@ func (f fakeSubnetsClient) Update(orgIdParam string, projectIdParam string, vpcI
 type fakeRealizedEntitiesClient struct {
 }
 
-func (f fakeRealizedEntitiesClient) List(orgIdParam string, projectIdParam string, intentPathParam string, sitePathParam *string) (model.GenericPolicyRealizedResourceListResult, error) {
+func (f fakeRealizedEntitiesClient) List(intentPathParam string, sitePathParam *string) (model.GenericPolicyRealizedResourceListResult, error) {
 	// GenericPolicyRealizedResource
 	state := model.GenericPolicyRealizedResource_STATE_REALIZED
 	return model.GenericPolicyRealizedResourceListResult{

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -66,7 +66,7 @@ func (c *fakePortClient) Delete(orgIdParam string, projectIdParam string, vpcIdP
 
 type fakeRealizedEntitiesClient struct{}
 
-func (c *fakeRealizedEntitiesClient) List(orgIdParam string, projectIdParam string, intentPathParam string, sitePathParam *string) (model.GenericPolicyRealizedResourceListResult, error) {
+func (c *fakeRealizedEntitiesClient) List(intentPathParam string, sitePathParam *string) (model.GenericPolicyRealizedResourceListResult, error) {
 
 	return model.GenericPolicyRealizedResourceListResult{
 		Results: []model.GenericPolicyRealizedResource{

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -2060,7 +2060,7 @@ func (f fakeOrgRootClient) Patch(orgRootParam model.OrgRoot, enforceRevisionChec
 type fakeRealizedEntitiesClient struct {
 }
 
-func (f fakeRealizedEntitiesClient) List(orgIdParam string, projectIdParam string, intentPathParam string, sitePathParam *string) (model.GenericPolicyRealizedResourceListResult, error) {
+func (f fakeRealizedEntitiesClient) List(intentPathParam string, sitePathParam *string) (model.GenericPolicyRealizedResourceListResult, error) {
 	state := model.GenericPolicyRealizedResource_STATE_REALIZED
 	return model.GenericPolicyRealizedResourceListResult{Results: []model.GenericPolicyRealizedResource{{State: &state}}}, nil
 }


### PR DESCRIPTION
For default project, the realized-state path should be "/policy/api/infra/realized-state/realized-entities?". There is no orgs and projects info in it

Using realizedEntitiesClient under infra to replace that under projects

Test Done:
1. replace the manager in QE env
2. run the test and check if query resources under /orgs/default/projects/default realized successfully