### PR TITLE
Create network errors from pod status message

### DIFF
--- a/pkg/nsx/services/inventory/build.go
+++ b/pkg/nsx/services/inventory/build.go
@@ -56,6 +56,27 @@ func (s *InventoryService) BuildPod(pod *corev1.Pod) (retry bool) {
 		status = InventoryStatusUnknown
 	}
 
+	// Create network errors from pod conditions and status message
+	var networkErrors []common.NetworkError
+	networkStatus := NetworkStatusHealthy
+	if pod.Status.Phase != corev1.PodRunning {
+		networkStatus = NetworkStatusUnhealthy
+		// Check for a message in pod status
+		if pod.Status.Message != "" {
+			networkErrors = append(networkErrors, common.NetworkError{
+				ErrorMessage: pod.Status.Message,
+			})
+		}
+		// Check conditions
+		for _, condition := range pod.Status.Conditions {
+			if condition.Message != "" {
+				networkErrors = append(networkErrors, common.NetworkError{
+					ErrorMessage: condition.Message,
+				})
+			}
+		}
+	}
+
 	ips := ""
 	if len(pod.Status.PodIPs) == 1 {
 		ips = pod.Status.PodIPs[0].IP
@@ -85,8 +106,8 @@ func (s *InventoryService) BuildPod(pod *corev1.Pod) (retry bool) {
 		ContainerClusterId:      s.NSXConfig.Cluster,
 		ContainerProjectId:      string(namespace.UID),
 		ExternalId:              string(pod.UID),
-		NetworkErrors:           nil,
-		NetworkStatus:           "",
+		NetworkErrors:           networkErrors,
+		NetworkStatus:           networkStatus,
 		OriginProperties:        originProperties,
 		Status:                  status,
 	}

--- a/pkg/nsx/services/inventory/compare.go
+++ b/pkg/nsx/services/inventory/compare.go
@@ -64,6 +64,12 @@ func compareContainerApplicationInstance(pre interface{}, cur interface{}, prope
 	if pre == nil || preAppInstance.Status != curAppInstance.Status {
 		property["status"] = curAppInstance.Status
 	}
+	if pre == nil || !reflect.DeepEqual(preAppInstance.NetworkStatus, curAppInstance.NetworkStatus) {
+		property["network_status"] = curAppInstance.NetworkStatus
+	}
+	if pre == nil || !reflect.DeepEqual(preAppInstance.NetworkErrors, curAppInstance.NetworkErrors) {
+		property["network_errors"] = curAppInstance.NetworkErrors
+	}
 	if pre == nil && len(curAppInstance.OriginProperties) == 1 {
 		property["origin_properties"] = curAppInstance.OriginProperties
 	} else if pre != nil && !reflect.DeepEqual(preAppInstance.OriginProperties, curAppInstance.OriginProperties) {

--- a/pkg/nsx/services/inventory/compare_test.go
+++ b/pkg/nsx/services/inventory/compare_test.go
@@ -37,6 +37,8 @@ func TestCompareContainerApplicationInstance(t *testing.T) {
 				"container_application_ids": []string{"App1", "App2"},
 				"status":                    "Running",
 				"origin_properties":         []common.KeyValuePair{{Key: "ip", Value: "192.168.1.1"}},
+				"network_status":            "",
+				"network_errors":            []common.NetworkError(nil),
 			},
 		},
 		{


### PR DESCRIPTION
Implemented logic to capture pod status messages when the pod is not running. These errors are now stored in the `ContainerApplicationInstance` for better troubleshooting. Added a new test case to validate this behavior and ensure accurate error reporting.