### PR TITLE
Fix deadlock in subnet lock after subnet deletion

### DIFF
--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -89,8 +89,8 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		contextID := *node.UniqueId
 		// There is a race condition that the subnetset controller may delete the
 		// subnet during CollectGarbage. So check the subnet under lock.
-		r.SubnetService.RLockSubnet(&nsxSubnetPath)
-		defer r.SubnetService.RUnlockSubnet(&nsxSubnetPath)
+		lock := r.SubnetService.RLockSubnet(&nsxSubnetPath)
+		defer r.SubnetService.RUnlockSubnet(&nsxSubnetPath, lock)
 
 		nsxSubnet, err := r.SubnetService.GetSubnetByPath(nsxSubnetPath)
 		if err != nil {

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -111,8 +111,8 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		// There is a race condition that the subnetset controller may delete the
 		// subnet during CollectGarbage. So check the subnet under lock.
-		r.SubnetService.RLockSubnet(&nsxSubnetPath)
-		defer r.SubnetService.RUnlockSubnet(&nsxSubnetPath)
+		lock := r.SubnetService.RLockSubnet(&nsxSubnetPath)
+		defer r.SubnetService.RUnlockSubnet(&nsxSubnetPath, lock)
 
 		nsxSubnet, err := r.SubnetService.GetSubnetByPath(nsxSubnetPath)
 		if err != nil {

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -381,9 +381,9 @@ func (r *SubnetSetReconciler) deleteSubnets(nsxSubnets []*model.VpcSubnet, delet
 	}
 	var deleteErrs []error
 	for _, nsxSubnet := range nsxSubnets {
-		r.SubnetService.LockSubnet(nsxSubnet.Path)
+		lock := r.SubnetService.LockSubnet(nsxSubnet.Path)
 		func() {
-			defer r.SubnetService.UnlockSubnet(nsxSubnet.Path)
+			defer r.SubnetService.UnlockSubnet(nsxSubnet.Path, lock)
 
 			portNums := len(r.SubnetPortService.GetPortsOfSubnet(*nsxSubnet.Id))
 			if portNums > 0 {

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"sync"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -79,19 +81,19 @@ func (m *MockSubnetServiceProvider) GenerateSubnetNSTags(obj client.Object) []mo
 	return []model.Tag{}
 }
 
-func (m *MockSubnetServiceProvider) LockSubnet(path *string) {
+func (m *MockSubnetServiceProvider) LockSubnet(path *string) *sync.RWMutex {
+	return nil
+}
+
+func (m *MockSubnetServiceProvider) UnlockSubnet(path *string, lock *sync.RWMutex) {
 	return
 }
 
-func (m *MockSubnetServiceProvider) UnlockSubnet(path *string) {
-	return
+func (m *MockSubnetServiceProvider) RLockSubnet(path *string) *sync.RWMutex {
+	return nil
 }
 
-func (m *MockSubnetServiceProvider) RLockSubnet(path *string) {
-	return
-}
-
-func (m *MockSubnetServiceProvider) RUnlockSubnet(path *string) {
+func (m *MockSubnetServiceProvider) RUnlockSubnet(path *string, lock *sync.RWMutex) {
 	return
 }
 

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"sync"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,10 +31,10 @@ type SubnetServiceProvider interface {
 	GetSubnetsByIndex(key, value string) []*model.VpcSubnet
 	CreateOrUpdateSubnet(obj client.Object, vpcInfo VPCResourceInfo, tags []model.Tag) (string, error)
 	GenerateSubnetNSTags(obj client.Object) []model.Tag
-	LockSubnet(path *string)
-	UnlockSubnet(path *string)
-	RLockSubnet(path *string)
-	RUnlockSubnet(path *string)
+	LockSubnet(path *string) *sync.RWMutex
+	UnlockSubnet(path *string, lock *sync.RWMutex)
+	RLockSubnet(path *string) *sync.RWMutex
+	RUnlockSubnet(path *string, lock *sync.RWMutex)
 }
 
 type SubnetPortServiceProvider interface {

--- a/pkg/nsx/services/subnet/store.go
+++ b/pkg/nsx/services/subnet/store.go
@@ -95,28 +95,18 @@ func (subnetStore *SubnetStore) Delete(i interface{}) error {
 	return subnetStore.ResourceStore.Delete(i)
 }
 
-func (subnetStore *SubnetStore) Lock(path string) {
+func (subnetStore *SubnetStore) Lock(path string) *sync.RWMutex {
 	lock := sync.RWMutex{}
 	subnetLock, _ := subnetStore.pathLocks.LoadOrStore(path, &lock)
 	subnetLock.(*sync.RWMutex).Lock()
+	return subnetLock.(*sync.RWMutex)
 }
 
-func (subnetStore *SubnetStore) Unlock(path string) {
-	if subnetLock, existed := subnetStore.pathLocks.Load(path); existed {
-		subnetLock.(*sync.RWMutex).Unlock()
-	}
-}
-
-func (subnetStore *SubnetStore) RLock(path string) {
+func (subnetStore *SubnetStore) RLock(path string) *sync.RWMutex {
 	lock := sync.RWMutex{}
 	subnetLock, _ := subnetStore.pathLocks.LoadOrStore(path, &lock)
 	subnetLock.(*sync.RWMutex).RLock()
-}
-
-func (subnetStore *SubnetStore) RUnlock(path string) {
-	if subnetLock, existed := subnetStore.pathLocks.Load(path); existed {
-		subnetLock.(*sync.RWMutex).RUnlock()
-	}
+	return subnetLock.(*sync.RWMutex)
 }
 
 func (subnetStore *SubnetStore) Apply(i interface{}) error {

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -479,30 +479,36 @@ func (service *SubnetService) UpdateSubnetSet(ns string, vpcSubnets []*model.Vpc
 	return nil
 }
 
-func (service *SubnetService) LockSubnet(path *string) {
+func (service *SubnetService) LockSubnet(path *string) *sync.RWMutex {
 	if path != nil && *path != "" {
 		log.V(1).Info("Locked Subnet for writing", "path", *path)
-		service.SubnetStore.Lock(*path)
+		return service.SubnetStore.Lock(*path)
+	}
+	return nil
+}
+
+func (service *SubnetService) UnlockSubnet(path *string, lock *sync.RWMutex) {
+	if lock != nil {
+		if path != nil && *path != "" {
+			log.V(1).Info("Unlocked Subnet for writing", "path", *path)
+		}
+		lock.Unlock()
 	}
 }
 
-func (service *SubnetService) UnlockSubnet(path *string) {
-	if path != nil && *path != "" {
-		log.V(1).Info("Unlocked Subnet for writing", "path", *path)
-		service.SubnetStore.Unlock(*path)
-	}
-}
-
-func (service *SubnetService) RLockSubnet(path *string) {
+func (service *SubnetService) RLockSubnet(path *string) *sync.RWMutex {
 	if path != nil && *path != "" {
 		log.V(1).Info("Locked Subnet for reading", "path", *path)
-		service.SubnetStore.RLock(*path)
+		return service.SubnetStore.RLock(*path)
 	}
+	return nil
 }
 
-func (service *SubnetService) RUnlockSubnet(path *string) {
-	if path != nil && *path != "" {
-		log.V(1).Info("Unlocked Subnet for reading", "path", *path)
-		service.SubnetStore.RUnlock(*path)
+func (service *SubnetService) RUnlockSubnet(path *string, lock *sync.RWMutex) {
+	if lock != nil {
+		if path != nil && *path != "" {
+			log.V(1).Info("Unlocked Subnet for reading", "path", *path)
+		}
+		lock.RUnlock()
 	}
 }


### PR DESCRIPTION
Currently we delete the Subnet lock from the store when Subnet is deleted. And the unlock
function still tries to get the lock from the store, which will fail and be skipped. This results
in other resources waiting for this lock will never be able to get the lock.

This PR returns the lock reference when locking the subnet so that the caller can always unlock
even if the lock is deleted from the store.

Testing done: Decrease the gc interval to 10s and create 32 pods, all pods reach Running status.