### PR TITLE
Add AllocationIPs to IPAddressAllocation

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_ipaddressallocations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_ipaddressallocations.yaml
@@ -48,6 +48,13 @@ spec:
           spec:
             description: IPAddressAllocationSpec defines the desired state of IPAddressAllocation.
             properties:
+              allocationIPs:
+                description: AllocationIPs specifies the Allocated IP addresses in
+                  CIDR or single IP Address format.
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               allocationSize:
                 description: |-
                   AllocationSize specifies the size of allocationIPs to be allocated.
@@ -71,6 +78,13 @@ spec:
                 - message: Value is immutable
                   rule: self == oldSelf
             type: object
+            x-kubernetes-validations:
+            - message: Only one of allocationSize or allocationIPs can be specified
+              rule: '!has(self.allocationSize) || !has(self.allocationIPs)'
+            - message: allocationSize is required once set
+              rule: '!has(oldSelf.allocationSize) || has(self.allocationSize)'
+            - message: allocationIPs is required once set
+              rule: '!has(oldSelf.allocationIPs) || has(self.allocationIPs)'
           status:
             description: IPAddressAllocationStatus defines the observed state of IPAddressAllocation.
             properties:

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -204,6 +204,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW. | Private | Enum: [External Private PrivateTGW] <br /> |
 | `allocationSize` _integer_ | AllocationSize specifies the size of allocationIPs to be allocated.<br />It should be a power of 2. |  | Minimum: 1 <br /> |
+| `allocationIPs` _string_ | AllocationIPs specifies the Allocated IP addresses in CIDR or single IP Address format. |  |  |
 
 
 #### IPAddressAllocationStatus

--- a/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
+++ b/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
@@ -39,6 +39,9 @@ type IPAddressAllocationList struct {
 }
 
 // IPAddressAllocationSpec defines the desired state of IPAddressAllocation.
+// +kubebuilder:validation:XValidation:rule="!has(self.allocationSize) || !has(self.allocationIPs)", message="Only one of allocationSize or allocationIPs can be specified"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.allocationSize) || has(self.allocationSize)", message="allocationSize is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.allocationIPs) || has(self.allocationIPs)", message="allocationIPs is required once set"
 type IPAddressAllocationSpec struct {
 	// IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.
 	// +kubebuilder:validation:Enum=External;Private;PrivateTGW
@@ -51,6 +54,9 @@ type IPAddressAllocationSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	// +kubebuilder:validation:Minimum:=1
 	AllocationSize int `json:"allocationSize,omitempty"`
+	// AllocationIPs specifies the Allocated IP addresses in CIDR or single IP Address format.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	AllocationIPs string `json:"allocationIPs,omitempty"`
 }
 
 // IPAddressAllocationStatus defines the observed state of IPAddressAllocation.

--- a/pkg/nsx/services/ipaddressallocation/builder.go
+++ b/pkg/nsx/services/ipaddressallocation/builder.go
@@ -39,7 +39,9 @@ func (service *IPAddressAllocationService) BuildIPAddressAllocation(obj metav1.O
 			return nil, fmt.Errorf("failed to find VPCInfo for IPAddressAllocation CR %s in Namespace %s", o.Name, o.Namespace)
 		}
 		ipAddressBlockVisibility = convertIpAddressBlockVisibility(o.Spec.IPAddressBlockVisibility)
-		if restoreMode && len(o.Status.AllocationIPs) > 0 {
+		if len(o.Spec.AllocationIPs) > 0 {
+			allocationIps = String(o.Spec.AllocationIPs)
+		} else if restoreMode && len(o.Status.AllocationIPs) > 0 {
 			allocationIps = String(o.Status.AllocationIPs)
 		} else {
 			// Field AllocationIPs and AllocationSize cannot be provided together for VPC IP allocation.


### PR DESCRIPTION
Testing done:

Case 1:
Create IPAddressAllocation with both allocationSize and allocationIPs
```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: IPAddressAllocation
metadata:
  name: ipa-1
spec:
  ipAddressBlockVisibility: Private
  allocationSize: 16
  allocationIPs: "172.26.0.32/28"
```
This will be blocked with the following message `The IPAddressAllocation "ipa-1" is invalid: spec: Invalid value: "object": Only one of allocationSize or allocationIPs can be specified`

Case 2:
Create IPAddressAllocation with allocationIPs and observe the NSX IPAddressAllocation is created and the IPAddressAllocation CR is updated with IPAddressAllocationReady
```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: IPAddressAllocation
metadata:
  name: ipa-1
spec:
  ipAddressBlockVisibility: Private
  allocationIPs: "172.26.0.32/28"
```
```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: IPAddressAllocation
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"IPAddressAllocation","metadata":{"annotations":{},"name":"ipa-1","namespace":"ns-1"},"spec":{"allocationIPs":"172.26.0.32/28","ipAddressBlockVisibility":"Private"}}
  creationTimestamp: "2025-06-13T08:38:44Z"
  generation: 1
  name: ipa-1
  namespace: ns-1
  resourceVersion: "6263328"
  uid: f41c3484-6541-4c15-b941-2d8ac298b01e
spec:
  allocationIPs: 172.26.0.32/28
  ipAddressBlockVisibility: Private
status:
  allocationIPs: 172.26.0.32/28
  conditions:
  - lastTransitionTime: "2025-06-13T08:38:45Z"
    message: NSX IPAddressAllocation has been successfully created/updated
    reason: IPAddressAllocationReady
    status: "True"
    type: Ready
```

Case 3:
Create IPAddressAllocation with allocationSize and observe the NSX IPAddressAllocation is created and the IPAddressAllocation CR is updated with IPAddressAllocationReady
```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: IPAddressAllocation
metadata:
  name: ipa-2
spec:
  ipAddressBlockVisibility: Private
  allocationSize: 16
```
```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: IPAddressAllocation
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"IPAddressAllocation","metadata":{"annotations":{},"name":"ipa-2","namespace":"ns-1"},"spec":{"allocationSize":16,"ipAddressBlockVisibility":"Private"}}
  creationTimestamp: "2025-06-13T08:47:37Z"
  generation: 1
  name: ipa-2
  namespace: ns-1
  resourceVersion: "6268778"
  uid: 7e32086f-a6eb-44e3-9dff-ed299e0c61db
spec:
  allocationSize: 16
  ipAddressBlockVisibility: Private
status:
  allocationIPs: 172.26.0.0/28
  conditions:
  - lastTransitionTime: "2025-06-13T08:47:37Z"
    message: NSX IPAddressAllocation has been successfully created/updated
    reason: IPAddressAllocationReady
    status: "True"
    type: Ready
```
