### PR TITLE
Remove cache stores for VPCNetworkConfig

### DIFF
--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -126,11 +126,15 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	if subnetCR.Spec.IPv4SubnetSize == 0 {
-		vpcNetworkConfig := r.VPCService.GetVPCNetworkConfigByNamespace(subnetCR.Namespace)
+		vpcNetworkConfig, err := r.VPCService.GetVPCNetworkConfigByNamespace(subnetCR.Namespace)
+		if err != nil {
+			log.Error(err, "Failed to get VPCNetworkConfig", "Namespace", subnetCR.Namespace)
+			return ResultRequeue, nil
+		}
 		if vpcNetworkConfig == nil {
 			err := fmt.Errorf("VPCNetworkConfig not found for Subnet CR")
 			r.StatusUpdater.UpdateFail(ctx, subnetCR, err, "Failed to find VPCNetworkConfig", setSubnetReadyStatusFalse)
-			return ResultRequeue, err
+			return ResultRequeue, nil
 		}
 		subnetCR.Spec.IPv4SubnetSize = vpcNetworkConfig.DefaultSubnetSize
 		specChanged = true

--- a/pkg/controllers/subnet/subnet_controller_test.go
+++ b/pkg/controllers/subnet/subnet_controller_test.go
@@ -483,8 +483,8 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
 			patches: func(r *SubnetReconciler) *gomonkey.Patches {
 				vpcConfig := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 16}
-				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
-					return vpcConfig
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*common.VPCNetworkConfigInfo, error) {
+					return vpcConfig, nil
 				})
 
 				patches.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnet", func(_ *SubnetReconciler, _ context.Context, _ *v1alpha1.Subnet) []v1alpha1.SubnetConnectionBindingMap {
@@ -515,8 +515,8 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
 			patches: func(r *SubnetReconciler) *gomonkey.Patches {
 				vpcConfig := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 16}
-				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
-					return vpcConfig
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*common.VPCNetworkConfigInfo, error) {
+					return vpcConfig, nil
 				})
 
 				patches.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnet", func(_ *SubnetReconciler, _ context.Context, _ *v1alpha1.Subnet) []v1alpha1.SubnetConnectionBindingMap {
@@ -569,8 +569,8 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
 			patches: func(r *SubnetReconciler) *gomonkey.Patches {
 				vpcConfig := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 16}
-				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
-					return vpcConfig
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*common.VPCNetworkConfigInfo, error) {
+					return vpcConfig, nil
 				})
 
 				patches.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnet", func(_ *SubnetReconciler, _ context.Context, _ *v1alpha1.Subnet) []v1alpha1.SubnetConnectionBindingMap {
@@ -609,8 +609,8 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 			name: "Create or Update Subnet with VPCNetworkConfig not found failure",
 			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
 			patches: func(r *SubnetReconciler) *gomonkey.Patches {
-				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
-					return nil
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*common.VPCNetworkConfigInfo, error) {
+					return nil, nil
 				})
 				patches.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnet", func(_ *SubnetReconciler, _ context.Context, _ *v1alpha1.Subnet) []v1alpha1.SubnetConnectionBindingMap {
 					return []v1alpha1.SubnetConnectionBindingMap{}
@@ -618,7 +618,6 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 				return patches
 			},
 			existingSubnetCR: createNewSubnet(),
-			expectErrStr:     "VPCNetworkConfig not found for Subnet CR",
 			expectRes:        ResultRequeue,
 		},
 		{
@@ -626,8 +625,8 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
 			patches: func(r *SubnetReconciler) *gomonkey.Patches {
 				vpcConfig := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 16}
-				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
-					return vpcConfig
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*common.VPCNetworkConfigInfo, error) {
+					return vpcConfig, nil
 				})
 
 				patches.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnet", func(_ *SubnetReconciler, _ context.Context, _ *v1alpha1.Subnet) []v1alpha1.SubnetConnectionBindingMap {
@@ -648,8 +647,8 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
 			patches: func(r *SubnetReconciler) *gomonkey.Patches {
 				vpcConfig := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 16}
