### PR TITLE
Update pod label based on the master election

### DIFF
--- a/build/yaml/webhook/service.yaml
+++ b/build/yaml/webhook/service.yaml
@@ -18,3 +18,4 @@ spec:
       targetPort: 9981
   selector:
     component: nsx-ncp
+    nsx-operator-role: master


### PR DESCRIPTION
To ensure the webhook targets the active endpoint in HA mode, we should label the pods accordingly and configure the webhook service to select these labeled pods.

Test Done:
 root@4221bc880b8fc4e819b7b3e62467e0e8 ~/nsx-operator  topic/zhengxie/v4.2.0/update_pod_labels kubectl get endpoints vmware-system-nsx-operator-webhook-service -n vmware-system-nsx
NAME                                         ENDPOINTS         AGE
vmware-system-nsx-operator-webhook-service   172.26.0.3:9981   30h   <--- only one endpoint
 root@4221bc880b8fc4e819b7b3e62467e0e8 ~/nsx-operator  topic/zhengxie/v4.2.0/update_pod_labels kubectl get pods -o wide -n vmware-system-nsx --show-labels                          
NAME                       READY   STATUS    RESTARTS   AGE     IP           NODE                               NOMINATED NODE   READINESS GATES   LABELS
nsx-ncp-69fc7f5b7d-5wbft   0/2     Pending   0          90s     <none>       <none>                             <none>           <none>            component=nsx-ncp,pod-template-hash=69fc7f5b7d,tier=nsx-networking,version=v1
nsx-ncp-69fc7f5b7d-nqvv7   0/2     Pending   0          90s     <none>       <none>                             <none>           <none>            component=nsx-ncp,pod-template-hash=69fc7f5b7d,tier=nsx-networking,version=v1
nsx-ncp-7d46449cd-w8wlk    2/2     Running   0          4m41s   172.26.0.3   4221bc880b8fc4e819b7b3e62467e0e8   <none>           <none>            component=nsx-ncp,pod-template-hash=7d46449cd,role=master,<-----  new label tier=nsx-networking,version=v1

And continuously curl webhook is OK
 root@4221bc880b8fc4e819b7b3e62467e0e8 ~/nsx-operator  topic/zhengxie/v4.2.0/update_pod_labels curl -k https://172.24.146.137:443/validate-crd-nsx-vmware-com-v1alpha1-subnetset
{"response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"request body is empty","code":400}}}