### PR TITLE
Refactor Subnet lock for SubnetPort creation

### DIFF
--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -120,7 +120,7 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 					Return([]*model.VpcSubnet{})
 				ssp.(*pkg_mock.MockSubnetServiceProvider).On("GenerateSubnetNSTags", mock.Anything)
 				vsp.(*pkg_mock.MockVPCServiceProvider).On("ListVPCInfo", mock.Anything).Return([]servicecommon.VPCResourceInfo{{}})
-				ssp.(*pkg_mock.MockSubnetServiceProvider).On("CreateOrUpdateSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(expectedSubnetPath, nil)
+				ssp.(*pkg_mock.MockSubnetServiceProvider).On("CreateOrUpdateSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&model.VpcSubnet{Path: &expectedSubnetPath}, nil)
 			},
 			expectedResult: expectedSubnetPath,
 		},

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -194,6 +194,7 @@ func (r *SubnetReconciler) deleteSubnets(nsxSubnets []*model.VpcSubnet) error {
 			log.Error(err, "Failed to delete Subnet", "ID", *nsxSubnet.Id)
 			return err
 		}
+		r.SubnetPortService.DeletePortCount(*nsxSubnet.Path)
 		log.Info("Successfully deleted Subnet", "ID", *nsxSubnet.Id)
 	}
 	log.Info("Successfully cleaned Subnets", "subnetCount", len(nsxSubnets))

--- a/pkg/controllers/subnet/subnet_controller_test.go
+++ b/pkg/controllers/subnet/subnet_controller_test.go
@@ -53,9 +53,9 @@ func TestSubnetReconciler_GarbageCollector(t *testing.T) {
 					tags2 := []model.Tag{{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-id2")}}
 					var nsxSubnets []*model.VpcSubnet
 					id1 := "fake-id1"
-					nsxSubnets = append(nsxSubnets, &model.VpcSubnet{Id: &id1, Tags: tags1})
+					nsxSubnets = append(nsxSubnets, &model.VpcSubnet{Id: &id1, Tags: tags1, Path: common.String("fake-path")})
 					id2 := "fake-id2"
-					nsxSubnets = append(nsxSubnets, &model.VpcSubnet{Id: &id2, Tags: tags2})
+					nsxSubnets = append(nsxSubnets, &model.VpcSubnet{Id: &id2, Tags: tags2, Path: common.String("fake-path")})
 					return nsxSubnets
 				})
 				patch.ApplyMethod(reflect.TypeOf(r.SubnetPortService), "GetPortsOfSubnet", func(_ *subnetport.SubnetPortService, _ string) (ports []*model.VpcSubnetPort) {
@@ -63,6 +63,9 @@ func TestSubnetReconciler_GarbageCollector(t *testing.T) {
 				})
 				patch.ApplyMethod(reflect.TypeOf(r.SubnetService), "DeleteSubnet", func(_ *subnet.SubnetService, subnet model.VpcSubnet) error {
 					return nil
+				})
+				patch.ApplyMethod(reflect.TypeOf(r.SubnetPortService), "DeletePortCount", func(_ *subnetport.SubnetPortService, _ string) {
+					return
 				})
 				return patch
 			},
@@ -272,6 +275,9 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "DeleteSubnet", func(_ *subnet.SubnetService, subnet model.VpcSubnet) error {
 					return nil
 				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetPortService), "DeletePortCount", func(_ *subnetport.SubnetPortService, _ string) {
+					return
+				})
 				return patches
 			},
 			expectRes:        ResultNormal,
@@ -342,6 +348,9 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 				})
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "DeleteSubnet", func(_ *subnet.SubnetService, subnet model.VpcSubnet) error {
 					return nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetPortService), "DeletePortCount", func(_ *subnetport.SubnetPortService, _ string) {
+					return
 				})
 				return patches
 			},
@@ -418,6 +427,9 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "DeleteSubnet", func(_ *subnet.SubnetService, subnet model.VpcSubnet) error {
 					return nil
 				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetPortService), "DeletePortCount", func(_ *subnetport.SubnetPortService, _ string) {
+					return
+				})
 				return patches
 			},
 			expectRes:        ResultNormal,
@@ -488,8 +500,8 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 						{OrgID: "org-id", ProjectID: "project-id", VPCID: "vpc-id", ID: "fake-id"},
 					}
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (string, error) {
-					return "", errors.New("create or update failed")
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (*model.VpcSubnet, error) {
+					return nil, errors.New("create or update failed")
 				})
 				return patches
 			},
@@ -521,8 +533,8 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 					}
 				})
 
