### PR TITLE
Truncate VPC display name if it exceeds 80 chars

### DIFF
--- a/pkg/nsx/services/vpc/builder.go
+++ b/pkg/nsx/services/vpc/builder.go
@@ -67,7 +67,7 @@ func buildNSXVPC(obj *v1alpha1.NetworkInfo, nsObj *v1.Namespace, nc common.VPCNe
 		*vpc = *nsxVPC
 	} else {
 		// for creating vpc case, fill in vpc properties based on networkconfig
-		vpcName := util.GenerateIDByObjectByLimit(obj, common.MaxNameLength)
+		vpcName := util.GenerateIDByObjectByLimit(obj, common.MaxSubnetNameLength)
 		vpc.DisplayName = &vpcName
 		vpc.Id = common.String(util.GenerateIDByObject(obj))
 		vpc.IpAddressType = &DefaultVPCIPAddressType


### PR DESCRIPTION
VPC display name needs to be <=80 when VPC in VC is enabled.

Tests:
For a NetworkInfo obj with Name: "test-ns-03a2def3-0087-4077-904e-23e4dd788fb7" and UID: "ecc6eb9f-92b5-4893-b809-e3ebc1fcf59e",
test that the VPC name created is truncated to ""test-ns-03a2def3-0087-4077-904e-23e4dd788fb7_f4f0080e".