### PR TITLE
Create network errors from networkpolicy nsx-op annotations

### DIFF
--- a/pkg/nsx/services/inventory/compare.go
+++ b/pkg/nsx/services/inventory/compare.go
@@ -197,6 +197,12 @@ func compareNetworkPolicy(pre interface{}, cur interface{}, property map[string]
 	if pre == nil || preNetworkPolicy.PolicyType != curNetworkPolicy.PolicyType {
 		property["policy_type"] = cur.(containerinventory.ContainerNetworkPolicy).PolicyType
 	}
+	if pre == nil || !reflect.DeepEqual(preNetworkPolicy.NetworkStatus, curNetworkPolicy.NetworkStatus) {
+		property["network_status"] = curNetworkPolicy.NetworkStatus
+	}
+	if pre == nil || !reflect.DeepEqual(preNetworkPolicy.NetworkErrors, curNetworkPolicy.NetworkErrors) {
+		property["network_errors"] = curNetworkPolicy.NetworkErrors
+	}
 	if pre == nil || !reflect.DeepEqual(preNetworkPolicy.OriginProperties, curNetworkPolicy.OriginProperties) {
 		property["origin_properties"] = curNetworkPolicy.OriginProperties
 	}

--- a/pkg/nsx/services/inventory/compare_test.go
+++ b/pkg/nsx/services/inventory/compare_test.go
@@ -208,6 +208,8 @@ func TestCompareNetworkPolicy(t *testing.T) {
 				"spec":                 "spec-content",
 				"origin_properties":    []common.KeyValuePair{{Key: "annotation", Value: "example"}},
 				"policy_type":          "NETWORK_POLICY",
+				"network_status":       "",
+				"network_errors":       []common.NetworkError(nil),
 			},
 		},
 		{


### PR DESCRIPTION
Introduced logic to parse annotations in network policies for network error messages. Updated the build process to include these errors in the `ContainerNetworkPolicy` object and added a test to validate this functionality.