### PR TITLE
Add IPAllocation support for AddressBinding

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_addressbindings.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_addressbindings.yaml
@@ -42,6 +42,11 @@ spec:
                 description: InterfaceName contains the interface name of the VM,
                   if not set, the first interface of the VM will be used
                 type: string
+              ipAddressAllocationName:
+                description: |-
+                  IPAddressAllocationName contains name of the external IPAddressAllocation.
+                  IP address will be allocated from an external IPBlock of the VPC when this field is not set.
+                type: string
               vmName:
                 description: VMName contains the VM's name
                 type: string

--- a/build/yaml/webhook/manifests.yaml
+++ b/build/yaml/webhook/manifests.yaml
@@ -48,6 +48,25 @@ webhooks:
     - addressbindings
   sideEffects: None
 - admissionReviewVersions:
+    - v1
+  clientConfig:
+    service:
+      name: vmware-system-nsx-operator-webhook-service
+      namespace: vmware-system-nsx
+      path: /validate-crd-nsx-vmware-com-v1alpha1-ipaddressallocation
+  failurePolicy: Fail
+  name: ipaddressallocation.validating.crd.nsx.vmware.com
+  rules:
+    - apiGroups:
+        - crd.nsx.vmware.com
+      apiVersions:
+        - v1alpha1
+      operations:
+        - DELETE
+      resources:
+        - ipaddressallocations
+  sideEffects: None
+- admissionReviewVersions:
   - v1
   clientConfig:
     service:

