### PR TITLE
Use read lock on subnet for subnetport/pod creation

### DIFF
--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -89,8 +89,8 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		contextID := *node.UniqueId
 		// There is a race condition that the subnetset controller may delete the
 		// subnet during CollectGarbage. So check the subnet under lock.
-		r.SubnetService.LockSubnet(&nsxSubnetPath)
-		defer r.SubnetService.UnlockSubnet(&nsxSubnetPath)
+		r.SubnetService.RLockSubnet(&nsxSubnetPath)
+		defer r.SubnetService.RUnlockSubnet(&nsxSubnetPath)
 
 		nsxSubnet, err := r.SubnetService.GetSubnetByPath(nsxSubnetPath)
 		if err != nil {

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -107,8 +107,8 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		// There is a race condition that the subnetset controller may delete the
 		// subnet during CollectGarbage. So check the subnet under lock.
-		r.SubnetService.LockSubnet(&nsxSubnetPath)
-		defer r.SubnetService.UnlockSubnet(&nsxSubnetPath)
+		r.SubnetService.RLockSubnet(&nsxSubnetPath)
+		defer r.SubnetService.RUnlockSubnet(&nsxSubnetPath)
 
 		nsxSubnet, err := r.SubnetService.GetSubnetByPath(nsxSubnetPath)
 		if err != nil {

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -87,6 +87,14 @@ func (m *MockSubnetServiceProvider) UnlockSubnet(path *string) {
 	return
 }
 
+func (m *MockSubnetServiceProvider) RLockSubnet(path *string) {
+	return
+}
+
+func (m *MockSubnetServiceProvider) RUnlockSubnet(path *string) {
+	return
+}
+
 type MockSubnetPortServiceProvider struct {
 	mock.Mock
 }

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -32,6 +32,8 @@ type SubnetServiceProvider interface {
 	GenerateSubnetNSTags(obj client.Object) []model.Tag
 	LockSubnet(path *string)
 	UnlockSubnet(path *string)
+	RLockSubnet(path *string)
+	RUnlockSubnet(path *string)
 }
 
 type SubnetPortServiceProvider interface {

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -480,14 +480,28 @@ func (service *SubnetService) UpdateSubnetSet(ns string, vpcSubnets []*model.Vpc
 
 func (service *SubnetService) LockSubnet(path *string) {
 	if path != nil && *path != "" {
-		log.V(1).Info("Locked Subnet", "path", *path)
+		log.V(1).Info("Locked Subnet for writing", "path", *path)
 		service.SubnetStore.Lock(*path)
 	}
 }
 
 func (service *SubnetService) UnlockSubnet(path *string) {
 	if path != nil && *path != "" {
-		log.V(1).Info("Unlocked Subnet", "path", *path)
+		log.V(1).Info("Unlocked Subnet for writing", "path", *path)
 		service.SubnetStore.Unlock(*path)
+	}
+}
+
+func (service *SubnetService) RLockSubnet(path *string) {
+	if path != nil && *path != "" {
+		log.V(1).Info("Locked Subnet for reading", "path", *path)
+		service.SubnetStore.RLock(*path)
+	}
+}
+
+func (service *SubnetService) RUnlockSubnet(path *string) {
+	if path != nil && *path != "" {
+		log.V(1).Info("Unlocked Subnet for reading", "path", *path)
+		service.SubnetStore.RUnlock(*path)
 	}
 }


### PR DESCRIPTION
Previously we add lock on subnet to prevent the race between SubnetPort/Pod controller and SubnetSet GC.
In this PR we replace the mutex lock by read-write lock to improve the parallelism of the SubnetPort creation.

Testing done:
- Created 32 SubnetPort at a time, each SubnetPort reconcile finished in 2-3 seconds