### PR TITLE
[NSXServiceAccount] Watch mgmt-proxy service and reconcile all NSXSA

### DIFF
--- a/pkg/nsx/services/nsxserviceaccount/cluster.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -571,4 +572,16 @@ func IsNSXServiceAccountRealized(status *v1alpha1.NSXServiceAccountStatus) bool 
 		}
 	}
 	return status.Phase == v1alpha1.NSXServiceAccountPhaseRealized
+}
+
+func (s *NSXServiceAccountService) UpdateProxyEndpointsIfNeeded(ctx context.Context, obj *v1alpha1.NSXServiceAccount) error {
+	proxyEndpoints, err := s.getProxyEndpoints(ctx)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(proxyEndpoints, obj.Status.ProxyEndpoints) {
+		obj.Status.ProxyEndpoints = proxyEndpoints
+		return s.Client.Status().Update(ctx, obj)
+	}
+	return nil
 }

--- a/pkg/nsx/services/nsxserviceaccount/cluster_test.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster_test.go
@@ -1720,3 +1720,106 @@ func TestIsNSXServiceAccountRealized(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateProxyEndpointsIfNeeded(t *testing.T) {
+	tests := []struct {
+		name                   string
+		nsxServiceAccount      *v1alpha1.NSXServiceAccount
+		prepareFunc            func(*testing.T, *NSXServiceAccountService, context.Context)
+		expectedProxyEndpoints v1alpha1.NSXProxyEndpoint
+	}{
+		{
+			name: "update nsx service account with proxy endpoints",
+			nsxServiceAccount: &v1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nsxsa1",
+					Namespace: "ns1",
+				},
+				Status: v1alpha1.NSXServiceAccountStatus{
+					Phase: v1alpha1.NSXServiceAccountPhaseRealized,
+					ProxyEndpoints: v1alpha1.NSXProxyEndpoint{
+						Addresses: []v1alpha1.NSXProxyEndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+						Ports: []v1alpha1.NSXProxyEndpointPort{
+							{
+								Name:     "rest-api",
+								Port:     10081,
+								Protocol: "TCP",
+							},
+							{
+								Name:     "nsx-rpc-fwd-proxy",
+								Protocol: "TCP",
+								Port:     10082,
+							},
+						},
+					},
+				},
+			},
+			prepareFunc: func(t *testing.T, s *NSXServiceAccountService, c context.Context) {
+				svc := &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "with-label",
+						Namespace: "any",
+						Labels:    map[string]string{"mgmt-proxy.antrea-nsx.vmware.com": "", "dummy": "dummy"},
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{
+							{
+								Name:     "rest-api",
+								Protocol: "TCP",
+								Port:     10081,
+							},
+							{
+								Name:     "nsx-rpc-fwd-proxy",
+								Protocol: "TCP",
+								Port:     10082,
+							},
+						},
+						Type: v1.ServiceTypeLoadBalancer,
+					},
+					Status: v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{IP: "1.2.3.5"}},
+						},
+					},
+				}
+				assert.NoError(t, s.Client.Create(c, svc))
+			},
+			expectedProxyEndpoints: v1alpha1.NSXProxyEndpoint{
+				Addresses: []v1alpha1.NSXProxyEndpointAddress{
+					{
+						IP: "1.2.3.5",
+					},
+				},
+				Ports: []v1alpha1.NSXProxyEndpointPort{
+					{
+						Name:     "rest-api",
+						Port:     10081,
+						Protocol: "TCP",
+					},
+					{
+						Name:     "nsx-rpc-fwd-proxy",
+						Protocol: "TCP",
+						Port:     10082,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			commonService := newFakeCommonService()
+			s := &NSXServiceAccountService{Service: commonService}
+			assert.NoError(t, s.Client.Create(ctx, tt.nsxServiceAccount))
+			tt.prepareFunc(t, s, ctx)
+
+			err := s.UpdateProxyEndpointsIfNeeded(ctx, tt.nsxServiceAccount)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedProxyEndpoints, tt.nsxServiceAccount.Status.ProxyEndpoints)
+		})
+	}
+}


### PR DESCRIPTION
Reconcile all existing NSXSA incase of following events of K8s service corresponding to mgmt-proxy.
- new service is created.
- existing service is deleted.
- existing service is updated with LB VIP.

While reconciling realized NSXSA, update proxyEndpoints if proxyEndpoints have changed.

Steps for testing -
1. Build nsx-operator image and save it in a tar file.
    Run `make photon` in nsx-operator repo.
    `docker image save github.com/vmware-tanzu/nsx-operator:latest -o my-nsx-operator.tar`
3. Get WCP testbed
4. Copy nsx-operator image `my-nsx-operator.tar` file to SVCP VMs using `scp`
5. Inside each SVCP VMs, run `ctr -n=k8s.io images import <path to my-nsx-operator.tar>` to load nsx-operator image.
6. Update nsx-ncp deployment.
    `kubectl set image deploy/nsx-ncp nsx-operator=github.com/vmware-tanzu/nsx-operator:latest -n vmware-system-nsx`
7. Create a guest cluster, nsxsa gets created with empty proxyEndpoints.
8. register and install nsx-mgmt-proxy supervisor service.
9. kubectl describe nsxsa, proxy endpoints get updated.
10. Change proxy LB IP from VC UI by filling data-value `loadBalancerIP: <someIP>`, check in VC UI, it gets updated, then kubectl describe nsxsa and see proxyEndpoints get updated with new LB IP. 