### PR TITLE
Support IPAddressAllocation restore

### DIFF
--- a/pkg/nsx/services/ipaddressallocation/builder_test.go
+++ b/pkg/nsx/services/ipaddressallocation/builder_test.go
@@ -103,7 +103,7 @@ func TestBuildIPAddressAllocation(t *testing.T) {
 		})
 		defer patch.Reset()
 
-		result, err := ipAllocService.BuildIPAddressAllocation(ipAlloc)
+		result, err := ipAllocService.BuildIPAddressAllocation(ipAlloc, false)
 		assert.Nil(t, result)
 		assert.EqualError(t, err, "failed to find VPCInfo for IPAddressAllocation CR test-ip-alloc in namespace default")
 	})
@@ -131,7 +131,7 @@ func TestBuildIPAddressAllocation(t *testing.T) {
 		})
 		defer patch.Reset()
 
-		result, err := ipAllocService.BuildIPAddressAllocation(ipAlloc)
+		result, err := ipAllocService.BuildIPAddressAllocation(ipAlloc, false)
 		assert.Nil(t, err)
 		assert.Equal(t, "test-ip-alloc_uid1", *result.Id)
 		assert.Equal(t, "test-ip-alloc", *result.DisplayName)


### PR DESCRIPTION
Testing done:
```
Case A
  Step 1. create an IPAddressAllocation CR with spec.allocationSize=32.
  Step 2. after the NSX VPC IP address allocation is created, stop the NSX operator.
  Step 3. delete the NSX VPC IP address allocation by manual and hack the ncpconfig
          CR to the restore mode.
  Step 4. start the NSX operator and check the NSX VPC IP address allocation is
          re-created and the allocation_ips matches the CR status.
  Step 5. rename the NSX VPC IP address allocation, hack the ncpconfig CR to quit
          the restore mode, then start the NSX operator again.
  Step 6. check the NSX VPC IP address allocation's name can be updated back.

Case B
  Step 1. create an IPAddressAllocation CR with spec.allocationSize=1.
  Step 2-4. similar to step 2-4 in case A.
  Step 5. hack the ncpconfig CR to quit the restore mode, start the NSX operator again.
  Step 6. check that the log can print "IPAddressAllocation is not changed".
```