### PR TITLE
Fix query bug

### DIFF
--- a/pkg/clean/clean_lb_infra_test.go
+++ b/pkg/clean/clean_lb_infra_test.go
@@ -521,7 +521,7 @@ func TestCleanupInfraDLBResources(t *testing.T) {
 			},
 			queriedObjects: []*model.LBHttpProfile{appProfile},
 			mockFn: func(svc *LBInfraCleaner, queryResponse model.SearchResponse, mockQueryClient *mocks.MockQueryClient) *gomonkey.Patches {
-				query := "(resource_type:LBHttpProfile OR resource_type:LBFastTcpProfile OR resource_type:LBFastUdpProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
+				query := "resource_type:(LBHttpProfile OR LBFastTcpProfile OR LBFastUdpProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
 				mockQueryClient.EXPECT().List(query, gomock.Any(), nil, gomock.Any(), nil, nil).Return(queryResponse, nil)
 				patches := gomonkey.ApplyMethodSeq(svc.NSXClient.LbAppProfileClient, "Delete", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{nil},
@@ -538,7 +538,7 @@ func TestCleanupInfraDLBResources(t *testing.T) {
 			},
 			queriedObjects: []*model.LBHttpProfile{appProfile},
 			mockFn: func(svc *LBInfraCleaner, queryResponse model.SearchResponse, mockQueryClient *mocks.MockQueryClient) *gomonkey.Patches {
-				query := "(resource_type:LBHttpProfile OR resource_type:LBFastTcpProfile OR resource_type:LBFastUdpProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
+				query := "resource_type:(LBHttpProfile OR LBFastTcpProfile OR LBFastUdpProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
 				mockQueryClient.EXPECT().List(query, gomock.Any(), nil, gomock.Any(), nil, nil).Return(queryResponse, nil)
 				return nil
 			},
@@ -552,7 +552,7 @@ func TestCleanupInfraDLBResources(t *testing.T) {
 			},
 			queriedObjects: []*model.LBHttpProfile{appProfile},
 			mockFn: func(svc *LBInfraCleaner, queryResponse model.SearchResponse, mockQueryClient *mocks.MockQueryClient) *gomonkey.Patches {
-				query := "(resource_type:LBHttpProfile OR resource_type:LBFastTcpProfile OR resource_type:LBFastUdpProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
+				query := "resource_type:(LBHttpProfile OR LBFastTcpProfile OR LBFastUdpProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
 				mockQueryClient.EXPECT().List(query, gomock.Any(), nil, gomock.Any(), nil, nil).Return(queryResponse, nil)
 				patches := gomonkey.ApplyMethodSeq(svc.NSXClient.LbAppProfileClient, "Delete", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{fmt.Errorf("server error")},
@@ -570,7 +570,7 @@ func TestCleanupInfraDLBResources(t *testing.T) {
 			},
 			queriedObjects: []*model.LBTcpMonitorProfile{monitorProfile},
 			mockFn: func(svc *LBInfraCleaner, queryResponse model.SearchResponse, mockQueryClient *mocks.MockQueryClient) *gomonkey.Patches {
-				query := "(resource_type:LBHttpMonitorProfile OR resource_type:LBTcpMonitorProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
+				query := "resource_type:(LBHttpMonitorProfile OR LBTcpMonitorProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
 				mockQueryClient.EXPECT().List(query, gomock.Any(), nil, gomock.Any(), nil, nil).Return(queryResponse, nil)
 				patches := gomonkey.ApplyMethodSeq(svc.NSXClient.LbMonitorProfilesClient, "Delete", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{nil},
@@ -587,7 +587,7 @@ func TestCleanupInfraDLBResources(t *testing.T) {
 			},
 			queriedObjects: []*model.LBTcpMonitorProfile{monitorProfile},
 			mockFn: func(svc *LBInfraCleaner, queryResponse model.SearchResponse, mockQueryClient *mocks.MockQueryClient) *gomonkey.Patches {
-				query := "(resource_type:LBHttpMonitorProfile OR resource_type:LBTcpMonitorProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
+				query := "resource_type:(LBHttpMonitorProfile OR LBTcpMonitorProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
 				mockQueryClient.EXPECT().List(query, gomock.Any(), nil, gomock.Any(), nil, nil).Return(queryResponse, nil)
 				return nil
 			},
@@ -601,7 +601,7 @@ func TestCleanupInfraDLBResources(t *testing.T) {
 			},
 			queriedObjects: []*model.LBTcpMonitorProfile{monitorProfile},
 			mockFn: func(svc *LBInfraCleaner, queryResponse model.SearchResponse, mockQueryClient *mocks.MockQueryClient) *gomonkey.Patches {
-				query := "(resource_type:LBHttpMonitorProfile OR resource_type:LBTcpMonitorProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
+				query := "resource_type:(LBHttpMonitorProfile OR LBTcpMonitorProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
 				mockQueryClient.EXPECT().List(query, gomock.Any(), nil, gomock.Any(), nil, nil).Return(queryResponse, nil)
 				patches := gomonkey.ApplyMethodSeq(svc.NSXClient.LbMonitorProfilesClient, "Delete", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{fmt.Errorf("server error")},
@@ -619,7 +619,7 @@ func TestCleanupInfraDLBResources(t *testing.T) {
 			},
 			queriedObjects: []*model.LBTcpMonitorProfile{monitorProfile},
 			mockFn: func(svc *LBInfraCleaner, queryResponse model.SearchResponse, mockQueryClient *mocks.MockQueryClient) *gomonkey.Patches {
-				query := "(resource_type:LBHttpMonitorProfile OR resource_type:LBTcpMonitorProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
+				query := "resource_type:(LBHttpMonitorProfile OR LBTcpMonitorProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
 				mockQueryClient.EXPECT().List(query, gomock.Any(), nil, gomock.Any(), nil, nil).Return(queryResponse, nil)
 				patches := gomonkey.ApplyMethodSeq(svc.NSXClient.LbMonitorProfilesClient, "Delete", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{nil},
@@ -636,7 +636,7 @@ func TestCleanupInfraDLBResources(t *testing.T) {
 			},
 			queriedObjects: []*model.LBTcpMonitorProfile{monitorProfile},
 			mockFn: func(svc *LBInfraCleaner, queryResponse model.SearchResponse, mockQueryClient *mocks.MockQueryClient) *gomonkey.Patches {
-				query := "(resource_type:LBHttpMonitorProfile OR resource_type:LBTcpMonitorProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
+				query := "resource_type:(LBHttpMonitorProfile OR LBTcpMonitorProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
 				mockQueryClient.EXPECT().List(query, gomock.Any(), nil, gomock.Any(), nil, nil).Return(queryResponse, nil)
 				return nil
 			},
@@ -650,7 +650,7 @@ func TestCleanupInfraDLBResources(t *testing.T) {
 			},
 			queriedObjects: []*model.LBTcpMonitorProfile{monitorProfile},
 			mockFn: func(svc *LBInfraCleaner, queryResponse model.SearchResponse, mockQueryClient *mocks.MockQueryClient) *gomonkey.Patches {
-				query := "(resource_type:LBHttpMonitorProfile OR resource_type:LBTcpMonitorProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
+				query := "resource_type:(LBHttpMonitorProfile OR LBTcpMonitorProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
 				mockQueryClient.EXPECT().List(query, gomock.Any(), nil, gomock.Any(), nil, nil).Return(queryResponse, nil)
 				patches := gomonkey.ApplyMethodSeq(svc.NSXClient.LbMonitorProfilesClient, "Delete", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{fmt.Errorf("server error")},
@@ -669,7 +669,7 @@ func TestCleanupInfraDLBResources(t *testing.T) {
 			},
 			queriedObjects: []*model.LBSourceIpPersistenceProfile{persistenceProfile},
 			mockFn: func(svc *LBInfraCleaner, queryResponse model.SearchResponse, mockQueryClient *mocks.MockQueryClient) *gomonkey.Patches {
-				query := "(resource_type:LBCookiePersistenceProfile OR resource_type:LBSourceIpPersistenceProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
+				query := "resource_type:(LBCookiePersistenceProfile OR LBSourceIpPersistenceProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
 				mockQueryClient.EXPECT().List(query, gomock.Any(), nil, gomock.Any(), nil, nil).Return(queryResponse, nil)
 				patches := gomonkey.ApplyMethodSeq(svc.NSXClient.LbPersistenceProfilesClient, "Delete", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{nil},
@@ -686,7 +686,7 @@ func TestCleanupInfraDLBResources(t *testing.T) {
 			},
 			queriedObjects: []*model.LBSourceIpPersistenceProfile{persistenceProfile},
 			mockFn: func(svc *LBInfraCleaner, queryResponse model.SearchResponse, mockQueryClient *mocks.MockQueryClient) *gomonkey.Patches {
-				query := "(resource_type:LBCookiePersistenceProfile OR resource_type:LBSourceIpPersistenceProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
+				query := "resource_type:(LBCookiePersistenceProfile OR LBSourceIpPersistenceProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
 				mockQueryClient.EXPECT().List(query, gomock.Any(), nil, gomock.Any(), nil, nil).Return(queryResponse, nil)
 				return nil
 			},
@@ -700,7 +700,7 @@ func TestCleanupInfraDLBResources(t *testing.T) {
 			},
 			queriedObjects: []*model.LBSourceIpPersistenceProfile{persistenceProfile},
 			mockFn: func(svc *LBInfraCleaner, queryResponse model.SearchResponse, mockQueryClient *mocks.MockQueryClient) *gomonkey.Patches {
-				query := "(resource_type:LBCookiePersistenceProfile OR resource_type:LBSourceIpPersistenceProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
+				query := "resource_type:(LBCookiePersistenceProfile OR LBSourceIpPersistenceProfile) AND tags.scope:ncp\\/cluster AND tags.tag:k8scl-one\\:test"
 				mockQueryClient.EXPECT().List(query, gomock.Any(), nil, gomock.Any(), nil, nil).Return(queryResponse, nil)
 				patches := gomonkey.ApplyMethodSeq(svc.NSXClient.LbPersistenceProfilesClient, "Delete", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{fmt.Errorf("server error")},

--- a/pkg/nsx/services/common/store.go
+++ b/pkg/nsx/services/common/store.go
@@ -283,19 +283,17 @@ func IndexByVPCFunc(obj interface{}) ([]string, error) {
 		return []string{}, errors.New("indexFunc doesn't support unknown type")
 	}
 }
-func (service *Service) QueryNCPCreatedResources(resourceTypes []string, store Store, additionalQueryFn func(query string) string) error {
-	resQuery := make([]string, 0)
-	for _, rt := range resourceTypes {
-		resQuery = append(resQuery, fmt.Sprintf("%s:%s", ResourceType, rt))
-	}
 
-	var query string
-	if len(resQuery) == 1 {
-		query = resQuery[0]
+func buildResourceType(resourceTypes []string) string {
+	if len(resourceTypes) == 1 {
+		return fmt.Sprintf("%s:%s", ResourceType, resourceTypes[0])
 	} else {
-		query = fmt.Sprintf("(%s)", strings.Join(resQuery, " OR "))
+		return fmt.Sprintf("%s:(%s)", ResourceType, strings.Join(resourceTypes, " OR "))
 	}
+}
 
+func (service *Service) QueryNCPCreatedResources(resourceTypes []string, store Store, additionalQueryFn func(query string) string) error {
+	query := buildResourceType(resourceTypes)
 	query = service.AddNCPClusterTag(query)
 	if additionalQueryFn != nil {
 		query = additionalQueryFn(query)

--- a/pkg/nsx/services/common/store_test.go
+++ b/pkg/nsx/services/common/store_test.go
@@ -459,3 +459,29 @@ func Test_formatTagParamTag(t *testing.T) {
 		})
 	}
 }
+
+func Test_buildResourceType(t *testing.T) {
+	tests := []struct {
+		name          string
+		resourceTypes []string
+		want          string
+	}{
+		{
+			name:          "Single resource type",
+			resourceTypes: []string{"VpcSubnetPort"},
+			want:          "resource_type:VpcSubnetPort",
+		},
+		{
+			name:          "Multiple resource types",
+			resourceTypes: []string{"VpcSubnetPort", "LBService", "SecurityPolicy"},
+			want:          "resource_type:(VpcSubnetPort OR LBService OR SecurityPolicy)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildResourceType(tt.resourceTypes)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
When using OR in query, the format should be resource_type:(A OR B) instead of (resource_type:A or resource_type:B). The later format makes search incorrectly derive the index names to query on. You'll get the resources unexpected