### PR TITLE
Update GetPolicyTier1UplinkPortIP id checking

### DIFF
--- a/pkg/nsx/services/realizestate/realize_state.go
+++ b/pkg/nsx/services/realizestate/realize_state.go
@@ -88,7 +88,8 @@ func (service *RealizeStateService) GetPolicyTier1UplinkPortIP(intentPath string
 
 	for _, result := range results.Results {
 		extendAttributes := result.ExtendedAttributes
-		if len(extendAttributes) == 0 || len(result.IntentPaths) != 1 || (result.EntityType != nil && *result.EntityType != "RealizedLogicalRouterPort") {
+		if len(extendAttributes) == 0 || len(result.IntentPaths) != 1 || *result.Id != "gateway-interface" ||
+			(result.EntityType != nil && *result.EntityType != "RealizedLogicalRouterPort") {
 			continue
 		}
 		for i := range extendAttributes {


### PR DESCRIPTION
In DTGW env, the previous iteration checking is not enough, add id checking, CTGW interface id is fixed as "gateway-interface".