### PR TITLE
Add validation on bindingmap for pre-created Subnet

### DIFF
--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -26,6 +26,8 @@ import (
 var (
 	log            = &logger.Log
 	SubnetSetLocks sync.Map
+	// Currently NSX only has default org
+	orgId = "default"
 )
 
 func AllocateSubnetFromSubnetSet(subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider) (string, error) {
@@ -263,4 +265,13 @@ func GetSubnetByIP(subnets []*model.VpcSubnet, ip net.IP) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("failed to find Subnet matching IP %s", ip)
+}
+
+func GetSubnetPathFromAssociatedResource(associatedResource string) (string, error) {
+	// associatedResource has the format projectID:vpcID:subnetID
+	parts := strings.Split(associatedResource, ":")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("failed to parse associated resource annotation %s", associatedResource)
+	}
+	return fmt.Sprintf("/orgs/%s/projects/%s/vpcs/%s/subnets/%s", orgId, parts[0], parts[1], parts[2]), nil
 }

--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -276,3 +276,12 @@ func TestStatusUpdater_DeleteFail(t *testing.T) {
 
 	statusUpdater.DeleteFail(types.NamespacedName{Name: "name", Namespace: "ns"}, &v1alpha1.Subnet{}, fmt.Errorf("mock error"))
 }
+
+func TestGetSubnetPathFromAssociatedResource(t *testing.T) {
+	path, err := GetSubnetPathFromAssociatedResource("project-1:ns-1:subnet-1")
+	assert.Nil(t, err)
+	assert.Equal(t, "/orgs/default/projects/project-1/vpcs/ns-1/subnets/subnet-1", path)
+
+	_, err = GetSubnetPathFromAssociatedResource("invalid-annotation")
+	assert.ErrorContains(t, err, "failed to parse associated resource annotation")
+}

--- a/pkg/nsx/services/common/builder.go
+++ b/pkg/nsx/services/common/builder.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -53,4 +54,14 @@ func ParseVPCResourcePath(nsxResourcePath string) (VPCResourceInfo, error) {
 	info.ID = layers[size-1]
 	info.ParentID = layers[size-3]
 	return info, nil
+}
+
+// parse org id and project id from nsxProject path
+// example /orgs/default/projects/nsx_operator_e2e_test
+func NSXProjectPathToId(path string) (string, string, error) {
+	parts := strings.Split(path, "/")
+	if len(parts) < 5 {
+		return "", "", errors.New("invalid NSX project path")
+	}
+	return parts[2], parts[4], nil
 }

