### PR TITLE
Create network errors from service ncp annotations

### DIFF
--- a/pkg/nsx/services/inventory/compare.go
+++ b/pkg/nsx/services/inventory/compare.go
@@ -142,6 +142,9 @@ func compareContainerApplication(pre interface{}, cur interface{}, property map[
 	if pre == nil || preApplication.Status != curApplication.Status {
 		property["status"] = curApplication.Status
 	}
+	if pre == nil || !reflect.DeepEqual(preApplication.NetworkErrors, curApplication.NetworkErrors) {
+		property["network_errors"] = preApplication.NetworkErrors
+	}
 	if pre == nil || !reflect.DeepEqual(preApplication.OriginProperties, curApplication.OriginProperties) {
 		property["origin_properties"] = curApplication.OriginProperties
 	}

--- a/pkg/nsx/services/inventory/types.go
+++ b/pkg/nsx/services/inventory/types.go
@@ -48,6 +48,13 @@ const (
 	InventoryStatusUp      = "UP"
 	InventoryStatusDown    = "DOWN"
 	InventoryStatusUnknown = "UNKNOWN"
+
+	NcpLbError        = "ncp/error.loadbalancer"
+	NcpLbPortError    = "ncp/error.loadbalancer.unrealized_ports"
+	NcpLbEpError      = "ncp/error.loadbalancer_endpoints"
+	NcpDlbError       = "ncp/error.distributed_loadbalancer"
+	NcpSnatError      = "ncp/error.snat"
+	NcpAccessLogError = "ncp/error.vc_access_log"
 )
 
 type InventoryKey struct {
@@ -55,3 +62,5 @@ type InventoryKey struct {
 	ExternalId    string
 	Key           string
 }
+
+var ServiceNCPErrors = []string{NcpLbError, NcpLbPortError, NcpLbEpError, NcpDlbError, NcpSnatError, NcpAccessLogError}


### PR DESCRIPTION
Introduced logic to extract NCP errors from service annotations and include them in network error handling. Updated `BuildService` to account for these errors and modified the service status when errors are present. Added comprehensive tests to verify functionality across various scenarios.