### PR TITLE
Refine NetworkInfo CR VPCState.LoadBalancerIPAddresses description

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_networkinfos.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_networkinfos.yaml
@@ -44,8 +44,7 @@ spec:
                   description: Default SNAT IP for Private Subnets.
                   type: string
                 loadBalancerIPAddresses:
-                  description: LoadBalancerIPAddresses (AVI SE Subnet CIDR or NSX
-                    LB SNAT IPs).
+                  description: LoadBalancerIPAddresses (AVI SE Subnet CIDR).
                   type: string
                 name:
                   description: VPC name.

--- a/pkg/apis/vpc/v1alpha1/networkinfo_types.go
+++ b/pkg/apis/vpc/v1alpha1/networkinfo_types.go
@@ -35,7 +35,7 @@ type VPCState struct {
 	Name string `json:"name"`
 	// Default SNAT IP for Private Subnets.
 	DefaultSNATIP string `json:"defaultSNATIP"`
-	// LoadBalancerIPAddresses (AVI SE Subnet CIDR or NSX LB SNAT IPs).
+	// LoadBalancerIPAddresses (AVI SE Subnet CIDR).
 	LoadBalancerIPAddresses string `json:"loadBalancerIPAddresses,omitempty"`
 	// Private CIDRs used for the VPC.
 	PrivateIPs []string `json:"privateIPs,omitempty"`


### PR DESCRIPTION
In NSX LB, we don't set NSX LN SNAT IPs in NetworkInfo CR VPCState.LoadBalancerIPAddresses and leave it as empty.
So, removing the description of adding NSX LB IPs not to make users confuse.