### PR TITLE
Handle VPC error annotations in namespace processing

### DIFF
--- a/pkg/controllers/common/types.go
+++ b/pkg/controllers/common/types.go
@@ -40,7 +40,8 @@ var (
 	ResultRequeueAfter10sec = ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}
 	ResultRequeueAfter60sec = ctrl.Result{Requeue: true, RequeueAfter: 60 * time.Second}
 	// for unstable event, eg: failed to k8s resources when reconciling, may due to k8s unstable
-	ResultRequeueAfter5mins = ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Minute}
+	ResultRequeueAfter5mins     = ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Minute}
+	AnnotationNamespaceVPCError = "nsx.vmware.com/vpc_error"
 )
 
 const (

--- a/pkg/controllers/namespace/namespace_controller.go
+++ b/pkg/controllers/namespace/namespace_controller.go
@@ -29,8 +29,7 @@ import (
 )
 
 var (
-	AnnotationNamespaceVPCError = " nsx.vmware.com/vpc_error"
-	log                         = &logger.Log
+	log = &logger.Log
 )
 
 // NamespaceReconciler process Namespace create/delete event
@@ -77,7 +76,7 @@ func (r *NamespaceReconciler) createNetworkInfoCR(ctx context.Context, obj clien
 		return nil, err
 	}
 
-	changes := map[string]string{AnnotationNamespaceVPCError: ""}
+	changes := map[string]string{common.AnnotationNamespaceVPCError: ""}
 	util.UpdateK8sResourceAnnotation(r.Client, ctx, obj, changes)
 
 	log.Info("Created NetworkInfo CR", "NetworkInfo", networkInfoCR.Name, "Namespace", networkInfoCR.Namespace)
@@ -160,7 +159,7 @@ func (r *NamespaceReconciler) deleteDefaultSubnetSet(ns string) error {
 func (r *NamespaceReconciler) namespaceError(ctx context.Context, k8sObj client.Object, msg string, err error) {
 	logErr := util.If(err == nil, errors.New(msg), err).(error)
 	log.Error(logErr, msg)
-	changes := map[string]string{AnnotationNamespaceVPCError: msg}
+	changes := map[string]string{common.AnnotationNamespaceVPCError: msg}
 	util.UpdateK8sResourceAnnotation(r.Client, ctx, k8sObj, changes)
 }
 

--- a/pkg/nsx/services/inventory/compare.go
+++ b/pkg/nsx/services/inventory/compare.go
@@ -31,12 +31,22 @@ func compareResources(pre interface{}, cur interface{}) map[string]interface{} {
 
 func compareContainerProject(pre interface{}, cur interface{}, property map[string]interface{}) {
 	curProject := cur.(containerinventory.ContainerProject)
+	preProject := containerinventory.ContainerProject{}
+	if pre != nil {
+		preProject = pre.(containerinventory.ContainerProject)
+	}
 	if pre == nil {
 		property["display_name"] = curProject.DisplayName
 		property["container_cluster_id"] = curProject.ContainerClusterId
 	}
-	if pre == nil || !reflect.DeepEqual(pre.(containerinventory.ContainerProject).Tags, curProject.Tags) {
+	if pre == nil || !reflect.DeepEqual(preProject.Tags, curProject.Tags) {
 		property["tags"] = curProject.Tags
+	}
+	if pre == nil || !reflect.DeepEqual(preProject.NetworkStatus, curProject.NetworkStatus) {
+		property["network_status"] = curProject.NetworkStatus
+	}
+	if pre == nil || !reflect.DeepEqual(preProject.NetworkErrors, curProject.NetworkErrors) {
+		property["network_errors"] = curProject.NetworkErrors
 	}
 }
 


### PR DESCRIPTION
Added support for detecting and processing VPC error annotations in namespaces. These errors are now saved as `NetworkErrors` in the `ContainerProject`, with the network status updated to unhealthy. Introduced a new test case to verify correct handling and reporting of these annotations.