--- a/pkg/apis/vpc/v1alpha1/addressbinding_types.go
+++ b/pkg/apis/vpc/v1alpha1/addressbinding_types.go
@@ -7,6 +7,9 @@ type AddressBindingSpec struct {
 	VMName string `json:"vmName"`
 	// InterfaceName contains the interface name of the VM, if not set, the first interface of the VM will be used
 	InterfaceName string `json:"interfaceName,omitempty"`
+	// IPAddressAllocationName contains name of the external IPAddressAllocation.
+	// IP address will be allocated from an external IPBlock of the VPC when this field is not set.
+	IPAddressAllocationName string `json:"ipAddressAllocationName,omitempty"`
 }
 
 type AddressBindingStatus struct {

--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook.go
@@ -1,0 +1,51 @@
+package ipaddressallocation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
+)
+
+// Create validator instead of using the existing one in controller-runtime because the existing one can't
+// inspect admission.Request in Handle function.
+
+//+kubebuilder:webhook:path=/validate-crd-nsx-vmware-com-v1alpha1-ipaddressallocation,mutating=false,failurePolicy=fail,sideEffects=None,groups=crd.nsx.vmware.com,resources=ipaddressallocations,verbs=create;update,versions=v1alpha1,name=ipaddressallocation.validating.crd.nsx.vmware.com,admissionReviewVersions=v1
+
+type IPAddressAllocationValidator struct {
+	Client  client.Client
+	decoder admission.Decoder
+}
+
+// Handle handles admission requests.
+func (v *IPAddressAllocationValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	ipAddressAllocation := &v1alpha1.IPAddressAllocation{}
+	var err error
+	if req.Operation == admissionv1.Delete {
+		err = v.decoder.DecodeRaw(req.OldObject, ipAddressAllocation)
+	} else {
+		err = v.decoder.Decode(req, ipAddressAllocation)
+	}
+	if err != nil {
+		log.Error(err, "error while decoding IPAddressAllocation", "IPAddressAllocation", req.Namespace+"/"+req.Name)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	switch req.Operation {
+	case admissionv1.Delete:
+		existingAddressBindingList := &v1alpha1.AddressBindingList{}
+		if err := v.Client.List(context.TODO(), existingAddressBindingList, client.InNamespace(ipAddressAllocation.Namespace), client.MatchingFields{util.AddressBindingIPAddressAllocationNameIndexKey: ipAddressAllocation.Name}); err != nil {
+			log.Error(err, "failed to list AddressBindings", "Namespace", ipAddressAllocation.Namespace)
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		if len(existingAddressBindingList.Items) > 0 {
+			return admission.Denied(fmt.Sprintf("IPAddressAllocation %s is used by AddressBinding %s", ipAddressAllocation.Name, existingAddressBindingList.Items[0].Name))
+		}
+	}
+	return admission.Allowed("")
+}

--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook_test.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook_test.go
@@ -1,0 +1,150 @@
+package ipaddressallocation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
+)
+
+func TestIPAddressAllocationValidator_Handle(t *testing.T) {
+	indexFunc := func(obj client.Object) []string {
+		if ab, ok := obj.(*v1alpha1.AddressBinding); !ok {
+			log.Info("Invalid object", "type", reflect.TypeOf(obj))
+			return []string{}
+		} else {
+			return []string{fmt.Sprintf("%s", ab.Spec.IPAddressAllocationName)}
+		}
+	}
+	reqDelete, _ := json.Marshal(&v1alpha1.IPAddressAllocation{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "ip1",
+		},
+		Spec: v1alpha1.IPAddressAllocationSpec{
+			IPAddressBlockVisibility: v1alpha1.IPAddressVisibilityExternal,
+			AllocationIPs:            "10.0.0.8",
+		},
+	})
+	reqCreate, _ := json.Marshal(&v1alpha1.IPAddressAllocation{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "ip2",
+		},
+		Spec: v1alpha1.IPAddressAllocationSpec{
+			IPAddressBlockVisibility: v1alpha1.IPAddressVisibilityExternal,
+			AllocationIPs:            "10.0.0.9",
+		},
+	})
+	reqUpdate, _ := json.Marshal(&v1alpha1.IPAddressAllocation{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "ip3",
+		},
+		Spec: v1alpha1.IPAddressAllocationSpec{
+			IPAddressBlockVisibility: v1alpha1.IPAddressVisibilityExternal,
+			AllocationIPs:            "10.0.0.10",
+		},
+	})
+	type args struct {
+		req admission.Request
+	}
+	tests := []struct {
+		name        string
+		args        args
+		prepareFunc func(*testing.T, client.Client, context.Context) *gomonkey.Patches
+		want        admission.Response
+	}{
+		{
+			name: "delete with existing address binding",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{Raw: reqDelete},
+			}}},
+			prepareFunc: func(t *testing.T, client client.Client, ctx context.Context) *gomonkey.Patches {
+				client.Create(ctx, &v1alpha1.AddressBinding{
+					ObjectMeta: v1.ObjectMeta{Namespace: "ns1", Name: "ab1"},
+					Spec: v1alpha1.AddressBindingSpec{
+						IPAddressAllocationName: "ip1",
+					},
+				})
+				return nil
+			},
+			want: admission.Denied("IPAddressAllocation ip1 is used by AddressBinding ab1"),
+		},
+		{
+			name: "delete without address binding",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{Raw: reqDelete},
+			}}},
+			want: admission.Allowed(""),
+		},
+		{
+			name: "create decode error",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+			}}},
+			want: admission.Errored(http.StatusBadRequest, fmt.Errorf("there is no content to decode")),
+		},
+		{
+			name: "create success",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Object:    runtime.RawExtension{Raw: reqCreate},
+			}}},
+			want: admission.Allowed(""),
+		},
+		{
+			name: "update decode error",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+			}}},
+			want: admission.Errored(http.StatusBadRequest, fmt.Errorf("there is no content to decode")),
+		},
+		{
+			name: "update success",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				Object:    runtime.RawExtension{Raw: reqUpdate},
+				OldObject: runtime.RawExtension{Raw: reqDelete},
+			}}},
+			want: admission.Allowed(""),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := clientgoscheme.Scheme
+			v1alpha1.AddToScheme(scheme)
+			client := fake.NewClientBuilder().WithScheme(scheme).WithIndex(&v1alpha1.AddressBinding{}, util.AddressBindingIPAddressAllocationNameIndexKey, indexFunc).Build()
+			decoder := admission.NewDecoder(scheme)
+			ctx := context.TODO()
+			if tt.prepareFunc != nil {
+				patches := tt.prepareFunc(t, client, ctx)
+				if patches != nil {
+					defer patches.Reset()
+				}
+			}
+			v := &IPAddressAllocationValidator{
+				Client:  client,
+				decoder: decoder,
+			}
+			assert.Equalf(t, tt.want, v.Handle(ctx, tt.args.req), "Handle()")
+		})
+	}
+}

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -288,6 +288,15 @@ func addressBindingNamespaceVMIndexFunc(obj client.Object) []string {
 	}
 }
 
