### PR TITLE
Fix a nil pointer issue in restore

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -126,11 +126,15 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 
 	checkLicense(nsxClient, cf.LicenseValidationInterval)
 
-	var err error
-	restoreMode, err = pkgutil.CompareNSXRestore(mgr.GetClient(), nsxClient)
-	if err != nil {
-		log.Error(err, "NSX restore check failed")
-		os.Exit(1)
+	if cf.K8sConfig.EnableRestore && cf.CoeConfig.EnableVPCNetwork {
+		var err error
+		restoreMode, err = pkgutil.CompareNSXRestore(mgr.GetClient(), nsxClient)
+		if err != nil {
+			log.Error(err, "NSX restore check failed")
+			os.Exit(1)
+		}
+	} else {
+		restoreMode = false
 	}
 
 	var reconcilerList []pkgutil.ReconcilerProvider
@@ -256,7 +260,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 	}
 
 	// Update pod labels to determine if this pod is the master
-	err = updatePodLabels(mgr)
+	err := updatePodLabels(mgr)
 	if err != nil {
 		log.Error(err, "Failed to update Pod labels")
 		panic(err)


### PR DESCRIPTION
This patch will avoid invoking function EnableRestoreMode in T1 to fix
the following nil poiner issue:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xb0 pc=0x1fba5ba]

goroutine 46 [running]:
github.com/vmware-tanzu/nsx-operator/pkg/controllers/subnetset.(*SubnetSetReconciler).EnableRestoreMode(...)
        /source/pkg/controllers/subnetset/subnetset_controller.go:313
main.startServiceController({0x2af6de8, 0xc00049a680}, 0xc000157188)
        /source/cmd/main.go:238 +0x127a
main.electMaster({0x2af6de8, 0xc00049a680}, 0xc000157188)
        /source/cmd/main.go:279 +0xf9
created by main.main in goroutine 1
        /source/cmd/main.go:305 +0x2df
```

Testing done:
Step 1. prepare a ncpconfig CR without annotation operator_restore_end_time in T1 env.
Step 2. start the NSX operator and check the operator_restore_end_time won't be
annotated and the NSX operator doesn't enter the restore mode.