### PR TITLE
Keep Namespace labels order in tags

### DIFF
--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -366,9 +367,14 @@ func (service *SubnetService) GenerateSubnetNSTags(obj client.Object) []model.Ta
 				model.Tag{Scope: common.String(common.TagScopeVMNamespace), Tag: common.String(obj.GetNamespace())})
 		}
 	}
-	// Append Namespace labels as tags
-	for k, v := range namespace.Labels {
-		tags = append(tags, model.Tag{Scope: common.String(k), Tag: common.String(v)})
+	// Append Namespace labels in order as tags
+	labelKeys := make([]string, 0, len(namespace.Labels))
+	for k := range namespace.Labels {
+		labelKeys = append(labelKeys, k)
+	}
+	sort.Strings(labelKeys)
+	for _, k := range labelKeys {
+		tags = append(tags, model.Tag{Scope: common.String(k), Tag: common.String(namespace.Labels[k])})
 	}
 	return tags
 }

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sort"
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -65,8 +66,14 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 	namespace_uid := namespace.UID
 	tags := util.BuildBasicTags(getCluster(service), obj, namespace_uid)
 	if labelTags != nil {
-		for k, v := range *labelTags {
-			tags = append(tags, model.Tag{Scope: String(k), Tag: String(v)})
+		// Append Namespace labels in order as tags
+		labelKeys := make([]string, 0, len(*labelTags))
+		for k := range *labelTags {
+			labelKeys = append(labelKeys, k)
+		}
+		sort.Strings(labelKeys)
+		for _, k := range labelKeys {
+			tags = append(tags, model.Tag{Scope: common.String(k), Tag: common.String((*labelTags)[k])})
 		}
 	}
 	nsxSubnetPort := &model.VpcSubnetPort{

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -130,7 +130,10 @@ func TestBuildSubnetPort(t *testing.T) {
 				Path: common.String("fake_path"),
 			},
 			contextID: "fake_context_id",
-			labelTags: nil,
+			labelTags: &map[string]string{
+				"kubernetes.io/metadata.name": "fake_ns",
+				"vSphereClusterID":            "domain-c11",
+			},
 			expectedPort: &model.VpcSubnetPort{
 				DisplayName: common.String("fake_pod"),
 				Id:          common.String("fake_pod_c5db1800-ce4c-11de-a935-8105ba7ace78"),
@@ -154,6 +157,14 @@ func TestBuildSubnetPort(t *testing.T) {
 					{
 						Scope: common.String("nsx-op/pod_uid"),
 						Tag:   common.String("c5db1800-ce4c-11de-a935-8105ba7ace78"),
+					},
+					{
+						Scope: common.String("kubernetes.io/metadata.name"),
+						Tag:   common.String("fake_ns"),
+					},
+					{
+						Scope: common.String("vSphereClusterID"),
+						Tag:   common.String("domain-c11"),
 					},
 				},
 				Path:       common.String("fake_path/ports/fake_pod_c5db1800-ce4c-11de-a935-8105ba7ace78"),


### PR DESCRIPTION
Follow the Alphabetical order when adding Namespace labels to Subnet/SubnetPort tags
to avoid updating due to tag order change.