+func addressBindingIPAddressAllocationNameIndexFunc(obj client.Object) []string {
+	if ab, ok := obj.(*v1alpha1.AddressBinding); !ok {
+		log.Info("Invalid object", "type", reflect.TypeOf(obj))
+		return []string{}
+	} else {
+		return []string{fmt.Sprintf("%s", ab.Spec.IPAddressAllocationName)}
+	}
+}
+
 func subnetPortSubnetIndexFunc(obj client.Object) []string {
 	if subnetPort, ok := obj.(*v1alpha1.SubnetPort); !ok {
 		log.Info("Invalid object", "type", reflect.TypeOf(obj))
@@ -344,6 +353,9 @@ func (r *SubnetPortReconciler) SetupFieldIndexers(mgr ctrl.Manager) error {
 		return err
 	}
 	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &v1alpha1.AddressBinding{}, util.AddressBindingNamespaceVMIndexKey, addressBindingNamespaceVMIndexFunc); err != nil {
+		return err
+	}
+	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &v1alpha1.AddressBinding{}, util.AddressBindingIPAddressAllocationNameIndexKey, addressBindingIPAddressAllocationNameIndexFunc); err != nil {
 		return err
 	}
 	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &v1alpha1.SubnetPort{}, "spec.subnet", subnetPortSubnetIndexFunc); err != nil {

--- a/pkg/nsx/services/ipaddressallocation/builder.go
+++ b/pkg/nsx/services/ipaddressallocation/builder.go
@@ -48,7 +48,7 @@ func (service *IPAddressAllocationService) BuildIPAddressAllocation(obj metav1.O
 			allocationSize = Int64(int64(o.Spec.AllocationSize))
 		}
 	case *v1alpha1.AddressBinding:
-		if !restoreMode || subnetPortCR == nil {
+		if !restoreMode || subnetPortCR == nil || o.Spec.IPAddressAllocationName != "" {
 			return nil, nil
 		}
 		allocationIps = &o.Status.IPAddress

--- a/pkg/nsx/services/subnetport/compare.go
+++ b/pkg/nsx/services/subnetport/compare.go
@@ -36,9 +36,8 @@ func (sp *SubnetPort) Value() data.DataValue {
 			Type_:             sp.Attachment.AllocateAddresses,
 		}
 	}
-	// only check existence of ExternalAddressBinding
 	if sp.ExternalAddressBinding != nil {
-		s.ExternalAddressBinding = &model.ExternalAddressBinding{}
+		s.ExternalAddressBinding = &model.ExternalAddressBinding{AllocatedExternalIpPath: sp.ExternalAddressBinding.AllocatedExternalIpPath}
 	}
 	dataValue, _ := ComparableToSubnetPort(s).GetDataValue__()
 	return dataValue

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -139,7 +139,6 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 		log.Info("NSX subnet port not changed, skipping the update", "nsxSubnetPort.Id", nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)
 		// We don't need to update it but still need to check realized state.
 	} else {
-		nsxSubnetPort = buildSubnetPortExternalAddressBindingFromExisting(nsxSubnetPort, existingSubnetPort)
 		log.Info("updating the NSX subnet port", "existingSubnetPort", existingSubnetPort, "desiredSubnetPort", nsxSubnetPort)
 		err = service.NSXClient.PortClient.Patch(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, *nsxSubnetPort.Id, *nsxSubnetPort)
 		err = nsxutil.TransNSXApiError(err)

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -2,3 +2,5 @@ package util
 
 const SubnetPortNamespaceVMIndexKey = "index/SubnetPort/NamespaceVM"
 const AddressBindingNamespaceVMIndexKey = "index/AddressBinding/NamespaceVM"
+
+const AddressBindingIPAddressAllocationNameIndexKey = "spec.ipAddressAllocationName"


### PR DESCRIPTION
Testing done:
```
root@4236480f9861e0b257fba4e4e029e9d7 [ ~ ]# kubectl create -f sp1
subnetport.crd.nsx.vmware.com/gran1 created
ipaddressallocation.crd.nsx.vmware.com/ip1 created
addressbinding.crd.nsx.vmware.com/gran1 created
root@4236480f9861e0b257fba4e4e029e9d7 [ ~ ]# kubectl get ipaddressallocation
NAME   IPADDRESSBLOCKVISIBILITY   ALLOCATIONIPS
ip1    External                   192.168.0.9
ip2    External                   192.168.0.8
ip3    Private                    172.26.0.32
ip4    External                   192.168.0.12/30
ip5    External                   192.168.0.16/31
root@4236480f9861e0b257fba4e4e029e9d7 [ ~ ]# kubectl get addressbinding -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  kind: AddressBinding
  metadata:
    creationTimestamp: "2025-06-26T03:19:03Z"
    generation: 1
    name: gran1
    namespace: default
    resourceVersion: "843450"
    uid: cebff921-65c9-482a-a495-bfa648a779d3
  spec:
    interfaceName: inf1
    ipAddressAllocationName: ip1
    vmName: vm1
  status:
    conditions:
    - lastTransitionTime: "2025-06-26T03:19:05Z"
      message: AddressBinding has been successfully created/updated
      reason: AddressBindingReady
      status: "True"
      type: Ready
    ipAddress: 192.168.0.9
kind: List
metadata:
  resourceVersion: ""

# change ipAddressAllocationName to "ip2"
root@4236b93d1881b0dce853c74a23597590 [ ~ ]# kubectl edit addressbinding gran1
addressbinding.crd.nsx.vmware.com/gran1 edited
root@4236b93d1881b0dce853c74a23597590 [ ~ ]# kubectl get addressbinding -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  kind: AddressBinding
  metadata:
    creationTimestamp: "2025-06-25T08:04:15Z"
    generation: 2
    name: gran1
    namespace: default
    resourceVersion: "56377"
    uid: a8b7e599-85a4-4e22-a117-45909ad0674e
  spec:
    interfaceName: inf1
    ipAddressAllocationName: ip2
    vmName: vm1
  status:
    conditions:
    - lastTransitionTime: "2025-06-25T08:04:15Z"
      message: AddressBinding has been successfully created/updated
      reason: AddressBindingReady
      status: "True"
      type: Ready
    ipAddress: 192.168.0.8
kind: List
metadata:
  resourceVersion: ""

# change ipAddressAllocationName to "ip3"
root@4236b93d1881b0dce853c74a23597590 [ ~ ]# kubectl edit addressbinding gran1
error: addressbindings.crd.nsx.vmware.com "gran1" could not be patched: admission webhook "addressbinding.validating.crd.nsx.vmware.com" denied the request: ipAddressBlockVisibility of IPAddressAllocation must be "External"
You can run `kubectl replace -f /tmp/kubectl-edit-3129431461.yaml` to try this update again.

# change ipAddressAllocationName to "ip4"
root@4236b93d1881b0dce853c74a23597590 [ ~ ]# kubectl edit addressbinding gran1
error: addressbindings.crd.nsx.vmware.com "gran1" could not be patched: admission webhook "addressbinding.validating.crd.nsx.vmware.com" denied the request: IPAddressAllocation is not realized or the allocation is not a single IP
You can run `kubectl replace -f /tmp/kubectl-edit-3741319486.yaml` to try this update again.

# change ipAddressAllocationName to ""
root@4236b93d1881b0dce853c74a23597590 [ ~ ]# kubectl edit addressbinding gran1
addressbinding.crd.nsx.vmware.com/gran1 edited
root@4236b93d1881b0dce853c74a23597590 [ ~ ]# kubectl get addressbinding -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  kind: AddressBinding
  metadata:
    creationTimestamp: "2025-06-25T08:04:15Z"
    generation: 3
    name: gran1
    namespace: default
    resourceVersion: "58220"
    uid: a8b7e599-85a4-4e22-a117-45909ad0674e
  spec:
    interfaceName: inf1
    ipAddressAllocationName: ""
    vmName: vm1
  status:
    conditions:
    - lastTransitionTime: "2025-06-25T08:04:15Z"
      message: AddressBinding has been successfully created/updated
      reason: AddressBindingReady
      status: "True"
      type: Ready
    ipAddress: 192.168.0.10
kind: List
metadata:
  resourceVersion: ""

# change ipAddressAllocationName to "abc"
root@4236b93d1881b0dce853c74a23597590 [ ~ ]# kubectl edit addressbinding gran1
error: addressbindings.crd.nsx.vmware.com "gran1" could not be patched: admission webhook "addressbinding.validating.crd.nsx.vmware.com" denied the request: ipAddressAllocationName is not valid
You can run `kubectl replace -f /tmp/kubectl-edit-2775627210.yaml` to try this update again.

# webhook
root@422df4dbea4c38c7dd45af0238d16b69 [ ~ ]# kubectl delete ipaddressallocation ip1
Error from server (Forbidden): admission webhook "ipaddressallocation.validating.crd.nsx.vmware.com" denied the request: IPAddressAllocation ip1 is used by AddressBinding gran1
root@422df4dbea4c38c7dd45af0238d16b69 [ ~ ]# kubectl delete addressbinding gran1
addressbinding.crd.nsx.vmware.com "gran1" deleted
root@422df4dbea4c38c7dd45af0238d16b69 [ ~ ]# kubectl delete ipaddressallocation ip1
ipaddressallocation.crd.nsx.vmware.com "ip1" deleted

# Single file with multiple resources
root@422df4dbea4c38c7dd45af0238d16b69 [ ~ ]# kubectl create -f sp1
subnetport.crd.nsx.vmware.com/gran1 created
ipaddressallocation.crd.nsx.vmware.com/ip1 created
addressbinding.crd.nsx.vmware.com/gran1 created
root@422df4dbea4c38c7dd45af0238d16b69 [ ~ ]# kubectl delete -f sp1
subnetport.crd.nsx.vmware.com "gran1" deleted
addressbinding.crd.nsx.vmware.com "gran1" deleted
Error from server (Forbidden): error when deleting "sp1": admission webhook "ipaddressallocation.validating.crd.nsx.vmware.com" denied the request: IPAddressAllocation ip1 is used by AddressBinding gran1
root@422df4dbea4c38c7dd45af0238d16b69 [ ~ ]# kubectl delete -f sp1
ipaddressallocation.crd.nsx.vmware.com "ip1" deleted
Error from server (NotFound): error when deleting "sp1": subnetports.crd.nsx.vmware.com "gran1" not found
Error from server (NotFound): error when deleting "sp1": addressbindings.crd.nsx.vmware.com "gran1" not found

```
