### PR TITLE
Collect related error message for realization check

### DIFF
--- a/pkg/nsx/services/realizestate/realize_state.go
+++ b/pkg/nsx/services/realizestate/realize_state.go
@@ -61,6 +61,13 @@ func (service *RealizeStateService) CheckRealizeState(backoff wait.Backoff, inte
 					if alarm.Message != nil {
 						errMsg = append(errMsg, *alarm.Message)
 					}
+					if alarm.ErrorDetails != nil {
+						for _, relatedErr := range alarm.ErrorDetails.RelatedErrors {
+							if relatedErr.ErrorMessage != nil {
+								errMsg = append(errMsg, *relatedErr.ErrorMessage)
+							}
+						}
+					}
 					if nsxutil.IsRetryRealizeError(alarm) {
 						return nsxutil.NewRetryRealizeError(fmt.Sprintf("%s not realized with errors: %s", intentPath, errMsg))
 					}


### PR DESCRIPTION
For some of the VPC realization errors like edge cluster capacity issue, the detailed error messages
are in related errors, which are not collected by previous NSX operator.

Testing done:

Before this PR is applied, when creating a Namespace on a edge cluster without enough capacity, the Namespace status will be the following.
```
status:
  conditions:
  - lastTransitionTime: "2025-06-06T08:30:34Z"
    message: 'Error happened to create or update VPC: /orgs/default/projects/project-quality/vpcs/ns-39_f0734a81-32af-43fe-8633-6ca8894baa0c
      realized with errors: [Found errors in the request. Please refer to the related
      errors for details.]'
    reason: VPCNotReady
    status: "False"
    type: NamespaceNetworkReady
  phase: Active
```

After applying this PR, when creating a Namespace on a edge cluster without enough capacity, the Namespace status will be the following.

```
status:
  conditions:
  - lastTransitionTime: "2025-06-10T06:39:41Z"
    message: 'Error happened to create or update VPC: /orgs/default/projects/project-quality/vpcs/ns-39_e8acda0e-e870-4fec-a153-337c6fcd1125
      realized with errors: [Found errors in the request. Please refer to the related
      errors for details. [Routing] Insufficient resources to do auto allocation in
      edge cluster 5162fb5e-4675-486d-9e7d-0723e1d80653 of pool type LB_ALLOCATION_POOL
      because of below reason(s). [Routing] Node(s) [EdgeTransportNode/4f883c18-428b-11f0-9f1d-000c2935a3b6,
      EdgeTransportNode/9aebbfa4-428b-11f0-b188-000c29204d81] don''t have enough capacity
      to allocate.]'
    reason: VPCNotReady
    status: "False"
    type: NamespaceNetworkReady
  phase: Active
```