-				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
-					return vpcConfig
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*common.VPCNetworkConfigInfo, error) {
+					return vpcConfig, nil
 				})
 
 				patches.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnet", func(_ *SubnetReconciler, _ context.Context, _ *v1alpha1.Subnet) []v1alpha1.SubnetConnectionBindingMap {

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -126,11 +126,15 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		specChanged = true
 	}
 	if subnetsetCR.Spec.IPv4SubnetSize == 0 {
-		vpcNetworkConfig := r.VPCService.GetVPCNetworkConfigByNamespace(subnetsetCR.Namespace)
+		vpcNetworkConfig, err := r.VPCService.GetVPCNetworkConfigByNamespace(subnetsetCR.Namespace)
+		if err != nil {
+			log.Error(err, "Failed to get VPCNetworkConfig", "Namespace", subnetsetCR.Namespace)
+			return ResultRequeue, nil
+		}
 		if vpcNetworkConfig == nil {
-			err := fmt.Errorf("failed to find VPCNetworkConfig for Namespace %s", subnetsetCR.Namespace)
+			err := fmt.Errorf("Failed to find VPCNetworkConfig for Namespace %s", subnetsetCR.Namespace)
 			r.StatusUpdater.UpdateFail(ctx, subnetsetCR, err, "", setSubnetSetReadyStatusFalse)
-			return ResultRequeue, err
+			return ResultRequeue, nil
 		}
 		subnetsetCR.Spec.IPv4SubnetSize = vpcNetworkConfig.DefaultSubnetSize
 		specChanged = true

--- a/pkg/controllers/subnetset/subnetset_controller_test.go
+++ b/pkg/controllers/subnetset/subnetset_controller_test.go
@@ -152,9 +152,8 @@ func TestReconcile(t *testing.T) {
 		patches      func(r *SubnetSetReconciler) *gomonkey.Patches
 	}{
 		{
-			name:         "Create a SubnetSet with find VPCNetworkConfig error",
-			expectRes:    ResultRequeue,
-			expectErrStr: "failed to find VPCNetworkConfig for Namespace",
+			name:      "Create a SubnetSet with find VPCNetworkConfig error",
+			expectRes: ResultRequeue,
 			patches: func(r *SubnetSetReconciler) *gomonkey.Patches {
 				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnetSet", func(_ *SubnetSetReconciler, _ context.Context, _ *v1alpha1.SubnetSet) []v1alpha1.SubnetConnectionBindingMap {
 					return []v1alpha1.SubnetConnectionBindingMap{}
@@ -167,8 +166,8 @@ func TestReconcile(t *testing.T) {
 			expectRes: ResultNormal,
 			patches: func(r *SubnetSetReconciler) *gomonkey.Patches {
 				vpcnetworkInfo := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 32}
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
-					return vpcnetworkInfo
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*common.VPCNetworkConfigInfo, error) {
+					return vpcnetworkInfo, nil
 				})
 
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService.SubnetStore), "GetByIndex", func(_ *subnet.SubnetStore, key string, value string) []*model.VpcSubnet {
@@ -192,8 +191,8 @@ func TestReconcile(t *testing.T) {
 			expectErrStr: "",
 			patches: func(r *SubnetSetReconciler) *gomonkey.Patches {
 				vpcnetworkInfo := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 32}
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
-					return vpcnetworkInfo
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*common.VPCNetworkConfigInfo, error) {
+					return vpcnetworkInfo, nil
 				})
 
 				patches.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnetSet", func(_ *SubnetSetReconciler, _ context.Context, _ *v1alpha1.SubnetSet) []v1alpha1.SubnetConnectionBindingMap {
@@ -222,8 +221,8 @@ func TestReconcile(t *testing.T) {
 			expectErrStr: "",
 			patches: func(r *SubnetSetReconciler) *gomonkey.Patches {
 				vpcnetworkInfo := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 32}
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
-					return vpcnetworkInfo
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*common.VPCNetworkConfigInfo, error) {
+					return vpcnetworkInfo, nil
 				})
 				patches.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnetSet", func(_ *SubnetSetReconciler, _ context.Context, _ *v1alpha1.SubnetSet) []*v1alpha1.SubnetConnectionBindingMap {
 					return []*v1alpha1.SubnetConnectionBindingMap{}
@@ -256,8 +255,8 @@ func TestReconcile(t *testing.T) {
 			expectErrStr: "",
 			patches: func(r *SubnetSetReconciler) *gomonkey.Patches {
 				vpcnetworkInfo := &common.VPCNetworkConfigInfo{DefaultSubnetSize: 32}
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) *common.VPCNetworkConfigInfo {
-					return vpcnetworkInfo
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*common.VPCNetworkConfigInfo, error) {
+					return vpcnetworkInfo, nil
 				})
 				patches.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnetSet", func(_ *SubnetSetReconciler, _ context.Context, _ *v1alpha1.SubnetSet) []v1alpha1.SubnetConnectionBindingMap {
 					return []v1alpha1.SubnetConnectionBindingMap{}

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -1,10 +1,13 @@
 package mock
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
@@ -12,24 +15,18 @@ type MockVPCServiceProvider struct {
 	mock.Mock
 }
 
-func (m *MockVPCServiceProvider) GetNamespacesByNetworkconfigName(nc string) []string {
+func (m *MockVPCServiceProvider) GetNamespacesByNetworkconfigName(nc string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *MockVPCServiceProvider) UpdateDefaultNetworkConfig(vpcNetworkConfig *v1alpha1.VPCNetworkConfiguration) error {
+	m.Called()
 	return nil
 }
 
-func (m *MockVPCServiceProvider) RegisterVPCNetworkConfig(ncCRName string, info common.VPCNetworkConfigInfo) {
-}
-
-func (m *MockVPCServiceProvider) RegisterNamespaceNetworkconfigBinding(ns string, ncCRName string) {
-	m.Called(ns, ncCRName)
-}
-
-func (m *MockVPCServiceProvider) UnRegisterNamespaceNetworkconfigBinding(ns string) {
-	m.Called(ns)
-}
-
-func (m *MockVPCServiceProvider) GetVPCNetworkConfig(ncCRName string) (common.VPCNetworkConfigInfo, bool) {
+func (m *MockVPCServiceProvider) GetVPCNetworkConfig(ncCRName string) (*common.VPCNetworkConfigInfo, bool, error) {
 	m.Called(ncCRName)
-	return common.VPCNetworkConfigInfo{}, false
+	return &common.VPCNetworkConfigInfo{}, false, nil
 }
 
 func (m *MockVPCServiceProvider) ValidateNetworkConfig(nc common.VPCNetworkConfigInfo) bool {
@@ -37,19 +34,24 @@ func (m *MockVPCServiceProvider) ValidateNetworkConfig(nc common.VPCNetworkConfi
 	return true
 }
 
-func (m *MockVPCServiceProvider) GetVPCNetworkConfigByNamespace(ns string) *common.VPCNetworkConfigInfo {
+func (m *MockVPCServiceProvider) GetVPCNetworkConfigByNamespace(ns string) (*common.VPCNetworkConfigInfo, error) {
 	m.Called()
-	return nil
+	return nil, nil
 }
 
-func (m *MockVPCServiceProvider) GetDefaultNetworkConfig() (bool, *common.VPCNetworkConfigInfo) {
+func (m *MockVPCServiceProvider) GetDefaultNetworkConfig() (*common.VPCNetworkConfigInfo, error) {
 	m.Called()
-	return false, nil
+	return nil, nil
 }
 
 func (m *MockVPCServiceProvider) ListVPCInfo(ns string) []common.VPCResourceInfo {
 	arg := m.Called(ns)
 	return arg.Get(0).([]common.VPCResourceInfo)
+}
+
+func (m *MockVPCServiceProvider) GetNetworkconfigNameFromNS(ctx context.Context, ns string) (string, error) {
+	m.Called()
+	return "", nil
 }
 
 type MockSubnetServiceProvider struct {

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -13,15 +13,13 @@ import (
 // Using interface instead vpc service instance can prevent other service
 // calling method that should not be exposed.
 type VPCServiceProvider interface {
-	RegisterNamespaceNetworkconfigBinding(ns string, ncCRName string)
-	GetNamespacesByNetworkconfigName(nc string) []string
-	RegisterVPCNetworkConfig(ncCRName string, info VPCNetworkConfigInfo)
-	UnRegisterNamespaceNetworkconfigBinding(ns string)
-	GetVPCNetworkConfig(ncCRName string) (VPCNetworkConfigInfo, bool)
+	GetNamespacesByNetworkconfigName(nc string) ([]string, error)
+	GetVPCNetworkConfig(ncCRName string) (*VPCNetworkConfigInfo, bool, error)
 	ValidateNetworkConfig(nc VPCNetworkConfigInfo) bool
-	GetVPCNetworkConfigByNamespace(ns string) *VPCNetworkConfigInfo
-	GetDefaultNetworkConfig() (bool, *VPCNetworkConfigInfo)
+	GetVPCNetworkConfigByNamespace(ns string) (*VPCNetworkConfigInfo, error)
+	GetDefaultNetworkConfig() (*VPCNetworkConfigInfo, error)
 	ListVPCInfo(ns string) []VPCResourceInfo
+	GetNetworkconfigNameFromNS(ctx context.Context, ns string) (string, error)
 }
 
 type SubnetServiceProvider interface {

--- a/pkg/nsx/services/ipaddressallocation/builder_test.go
+++ b/pkg/nsx/services/ipaddressallocation/builder_test.go
@@ -69,12 +69,6 @@ func createService(t *testing.T) (*vpc.VPCService, *gomock.Controller, *mocks.Mo
 			},
 		},
 		VpcStore: vpcStore,
-		VPCNetworkConfigStore: vpc.VPCNetworkInfoStore{
-			VPCNetworkConfigMap: map[string]common.VPCNetworkConfigInfo{},
-		},
-		VPCNSNetworkConfigStore: vpc.VPCNsNetworkConfigStore{
-			VPCNSNetworkConfigMap: map[string]string{},
-		},
 	}
 	return service, mockCtrl, mockVpcclient
 }

--- a/pkg/nsx/services/ipaddressallocation/ipaddressallocation.go
+++ b/pkg/nsx/services/ipaddressallocation/ipaddressallocation.go
@@ -107,6 +107,7 @@ func (service *IPAddressAllocationService) Apply(nsxIPAddressAllocation *model.V
 	VPCInfo := service.VPCService.ListVPCInfo(ns)
 	if len(VPCInfo) == 0 {
 		err := util.NoEffectiveOption{Desc: "no valid org and project for ipaddressallocation"}
+		log.Error(err, "Failed to list VPCInfo for IPAddressAllocation")
 		return err
 	}
 	errPatch := service.NSXClient.IPAddressAllocationClient.Patch(VPCInfo[0].OrgID, VPCInfo[0].ProjectID, VPCInfo[0].ID, *nsxIPAddressAllocation.Id, *nsxIPAddressAllocation)

--- a/pkg/nsx/services/vpc/builder_test.go
+++ b/pkg/nsx/services/vpc/builder_test.go
@@ -337,3 +337,151 @@ func Test_generateLBSKey(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildNetworkConfigInfo(t *testing.T) {
+	emptyCRD := &v1alpha1.VPCNetworkConfiguration{}
+	emptyCRD2 := &v1alpha1.VPCNetworkConfiguration{
+		Spec: v1alpha1.VPCNetworkConfigurationSpec{
+			NSXProject: "/invalid/path",
+		},
+	}
+	_, e := buildNetworkConfigInfo(emptyCRD)
+	assert.NotNil(t, e)
+	_, e = buildNetworkConfigInfo(emptyCRD2)
+	assert.NotNil(t, e)
+
+	spec1 := v1alpha1.VPCNetworkConfigurationSpec{
+		PrivateIPs:             []string{"private-ipb-1", "private-ipb-2"},
+		DefaultSubnetSize:      64,
+		VPCConnectivityProfile: "test-VPCConnectivityProfile",
+		NSXProject:             "/orgs/default/projects/nsx_operator_e2e_test",
+	}
+	spec2 := v1alpha1.VPCNetworkConfigurationSpec{
+		PrivateIPs:        []string{"private-ipb-1", "private-ipb-2"},
+		DefaultSubnetSize: 32,
+		NSXProject:        "/orgs/anotherOrg/projects/anotherProject",
+	}
+	spec3 := v1alpha1.VPCNetworkConfigurationSpec{
+		DefaultSubnetSize: 28,
+		NSXProject:        "/orgs/anotherOrg/projects/anotherProject",
+		VPC:               "vpc33",
+	}
+	testCRD1 := v1alpha1.VPCNetworkConfiguration{
+		Spec: spec1,
+	}
+	testCRD1.Name = "test-1"
+	testCRD2 := v1alpha1.VPCNetworkConfiguration{
+		Spec: spec2,
+	}
+	testCRD2.Name = "test-2"
+
+	testCRD3 := v1alpha1.VPCNetworkConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				common.AnnotationDefaultNetworkConfig: "true",
+			},
+		},
+		Spec: spec2,
+	}
+	testCRD3.Name = "test-3"
+
+	testCRD4 := v1alpha1.VPCNetworkConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				common.AnnotationDefaultNetworkConfig: "false",
+			},
+		},
+		Spec: spec3,
+	}
+	testCRD4.Name = "test-4"
+
+	testCRD5 := v1alpha1.VPCNetworkConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				common.AnnotationDefaultNetworkConfig: "failed",
+			},
+		},
+		Spec: spec3,
+	}
+	testCRD5.Name = "test-5"
+
+	tests := []struct {
+		name                   string
+		nc                     v1alpha1.VPCNetworkConfiguration
+		gw                     string
+		edge                   string
+		org                    string
+		project                string
+		subnetSize             int
+		accessMode             string
+		isDefault              bool
+		vpcConnectivityProfile string
+		vpcPath                string
+	}{
+		{"test-nsxProjectPathToId", testCRD1, "test-gw-path-1", "test-edge-path-1", "default", "nsx_operator_e2e_test", 64, "Public", false, "", ""},
+		{"with-VPCConnectivityProfile", testCRD2, "test-gw-path-2", "test-edge-path-2", "anotherOrg", "anotherProject", 32, "Private", false, "test-VPCConnectivityProfile", ""},
+		{"with-defaultNetworkConfig", testCRD3, "test-gw-path-2", "test-edge-path-2", "anotherOrg", "anotherProject", 32, "Private", true, "", ""},
+		{"with-preCreatedVPC", testCRD4, "", "", "anotherOrg", "anotherProject", 28, "Private", false, "", "vpc33"},
+		{"annotation-error", testCRD5, "", "", "anotherOrg", "anotherProject", 28, "Private", false, "", "vpc33"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nc, e := buildNetworkConfigInfo(&tt.nc)
+			assert.Nil(t, e)
+			assert.Equal(t, tt.org, nc.Org)
+			assert.Equal(t, tt.project, nc.NSXProject)
+			assert.Equal(t, tt.subnetSize, nc.DefaultSubnetSize)
+			assert.Equal(t, tt.isDefault, nc.IsDefault)
+			assert.Equal(t, tt.vpcPath, nc.VPCPath)
+		})
+	}
+}
+
+func TestNsxProjectPathToId(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		org       string
+		project   string
+		expectErr string
+	}{
+		{"Valid project path", "/orgs/default/projects/nsx_operator_e2e_test", "default", "nsx_operator_e2e_test", ""},
+		{"Invalid project path", "", "", "", "invalid NSX project path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o, p, err := nsxProjectPathToId(tt.path)
+			if tt.expectErr != "" {
+				assert.ErrorContains(t, err, tt.expectErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.org, o)
+			assert.Equal(t, tt.project, p)
+		})
+	}
+}
+
+func TestIsDefaultNetworkConfigCR(t *testing.T) {
+	testCRD1 := v1alpha1.VPCNetworkConfiguration{}
+	testCRD1.Name = "test-1"
+	testCRD2 := v1alpha1.VPCNetworkConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				common.AnnotationDefaultNetworkConfig: "invalid",
+			},
+		},
+	}
+	testCRD2.Name = "test-2"
+	testCRD3 := v1alpha1.VPCNetworkConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				common.AnnotationDefaultNetworkConfig: "true",
+			},
+		},
+	}
+	testCRD3.Name = "test-3"
+	assert.Equal(t, isDefaultNetworkConfigCR(&testCRD1), false)
+	assert.Equal(t, isDefaultNetworkConfigCR(&testCRD2), false)
+	assert.Equal(t, isDefaultNetworkConfigCR(&testCRD3), true)
+}

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -12,3 +12,10 @@ var NSXTRealizeRetry = wait.Backoff{
 	Factor:   1.0,
 	Jitter:   0.1,
 }
+
+var K8sClientRetry = wait.Backoff{
+	Steps:    60,
+	Duration: 1 * time.Second,
+	Factor:   1.0,
+	Jitter:   0.1,
+}


### PR DESCRIPTION
Current we maintain 2 caches, VPCNSNetworkConfigStore and VPCNetworkConfigStore,
for mapping between Namespace, VPCNetworkConfig name and VPCNetworkConfig Info.
But those information are parsed based Namespace and VPCNetworkConfig CRs, which
are cached in controller runtime client. Thus this PR
- Removes the cache in NSX Operator and relies on controller runtime client cache to get
those information.
- Removes defaultNetworkConfigCR and get it by listing VPCNetworkConfiguration

Testing done:
Create a Namespace and create VM on the Namespace. The VM can power on with IP.