### PR TITLE
Add keyFunc for shared resources

### DIFF
--- a/pkg/nsx/services/vpc/store.go
+++ b/pkg/nsx/services/vpc/store.go
@@ -19,6 +19,18 @@ func keyFunc(obj interface{}) (string, error) {
 		return generateVirtualServerKey(*v)
 	case *model.LBPool:
 		return generatePoolKey(*v)
+	case *model.SharedResource:
+		return *v.Path, nil
+	case *model.LBAppProfile:
+		return *v.Path, nil
+	case *model.TlsCertificate:
+		return *v.Path, nil
+	case *model.LBPersistenceProfile:
+		return *v.Path, nil
+	case *model.Share:
+		return *v.Path, nil
+	case *model.LBMonitorProfile:
+		return *v.Path, nil
 	default:
 		return "", errors.New("keyFunc doesn't support unknown type")
 	}


### PR DESCRIPTION
While listing the resources in cleanup, each resource type should be added in keyFunc.
Add shared resources to keyFunc

while disable cluster:
2025-01-23 06:38:28.141 ^[[34mINFO^[[0m ^[[33mvpc/vpc.go:1003^[[0m      Cleaning up sharedResources     {"Count": 0}
2025-01-23 06:38:28.335 ^[[31mERROR^[[0m        ^[[33mvpc/vpc.go:299^[[0m       Failed to query share   {"query": "resource_type:Share AND tags.scope:ncp\\/cluster AND tags.tag:af33355b-c022-4de2-b365-27644454a57f", "error": "couldn't create key for object &{Links:[] Schema:<nil> Self:<nil> Revision:0xc0057314c8 CreateTime:0xc005731418 CreateUser:0xc006dca4c0 LastModifiedTime:0xc0057313a8 LastModifiedUser:0xc006dca230 Protection:0xc006dca460 SystemOwned:0xc00573144f Description:<nil> DisplayName:0xc006dca250 Id:0xc006dca1f0 ResourceType:0xc006dca480 Tags:[{Scope:0xc006dca320 Tag:0xc006dca340} {Scope:0xc006dca3b0 Tag:0xc006dca3d0}] OriginSiteId:<nil> OwnerId:0xc006dca400 ParentPath:0xc006dca1a0 Path:0xc006dca420 RealizationId:0xc006dca180 RelativePath:0xc006dca440 RemotePath:0xc006dca270 UniqueId:0xc006dca210 Children:[] MarkedForDelete:0xc00573137f Overridden:0xc0057313ff SharedWith:[/orgs/default] SharingStrategy:0xc006dca4a0}: keyFunc doesn't support unknown type"}
2025-01-23 06:38:28.335 ^[[34mINFO^[[0m ^[[33mvpc/vpc.go:1018^[[0m      Cleaning up shares      {"Count": 0}

Test Done:
1. hack the code to only ListXXX function left
2. run the cleanup to check if the resources download

