### PR TITLE
Add ServiceClusterReady condition

### DIFF
--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -134,6 +134,7 @@ _Appears in:_
 | --- | --- |
 | `Ready` |  |
 | `GatewayConnectionReady` |  |
+| `ServiceClusterReady` |  |
 | `AutoSnatEnabled` |  |
 | `ExternalIPBlocksConfigured` |  |
 | `DeletionFailed` |  |

--- a/pkg/apis/vpc/v1alpha1/condition_types.go
+++ b/pkg/apis/vpc/v1alpha1/condition_types.go
@@ -10,6 +10,7 @@ type ConditionType string
 const (
 	Ready                      ConditionType = "Ready"
 	GatewayConnectionReady     ConditionType = "GatewayConnectionReady"
+	ServiceClusterReady        ConditionType = "ServiceClusterReady"
 	AutoSnatEnabled            ConditionType = "AutoSnatEnabled"
 	ExternalIPBlocksConfigured ConditionType = "ExternalIPBlocksConfigured"
 	DeleteFailure              ConditionType = "DeletionFailed"

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -185,6 +185,7 @@ var (
 	ReasonEdgeMissingInProject                       = "EdgeMissingInProject"
 	ReasonDistributedGatewayConnectionNotSupported   = "DistributedGatewayConnectionNotSupported"
 	ReasonGatewayConnectionNotSet                    = "GatewayConnectionNotSet"
+	ReasonServiceClusterNotSet                       = "ServiceClusterNotSet"
 	ReasonNoExternalIPBlocksInVPCConnectivityProfile = "ExternalIPBlockMissingInProfile"
 )
 


### PR DESCRIPTION
For VPC networking with D-TGW, we need a new condition "ServiceClusterReady" to indicate if serviceCluster is configured.