### PR TITLE
Support SubnetPort creation with AddressBindings

### DIFF
--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	nsx_policy "github.com/vmware/vsphere-automation-sdk-go/services/nsxt"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/cluster/restore"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/pools"
 	mpsearch "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/search"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/trust_management"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/trust_management/principal_identities"
@@ -104,6 +105,7 @@ type Client struct {
 	LbMonitorProfilesClient           infra.LbMonitorProfilesClient
 	SubnetConnectionBindingMapsClient subnets.SubnetConnectionBindingMapsClient
 	NsxApiClient                      *nsxt.APIClient
+	MacPoolsClient                    pools.MacPoolsClient
 
 	NSXChecker    NSXHealthChecker
 	NSXVerChecker NSXVersionChecker
@@ -210,6 +212,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 	subnetConnectionBindingMapsClient := subnets.NewSubnetConnectionBindingMapsClient(connector)
 
 	nsxApiClient, _ := CreateNsxtApiClient(cf, cluster.client)
+	macPoolsClient := pools.NewMacPoolsClient(connector)
 
 	nsxChecker := &NSXHealthChecker{
 		cluster: cluster,
@@ -268,6 +271,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 		LbPersistenceProfilesClient:       lbPersistenceProfilesClient,
 		LbMonitorProfilesClient:           lbMonitorProfilesClient,
 		NsxApiClient:                      nsxApiClient,
+		MacPoolsClient:                    macPoolsClient,
 	}
 	// NSX version check will be restarted during SecurityPolicy reconcile
 	// So, it's unnecessary to exit even if failed in the first time


### PR DESCRIPTION
Testing done:

- Create a SubnetPort with MAC in NSX MAC pool on DHCPDeactivated Subnet, observed the NSX SubnetPort created with the same IP/MAC and allocate_addresses as BOTH 
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: subnetport-test-1
spec:
  subnet: subnet-test-1
  addressBindings:
    - ipAddress: 192.168.0.20
      macAddress: 04:50:56:00:f4:a0
```
- Create a SubnetPort with MAC outside NSX MAC pool on DHCPDeactivated Subnet, observed the NSX SubnetPort created with the same IP/MAC and allocate_addresses as IP_POOL 
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: subnetport-test-2
spec:
  subnet: subnet-test-1
  addressBindings:
    - ipAddress: 192.168.0.21
      macAddress: 04:50:56:01:f4:a0
```
- Create a SubnetPort on DHCPServer Subnet, observed the NSX SubnetPort created with the same IP/MAC and allocate_addresses as DHCP 
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: subnetport-test-3
spec:
  subnet: subnet-test-2
  addressBindings:
    - ipAddress: 192.168.0.36
      macAddress: 04:50:56:02:f4:a0
```

