### PR TITLE
New string generator for the hash string in NSX resources

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	HashLength                         int    = 8
+	Base62HashLength                   int    = 6
 	MaxTagsCount                       int    = 26
 	MaxTagScopeLength                  int    = 128
 	MaxTagValueLength                  int    = 256

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -1274,8 +1274,8 @@ func Test_BuildSecurityPolicyName(t *testing.T) {
 				},
 			},
 			createdFor: common.ResourceTypeNetworkPolicy,
-			expName:    fmt.Sprintf("%s_c64163f0", strings.Repeat("a", 246)),
-			expId:      fmt.Sprintf("%s_fb85d834", strings.Repeat("a", 246)),
+			expName:    fmt.Sprintf("%s_shQDwf", strings.Repeat("a", 248)),
+			expId:      fmt.Sprintf("%s_zT4Byn", strings.Repeat("a", 248)),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/nsx/services/vpc/builder_test.go
+++ b/pkg/nsx/services/vpc/builder_test.go
@@ -171,7 +171,7 @@ func TestBuildNSXVPC(t *testing.T) {
 			},
 			expVPC: &model.Vpc{
 				Id:            common.String("test-ns-03a2def3-0087-4077-904e-23e4dd788fb7_ecc6eb9f-92b5-4893-b809-e3ebc1fcf59e"),
-				DisplayName:   common.String("test-ns-03a2def3-0087-4077-904e-23e4dd788fb7_f4f0080e"),
+				DisplayName:   common.String("test-ns-03a2def3-0087-4077-904e-23e4dd788fb7_yWOLBB"),
 				PrivateIps:    []string{"192.168.3.0/24"},
 				IpAddressType: common.String("IPV4"),
 				Tags: []model.Tag{

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -12,14 +12,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
-
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
 func TestSha1(t *testing.T) {
@@ -28,16 +30,16 @@ func TestSha1(t *testing.T) {
 
 func TestNormalizeName(t *testing.T) {
 	shortName := strings.Repeat("a", 256)
-	assert.Equal(t, NormalizeName(shortName), shortName)
+	assert.Equal(t, NormalizeName(shortName, truncateLabelHash), shortName)
 	longName := strings.Repeat("a", 257)
-	assert.Equal(t, NormalizeName(longName), fmt.Sprintf("%s_%s", strings.Repeat("a", 256-common.HashLength-1), "0c103888"))
+	assert.Equal(t, NormalizeName(longName, truncateLabelHash), fmt.Sprintf("%s_%s", strings.Repeat("a", 256-common.HashLength-1), "0c103888"))
 }
 
 func TestNormalizeLabelKey(t *testing.T) {
 	shortKey := strings.Repeat("a", 128)
-	assert.Equal(t, NormalizeLabelKey(shortKey), shortKey)
+	assert.Equal(t, NormalizeLabelKey(shortKey, truncateLabelHash), shortKey)
 	longKey := strings.Repeat("a", 129) + "/def"
-	assert.Equal(t, NormalizeLabelKey(longKey), "def")
+	assert.Equal(t, NormalizeLabelKey(longKey, truncateLabelHash), "def")
 }
 
 func TestNormalizeLabels(t *testing.T) {
@@ -55,7 +57,7 @@ func TestNormalizeLabels(t *testing.T) {
 				longKey: longValue,
 			},
 			expectedLabels: &map[string]string{
-				"def": NormalizeName(longValue),
+				"def": NormalizeName(longValue, truncateLabelHash),
 			},
 		},
 		{
@@ -64,7 +66,7 @@ func TestNormalizeLabels(t *testing.T) {
 				shortKey: longValue,
 			},
 			expectedLabels: &map[string]string{
-				shortKey: NormalizeName(longValue),
+				shortKey: NormalizeName(longValue, truncateLabelHash),
 			},
 		},
 	}
@@ -500,7 +502,7 @@ func TestGenerateTruncName(t *testing.T) {
 				project:  strings.Repeat("s", 300),
 				cluster:  "k8scl-one",
 			},
-			want: "sr_k8scl-one_1234-456_ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss_e89b45cc_scope",
+			want: "sr_k8scl-one_1234-456_ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss_xbJrtX_scope",
 		},
 	}
 	for _, tt := range tests {
@@ -660,13 +662,13 @@ func TestGenerateIDByObject(t *testing.T) {
 			name:  "truncate with hash on uid",
 			obj:   &metav1.ObjectMeta{Name: "abcdefg", UID: "b720ee2c-5788-4680-9796-0f93db33d8a9"},
 			limit: 20,
-			expID: "abcdefg_df78acb2",
+			expID: "abcdefg_vSV1eZ",
 		},
 		{
 			name:  "longer name with truncate",
 			obj:   &metav1.ObjectMeta{Name: strings.Repeat("a", 256), UID: "b720ee2c-5788-4680-9796-0f93db33d8a9"},
 			limit: 0,
-			expID: fmt.Sprintf("%s_df78acb2", strings.Repeat("a", 246)),
+			expID: fmt.Sprintf("%s_vSV1eZ", strings.Repeat("a", 248)),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -701,7 +703,7 @@ func TestGenerateIDByObjectWithSuffix(t *testing.T) {
 			obj:    &metav1.ObjectMeta{Name: strings.Repeat("a", 256), UID: "b720ee2c-5788-4680-9796-0f93db33d8a9"},
 			limit:  0,
 			suffix: "28e85c0b-21e4-4cab-b1c3-597639dfe752",
-			expID:  fmt.Sprintf("%s_df78acb2_28e85c0b-21e4-4cab-b1c3-597639dfe752", strings.Repeat("a", 209)),
+			expID:  fmt.Sprintf("%s_vSV1eZ_28e85c0b-21e4-4cab-b1c3-597639dfe752", strings.Repeat("a", 211)),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -733,4 +735,21 @@ func TestConnectStrings(t *testing.T) {
 	expString = "aa" + common.ConnectorUnderline + "22"
 	expString = fmt.Sprintf("%s%s%d", string1, common.ConnectorUnderline, int2)
 	assert.Equal(t, connectString, expString)
+}
+
+func TestNewSha1(t *testing.T) {
+	assert.Equal(t, "ffN5UpVkkQYbocYDKFXOAMN4AsA", Sha1WithBase62("name"))
+	assert.Equal(t, "hZBZpydbX1XIFhgs9m6Lt2for9m", Sha1WithBase62("namee"))
+
+	allowedChars := sets.New[rune]()
+	for _, c := range base62Chars {
+		allowedChars.Insert(c)
+	}
+	randUID, err := uuid.NewRandom()
+	require.NoError(t, err)
+	hashString := Sha1WithBase62(randUID.String())
+	// Verify all chars in the hash string are contained in base62Chars.
+	for _, c := range hashString {
+		assert.True(t, allowedChars.Has(c))
+	}
 }


### PR DESCRIPTION
1. Use chars 0-9,a-z,A-Z to generate the hash string for ID/DisplayName in NSX resources with VPC scenario. It also works on the Security Policy related resources' display name in T1.
2. The length is 6 chars when using the new hash string function.

Test Done:
1. VPC pipeline has passed, the supervisor is running, and the cluster status is ready.
2. T1 pipeline has passed.

Manual Verification
1. Created a subnetset with a long name which is longer than 80 char:
```
# k get subnetset -n antrea-test
NAME                                                                           ACCESSMODE   IPV4SUBNETSIZE   NETWORKADDRESSES
subnetset-sample-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   Private      64               172.26.0.0/26
```
2. Created a VM using the subnetset to enforce a NSX subnet is created,
3. Check the NSX subnet configurations, and observed its display name is shorter than 80 chars and all chars are allowed.
```
{
    "ipv4_subnet_size": 64,
    "access_mode": "Private",
    "ip_addresses": [
        "172.26.0.0/26"
    ],
    "advanced_config": {
        "static_ip_allocation": {
            "enabled": true
        },
        "connectivity_state": "CONNECTED",
        "gateway_addresses": [
            "172.26.0.1/26"
        ]
    },
    "ip_blocks": [
        "/orgs/default/projects/project-quality/infra/ip-blocks/antrea-test_5110d687-625f-4d36-8a69-3642a46eaa15-172_26_0_0_16"
    ],
    "subnet_dhcp_config": {
        "mode": "DHCP_DEACTIVATED"
    },
    "resource_type": "VpcSubnet",
    "id": "subnetset-sample-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_ccfb9059-fc0f-4eb9-945e-10c525630f25_7316e37e",
    "display_name": "subnetset-sample-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_qepgkF_7316e37e",
    "tags": [
        {
            "scope": "nsx-op/cluster",
            "tag": "1ea68964-9a4a-465d-98ec-e0cf5b49088e"
        },
        {
            "scope": "nsx-op/version",
            "tag": "1.0.0"
        },
        {
            "scope": "nsx-op/subnetset_name",
            "tag": "subnetset-sample-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
        },
        {
            "scope": "nsx-op/subnetset_uid",
            "tag": "ccfb9059-fc0f-4eb9-945e-10c525630f25"
        },
        {
            "scope": "nsx-op/vm_namespace_uid",
            "tag": "a15e101c-1fe0-4eb2-b6e2-6afba280fd2b"
        },
        {
            "scope": "nsx-op/vm_namespace",
            "tag": "antrea-test"
        },
        {
            "scope": "kubernetes.io/metadata.name",
            "tag": "antrea-test"
        },
        {
            "scope": "vSphereClusterID",
            "tag": "domain-c11"
        }
    ],
    "path": "/orgs/default/projects/project-quality/vpcs/antrea-test_5110d687-625f-4d36-8a69-3642a46eaa15/subnets/subnetset-sample-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_ccfb9059-fc0f-4eb9-945e-10c525630f25_7316e37e",
    "relative_path": "subnetset-sample-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_ccfb9059-fc0f-4eb9-945e-10c525630f25_7316e37e",
    "parent_path": "/orgs/default/projects/project-quality/vpcs/antrea-test_5110d687-625f-4d36-8a69-3642a46eaa15",
    "remote_path": "",
    "unique_id": "4d32b77d-3b82-4e7d-9166-4415eb4b8159",
    "realization_id": "4d32b77d-3b82-4e7d-9166-4415eb4b8159",
    "owner_id": "4150403c-990c-42e0-8a99-719a8ade14f3",
    "marked_for_delete": false,
    "overridden": false,
    "_create_time": 1736481273138,
    "_create_user": "wcp-cluster-user-1ea68964-9a4a-465d-98ec-e0cf5b49088e-fc8ae4db-0e7e-44bd-848f-b5964f0f9af2",
    "_last_modified_time": 1736481273138,
    "_last_modified_user": "wcp-cluster-user-1ea68964-9a4a-465d-98ec-e0cf5b49088e-fc8ae4db-0e7e-44bd-848f-b5964f0f9af2",
    "_system_owned": false,
    "_protection": "REQUIRE_OVERRIDE",
    "_revision": 0
}
```