### PR TITLE
Start controller in goroutine

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -302,7 +302,7 @@ func main() {
 	if cf.HAEnabled() {
 		go electMaster(mgr, nsxClient)
 	} else {
-		startServiceController(mgr, nsxClient)
+		go startServiceController(mgr, nsxClient)
 	}
 
 	if metrics.AreMetricsExposed(cf) {


### PR DESCRIPTION
Controller runtime manager needs to start before calling List/Get on manager client.
Otherwise we will get error `the cache is not started, can not read objects`