-				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (string, error) {
-					return "", nil
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (*model.VpcSubnet, error) {
+					return nil, nil
 				})
 
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetByKey", func(_ *subnet.SubnetService, key string) (*model.VpcSubnet, error) {
@@ -575,8 +587,8 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 					}
 				})
 
-				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (string, error) {
-					return "", nil
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (*model.VpcSubnet, error) {
+					return nil, nil
 				})
 
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetByKey", func(_ *subnet.SubnetService, key string) (*model.VpcSubnet, error) {

--- a/pkg/controllers/subnetset/subnetset_controller_test.go
+++ b/pkg/controllers/subnetset/subnetset_controller_test.go
@@ -119,7 +119,7 @@ func createFakeSubnetSetReconciler(objs []client.Object) *SubnetSetReconciler {
 			Client:    nil,
 			NSXClient: &nsx.Client{},
 		},
-		SubnetPortStore: nil,
+		SubnetPortStore: &subnetport.SubnetPortStore{},
 	}
 
 	return &SubnetSetReconciler{
@@ -396,13 +396,8 @@ func TestReconcile_DeleteSubnetSet(t *testing.T) {
 					return nil
 				})
 
-				patches.ApplyMethod(reflect.TypeOf(r.SubnetPortService), "GetPortsOfSubnet", func(_ *subnetport.SubnetPortService, _ string) (ports []*model.VpcSubnetPort) {
-					id := "fake-subnetport-0"
-					return []*model.VpcSubnetPort{
-						{
-							Id: &id,
-						},
-					}
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetPortService), "IsEmptySubnet", func(_ *subnetport.SubnetPortService, _ string) bool {
+					return false
 				})
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "DeleteSubnet", func(_ *subnet.SubnetService, subnet model.VpcSubnet) error {
 					return nil

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -1,8 +1,6 @@
 package mock
 
 import (
-	"sync"
-
 	"github.com/stretchr/testify/mock"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -71,9 +69,9 @@ func (m *MockSubnetServiceProvider) GetSubnetsByIndex(key, value string) []*mode
 	return arg.Get(0).([]*model.VpcSubnet)
 }
 
-func (m *MockSubnetServiceProvider) CreateOrUpdateSubnet(obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (string, error) {
+func (m *MockSubnetServiceProvider) CreateOrUpdateSubnet(obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (*model.VpcSubnet, error) {
 	arg := m.Called(obj, vpcInfo, tags)
-	return arg.Get(0).(string), arg.Error(1)
+	return arg.Get(0).(*model.VpcSubnet), arg.Error(1)
 }
 
 func (m *MockSubnetServiceProvider) GenerateSubnetNSTags(obj client.Object) []model.Tag {
@@ -81,26 +79,26 @@ func (m *MockSubnetServiceProvider) GenerateSubnetNSTags(obj client.Object) []mo
 	return []model.Tag{}
 }
 
-func (m *MockSubnetServiceProvider) LockSubnet(path *string) *sync.RWMutex {
-	return nil
-}
-
-func (m *MockSubnetServiceProvider) UnlockSubnet(path *string, lock *sync.RWMutex) {
-	return
-}
-
-func (m *MockSubnetServiceProvider) RLockSubnet(path *string) *sync.RWMutex {
-	return nil
-}
-
-func (m *MockSubnetServiceProvider) RUnlockSubnet(path *string, lock *sync.RWMutex) {
-	return
-}
-
 type MockSubnetPortServiceProvider struct {
 	mock.Mock
 }
 
 func (m *MockSubnetPortServiceProvider) GetPortsOfSubnet(nsxSubnetID string) (ports []*model.VpcSubnetPort) {
+	return
+}
+
+func (m *MockSubnetPortServiceProvider) AllocatePortFromSubnet(subnet *model.VpcSubnet) bool {
+	return true
+}
+
+func (m *MockSubnetPortServiceProvider) ReleasePortInSubnet(path string) {
+	return
+}
+
+func (m *MockSubnetPortServiceProvider) IsEmptySubnet(id string, path string) bool {
+	return true
+}
+
+func (m *MockSubnetPortServiceProvider) DeletePortCount(path string) {
 	return
 }

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"sync"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,16 +28,16 @@ type SubnetServiceProvider interface {
 	GetSubnetByKey(key string) (*model.VpcSubnet, error)
 	GetSubnetByPath(path string) (*model.VpcSubnet, error)
 	GetSubnetsByIndex(key, value string) []*model.VpcSubnet
-	CreateOrUpdateSubnet(obj client.Object, vpcInfo VPCResourceInfo, tags []model.Tag) (string, error)
+	CreateOrUpdateSubnet(obj client.Object, vpcInfo VPCResourceInfo, tags []model.Tag) (*model.VpcSubnet, error)
 	GenerateSubnetNSTags(obj client.Object) []model.Tag
-	LockSubnet(path *string) *sync.RWMutex
-	UnlockSubnet(path *string, lock *sync.RWMutex)
-	RLockSubnet(path *string) *sync.RWMutex
-	RUnlockSubnet(path *string, lock *sync.RWMutex)
 }
 
 type SubnetPortServiceProvider interface {
 	GetPortsOfSubnet(nsxSubnetID string) (ports []*model.VpcSubnetPort)
+	AllocatePortFromSubnet(subnet *model.VpcSubnet) bool
+	ReleasePortInSubnet(path string)
+	IsEmptySubnet(id string, path string) bool
+	DeletePortCount(path string)
 }
 
 type NodeServiceReader interface {

--- a/pkg/nsx/services/subnet/store.go
+++ b/pkg/nsx/services/subnet/store.go
@@ -2,7 +2,6 @@ package subnet
 
 import (
 	"errors"
-	"sync"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
@@ -70,43 +69,6 @@ func subnetSetIndexFunc(obj interface{}) ([]string, error) {
 // SubnetStore is a store for subnet.
 type SubnetStore struct {
 	common.ResourceStore
-	// save locks for subnet by path
-	pathLocks sync.Map
-}
-
-func (subnetStore *SubnetStore) Add(i interface{}) error {
-	subnet := i.(*model.VpcSubnet)
-	if subnet.Path == nil {
-		log.Info("Store a subnet without path", "subnet", subnet)
-		return subnetStore.ResourceStore.Add(i)
-	}
-	lock := sync.RWMutex{}
-	subnetStore.pathLocks.LoadOrStore(*subnet.Path, &lock)
-	return subnetStore.ResourceStore.Add(i)
-}
-
-func (subnetStore *SubnetStore) Delete(i interface{}) error {
-	subnet := i.(*model.VpcSubnet)
-	if subnet.Path == nil {
-		log.Info("Delete a subnet without path", "subnet", subnet)
-		return subnetStore.ResourceStore.Delete(i)
-	}
-	subnetStore.pathLocks.Delete(*subnet.Path)
-	return subnetStore.ResourceStore.Delete(i)
-}
-
-func (subnetStore *SubnetStore) Lock(path string) *sync.RWMutex {
-	lock := sync.RWMutex{}
-	subnetLock, _ := subnetStore.pathLocks.LoadOrStore(path, &lock)
-	subnetLock.(*sync.RWMutex).Lock()
-	return subnetLock.(*sync.RWMutex)
-}
-
-func (subnetStore *SubnetStore) RLock(path string) *sync.RWMutex {
-	lock := sync.RWMutex{}
-	subnetLock, _ := subnetStore.pathLocks.LoadOrStore(path, &lock)
-	subnetLock.(*sync.RWMutex).RLock()
-	return subnetLock.(*sync.RWMutex)
 }
 
 func (subnetStore *SubnetStore) Apply(i interface{}) error {

--- a/pkg/nsx/services/subnet/subnet_test.go
+++ b/pkg/nsx/services/subnet/subnet_test.go
@@ -199,7 +199,7 @@ func TestInitializeSubnetService(t *testing.T) {
 			},
 			subnetCRTags:                  []model.Tag{},
 			expectAllSubnetNumAfterCreate: 1,
-			expectCreateSubnetUID:         fakeSubnetPath,
+			expectCreateSubnetUID:         nsxSubnetID,
 		},
 		{
 			name:             "Subnet exists and not change",
@@ -232,7 +232,7 @@ func TestInitializeSubnetService(t *testing.T) {
 			},
 			expectAllSubnetNum:            1,
 			expectAllSubnetNumAfterCreate: 1,
-			expectCreateSubnetUID:         subnetID,
+			expectCreateSubnetUID:         nsxSubnetID,
 		},
 		{
 			name:             "Subnet exists and changed",
@@ -267,7 +267,7 @@ func TestInitializeSubnetService(t *testing.T) {
 			},
 			expectAllSubnetNum:            1,
 			expectAllSubnetNumAfterCreate: 1,
-			expectCreateSubnetUID:         fakeSubnetPath,
+			expectCreateSubnetUID:         nsxSubnetID,
 		},
 	}
 
@@ -307,9 +307,9 @@ func TestInitializeSubnetService(t *testing.T) {
 			res := service.ListAllSubnet()
 			assert.Equal(t, tc.expectAllSubnetNum, len(res))
 
-			createdNSXSubnetUID, err := service.CreateOrUpdateSubnet(tc.existingSubnetCR, *tc.existingVPCInfo, tc.subnetCRTags)
+			createdNSXSubnet, err := service.CreateOrUpdateSubnet(tc.existingSubnetCR, *tc.existingVPCInfo, tc.subnetCRTags)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expectCreateSubnetUID, createdNSXSubnetUID)
+			assert.Equal(t, tc.expectCreateSubnetUID, *createdNSXSubnet.Id)
 
 			res = service.ListAllSubnet()
 
@@ -398,8 +398,8 @@ func TestSubnetService_UpdateSubnetSet(t *testing.T) {
 	})
 
 	patchesCreateOrUpdateSubnet := gomonkey.ApplyFunc((*SubnetService).createOrUpdateSubnet,
-		func(r *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo) (string, error) {
-			return fakeSubnetPath, nil
+		func(r *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo) (*model.VpcSubnet, error) {
+			return &model.VpcSubnet{Path: &fakeSubnetPath}, nil
 		})
 	defer patchesCreateOrUpdateSubnet.Reset()
 

--- a/pkg/nsx/services/subnetport/store.go
+++ b/pkg/nsx/services/subnetport/store.go
@@ -2,6 +2,7 @@ package subnetport
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"k8s.io/apimachinery/pkg/types"
@@ -88,6 +89,17 @@ func subnetPortIndexPodNamespace(obj interface{}) ([]string, error) {
 // SubnetPortStore is a store for SubnetPorts
 type SubnetPortStore struct {
 	common.ResourceStore
+	// PortCountInfo stores the Subnet and the information
+	// regarding SubnetPort count on that Subnet
+	PortCountInfo sync.Map
+}
+
+type CountInfo struct {
+	// dirtyCount defines the number of SubnetPorts under creation in the Subnet
+	dirtyCount int
+	lock       sync.Mutex
+	// totalIp defines the number of available IP in the Subnet
+	totalIp int
 }
 
 func (vs *SubnetPortStore) Apply(i interface{}) error {

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -813,6 +813,24 @@ func TestSubnetPortService_ListSubnetPortByPodName(t *testing.T) {
 	assert.Equal(t, subnetPort2, subnetPorts[0])
 }
 
+func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
+	subnetPath := "subnet-path-1"
+	subnetId := "subnet-id-1"
+	subnetPortService := createSubnetPortService()
+	ok := subnetPortService.AllocatePortFromSubnet(&model.VpcSubnet{
+		Ipv4SubnetSize: common.Int64(16),
+		IpAddresses:    []string{"10.0.0.1/28"},
+		Path:           &subnetPath,
+		Id:             &subnetId,
+	})
+	assert.True(t, ok)
+	empty := subnetPortService.IsEmptySubnet(subnetId, subnetPath)
+	assert.False(t, empty)
+	subnetPortService.ReleasePortInSubnet(subnetPath)
+	empty = subnetPortService.IsEmptySubnet(subnetId, subnetPath)
+	assert.True(t, empty)
+}
+
 func createSubnetPortService() *SubnetPortService {
 	return &SubnetPortService{
 		SubnetPortStore: &SubnetPortStore{ResourceStore: common.ResourceStore{


### PR DESCRIPTION
Instead of using lock for Subnet, this PR adds a cache in SubnetPort service
to record the number of SubnetPorts on each Subnet.
Read/Write operation for this cache is protected by lock to avoid race condition
and ensure the number of SubnetPort on the Subnet will be controlled below
the Subnet capacity.

Testing done:
- Create 16 Pods on default SubnetSet with size 16 (capacity 12), got all Pods ready; 
   delete all Pods and observe the Subnets under the SubnetSet will be deleted by GC.
- Create 16 VMs on DHCPServer SubnetSet with size 16 (capacity 12), all Vms can get IP; 
   delete all VMs and observe the Subnet under the SubnetSet will be deleted by GC.
- Create 16 VMs on DHCPServer Subnet with size 16 (capacity 12), only 12 VMs can PowerOn
   and get IP. The remainings will have `VirtualMachineNetworkReady` as `NotReady` and
   Message like `network interface "eth0" error: subnetPort is not ready: SubnetPortNotReady - error occurred while processing the SubnetPort CR. Error: no valid IP in Subnet /orgs/default/projects/project-quality/vpcs/ns-1_7fcad11c-da38-4137-96ec-f0f80ae8d96b/subnets/subnet-test-1_60ebfa36-bbe2-4e6e-85df-8228be4e190a`
