### PR TITLE
[Cherry-Pick] New string generator for the hash string in NSX resources (#995)

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	HashLength                         int    = 8
+	Base62HashLength                   int    = 6
 	MaxTagsCount                       int    = 26
 	MaxTagScopeLength                  int    = 128
 	MaxTagValueLength                  int    = 256

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -1274,8 +1274,8 @@ func Test_BuildSecurityPolicyName(t *testing.T) {
 				},
 			},
 			createdFor: common.ResourceTypeNetworkPolicy,
-			expName:    fmt.Sprintf("%s_c64163f0", strings.Repeat("a", 246)),
-			expId:      fmt.Sprintf("%s_fb85d834", strings.Repeat("a", 246)),
+			expName:    fmt.Sprintf("%s_shQDwf", strings.Repeat("a", 248)),
+			expId:      fmt.Sprintf("%s_zT4Byn", strings.Repeat("a", 248)),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/nsx/services/vpc/builder_test.go
+++ b/pkg/nsx/services/vpc/builder_test.go
@@ -171,7 +171,7 @@ func TestBuildNSXVPC(t *testing.T) {
 			},
 			expVPC: &model.Vpc{
 				Id:            common.String("test-ns-03a2def3-0087-4077-904e-23e4dd788fb7_ecc6eb9f-92b5-4893-b809-e3ebc1fcf59e"),
-				DisplayName:   common.String("test-ns-03a2def3-0087-4077-904e-23e4dd788fb7_f4f0080e"),
+				DisplayName:   common.String("test-ns-03a2def3-0087-4077-904e-23e4dd788fb7_yWOLBB"),
 				PrivateIps:    []string{"192.168.3.0/24"},
 				IpAddressType: common.String("IPV4"),
 				Tags: []model.Tag{

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -12,14 +12,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
-
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
 func TestSha1(t *testing.T) {
@@ -28,16 +30,16 @@ func TestSha1(t *testing.T) {
 
 func TestNormalizeName(t *testing.T) {
 	shortName := strings.Repeat("a", 256)
-	assert.Equal(t, NormalizeName(shortName), shortName)
+	assert.Equal(t, NormalizeName(shortName, truncateLabelHash), shortName)
 	longName := strings.Repeat("a", 257)
-	assert.Equal(t, NormalizeName(longName), fmt.Sprintf("%s_%s", strings.Repeat("a", 256-common.HashLength-1), "0c103888"))
+	assert.Equal(t, NormalizeName(longName, truncateLabelHash), fmt.Sprintf("%s_%s", strings.Repeat("a", 256-common.HashLength-1), "0c103888"))
 }
 
 func TestNormalizeLabelKey(t *testing.T) {
 	shortKey := strings.Repeat("a", 128)
-	assert.Equal(t, NormalizeLabelKey(shortKey), shortKey)
+	assert.Equal(t, NormalizeLabelKey(shortKey, truncateLabelHash), shortKey)
 	longKey := strings.Repeat("a", 129) + "/def"
-	assert.Equal(t, NormalizeLabelKey(longKey), "def")
+	assert.Equal(t, NormalizeLabelKey(longKey, truncateLabelHash), "def")
 }
 
 func TestNormalizeLabels(t *testing.T) {
@@ -55,7 +57,7 @@ func TestNormalizeLabels(t *testing.T) {
 				longKey: longValue,
 			},
 			expectedLabels: &map[string]string{
-				"def": NormalizeName(longValue),
+				"def": NormalizeName(longValue, truncateLabelHash),
 			},
 		},
 		{
@@ -64,7 +66,7 @@ func TestNormalizeLabels(t *testing.T) {
 				shortKey: longValue,
 			},
 			expectedLabels: &map[string]string{
-				shortKey: NormalizeName(longValue),
+				shortKey: NormalizeName(longValue, truncateLabelHash),
 			},
 		},
 	}
@@ -500,7 +502,7 @@ func TestGenerateTruncName(t *testing.T) {
 				project:  strings.Repeat("s", 300),
 				cluster:  "k8scl-one",
 			},
-			want: "sr_k8scl-one_1234-456_ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss_e89b45cc_scope",
+			want: "sr_k8scl-one_1234-456_ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss_xbJrtX_scope",
 		},
 	}
 	for _, tt := range tests {
@@ -660,13 +662,13 @@ func TestGenerateIDByObject(t *testing.T) {
 			name:  "truncate with hash on uid",
 			obj:   &metav1.ObjectMeta{Name: "abcdefg", UID: "b720ee2c-5788-4680-9796-0f93db33d8a9"},
 			limit: 20,
-			expID: "abcdefg_df78acb2",
+			expID: "abcdefg_vSV1eZ",
 		},
 		{
 			name:  "longer name with truncate",
 			obj:   &metav1.ObjectMeta{Name: strings.Repeat("a", 256), UID: "b720ee2c-5788-4680-9796-0f93db33d8a9"},
 			limit: 0,
-			expID: fmt.Sprintf("%s_df78acb2", strings.Repeat("a", 246)),
+			expID: fmt.Sprintf("%s_vSV1eZ", strings.Repeat("a", 248)),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -701,7 +703,7 @@ func TestGenerateIDByObjectWithSuffix(t *testing.T) {
 			obj:    &metav1.ObjectMeta{Name: strings.Repeat("a", 256), UID: "b720ee2c-5788-4680-9796-0f93db33d8a9"},
 			limit:  0,
 			suffix: "28e85c0b-21e4-4cab-b1c3-597639dfe752",
-			expID:  fmt.Sprintf("%s_df78acb2_28e85c0b-21e4-4cab-b1c3-597639dfe752", strings.Repeat("a", 209)),
+			expID:  fmt.Sprintf("%s_vSV1eZ_28e85c0b-21e4-4cab-b1c3-597639dfe752", strings.Repeat("a", 211)),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -733,4 +735,21 @@ func TestConnectStrings(t *testing.T) {
 	expString = "aa" + common.ConnectorUnderline + "22"
 	expString = fmt.Sprintf("%s%s%d", string1, common.ConnectorUnderline, int2)
 	assert.Equal(t, connectString, expString)
+}
+
+func TestNewSha1(t *testing.T) {
+	assert.Equal(t, "ffN5UpVkkQYbocYDKFXOAMN4AsA", Sha1WithBase62("name"))
+	assert.Equal(t, "hZBZpydbX1XIFhgs9m6Lt2for9m", Sha1WithBase62("namee"))
+
+	allowedChars := sets.New[rune]()
+	for _, c := range base62Chars {
+		allowedChars.Insert(c)
+	}
+	randUID, err := uuid.NewRandom()
+	require.NoError(t, err)
+	hashString := Sha1WithBase62(randUID.String())
+	// Verify all chars in the hash string are contained in base62Chars.
+	for _, c := range hashString {
+		assert.True(t, allowedChars.Has(c))
+	}
 }


### PR DESCRIPTION
1. Use chars 0-9,a-z,A-Z to generate the hash string for ID/DisplayName in NSX resources with VPC scenario. It also works on the Security Policy related resources' display name in T1.
2. The length is 6 chars when using the new hash string function.