### PR TITLE
Add basic validations for IPAddressAllocation CRD

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_ipaddressallocations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_ipaddressallocations.yaml
@@ -49,9 +49,14 @@ spec:
             description: IPAddressAllocationSpec defines the desired state of IPAddressAllocation.
             properties:
               allocationSize:
-                description: AllocationSize specifies the size of allocationIPs to
-                  be allocated.
+                description: |-
+                  AllocationSize specifies the size of allocationIPs to be allocated.
+                  It should be a power of 2.
+                minimum: 1
                 type: integer
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               ipAddressBlockVisibility:
                 default: Private
                 description: IPAddressBlockVisibility specifies the visibility of
@@ -62,6 +67,9 @@ spec:
                 - Private
                 - PrivateTGW
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
             type: object
           status:
             description: IPAddressAllocationStatus defines the observed state of IPAddressAllocation.

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -186,7 +186,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW. | Private | Enum: [External Private PrivateTGW] <br /> |
-| `allocationSize` _integer_ | AllocationSize specifies the size of allocationIPs to be allocated. |  |  |
+| `allocationSize` _integer_ | AllocationSize specifies the size of allocationIPs to be allocated.<br />It should be a power of 2. |  | Minimum: 1 <br /> |
 
 
 #### IPAddressAllocationStatus

--- a/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
+++ b/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
@@ -44,8 +44,12 @@ type IPAddressAllocationSpec struct {
 	// +kubebuilder:validation:Enum=External;Private;PrivateTGW
 	// +kubebuilder:default=Private
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	IPAddressBlockVisibility IPAddressVisibility `json:"ipAddressBlockVisibility,omitempty"`
 	// AllocationSize specifies the size of allocationIPs to be allocated.
+	// It should be a power of 2.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +kubebuilder:validation:Minimum:=1
 	AllocationSize int `json:"allocationSize,omitempty"`
 }
 


### PR DESCRIPTION
Testing done:
```
Case 1. create CR with allocationSize=0, the K8s reports error : ... spec.allocationSize in body should be greater than or equal to 1
Case 2. create CR with allocationSize=1 then try to modify it to 2, the K8s reports error : ... Value is immutable
Case 3. create CR without ipAddressBlockVisibility, then apply a new configuration with ipAddressBlockVisibility=Private, the apply operation can be done.
Case 4. create CR with ipAddressBlockVisibility=Private, then try to modify it to External, the K8s reports error: spec.ipAddressBlockVisibility: Invalid value: "string": Value is immutable
```