### PR TITLE
Unify log format in e2e running

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -5,7 +5,6 @@ package e2e
 
 import (
 	"flag"
-	"log"
 	"os"
 	"testing"
 
@@ -32,26 +31,28 @@ func testMain(m *testing.M) int {
 	}
 
 	if err := initProvider(); err != nil {
-		log.Fatalf("Error when initializing provider: %v", err)
+		log.Error(err, "Error when initializing provider")
+		panic(err)
 	}
 
-	log.Println("Creating clientSets")
+	log.Info("Creating clientSets")
 
 	if err := NewTestData(testOptions.operatorConfigPath); err != nil {
-		log.Fatalf("Error when creating client: %v", err)
+		log.Error(err, "Error when creating client")
 		return 1
 	}
-	log.Println("Collecting information about K8s cluster")
+
+	log.Info("Collecting information about K8s cluster")
 	if err := collectClusterInfo(); err != nil {
-		log.Fatalf("Error when collecting information about K8s cluster: %v", err)
+		log.Error(err, "Error when collecting information about K8s cluster")
+		panic(err)
 	}
 	if clusterInfo.podV4NetworkCIDR != "" {
-		log.Printf("Pod IPv4 network: '%s'", clusterInfo.podV4NetworkCIDR)
+		log.Info("Pod IPv4: ", "network", clusterInfo.podV4NetworkCIDR)
 	}
 	if clusterInfo.podV6NetworkCIDR != "" {
-		log.Printf("Pod IPv6 network: '%s'", clusterInfo.podV6NetworkCIDR)
+		log.Info("Pod IPv6: ", "network", clusterInfo.podV6NetworkCIDR)
 	}
-	log.Printf("Num nodes: %d", clusterInfo.numNodes)
 
 	ret := m.Run()
 	return ret

--- a/test/e2e/nsx_networkinfo_test.go
+++ b/test/e2e/nsx_networkinfo_test.go
@@ -38,7 +38,9 @@ func TestNetworkInfo(t *testing.T) {
 	defer t.Cleanup(
 		func() {
 			err := testData.crdClientset.CrdV1alpha1().VPCNetworkConfigurations().Delete(context.Background(), testCustomizedNetworkConfigName, v1.DeleteOptions{})
-			t.Logf("Delete VPCNetworkConfigurations %s: %v", testCustomizedNetworkConfigName, err)
+			if err != nil {
+				log.Error(err, "Delete VPCNetworkConfigurations", "name", testCustomizedNetworkConfigName)
+			}
 			teardownTest(t, e2eNetworkInfoNamespace, defaultTimeout)
 			teardownTest(t, e2eNetworkInfoNamespaceShare0, defaultTimeout)
 			teardownTest(t, e2eNetworkInfoNamespaceShare1, defaultTimeout)
@@ -181,12 +183,12 @@ func assureNetworkInfo(t *testing.T, ns, networkInfoName string) (res *v1alpha1.
 	defer deadlineCancel()
 	err := wait.PollUntilContextTimeout(deadlineCtx, 1*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
 		res, err = testData.crdClientset.CrdV1alpha1().NetworkInfos(ns).Get(context.Background(), networkInfoName, v1.GetOptions{})
-		t.Logf("Get NetworkInfos: %v, Namespace: %s, Name: %s, error: %v", res, ns, networkInfoName, err)
+		log.V(2).Info("Get NetworkInfos", "res", res, "Namespace", ns, "Name", networkInfoName)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil
 			}
-			return false, fmt.Errorf("error when waiting for  %s", networkInfoName)
+			return false, fmt.Errorf("error when waiting for %s", networkInfoName)
 		}
 		return true, nil
 	})
@@ -206,7 +208,7 @@ func assureNetworkInfoDeleted(t *testing.T, ns string) {
 			return false, fmt.Errorf("error when deleting Namespace %s", ns)
 		}
 		res, err := testData.crdClientset.CrdV1alpha1().NetworkInfos(ns).Get(context.Background(), ns, v1.GetOptions{})
-		t.Logf("Deleting NetworkInfos: %v, Namespace: %s, Name: %s, error: %v", res, ns, ns, err)
+		log.V(2).Info("Deleting NetworkInfos", "res", res, "Namespace", ns, "Name", ns)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
@@ -224,7 +226,7 @@ func assureNamespace(t *testing.T, ns string) (res *v12.Namespace) {
 	defer deadlineCancel()
 	err := wait.PollUntilContextTimeout(deadlineCtx, 1*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
 		res, err = testData.clientset.CoreV1().Namespaces().Get(context.Background(), ns, v1.GetOptions{})
-		t.Logf("Get Namespaces: %v, Name: %s, error: %v", res, ns, err)
+		log.V(2).Info("Get Namespaces", "res", res, "Name", ns)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil
@@ -249,7 +251,7 @@ func assureNamespaceDeleted(t *testing.T, ns string) {
 			return false, fmt.Errorf("error when deleting Namespace %s", ns)
 		}
 		res, err := testData.clientset.CoreV1().Namespaces().Get(context.Background(), ns, v1.GetOptions{})
-		t.Logf("Deleting Namespace: %v, Name: %s, error: %v", res, ns, err)
+		log.V(2).Info("Deleting Namespace", "res", res, "Name", ns)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
@@ -268,7 +270,7 @@ func getNetworkInfoWithPrivateIPs(t *testing.T, ns, networkInfoName string) (net
 	err := wait.PollUntilContextTimeout(deadlineCtx, 1*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
 		networkInfo, err = testData.crdClientset.CrdV1alpha1().NetworkInfos(ns).Get(ctx, networkInfoName, v1.GetOptions{})
 		if err != nil {
-			t.Logf("Check private ips of networkinfo: %v, error: %+v", networkInfo, err)
+			log.V(2).Info("Check private ips of networkinfo", "networkInfo", networkInfo, "error", err)
 			return false, fmt.Errorf("error when waiting for vpcnetworkinfo private ips: %s", networkInfoName)
 		}
 		if len(networkInfo.VPCs) > 0 && len(networkInfo.VPCs[0].PrivateIPs) > 0 {
@@ -286,7 +288,7 @@ func getVPCPathFromVPCNetworkConfiguration(t *testing.T, ncName string) (vpcPath
 	err := wait.PollUntilContextTimeout(deadlineCtx, 1*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
 		resp, err := testData.crdClientset.CrdV1alpha1().VPCNetworkConfigurations().Get(ctx, ncName, v1.GetOptions{})
 		if err != nil {
-			t.Logf("Check VPC path of vpcnetworkconfigurations: %+v, error: %+v", resp, err)
+			log.V(2).Info("Check VPC path of vpcnetworkconfigurations", "resp", resp)
 			return false, fmt.Errorf("error when waiting for vpcnetworkconfigurations VPC path: %s", ncName)
 		}
 		if len(resp.Status.VPCs) > 0 && resp.Status.VPCs[0].VPCPath != "" {
@@ -303,12 +305,12 @@ func deleteVPCNetworkConfiguration(t *testing.T, ncName string) {
 	deadlineCtx, deadlineCancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer deadlineCancel()
 	err := wait.PollUntilContextTimeout(deadlineCtx, 1*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
-		deleteErr := testData.crdClientset.CrdV1alpha1().VPCNetworkConfigurations().Delete(context.Background(), ncName, v1.DeleteOptions{})
-		t.Logf("Delete VPCNetworkConfigurations %s: %v", testCustomizedNetworkConfigName, deleteErr)
+		_ = testData.crdClientset.CrdV1alpha1().VPCNetworkConfigurations().Delete(context.Background(), ncName, v1.DeleteOptions{})
+		log.V(2).Info("Delete VPCNetworkConfigurations", "name", testCustomizedNetworkConfigName)
 
 		resp, err := testData.crdClientset.CrdV1alpha1().VPCNetworkConfigurations().Get(ctx, ncName, v1.GetOptions{})
 		if err != nil {
-			t.Logf("Check stale vpcnetworkconfigurations: %+v, error: %+v", resp, err)
+			log.V(2).Info("Check stale vpcnetworkconfigurations", "resp", resp)
 			if errors.IsNotFound(err) {
 				return true, nil
 			}

--- a/test/e2e/nsx_security_policy_test.go
+++ b/test/e2e/nsx_security_policy_test.go
@@ -95,7 +95,7 @@ func testSecurityPolicyBasicTraffic(t *testing.T) {
 	_ = deleteYAML(nsIsolationPath, ns)
 	err = wait.PollUntilContextTimeout(deadlineCtx, 1*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
 		resp, err := testData.crdClientset.CrdV1alpha1().SecurityPolicies(ns).Get(ctx, securityPolicyName, v1.GetOptions{})
-		t.Logf("Check resource: %v", resp)
+		log.V(2).Info("Check resource", "resp", resp)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
@@ -159,7 +159,7 @@ func testSecurityPolicyAddDeleteRule(t *testing.T) {
 
 	err := wait.PollUntilContextTimeout(deadlineCtx, 1*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
 		resp, err := testData.crdClientset.CrdV1alpha1().SecurityPolicies(ns).Get(ctx, securityPolicyName, v1.GetOptions{})
-		t.Logf("Check resource: %v", resp)
+		log.V(2).Info("Check resource", "resp", resp)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
@@ -241,7 +241,7 @@ func testSecurityPolicyMatchExpression(t *testing.T) {
 
 	err = wait.PollUntilContextTimeout(deadlineCtx, 1*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
 		resp, err := testData.crdClientset.CrdV1alpha1().SecurityPolicies(ns).Get(ctx, securityPolicyName, v1.GetOptions{})
-		t.Logf("Check resource: %v", resp)
+		log.V(2).Info("Check resource", "resp", resp)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
@@ -291,7 +291,7 @@ func testSecurityPolicyNamedPortWithoutPod(t *testing.T) {
 	defer deleteYAML(yamlPath, "")
 
 	psb, err := testData.deploymentWaitForNames(defaultTimeout, nsWeb, labelWeb)
-	t.Logf("Pods are %v", psb)
+	log.V(2).Info("Pods", "pods", psb)
 	assert.NoError(t, err, "Error when waiting for IP for Pod %s", webA)
 	assureSecurityPolicyReady(t, nsWeb, securityPolicyCRName)
 
@@ -309,7 +309,7 @@ func assureSecurityPolicyReady(t *testing.T, ns, spName string) {
 	defer deadlineCancel()
 	err := wait.PollUntilContextTimeout(deadlineCtx, 1*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
 		resp, err := testData.crdClientset.CrdV1alpha1().SecurityPolicies(ns).Get(context.Background(), spName, v1.GetOptions{})
-		t.Logf("Get SecurityPolicies: %v, Namespace: %s, Name: %s", resp, ns, spName)
+		log.V(2).Info("Get resources", "SecurityPolicies", resp, "Namespace", ns, "Name", spName)
 		if err != nil {
 			return false, fmt.Errorf("error when waiting for  %s", spName)
 		}


### PR DESCRIPTION
Be a straight boy, we make the e2e output more simplified.


0. Follow the principle of knowing the minimum amount of information, remove the irregular output that affects the view. Of course, if you wish, you can also turn on the debug switch to see the complex output.
1. Replace all the `t.Logf` with the global logger, it supports color and tracing file line number.
2. Use `github.com/rakyll/gotest` instead of `go test`, it supports colorful failed and successful cases.
3. Disable `codecov` uploading process, it is a bit slow.