### PR TITLE
Support Pod restore

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,7 +50,6 @@ import (
 	subnetbindingservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetbinding"
 	subnetportservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
 
-	commonctl "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	nsxserviceaccountcontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/nsxserviceaccount"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
@@ -134,7 +133,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 		os.Exit(1)
 	}
 
-	var reconcilerList []commonctl.ReconcilerProvider
+	var reconcilerList []pkgutil.ReconcilerProvider
 
 	var vpcService *vpc.VPCService
 	var hookServer webhook.Server

--- a/pkg/controllers/common/types.go
+++ b/pkg/controllers/common/types.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 const (
@@ -54,10 +53,4 @@ const (
 // GarbageCollector interface with collectGarbage method
 type GarbageCollector interface {
 	CollectGarbage(ctx context.Context) error
-}
-
-type ReconcilerProvider interface {
-	RestoreReconcile() error
-	CollectGarbage(ctx context.Context) error
-	StartController(mgr ctrl.Manager, hookServer webhook.Server) error
 }

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -89,6 +89,7 @@ const (
 	AnnotationDefaultNetworkConfig     string = "nsx.vmware.com/default"
 	AnnotationAttachmentRef            string = "nsx.vmware.com/attachment_ref"
 	AnnotationRestore                  string = "nsx/restore"
+	AnnotationPodMAC                   string = "nsx.vmware.com/mac"
 	LabelCPVM                          string = "iaas.vmware.com/is-cpvm-subnetport"
 	TagScopePodName                    string = "nsx-op/pod_name"
 	TagScopePodUID                     string = "nsx-op/pod_uid"

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -51,6 +51,18 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 				},
 			}
 		}
+	case *corev1.Pod:
+		if restoreMode && len(o.Status.PodIP) > 0 {
+			addressBindings = []model.PortAddressBindingEntry{
+				{IpAddress: &o.Status.PodIP},
+			}
+			mac, ok := o.GetAnnotations()[common.AnnotationPodMAC]
+			if ok && mac != "" {
+				addressBindings[0].MacAddress = &mac
+			} else {
+				log.Error(nil, "MAC address annotation not found in Pod", "Pod", o)
+			}
+		}
 	}
 
 	if nsxSubnet.SubnetDhcpConfig != nil && nsxSubnet.SubnetDhcpConfig.Mode != nil && *nsxSubnet.SubnetDhcpConfig.Mode != nsxutil.ParseDHCPMode(v1alpha1.DHCPConfigModeDeactivated) {

--- a/pkg/util/restore_test.go
+++ b/pkg/util/restore_test.go
@@ -18,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	commonctl "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
@@ -219,7 +218,7 @@ func TestUpdateRestoreEndTime(t *testing.T) {
 }
 
 func TestProcessRestore(t *testing.T) {
-	reconcilerList := []commonctl.ReconcilerProvider{
+	reconcilerList := []ReconcilerProvider{
 		&fakeReconcilerProvider{"VPC reconciler"},
 		&fakeReconcilerProvider{"Subnet reconciler"},
 		&fakeReconcilerProvider{"SubnetPort reconciler"},


### PR DESCRIPTION
Testing done:
Create 2 Pods, delete the NSX SubnetPort for one of the Pod, force the restore mode and restart NSX Operator.
Observed the NSX SubnetPort is created with the same IP and MAC, and Pod is annotated with `nsx/restore: eth0`
Then labeled the restored Pod with test=true, observed the annotation was updated on SubnetPort and other fields
like attachment/mac/ip are not changed.