### PR TITLE
Not share Subnet between shared Namespaces

### DIFF
--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -300,7 +300,7 @@ func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (b
 		log.V(1).Info("NSX subnet port had been created, returning the existing NSX subnet path", "pod.UID", pod.UID, "subnetPath", subnetPath)
 		return true, subnetPath, nil
 	}
-	subnetSet, err := common.GetDefaultSubnetSet(r.SubnetPortService.Client, ctx, pod.Namespace, servicecommon.LabelDefaultPodSubnetSet)
+	subnetSet, err := common.GetDefaultSubnetSetByNamespace(r.SubnetPortService.Client, pod.Namespace, servicecommon.LabelDefaultPodSubnetSet)
 	if err != nil {
 		return false, "", err
 	}

--- a/pkg/controllers/pod/pod_controller_test.go
+++ b/pkg/controllers/pod/pod_controller_test.go
@@ -476,8 +476,8 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 					func(s *subnetport.SubnetPortService, nsxSubnetPortID string) string {
 						return ""
 					})
-				patches.ApplyFunc(common.GetDefaultSubnetSet,
-					func(client client.Client, ctx context.Context, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
+				patches.ApplyFunc(common.GetDefaultSubnetSetByNamespace,
+					func(client client.Client, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
 						return nil, errors.New("failed to get default SubnetSet")
 					})
 				return patches
@@ -491,8 +491,8 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 					func(s *subnetport.SubnetPortService, nsxSubnetPortID string) string {
 						return ""
 					})
-				patches.ApplyFunc(common.GetDefaultSubnetSet,
-					func(client client.Client, ctx context.Context, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
+				patches.ApplyFunc(common.GetDefaultSubnetSetByNamespace,
+					func(client client.Client, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
 						return &v1alpha1.SubnetSet{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "subnetset-1",
@@ -515,8 +515,8 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 					func(s *subnetport.SubnetPortService, nsxSubnetPortID string) string {
 						return ""
 					})
-				patches.ApplyFunc(common.GetDefaultSubnetSet,
-					func(client client.Client, ctx context.Context, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
+				patches.ApplyFunc(common.GetDefaultSubnetSetByNamespace,
+					func(client client.Client, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
 						return &v1alpha1.SubnetSet{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "subnetset-1",

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -532,7 +532,7 @@ func (r *SubnetPortReconciler) getSubnetByIP(subnetPort *v1alpha1.SubnetPort) (s
 	} else if len(subnetPort.Spec.SubnetSet) > 0 {
 		subnets = r.SubnetService.ListSubnetBySubnetSetName(subnetPort.Namespace, subnetPort.Spec.SubnetSet)
 	} else {
-		subnetSet, err := common.GetDefaultSubnetSet(r.Client, context.Background(), subnetPort.Namespace, servicecommon.LabelDefaultVMSubnetSet)
+		subnetSet, err := common.GetDefaultSubnetSetByNamespace(r.Client, subnetPort.Namespace, servicecommon.LabelDefaultVMSubnetSet)
 		if err != nil {
 			return "", err
 		}
@@ -640,7 +640,7 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 		}
 	} else {
 		subnetSet := &v1alpha1.SubnetSet{}
-		subnetSet, err = common.GetDefaultSubnetSet(r.Client, ctx, subnetPort.Namespace, servicecommon.LabelDefaultVMSubnetSet)
+		subnetSet, err = common.GetDefaultSubnetSetByNamespace(r.Client, subnetPort.Namespace, servicecommon.LabelDefaultVMSubnetSet)
 		if err != nil {
 			return
 		}

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -902,8 +902,8 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 					func(s *subnetport.SubnetPortService, nsxSubnetPortID string) string {
 						return ""
 					})
-				patches.ApplyFunc(common.GetDefaultSubnetSet,
-					func(client client.Client, ctx context.Context, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
+				patches.ApplyFunc(common.GetDefaultSubnetSetByNamespace,
+					func(client client.Client, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
 						subnetSetCR := &v1alpha1.SubnetSet{}
 						subnetSetCR.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 						subnetSetCR.Name = "default-subnetset"
@@ -927,8 +927,8 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 					func(s *subnetport.SubnetPortService, nsxSubnetPortID string) string {
 						return ""
 					})
-				patches.ApplyFunc(common.GetDefaultSubnetSet,
-					func(client client.Client, ctx context.Context, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
+				patches.ApplyFunc(common.GetDefaultSubnetSetByNamespace,
+					func(client client.Client, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
 						subnetSetCR := &v1alpha1.SubnetSet{}
 						subnetSetCR.Name = "default-subnetset"
 						return subnetSetCR, nil
@@ -1070,7 +1070,7 @@ func TestSubnetPortReconciler_getSubnetByIP(t *testing.T) {
 	})
 
 	// SubnetPort with default SubnetSet
-	patches.ApplyFunc(common.GetDefaultSubnetSet, func(client client.Client, ctx context.Context, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
+	patches.ApplyFunc(common.GetDefaultSubnetSetByNamespace, func(client client.Client, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
 		return &v1alpha1.SubnetSet{
 			ObjectMeta: metav1.ObjectMeta{Name: "vm-default", Namespace: "ns-1"},
 		}, nil

--- a/test/e2e/nsx_subnet_test.go
+++ b/test/e2e/nsx_subnet_test.go
@@ -251,6 +251,8 @@ func sharedSubnetSet(t *testing.T) {
 	// 1. Check whether default-vm-subnetset and default-pod-subnetset are created.
 	assureSubnetSet(t, subnetTestNamespaceTarget, common.DefaultVMSubnetSet)
 	assureSubnetSet(t, subnetTestNamespaceTarget, common.DefaultPodSubnetSet)
+	assureSubnetSet(t, subnetTestNamespaceShared, common.DefaultVMSubnetSet)
+	assureSubnetSet(t, subnetTestNamespaceShared, common.DefaultPodSubnetSet)
 
 	// 2. Check `Ipv4SubnetSize` and `AccessMode` should be same with related fields in VPCNetworkConfig.
 	require.True(t, verifySubnetSetCR(common.DefaultVMSubnetSet))
@@ -263,7 +265,7 @@ func sharedSubnetSet(t *testing.T) {
 	defer deleteYAML(portPath, subnetTestNamespaceShared)
 
 	// 3. Check SubnetSet CR status should be updated with NSX Subnet info.
-	subnetSet, err := testData.crdClientset.CrdV1alpha1().SubnetSets(subnetTestNamespaceTarget).Get(context.TODO(), common.DefaultVMSubnetSet, v1.GetOptions{})
+	subnetSet, err := testData.crdClientset.CrdV1alpha1().SubnetSets(subnetTestNamespaceShared).Get(context.TODO(), common.DefaultVMSubnetSet, v1.GetOptions{})
 	require.NoError(t, err)
 	require.NotEmpty(t, subnetSet.Status.Subnets, "No Subnet info in SubnetSet")
 
@@ -273,7 +275,6 @@ func sharedSubnetSet(t *testing.T) {
 	require.NotEmpty(t, port.Status.NetworkInterfaceConfig.IPAddresses[0].IPAddress, "No IP address in SubnetPort")
 
 	// 5. Check Subnet CIDR contains SubnetPort IP.
-
 	portIP := net.ParseIP(strings.Split(port.Status.NetworkInterfaceConfig.IPAddresses[0].IPAddress, "/")[0])
 	_, subnetCIDR, err := net.ParseCIDR(subnetSet.Status.Subnets[0].NetworkAddresses[0])
 	require.NoError(t, err)


### PR DESCRIPTION
Testing done:
Create ns1 and ns2 sharing the same VPC, create a SubnetPort on ns1 and another on ns2. Observe the two SubnetPort is created under the SubnetSet belonging to ns1 and ns2 correspondingly.