### PR TITLE
Improve realizedstate check for resources with dependency (#1014)

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -120,6 +120,8 @@ const (
 	DstGroupSuffix         = "dst"
 	IpSetGroupSuffix       = "ipset"
 	ShareSuffix            = "share"
+
+	GatewayInterfaceId = "gateway-interface"
 )
 
 var (

--- a/pkg/nsx/services/realizestate/realize_state.go
+++ b/pkg/nsx/services/realizestate/realize_state.go
@@ -10,29 +10,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
-const (
-	RealizedLogicalPort   = "RealizedLogicalPort"
-	RealizedLogicalRouter = "RealizedLogicalRouter"
+var (
+	log = &logger.Log
 )
 
 type RealizeStateService struct {
 	common.Service
-}
-
-type RealizeStateError struct {
-	message string
-}
-
-func (e *RealizeStateError) Error() string {
-	return e.message
-}
-
-func NewRealizeStateError(msg string) *RealizeStateError {
-	return &RealizeStateError{message: msg}
 }
 
 func InitializeRealizeState(service common.Service) *RealizeStateService {
@@ -41,19 +29,14 @@ func InitializeRealizeState(service common.Service) *RealizeStateService {
 	}
 }
 
-func IsRealizeStateError(err error) bool {
-	_, ok := err.(*RealizeStateError)
-	return ok
-}
-
 // CheckRealizeState allows the caller to check realize status of intentPath with retries.
 // Backoff defines the maximum retries and the wait interval between two retries.
 // Check all the entities, all entities should be in the REALIZED state to be treated as REALIZED
-func (service *RealizeStateService) CheckRealizeState(backoff wait.Backoff, intentPath string) error {
+func (service *RealizeStateService) CheckRealizeState(backoff wait.Backoff, intentPath string, extraIds []string) error {
 	// TODO， ask NSX if there were multiple realize states could we check only the latest one?
 	return retry.OnError(backoff, func(err error) bool {
 		// Won't retry when realized state is `ERROR`.
-		return !IsRealizeStateError(err)
+		return !nsxutil.IsRealizeStateError(err)
 	}, func() error {
 		results, err := service.NSXClient.RealizedEntitiesClient.List(intentPath, nil)
 		err = nsxutil.TransNSXApiError(err)
@@ -61,22 +44,33 @@ func (service *RealizeStateService) CheckRealizeState(backoff wait.Backoff, inte
 			return err
 		}
 		entitiesRealized := 0
+		extraIdsRealized := 0
 		for _, result := range results.Results {
 			if *result.State == model.GenericPolicyRealizedResource_STATE_REALIZED {
+				for _, id := range extraIds {
+					if *result.Id == id {
+						extraIdsRealized++
+					}
+				}
 				entitiesRealized++
 				continue
 			}
 			if *result.State == model.GenericPolicyRealizedResource_STATE_ERROR {
+				log.Error(nil, "Found realized state with error", "result", result)
 				var errMsg []string
 				for _, alarm := range result.Alarms {
 					if alarm.Message != nil {
 						errMsg = append(errMsg, *alarm.Message)
 					}
+					if nsxutil.IsRetryRealizeError(alarm) {
+						return nsxutil.NewRetryRealizeError(fmt.Sprintf("%s not realized with errors: %s", intentPath, errMsg))
+					}
 				}
-				return NewRealizeStateError(fmt.Sprintf("%s realized with errors: %s", intentPath, errMsg))
+				return nsxutil.NewRealizeStateError(fmt.Sprintf("%s realized with errors: %s", intentPath, errMsg))
 			}
 		}
-		if len(results.Results) != 0 && entitiesRealized == len(results.Results) {
+		// extraIdsRealized can be greater than extraIds length as id is not unique in result list.
+		if len(results.Results) != 0 && entitiesRealized == len(results.Results) && extraIdsRealized >= len(extraIds) {
 			return nil
 		}
 		return fmt.Errorf("%s not realized", intentPath)

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -135,7 +135,7 @@ func (service *SubnetService) createOrUpdateSubnet(obj client.Object, nsxSubnet 
 	// For Subnets, it's important to reuse the already created NSXSubnet.
 	// For SubnetSets, since the ID includes a random value, the created NSX Subnet needs to be deleted and recreated.
 
-	if err = realizeService.CheckRealizeState(util.NSXTRealizeRetry, *nsxSubnet.Path); err != nil {
+	if err = realizeService.CheckRealizeState(util.NSXTRealizeRetry, *nsxSubnet.Path, []string{}); err != nil {
 		log.Error(err, "Failed to check subnet realization state", "ID", *nsxSubnet.Id)
 		// Delete the subnet if realization check fails, avoiding creating duplicate subnets continuously.
 		deleteErr := service.DeleteSubnet(*nsxSubnet)

--- a/pkg/nsx/services/subnet/subnet_test.go
+++ b/pkg/nsx/services/subnet/subnet_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/realizestate"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
@@ -480,8 +481,8 @@ func TestSubnetService_createOrUpdateSubnet(t *testing.T) {
 			name: "Update Subnet with RealizedState and deletion error",
 			prepareFunc: func() *gomonkey.Patches {
 				patches := gomonkey.ApplyFunc((*realizestate.RealizeStateService).CheckRealizeState,
-					func(_ *realizestate.RealizeStateService, _ wait.Backoff, _ string) error {
-						return realizestate.NewRealizeStateError("mocked realized error")
+					func(_ *realizestate.RealizeStateService, _ wait.Backoff, _ string, _ []string) error {
+						return nsxutil.NewRealizeStateError("mocked realized error")
 					})
 				patches.ApplyFunc((*SubnetService).DeleteSubnet, func(_ *SubnetService, _ model.VpcSubnet) error {
 					return errors.New("mocked deletion error")
@@ -498,7 +499,7 @@ func TestSubnetService_createOrUpdateSubnet(t *testing.T) {
 			name: "Create Subnet for SubnetSet Success",
 			prepareFunc: func() *gomonkey.Patches {
 				patches := gomonkey.ApplyFunc((*realizestate.RealizeStateService).CheckRealizeState,
-					func(_ *realizestate.RealizeStateService, _ wait.Backoff, _ string) error {
+					func(_ *realizestate.RealizeStateService, _ wait.Backoff, _ string, _ []string) error {
 						return nil
 					})
 				patches.ApplyFunc(fakeSubnetsClient.Get,

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -168,9 +168,9 @@ func (service *SubnetPortService) CheckSubnetPortState(obj interface{}, nsxSubne
 	}
 	realizeService := realizestate.InitializeRealizeState(service.Service)
 
-	if err := realizeService.CheckRealizeState(util.NSXTRealizeRetry, *nsxSubnetPort.Path); err != nil {
+	if err := realizeService.CheckRealizeState(util.NSXTRealizeRetry, *nsxSubnetPort.Path, []string{}); err != nil {
 		log.Error(err, "failed to get realized status", "subnetport path", *nsxSubnetPort.Path)
-		if realizestate.IsRealizeStateError(err) {
+		if nsxutil.IsRealizeStateError(err) {
 			log.Error(err, "the created subnet port is in error realization state, cleaning the resource", "subnetport", portID)
 			// only recreate subnet port on RealizationErrorStateError.
 			if err := service.DeleteSubnetPortById(portID); err != nil {

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -21,7 +21,7 @@ import (
 	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/realizestate"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 var (
@@ -247,7 +247,7 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 				})
 
 				patches := gomonkey.ApplyMethodSeq(service.NSXClient.RealizedEntitiesClient, "List", []gomonkey.OutputCell{{
-					Values: gomonkey.Params{model.GenericPolicyRealizedResourceListResult{}, realizestate.NewRealizeStateError("realized state error")},
+					Values: gomonkey.Params{model.GenericPolicyRealizedResourceListResult{}, nsxutil.NewRealizeStateError("realized state error")},
 					Times:  1,
 				}})
 				return patches

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -856,9 +856,9 @@ func (s *VPCService) createNSXVPC(createdVpc *model.Vpc, nc *common.VPCNetworkCo
 func (s *VPCService) checkVPCRealizationState(createdVpc *model.Vpc, newVpcPath string) error {
 	log.V(2).Info("Check VPC realization state", "VPC", *createdVpc.Id)
 	realizeService := realizestate.InitializeRealizeState(s.Service)
-	if err := realizeService.CheckRealizeState(util.NSXTRealizeRetry, newVpcPath); err != nil {
+	if err := realizeService.CheckRealizeState(util.NSXTRealizeRetry, newVpcPath, []string{common.GatewayInterfaceId}); err != nil {
 		log.Error(err, "Failed to check VPC realization state", "VPC", *createdVpc.Id)
-		if realizestate.IsRealizeStateError(err) {
+		if nsxutil.IsRealizeStateError(err) {
 			log.Error(err, "The created VPC is in error realization state, cleaning the resource", "VPC", *createdVpc.Id)
 			// delete the nsx vpc object and re-create it in the next loop
 			if err := s.DeleteVPC(newVpcPath); err != nil {
@@ -884,9 +884,9 @@ func (s *VPCService) checkLBSRealization(createdLBS *model.LBService, createdVpc
 
 	log.V(2).Info("Check LBS realization state", "LBS", *createdLBS.Id)
 	realizeService := realizestate.InitializeRealizeState(s.Service)
-	if err = realizeService.CheckRealizeState(util.NSXTRealizeRetry, *newLBS.Path); err != nil {
+	if err = realizeService.CheckRealizeState(util.NSXTRealizeRetry, *newLBS.Path, []string{}); err != nil {
 		log.Error(err, "Failed to check LBS realization state", "LBS", *createdLBS.Id)
-		if realizestate.IsRealizeStateError(err) {
+		if nsxutil.IsRealizeStateError(err) {
 			log.Error(err, "The created LBS is in error realization state, cleaning the resource", "LBS", *createdLBS.Id)
 			// delete the nsx vpc object and re-create it in the next loop
 			if err := s.DeleteVPC(newVpcPath); err != nil {
@@ -910,9 +910,9 @@ func (s *VPCService) checkVpcAttachmentRealization(createdAttachment *model.VpcA
 	}
 	log.V(2).Info("Check VPC attachment realization state", "VpcAttachment", *createdAttachment.Id)
 	realizeService := realizestate.InitializeRealizeState(s.Service)
-	if err = realizeService.CheckRealizeState(util.NSXTRealizeRetry, *newAttachment.Path); err != nil {
+	if err = realizeService.CheckRealizeState(util.NSXTRealizeRetry, *newAttachment.Path, []string{}); err != nil {
 		log.Error(err, "Failed to check VPC attachment realization state", "VpcAttachment", *createdAttachment.Id)
-		if realizestate.IsRealizeStateError(err) {
+		if nsxutil.IsRealizeStateError(err) {
 			log.Error(err, "The created VPC attachment is in error realization state, cleaning the resource", "VpcAttachment", *createdAttachment.Id)
 			// delete the nsx vpc object and re-create it in the next loop
 			if err := s.DeleteVPC(newVpcPath); err != nil {

--- a/test/e2e/precreated_vpc_test.go
+++ b/test/e2e/precreated_vpc_test.go
@@ -292,17 +292,17 @@ func (data *TestData) createVPC(orgID, projectID, vpcID string, privateIPs []str
 	log.Info("Successfully requested VPC on NSX", "path", vpcPath)
 	realizeService := realizestate.InitializeRealizeState(common.Service{NSXClient: data.nsxClient.Client})
 	if pollErr := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
-		if err = realizeService.CheckRealizeState(pkgutil.NSXTRealizeRetry, vpcPath); err != nil {
+		if err = realizeService.CheckRealizeState(pkgutil.NSXTRealizeRetry, vpcPath, []string{common.GatewayInterfaceId}); err != nil {
 			log.Error(err, "NSX VPC is not yet realized", "path", vpcPath)
 			return false, nil
 		}
 		if lbsPath != "" {
-			if err := realizeService.CheckRealizeState(pkgutil.NSXTRealizeRetry, lbsPath); err != nil {
+			if err := realizeService.CheckRealizeState(pkgutil.NSXTRealizeRetry, lbsPath, []string{}); err != nil {
 				log.Error(err, "NSX LBS is not yet realized", "path", lbsPath)
 				return false, nil
 			}
 		}
-		if err = realizeService.CheckRealizeState(pkgutil.NSXTRealizeRetry, attachmentPath); err != nil {
+		if err = realizeService.CheckRealizeState(pkgutil.NSXTRealizeRetry, attachmentPath, []string{}); err != nil {
 			log.Error(err, "VPC attachment is not yet realized", "path", attachmentPath)
 			return false, nil
 		}


### PR DESCRIPTION
NSX LBS realization has dependency on the gateway-interface. If gateway-interface
is not realized before NSX LBS realization timeout, the realized state API will return
a ProviderNotReady error. But later on the NSX LBS realization can become Realized
after the gateway-interface realization succeeds. Thus for NSX operator, we enhance
the realized state check to

- Check gateway-interface when check the VPC realized state
- Retry when ProviderNotReady error is detected