### PR TITLE
Fix Subnet update error detection

### DIFF
--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -70,7 +70,7 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (
 		if dhcpMode == "" {
 			dhcpMode = v1alpha1.DHCPConfigModeDeactivated
 		}
-		nsxSubnet.SubnetDhcpConfig = service.buildSubnetDHCPConfig(dhcpMode)
+		nsxSubnet.SubnetDhcpConfig = service.buildSubnetDHCPConfig(dhcpMode, nil)
 		nsxSubnet.IpAddresses = o.Spec.IPAddresses
 	case *v1alpha1.SubnetSet:
 		// The index is a random string with the length of 8 chars. It is the first 8 chars of the hash
@@ -87,7 +87,7 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (
 		if dhcpMode == "" {
 			dhcpMode = v1alpha1.DHCPConfigModeDeactivated
 		}
-		nsxSubnet.SubnetDhcpConfig = service.buildSubnetDHCPConfig(dhcpMode)
+		nsxSubnet.SubnetDhcpConfig = service.buildSubnetDHCPConfig(dhcpMode, nil)
 	default:
 		return nil, SubnetTypeError
 	}
@@ -105,10 +105,11 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag) (
 	return nsxSubnet, nil
 }
 
-func (service *SubnetService) buildSubnetDHCPConfig(mode string) *model.SubnetDhcpConfig {
+func (service *SubnetService) buildSubnetDHCPConfig(mode string, dhcpServerAdditionalConfig *model.DhcpServerAdditionalConfig) *model.SubnetDhcpConfig {
 	nsxMode := nsxutil.ParseDHCPMode(mode)
 	subnetDhcpConfig := &model.SubnetDhcpConfig{
-		Mode: &nsxMode,
+		DhcpServerAdditionalConfig: dhcpServerAdditionalConfig,
+		Mode:                       &nsxMode,
 	}
 	return subnetDhcpConfig
 }


### PR DESCRIPTION
Operator modifies the existing Subnet in store before updating the NSX Subnet,
which results in the next reconcile will find the updated Subnet already in store,
skip the update, and overwrite the Status as Ready.
This PR uses a copy when updating the Subnet to avoid this issue.