### PR TITLE
Support AddressBinding restore

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -162,7 +162,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 		if err != nil {
 			log.Error(err, "Failed to initialize ipaddressallocation commonService", "controller", "IPAddressAllocation")
 		}
-		subnetPortService, err := subnetportservice.InitializeSubnetPort(commonService)
+		subnetPortService, err := subnetportservice.InitializeSubnetPort(commonService, vpcService, ipAddressAllocationService)
 		if err != nil {
 			log.Error(err, "Failed to initialize subnetport commonService", "controller", "SubnetPort")
 			os.Exit(1)
@@ -216,7 +216,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			subnetSetReconcile,
 			node.NewNodeReconciler(mgr, nodeService),
 			staticroutecontroller.NewStaticRouteReconciler(mgr, staticRouteService),
-			subnetport.NewSubnetPortReconciler(mgr, subnetPortService, subnetService, vpcService),
+			subnetport.NewSubnetPortReconciler(mgr, subnetPortService, subnetService, vpcService, ipAddressAllocationService),
 			pod.NewPodReconciler(mgr, subnetPortService, subnetService, vpcService, nodeService),
 			ipaddressallocation.NewIPAddressAllocationReconciler(mgr, ipAddressAllocationService, vpcService),
 			networkpolicycontroller.NewNetworkPolicyReconciler(mgr, commonService, vpcService),

--- a/pkg/clean/clean.go
+++ b/pkg/clean/clean.go
@@ -105,6 +105,10 @@ func InitializeCleanupService(cf *config.NSXOperatorConfig, nsxClient *nsx.Clien
 		NSXConfig: cf,
 	}
 	vpcService, vpcErr := vpc.InitializeVPC(commonService)
+	ipAddressAllocationService, err := ipaddressallocation.InitializeIPAddressAllocation(commonService, vpcService, true)
+	if err != nil {
+		return nil, err
+	}
 
 	// initialize all the CR services
 	// Use Fluent Interface to escape error check hell
@@ -133,12 +137,12 @@ func InitializeCleanupService(cf *config.NSXOperatorConfig, nsxClient *nsx.Clien
 
 	wrapInitializeSubnetPort := func(service common.Service) cleanupFunc {
 		return func() (interface{}, error) {
-			return subnetport.InitializeSubnetPort(service)
+			return subnetport.InitializeSubnetPort(service, vpcService, ipAddressAllocationService)
 		}
 	}
 	wrapInitializeIPAddressAllocation := func(service common.Service) cleanupFunc {
 		return func() (interface{}, error) {
-			return ipaddressallocation.InitializeIPAddressAllocation(service, vpcService, true)
+			return ipAddressAllocationService, nil
 		}
 	}
 	wrapInitializeSubnetBinding := func(service common.Service) cleanupFunc {

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
@@ -111,4 +112,32 @@ func (m *MockSubnetPortServiceProvider) IsEmptySubnet(id string, path string) bo
 
 func (m *MockSubnetPortServiceProvider) DeletePortCount(path string) {
 	return
+}
+
+type MockIPAddressAllocationProvider struct {
+	mock.Mock
+}
+
+func (m *MockIPAddressAllocationProvider) BuildIPAddressAllocationID(obj metav1.Object) string {
+	return ""
+}
+
+func (m *MockIPAddressAllocationProvider) GetIPAddressAllocationByOwner(owner metav1.Object) (*model.VpcIpAddressAllocation, error) {
+	return nil, nil
+}
+
+func (m *MockIPAddressAllocationProvider) CreateIPAddressAllocationForAddressBinding(addressBinding *v1alpha1.AddressBinding, subnetPort *v1alpha1.SubnetPort, restoreMode bool) error {
+	return nil
+}
+
+func (m *MockIPAddressAllocationProvider) DeleteIPAddressAllocationForAddressBinding(obj metav1.Object) error {
+	return nil
+}
+
+func (m *MockIPAddressAllocationProvider) DeleteIPAddressAllocationByNSXResource(nsxIPAddressAllocation *model.VpcIpAddressAllocation) error {
+	return nil
+}
+
+func (m *MockIPAddressAllocationProvider) ListIPAddressAllocationWithAddressBinding() []*model.VpcIpAddressAllocation {
+	return []*model.VpcIpAddressAllocation{}
 }

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
@@ -48,4 +49,13 @@ type IPBlocksInfoServiceProvider interface {
 	SyncIPBlocksInfo(ctx context.Context) error
 	UpdateIPBlocksInfo(ctx context.Context, vpcConfigCR *v1alpha1.VPCNetworkConfiguration) error
 	ResetPeriodicSync()
+}
+
+type IPAddressAllocationServiceProvider interface {
+	GetIPAddressAllocationByOwner(owner metav1.Object) (*model.VpcIpAddressAllocation, error)
+	CreateIPAddressAllocationForAddressBinding(addressBinding *v1alpha1.AddressBinding, subnetPort *v1alpha1.SubnetPort, restoreMode bool) error
+	DeleteIPAddressAllocationForAddressBinding(obj metav1.Object) error
+	BuildIPAddressAllocationID(obj metav1.Object) string
+	DeleteIPAddressAllocationByNSXResource(nsxIPAddressAllocation *model.VpcIpAddressAllocation) error
+	ListIPAddressAllocationWithAddressBinding() []*model.VpcIpAddressAllocation
 }

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -56,6 +56,8 @@ const (
 	TagScopeSubnetPortCRUID            string = "nsx-op/subnetport_uid"
 	TagScopeIPAddressAllocationCRName  string = "nsx-op/ipaddressallocation_name"
 	TagScopeIPAddressAllocationCRUID   string = "nsx-op/ipaddressallocation_uid"
+	TagScopeAddressBindingCRName       string = "nsx-op/addressbinding_name"
+	TagScopeAddressBindingCRUID        string = "nsx-op/addressbinding_uid"
 	TagScopeVMNamespaceUID             string = "nsx-op/vm_namespace_uid"
 	TagScopeVMNamespace                string = "nsx-op/vm_namespace"
 	TagScopeVPCManagedBy               string = "nsx/managed-by"

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -34,13 +34,15 @@ var (
 
 type SubnetPortService struct {
 	servicecommon.Service
-	SubnetPortStore *SubnetPortStore
-	builder         *servicecommon.PolicyTreeBuilder[*model.VpcSubnetPort]
-	macPool         *mp_model.MacPool
+	SubnetPortStore            *SubnetPortStore
+	VPCService                 servicecommon.VPCServiceProvider
+	IpAddressAllocationService servicecommon.IPAddressAllocationServiceProvider
+	builder                    *servicecommon.PolicyTreeBuilder[*model.VpcSubnetPort]
+	macPool                    *mp_model.MacPool
 }
 
 // InitializeSubnetPort sync NSX resources.
-func InitializeSubnetPort(service servicecommon.Service) (*SubnetPortService, error) {
+func InitializeSubnetPort(service servicecommon.Service, vpcService servicecommon.VPCServiceProvider, ipAddressAllocationService servicecommon.IPAddressAllocationServiceProvider) (*SubnetPortService, error) {
 	builder, _ := servicecommon.PolicyPathVpcSubnetPort.NewPolicyTreeBuilder()
 
 	wg := sync.WaitGroup{}
@@ -49,7 +51,12 @@ func InitializeSubnetPort(service servicecommon.Service) (*SubnetPortService, er
 
 	wg.Add(1)
 
-	subnetPortService := &SubnetPortService{Service: service, builder: builder}
+	subnetPortService := &SubnetPortService{
+		Service:                    service,
+		VPCService:                 vpcService,
+		IpAddressAllocationService: ipAddressAllocationService,
+		builder:                    builder,
+	}
 
 	subnetPortService.SubnetPortStore = &SubnetPortStore{
 		ResourceStore: servicecommon.ResourceStore{

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -23,6 +23,8 @@ import (
 	mock_org_root "github.com/vmware-tanzu/nsx-operator/pkg/mock/orgrootclient"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/ipaddressallocation"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
@@ -169,9 +171,11 @@ func Test_InitializeSubnetPort(t *testing.T) {
 					},
 				},
 			}
+			vpcService := &vpc.VPCService{}
+			ipAddressAllocationService := &ipaddressallocation.IPAddressAllocationService{}
 			patches := tt.prepareFunc(t, &commonService, ctx)
 			defer patches.Reset()
-			got, err := InitializeSubnetPort(commonService)
+			got, err := InitializeSubnetPort(commonService, vpcService, ipAddressAllocationService)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InitializeSubnetPort() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -488,6 +488,10 @@ func BuildBasicTags(cluster string, obj interface{}, namespaceID types.UID) []mo
 		tags = append(tags, model.Tag{Scope: String(common.TagScopeNamespace), Tag: String(i.ObjectMeta.Namespace)})
 		tags = append(tags, model.Tag{Scope: String(common.TagScopeSubnetBindingCRName), Tag: String(i.ObjectMeta.Name)})
 		tags = append(tags, model.Tag{Scope: String(common.TagScopeSubnetBindingCRUID), Tag: String(string(i.ObjectMeta.UID))})
+	case *v1alpha1.AddressBinding:
+		tags = append(tags, model.Tag{Scope: String(common.TagScopeNamespace), Tag: String(i.ObjectMeta.Namespace)})
+		tags = append(tags, model.Tag{Scope: String(common.TagScopeAddressBindingCRName), Tag: String(i.ObjectMeta.Name)})
+		tags = append(tags, model.Tag{Scope: String(common.TagScopeAddressBindingCRUID), Tag: String(string(i.UID))})
 	default:
 		log.Info("Unknown obj type", "obj", obj)
 	}


### PR DESCRIPTION
The AddressBinding CR maps the port's external_address_binding property.
However, when we want to restore it, we cannot specify the previous
IP because the port.external_address_binding.external_ip_address is
ready only. So this patch will create the NSX IPAddressAllocation in
the external AddressBinding restore then write it into port's
external_address_binding.allocated_external_ip_path to keep the IP
consistent after the restore.

For the new created NSX IPAddressAllocation, its format is as follows:
(the rule of name and id is similar to the rule for IPAddressAllocation CR)

```
display_name: <AddressBinding CR name>
id: <AddressBinding CR name>_<AddressBinding CR UID>
special tags:
    {
        "scope": "nsx-op/addressbinding_name",
        "tag": "addressbinding-01"
    },
    {
        "scope": "nsx-op/addressbinding_uid",
        "tag": "53bfadad-ef3b-42c7-8879-6d25431f6336"
    },
    {
        "scope": "nsx-op/subnetport_name",
        "tag": "private-vm2-eth0"
    },
    {
        "scope": "nsx-op/subnetport_uid",
        "tag": "d90fc86f-7a16-488d-9f49-f83c69c45d2e"
    }
```
The new NSX IPAddressAllocation is only created in the restore stage
and it won't be removed until the AddressBinding CR or SubnetPort CR is
removed.

Testing done:

Case 1. regression case: create address binding, check port has
external_address_binding; delete address binding CR, check port's
external_address_binding is removed.

Case 2. regression case: create IPAddressAllocation CR, check the NSX
IPAddressAllocation can be created and its tags are expected; delete
the CR, check the NSX IPAddressAllocation can be removed.

Case 3. delete NSX port and reserve AddressBinding CR, enter restore
mode (both check in 2min and after 2min), check NSX IPAddressAllocation
is created and port can be restored with external_address_binding.

Case 4. after 2, delete AddressBinding CR in normal mode, check
the NSX IPAddressAllocation can be deleted and the port's
external_address_binding is removed.

Case 5. remove port's external_address_binding, reserve NSX port and
AddressBinding CR, check the port's external_address_binding can be
restored and the NSX IPAddressAllocation is created.

Case 6. Leave a stale NSX IPAddressAllocation, check that it can
removed by the GC when its AddressBinding and port is removed.