--- a/pkg/nsx/services/common/builder_test.go
+++ b/pkg/nsx/services/common/builder_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
@@ -193,6 +194,31 @@ func TestParseVPCResourcePath(t *testing.T) {
 			if !reflect.DeepEqual(tt.want, got) {
 				t.Errorf("ParseVPCResourcePath() got = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestNsxProjectPathToId(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		org       string
+		project   string
+		expectErr string
+	}{
+		{"Valid project path", "/orgs/default/projects/nsx_operator_e2e_test", "default", "nsx_operator_e2e_test", ""},
+		{"Invalid project path", "", "", "", "invalid NSX project path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o, p, err := NSXProjectPathToId(tt.path)
+			if tt.expectErr != "" {
+				assert.ErrorContains(t, err, tt.expectErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.org, o)
+			assert.Equal(t, tt.project, p)
 		})
 	}
 }

--- a/pkg/nsx/services/subnetbinding/builder_test.go
+++ b/pkg/nsx/services/subnetbinding/builder_test.go
@@ -89,8 +89,8 @@ var (
 
 func TestBuildSubnetBindings(t *testing.T) {
 	service := mockService()
-	parentSubnets := []*model.VpcSubnet{parentSubnet1, parentSubnet2}
-	bindingMaps := service.buildSubnetBindings(binding1, parentSubnets)
+	parentSubnetPaths := []string{parentSubnetPath1, parentSubnetPath2}
+	bindingMaps := service.buildSubnetBindings(binding1, parentSubnetPaths)
 	require.Equal(t, 2, len(bindingMaps))
 	expBindingMaps := []*model.SubnetConnectionBindingMap{
 		bindingMap1, bindingMap2,

--- a/pkg/nsx/services/subnetbinding/subnetbinding_test.go
+++ b/pkg/nsx/services/subnetbinding/subnetbinding_test.go
@@ -116,7 +116,7 @@ func TestGetSubnetConnectionBindingMapCRsBySubnet(t *testing.T) {
 	require.Equal(t, 0, len(gotBMs1))
 
 	// Case: success.
-	bindingMaps := svc.buildSubnetBindings(binding1, []*model.VpcSubnet{parentSubnet1})
+	bindingMaps := svc.buildSubnetBindings(binding1, []string{*parentSubnet1.Path})
 	require.Equal(t, 1, len(bindingMaps))
 	bm := bindingMaps[0]
 	bm.ParentPath = childSubnet.Path
@@ -146,10 +146,10 @@ func TestListSubnetConnectionBindingMapCRUIDsInStore(t *testing.T) {
 	require.Equal(t, 0, crIDs.Len())
 
 	// Case: success
-	bm := svc.buildSubnetBindings(binding1, []*model.VpcSubnet{parentSubnet1})[0]
+	bm := svc.buildSubnetBindings(binding1, []string{*parentSubnet1.Path})[0]
 	bm.ParentPath = String(childSubnetPath1)
 	bm.Path = String(fmt.Sprintf("%s/subnet-connection-binding-maps/%s", *bm.ParentPath, *bm.Id))
-	bm2 := svc.buildSubnetBindings(binding2, []*model.VpcSubnet{parentSubnet2})[0]
+	bm2 := svc.buildSubnetBindings(binding2, []string{*parentSubnet2.Path})[0]
 	bm2.ParentPath = String(childSubnetPath2)
 	bm2.Path = String(fmt.Sprintf("%s/subnet-connection-binding-maps/%s", *bm2.ParentPath, *bm2.Id))
 	svc.BindingStore.Apply(bm)
@@ -344,7 +344,7 @@ func TestCreateOrUpdateSubnetConnectionBindingMap(t *testing.T) {
 			}
 			tc.prepareFunc()
 
-			err := svc.CreateOrUpdateSubnetConnectionBindingMap(binding1, childSubnet, []*model.VpcSubnet{parentSubnet2})
+			err := svc.CreateOrUpdateSubnetConnectionBindingMap(binding1, *childSubnet.Path, []string{*parentSubnet2.Path})
 			if tc.expErr != "" {
 				require.EqualError(t, err, tc.expErr)
 			} else {

--- a/pkg/nsx/services/vpc/builder.go
+++ b/pkg/nsx/services/vpc/builder.go
@@ -1,7 +1,6 @@
 package vpc
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -114,16 +113,6 @@ func buildVpcAttachment(obj *v1alpha1.NetworkInfo, nsObj *v1.Namespace, cluster 
 	attachment.Id = common.String(common.DefaultVpcAttachmentId)
 	attachment.Tags = util.BuildBasicTags(cluster, obj, nsObj.GetUID())
 	return attachment, nil
-}
-
-// parse org id and project id from nsxProject path
-// example /orgs/default/projects/nsx_operator_e2e_test
-func nsxProjectPathToId(path string) (string, string, error) {
-	parts := strings.Split(path, "/")
-	if len(parts) < 4 {
-		return "", "", errors.New("invalid NSX project path")
-	}
-	return parts[2], parts[len(parts)-1], nil
 }
 
 func isDefaultNetworkConfigCR(vpcConfigCR *v1alpha1.VPCNetworkConfiguration) bool {

--- a/pkg/nsx/services/vpc/builder_test.go
+++ b/pkg/nsx/services/vpc/builder_test.go
@@ -369,31 +369,6 @@ func Test_generateLBSKey(t *testing.T) {
 	}
 }
 
-func TestNsxProjectPathToId(t *testing.T) {
-	tests := []struct {
-		name      string
-		path      string
-		org       string
-		project   string
-		expectErr string
-	}{
-		{"Valid project path", "/orgs/default/projects/nsx_operator_e2e_test", "default", "nsx_operator_e2e_test", ""},
-		{"Invalid project path", "", "", "", "invalid NSX project path"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			o, p, err := nsxProjectPathToId(tt.path)
-			if tt.expectErr != "" {
-				assert.ErrorContains(t, err, tt.expectErr)
-			} else {
-				assert.NoError(t, err)
-			}
-			assert.Equal(t, tt.org, o)
-			assert.Equal(t, tt.project, p)
-		})
-	}
-}
-
 func TestIsDefaultNetworkConfigCR(t *testing.T) {
 	testCRD1 := v1alpha1.VPCNetworkConfiguration{}
 	testCRD1.Name = "test-1"

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -121,7 +121,7 @@ func (s *VPCService) GetVPCNetworkConfigByNamespace(ns string) (*v1alpha1.VPCNet
 // incorrect configuration, and skip creating this VPC CR
 func (s *VPCService) ValidateNetworkConfig(nc *v1alpha1.VPCNetworkConfiguration) error {
 	// Skip creating VPC if NSX Project Path is invalid
-	_, _, err := nsxProjectPathToId(nc.Spec.NSXProject)
+	_, _, err := common.NSXProjectPathToId(nc.Spec.NSXProject)
 	if err != nil {
 		err = fmt.Errorf("invalid NSXProject: %s, error: %w", nc.Spec.NSXProject, err)
 		log.Error(err, "Failed to parse NSXProject in NetworkConfig")
@@ -415,7 +415,7 @@ func (s *VPCService) GetVpcConnectivityProfile(nc *v1alpha1.VPCNetworkConfigurat
 		return nil, fmt.Errorf("failed to check VPCConnectivityProfile(%s) length", nc.Spec.VPCConnectivityProfile)
 	}
 	vpcConnectivityProfileName := parts[len(parts)-1]
-	org, project, err := nsxProjectPathToId(nc.Spec.NSXProject)
+	org, project, err := common.NSXProjectPathToId(nc.Spec.NSXProject)
 	if err != nil {
 		log.Error(err, "Failed to parse NSX project in NetworkConfig", "ProjectPath", nc.Spec.NSXProject)
 		return nil, err
@@ -457,7 +457,7 @@ func (s *VPCService) IsLBProviderChanged(existingVPC *model.Vpc, lbProvider LBPr
 
 func (s *VPCService) CreateOrUpdateVPC(ctx context.Context, obj *v1alpha1.NetworkInfo, nc *v1alpha1.VPCNetworkConfiguration, lbProvider LBProvider, serviceClusterReady bool) (*model.Vpc, error) {
 	// parse project path in NetworkConfig
-	org, project, err := nsxProjectPathToId(nc.Spec.NSXProject)
+	org, project, err := common.NSXProjectPathToId(nc.Spec.NSXProject)
 	if err != nil {
 		log.Error(err, "Failed to parse NSX project in NetworkConfig", "ProjectPath", nc.Spec.NSXProject)
 		return nil, err
@@ -576,7 +576,7 @@ func (s *VPCService) CreateOrUpdateVPC(ctx context.Context, obj *v1alpha1.Networ
 
 func (s *VPCService) createNSXVPC(createdVpc *model.Vpc, nc *v1alpha1.VPCNetworkConfiguration, orgRoot *model.OrgRoot) error {
 	log.Info("Creating NSX VPC", "VPC", *createdVpc.Id)
-	org, project, err := nsxProjectPathToId(nc.Spec.NSXProject)
+	org, project, err := common.NSXProjectPathToId(nc.Spec.NSXProject)
 	if err != nil {
 		log.Error(err, "Failed to parse NSX project in NetworkConfig", "ProjectPath", nc.Spec.NSXProject)
 		return err
@@ -623,7 +623,7 @@ func (s *VPCService) checkLBSRealization(createdLBS *model.LBService, createdVpc
 	if createdLBS == nil {
 		return nil
 	}
-	org, project, err := nsxProjectPathToId(nc.Spec.NSXProject)
+	org, project, err := common.NSXProjectPathToId(nc.Spec.NSXProject)
 	if err != nil {
 		log.Error(err, "Failed to parse NSX project in NetworkConfig", "ProjectPath", nc.Spec.NSXProject)
 		return err
@@ -659,7 +659,7 @@ func (s *VPCService) checkVpcAttachmentRealization(createdAttachment *model.VpcA
 	if createdAttachment == nil {
 		return nil
 	}
-	org, project, err := nsxProjectPathToId(nc.Spec.NSXProject)
+	org, project, err := common.NSXProjectPathToId(nc.Spec.NSXProject)
 	if err != nil {
 		log.Error(err, "Failed to parse NSX project in NetworkConfig", "ProjectPath", nc.Spec.NSXProject)
 		return err
@@ -702,7 +702,7 @@ func (s *VPCService) GetGatewayConnectionTypeFromConnectionPath(connectionPath s
 }
 
 func (s *VPCService) ValidateConnectionStatus(nc *v1alpha1.VPCNetworkConfiguration) (*common.VPCConnectionStatus, error) {
-	org, project, err := nsxProjectPathToId(nc.Spec.NSXProject)
+	org, project, err := common.NSXProjectPathToId(nc.Spec.NSXProject)
 	if err != nil {
 		log.Error(err, "Failed to parse NSX project in NetworkConfig", "ProjectPath", nc.Spec.NSXProject)
 		return nil, err


### PR DESCRIPTION
After introducing the pre-created Subnet, we need 2 more validations on the SubnetBindingMap
1. Parent Subnet cannot be pre-created Subnet
2. Parent Subnets and child subnet should be in the same VPC

Testing done:
- Case 1: Create a BindingMap with pre-created Subnet as child subnet and set a SubnetSet as parent. The BindingMap is created as expected.
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetConnectionBindingMap
metadata:
  name: binding1
  namespace: ns-1
spec:
  subnetName: subnet-precreated-1
  targetSubnetSetName: vm-default
  vlanTrafficTag: 201
```
- Case 2: Create a BindingMap with pre-created Subnet as child subnet and set a Subnet as parent. The BindingMap is created as expected.
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetConnectionBindingMap
metadata:
  name: binding2
  namespace: ns-1
spec:
  subnetName: subnet-precreated-1
  targetSubnetName: subnet-test-1
  vlanTrafficTag: 201
```
- Case 3: Create a BindingMap with pre-created Subnet as parent. The CR reports error `Target Subnet ns-1/subnet-precreated-1 is a pre-created Subnet`
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetConnectionBindingMap
metadata:
  name: binding3
  namespace: ns-1
spec:
  subnetName: subnet-test-1
  targetSubnetName: subnet-precreated-1
  vlanTrafficTag: 201
```
- Case 4: Create a BindingMap, the child pre-created Subnet has vpcName as `:kube-system_857f4b84-894d-42ac-a9ec-34d1c8f6a928` and parent Subnet has vpcName as `:ns-1_9c32dcad-dd4c-4481-a351-e462e9eb40e6`. The CR reports error 
```
Subnet /orgs/default/projects/project-quality/vpcs/kube-system_a9e5eaf4-6daa-4bb6-84a4-a6d852888dd3/subnets/subnet-precreated-2
and target Subnet /orgs/default/projects/project-quality/vpcs/ns-1_ad49141b-d3ce-48cd-9e03-c14ce2b28128/subnets/subnet-test-1_b2d0077e-c5d3-402e-8eb4-44d87280348d
are in different VPCs
```
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetConnectionBindingMap
metadata:
  name: binding4
  namespace: ns-1
spec:
  subnetName: subnet-precreated-2
  targetSubnetName: subnet-test-1
  vlanTrafficTag: 201
```