### PR TITLE
Support to restore VPC with preferred_default_snat_ip

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/vmware/govmomi v0.27.4
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.7.0
 	github.com/vmware/vsphere-automation-sdk-go/runtime v0.7.0
-	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.0.0-20250403071254-735943254124
+	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20250603090132-4175b4eea228
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20241118070432-460aadb3b866
 	go.uber.org/automaxprocs v1.5.3
 	go.uber.org/zap v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/vmware/vsphere-automation-sdk-go/runtime v0.7.0 h1:pSBxa9Agh6bgW8Hr0A
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.7.0/go.mod h1:qdzEFm2iK3dvlmm99EYYNxs70HbzuiHyENFD24Ps8fQ=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.0.0-20250403071254-735943254124 h1:s563zUNxWDtNV82uZV0b9UMZTnz3HAr9neLNYAs1QDk=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.0.0-20250403071254-735943254124/go.mod h1:upLH9b9zpG86P0wwO4+gREf0lBXr8gYcs7P1FRZ9n30=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20250603090132-4175b4eea228 h1:VNWQrZZOudosbD0YTCaeu9/Cl6GXKrlvJZBycflNFOo=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20250603090132-4175b4eea228/go.mod h1:C3JVOHRVLrGBQ8kTWAiGYlRz5UQC5qAcTdt3tvA+5P0=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20241118070432-460aadb3b866 h1:mwJJpmzEzej5BD53jz6l+6mJIE9I1nN79xx9JrWuQIE=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20241118070432-460aadb3b866/go.mod h1:ugk9I4YM62SSAox57l5NAVBCRIkPQ1RNLb3URxyTADc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -48,10 +48,11 @@ const (
 	ServiceAccountRestore
 	ServiceAccountCertRotation
 	StaticRoute
+	VPCPreferredDefaultSNATIP
 	AllFeatures
 )
 
