### PR TITLE
[CP]Update pod label based on the master election(#908)

### DIFF
--- a/build/yaml/webhook/service.yaml
+++ b/build/yaml/webhook/service.yaml
@@ -18,3 +18,4 @@ spec:
       targetPort: 9981
   selector:
     component: nsx-ncp
+    nsx-operator-role: master


### PR DESCRIPTION
To ensure the webhook targets the active endpoint in HA mode, we should label the pods accordingly and configure the webhook service to select these labeled pods.