### PR TITLE
Add keyFunc for shared resources

### DIFF
--- a/pkg/nsx/services/vpc/store.go
+++ b/pkg/nsx/services/vpc/store.go
@@ -19,6 +19,18 @@ func keyFunc(obj interface{}) (string, error) {
 		return generateVirtualServerKey(*v)
 	case *model.LBPool:
 		return generatePoolKey(*v)
+	case *model.SharedResource:
+		return *v.Path, nil
+	case *model.LBAppProfile:
+		return *v.Path, nil
+	case *model.TlsCertificate:
+		return *v.Path, nil
+	case *model.LBPersistenceProfile:
+		return *v.Path, nil
+	case *model.Share:
+		return *v.Path, nil
+	case *model.LBMonitorProfile:
+		return *v.Path, nil
 	default:
 		return "", errors.New("keyFunc doesn't support unknown type")
 	}


### PR DESCRIPTION
While listing the resources in cleanup, each resource type should be added in keyFunc.
Add shared resources to keyFunc

Test Done:
1. upload the wcpsvc
2. disable the cluster
3. check if the resources have been clean