### PR TITLE
Add FieldIndexers for SubnetPort and SubnetConnectionBindingMap

### DIFF
--- a/pkg/controllers/namespace/subnet_share_controller.go
+++ b/pkg/controllers/namespace/subnet_share_controller.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -154,10 +152,7 @@ func (r *NamespaceReconciler) processNewSharedSubnets(ctx context.Context, ns st
 func (r *NamespaceReconciler) checkSubnetReferences(ctx context.Context, ns string, subnet *v1alpha1.Subnet) (bool, error) {
 	// Check if there are any SubnetPort CRs referencing this Subnet CR
 	subnetPortList := &v1alpha1.SubnetPortList{}
-	option := metav1.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("spec.subnet", subnet.Name).String(),
-	}
-	err := r.Client.List(ctx, subnetPortList, client.InNamespace(ns), &client.ListOptions{Raw: &option})
+	err := r.Client.List(ctx, subnetPortList, client.InNamespace(ns), client.MatchingFields{"spec.subnet": subnet.Name})
 	if err != nil {
 		return false, fmt.Errorf("failed to list SubnetPort CRs: %w", err)
 	}
@@ -170,10 +165,7 @@ func (r *NamespaceReconciler) checkSubnetReferences(ctx context.Context, ns stri
 
 	// Check if there are any SubnetConnectionBindingMap CRs referencing this Subnet CR
 	subnetBindingList := &v1alpha1.SubnetConnectionBindingMapList{}
-	option = metav1.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("spec.subnetName", subnet.Name).String(),
-	}
-	err = r.Client.List(ctx, subnetBindingList, client.InNamespace(ns), &client.ListOptions{Raw: &option})
+	err = r.Client.List(ctx, subnetBindingList, client.InNamespace(ns), client.MatchingFields{"spec.subnetName": subnet.Name})
 	if err != nil {
 		return false, fmt.Errorf("failed to list SubnetConnectionBindingMap CRs: %w", err)
 	}

--- a/pkg/controllers/subnetbinding/subnetbinding_controller_test.go
+++ b/pkg/controllers/subnetbinding/subnetbinding_controller_test.go
@@ -949,6 +949,50 @@ func TestPredicateFuncsBindingMaps(t *testing.T) {
 	assert.False(t, PredicateFuncsForBindingMaps.GenericFunc(genericEvent))
 }
 
+func TestSubnetConnectionBindingMapNameIndexFunc(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedResult []string
+		obj            client.Object
+	}{
+		{
+			name:           "Success",
+			expectedResult: []string{"subnet1"},
+			obj: &v1alpha1.SubnetConnectionBindingMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+				},
+				Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+					SubnetName: "subnet1",
+				},
+			},
+		},
+		{
+			name:           "EmptySubnetName",
+			expectedResult: []string{},
+			obj: &v1alpha1.SubnetConnectionBindingMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+				},
+				Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+					SubnetName: "",
+				},
+			},
+		},
+		{
+			name:           "InvalidObj",
+			expectedResult: []string{},
+			obj:            &v1alpha1.Subnet{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := subnetConnectionBindingMapSubnetNameIndexFunc(tt.obj)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
 func createFakeReconciler(objs ...client.Object) *Reconciler {
 	var mgr ctrl.Manager
 	if len(objs) == 0 {

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -250,6 +250,18 @@ func addressBindingNamespaceVMIndexFunc(obj client.Object) []string {
 	}
 }
 
+func subnetPortSubnetIndexFunc(obj client.Object) []string {
+	if subnetPort, ok := obj.(*v1alpha1.SubnetPort); !ok {
+		log.Info("Invalid object", "type", reflect.TypeOf(obj))
+		return []string{}
+	} else {
+		if subnetPort.Spec.Subnet == "" {
+			return []string{}
+		}
+		return []string{subnetPort.Spec.Subnet}
+	}
+}
+
 func (r *SubnetPortReconciler) deleteSubnetPortByName(ctx context.Context, ns string, name string) error {
 	// NamespacedName is a unique identity in store as only one worker can deal with the NamespacedName at a time
 	nsxSubnetPorts := r.SubnetPortService.ListSubnetPortByName(ns, name)
@@ -296,6 +308,10 @@ func (r *SubnetPortReconciler) SetupFieldIndexers(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &v1alpha1.AddressBinding{}, util.AddressBindingNamespaceVMIndexKey, addressBindingNamespaceVMIndexFunc); err != nil {
 		return err
 	}
+	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &v1alpha1.SubnetPort{}, "spec.subnet", subnetPortSubnetIndexFunc); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -503,6 +503,50 @@ func TestSubnetPortReconciler_addressBindingNamespaceVMIndexFunc(t *testing.T) {
 	}
 }
 
+func TestSubnetPortReconciler_subnetPortSubnetIndexFunc(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedResult []string
+		obj            client.Object
+	}{
+		{
+			name:           "Success",
+			expectedResult: []string{"subnet1"},
+			obj: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					Subnet: "subnet1",
+				},
+			},
+		},
+		{
+			name:           "EmptySubnet",
+			expectedResult: []string{},
+			obj: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					Subnet: "",
+				},
+			},
+		},
+		{
+			name:           "InvalidObj",
+			expectedResult: []string{},
+			obj:            &v1alpha1.Subnet{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := subnetPortSubnetIndexFunc(tt.obj)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
 func TestSubnetPortReconciler_vmMapFunc(t *testing.T) {
 	mockCtl := gomock.NewController(t)
 	k8sClient := mock_client.NewMockClient(mockCtl)


### PR DESCRIPTION
Resolve the issue where checkSubnetReferences is ineffective; it currently lists all subnet ports within a namespace.

Before:
![image](https://github.com/user-attachments/assets/7041e58e-e462-4add-b797-1eed3a33ce51)
nsx-ncp-84dbd95787-zmjk2 nsx-operator 2025-06-23 08:50:57.622	INFO	namespace/subnet_share_controller.go:167	Cannot delete Subnet CR for shared subnet because it is referenced by a SubnetPort CR	{"Namespace": "ns1", "Name": "subnetc-2dj8s", "SubnetPort": "subnetc-port"}
nsx-ncp-84dbd95787-zmjk2 nsx-operator 2025-06-23 08:50:57.623	ERROR	namespace/subnet_share_controller.go:224	Cannot delete Subnet CR for shared subnet because it is still referenced	{"error": "subnet CR ns1/subnetc-2dj8s is still referenced and cannot be deleted"}

subnetc-port locates on subnetc, not subnetc-2dj8s, but it still filters out in checkSubnetReferences

After:
nsx-ncp-84dbd95787-4s8qr nsx-operator 2025-06-23 09:55:57.793	INFO	namespace/subnet_share_controller.go:210	Deleted Subnet CR for shared Subnet	{"Namespace": "ns1", "Name": "subnetc-hs92f", "AssociatedResource": "project-quality:ns-shared_3fdd4d43-c947-40e9-8143-612fcbf5125c:subnetc"}