-var FeaturesName = [AllFeatures]string{"VPC", "SECURITY_POLICY", "NSX_SERVICE_ACCOUNT", "NSX_SERVICE_ACCOUNT_RESTORE", "NSX_SERVICE_ACCOUNT_CERT_ROTATION", "STATIC_ROUTE"}
+var FeaturesName = [AllFeatures]string{"VPC", "SECURITY_POLICY", "NSX_SERVICE_ACCOUNT", "NSX_SERVICE_ACCOUNT_RESTORE", "NSX_SERVICE_ACCOUNT_CERT_ROTATION", "STATIC_ROUTE", "VPC_PREFERRED_DEFAULT_SNAT_IP"}
 
 type Client struct {
 	NsxConfig     *config.NSXOperatorConfig
@@ -118,6 +119,7 @@ var (
 	nsx411Version = [3]int64{4, 1, 1}
 	nsx412Version = [3]int64{4, 1, 2}
 	nsx413Version = [3]int64{4, 1, 3}
+	nsx910Version = [3]int64{9, 1, 0}
 )
 
 type NSXHealthChecker struct {

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -445,6 +445,9 @@ func (nsxVersion *NsxVersion) featureSupported(feature int) bool {
 	case ServiceAccountCertRotation:
 		minVersion = nsx413Version
 		validFeature = true
+	case VPCPreferredDefaultSNATIP:
+		minVersion = nsx910Version
+		validFeature = true
 	}
 
 	if validFeature {

--- a/pkg/nsx/services/ipblocksinfo/ipblocksinfo.go
+++ b/pkg/nsx/services/ipblocksinfo/ipblocksinfo.go
@@ -317,11 +317,11 @@ func (s *IPBlocksInfoService) getIPBlockCIDRsFromStore(pathSet sets.Set[string],
 			return nil, fmt.Errorf("failed to get IPBlock %s from NSX", path)
 		}
 		ipblock := obj.(*model.IpAddressBlock)
-		if ipblock.Cidr == nil {
+		if ipblock.Cidr == nil { //nolint:staticcheck //ipblock.Cidr is deprecated
 			return nil, fmt.Errorf("failed to get CIDR from ipblock %s", path)
 		}
-		log.V(2).Info("successfully get cidr for IPBblock", "path", path, "cidr", *ipblock.Cidr)
-		ipCIDRs = append(ipCIDRs, *ipblock.Cidr)
+		log.V(2).Info("successfully get cidr for IPBblock", "path", path, "cidr", *ipblock.Cidr) //nolint:staticcheck //ipblock.Cidr is deprecated
+		ipCIDRs = append(ipCIDRs, *ipblock.Cidr)                                                 //nolint:staticcheck //ipblock.Cidr is deprecated
 	}
 	return ipCIDRs, nil
 }

--- a/pkg/nsx/services/vpc/builder.go
+++ b/pkg/nsx/services/vpc/builder.go
@@ -106,12 +106,16 @@ func buildNSXLBS(obj *v1alpha1.NetworkInfo, nsObj *v1.Namespace, cluster, lbsSiz
 	return lbs, nil
 }
 
-func buildVpcAttachment(obj *v1alpha1.NetworkInfo, nsObj *v1.Namespace, cluster string, vpcconnectiveprofile string) (*model.VpcAttachment, error) {
+func buildVpcAttachment(obj *v1alpha1.NetworkInfo, nsObj *v1.Namespace, cluster string, vpcconnectiveprofile string, restoreMode bool) (*model.VpcAttachment, error) {
 	attachment := &model.VpcAttachment{}
 	attachment.VpcConnectivityProfile = &vpcconnectiveprofile
 	attachment.DisplayName = common.String(common.DefaultVpcAttachmentId)
 	attachment.Id = common.String(common.DefaultVpcAttachmentId)
 	attachment.Tags = util.BuildBasicTags(cluster, obj, nsObj.GetUID())
+	if restoreMode && len(obj.VPCs) > 0 && len(obj.VPCs[0].DefaultSNATIP) > 0 {
+		log.V(1).Info("Restoring DefaultSNATIP", "DefaultSNATIP", obj.VPCs[0].DefaultSNATIP, "NetworkInfo", obj.Name)
+		attachment.PreferredDefaultSnatIp = &obj.VPCs[0].DefaultSNATIP
+	}
 	return attachment, nil
 }
 

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -455,7 +455,7 @@ func (s *VPCService) IsLBProviderChanged(existingVPC *model.Vpc, lbProvider LBPr
 	return false
 }
 
-func (s *VPCService) CreateOrUpdateVPC(ctx context.Context, obj *v1alpha1.NetworkInfo, nc *v1alpha1.VPCNetworkConfiguration, lbProvider LBProvider, serviceClusterReady bool) (*model.Vpc, error) {
+func (s *VPCService) CreateOrUpdateVPC(ctx context.Context, obj *v1alpha1.NetworkInfo, nc *v1alpha1.VPCNetworkConfiguration, lbProvider LBProvider, serviceClusterReady bool, restoreMode bool) (*model.Vpc, error) {
 	// parse project path in NetworkConfig
 	org, project, err := common.NSXProjectPathToId(nc.Spec.NSXProject)
 	if err != nil {
@@ -532,7 +532,7 @@ func (s *VPCService) CreateOrUpdateVPC(ctx context.Context, obj *v1alpha1.Networ
 		createdLBS, _ = buildNSXLBS(obj, nsObj, s.NSXConfig.Cluster, lbsSize, vpcPath, relaxScaleValidation)
 	}
 	// build HAPI request
-	createdAttachment, _ := buildVpcAttachment(obj, nsObj, s.NSXConfig.Cluster, nc.Spec.VPCConnectivityProfile)
+	createdAttachment, _ := buildVpcAttachment(obj, nsObj, s.NSXConfig.Cluster, nc.Spec.VPCConnectivityProfile, restoreMode)
 	orgRoot, err := s.WrapHierarchyVPC(org, project, createdVpc, createdLBS, createdAttachment)
 	if err != nil {
 		log.Error(err, "Failed to build HAPI request")

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -2040,7 +2040,7 @@ func TestVPCService_CreateOrUpdateVPC(t *testing.T) {
 				defer patches.Reset()
 			}
 
-			newVPCModel, err := service.CreateOrUpdateVPC(ctx, tc.existingNetworkInfo, tc.existingVPCNetworkConfig, tc.lbProvider, tc.serviceClusterReady)
+			newVPCModel, err := service.CreateOrUpdateVPC(ctx, tc.existingNetworkInfo, tc.existingVPCNetworkConfig, tc.lbProvider, tc.serviceClusterReady, false)
 
 			if tc.expectErrStr != "" {
 				assert.ErrorContains(t, err, tc.expectErrStr)

--- a/test/e2e/nsx_ipblocksinfo_test.go
+++ b/test/e2e/nsx_ipblocksinfo_test.go
@@ -118,11 +118,11 @@ func getDefaultIPBlocksCidrs(t *testing.T) (privateTGWIPCIDRs []string, external
 			break
 		}
 		if *ipblock.Path == externalBlock {
-			externalIPCIDRs = append(externalIPCIDRs, *ipblock.Cidr)
+			externalIPCIDRs = append(externalIPCIDRs, *ipblock.Cidr) //nolint:staticcheck //ipblock.Cidr is deprecated
 			count++
 		}
 		if *ipblock.Path == privateTGWBlock {
-			privateTGWIPCIDRs = append(privateTGWIPCIDRs, *ipblock.Cidr)
+			privateTGWIPCIDRs = append(privateTGWIPCIDRs, *ipblock.Cidr) //nolint:staticcheck //ipblock.Cidr is deprecated
 			count++
 		}
 	}


### PR DESCRIPTION
Testing done:
1. Delete the VPC by manual and boot the NSX operator in restore mode,
the VPC can be re-created with log "Restoring DefaultSNATIP ...".
2. Start the NSX operator with NSX 9.0, check the log "NetworkInfo restore
is not supported" can be printed.
3. Add a private CIDR in the VC UI namespace page during the NSX operator
downtime, manually add the CIDR to the NetworkInfo CR's privateIPs, then
confirm that the NSX operator can append this CIDR in restore mode.