### PR TITLE
Fix invalid port issue while creating ServiceEntry

### DIFF
--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -489,7 +489,7 @@ func buildRuleServiceEntries(port v1alpha1.SecurityPolicyPort) *data.StructValue
 	// Note: the caller ensures the given port.Port type is Int. For named port case, the caller should
 	// convert to a new SecurityPolicyPort using the correct port number.
 	// In case that the destination_port in NSX-T is 0.
-	if port.EndPort == 0 {
+	if port.EndPort == 0 || port.EndPort == port.Port.IntValue() {
 		portRange = port.Port.String()
 	} else {
 		portRange = fmt.Sprintf("%s-%d", port.Port.String(), port.EndPort)

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -1440,3 +1440,42 @@ func Test_BuildGroupName(t *testing.T) {
 		}
 	})
 }
+
+func Test_buildRuleServiceEntries(t *testing.T) {
+	tests := []struct {
+		name     string
+		port     v1alpha1.SecurityPolicyPort
+		expected *data.StructValue
+	}{
+		{
+			name: "port with the same Port and EndPort",
+			port: v1alpha1.SecurityPolicyPort{
+				Port:     intstr.FromInt(80),
+				EndPort:  80,
+				Protocol: "TCP",
+			},
+			expected: func() *data.StructValue {
+				destinationPorts := data.NewListValue()
+				destinationPorts.Add(data.NewStringValue("80"))
+				return data.NewStructValue(
+					"",
+					map[string]data.DataValue{
+						"source_ports":      data.NewListValue(),
+						"destination_ports": destinationPorts,
+						"l4_protocol":       data.NewStringValue("TCP"),
+						"resource_type":     data.NewStringValue("L4PortSetServiceEntry"),
+						"marked_for_delete": data.NewBooleanValue(false),
+						"overridden":        data.NewBooleanValue(false),
+					},
+				)
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := buildRuleServiceEntries(tt.port)
+			assert.Equal(t, actual, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
The NSX doesn't support the port range format likes "6000-6000" in the NSX security policy, it reports the following error:

> Invalid port provided while creating/updating Service / ServiceEntry

This patch will change "6000-6000" to "6000" to avoid this issue.

Testing done:
create the following network policy and the NSX security policy can be created:
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  annotations:
    ncp/log_traffic: ALL
  name: np-ingress-allow-multiselector-namedport-endport
spec:
  ingress:
  - from:
    - podSelector:
        matchLabels:
          app: tcp
    ports:
    - endPort: 6000
      port: 6000
      protocol: TCP
    - endPort: 6010
      port: 6001
      protocol: UDP
  podSelector:
    matchLabels:
      app: coffee
  policyTypes:
  - Ingress
```