### PR TITLE
Handle nil checks for NetworkPolicyPort fields in SecurityPolicy conversion

### DIFF
--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -486,15 +486,17 @@ func buildRuleServiceEntries(port v1alpha1.SecurityPolicyPort) *data.StructValue
 	sourcePorts := data.NewListValue()
 	destinationPorts := data.NewListValue()
 
-	// Note: the caller ensures the given port.Port type is Int. For named port case, the caller should
+	// For the named port case, the caller should
 	// convert to a new SecurityPolicyPort using the correct port number.
-	// In case that the destination_port in NSX-T is 0.
-	if port.EndPort == 0 || port.EndPort == port.Port.IntValue() {
-		portRange = port.Port.String()
-	} else {
-		portRange = fmt.Sprintf("%s-%d", port.Port.String(), port.EndPort)
+	var zeroPort intstr.IntOrString
+	if port.Port != zeroPort {
+		if port.EndPort == 0 || port.EndPort == port.Port.IntValue() {
+			portRange = port.Port.String()
+		} else {
+			portRange = fmt.Sprintf("%s-%d", port.Port.String(), port.EndPort)
+		}
+		destinationPorts.Add(data.NewStringValue(portRange))
 	}
-	destinationPorts.Add(data.NewStringValue(portRange))
 
 	serviceEntry := data.NewStructValue(
 		"",
@@ -504,7 +506,7 @@ func buildRuleServiceEntries(port v1alpha1.SecurityPolicyPort) *data.StructValue
 			"l4_protocol":       data.NewStringValue(string(port.Protocol)),
 			"resource_type":     data.NewStringValue("L4PortSetServiceEntry"),
 			// Adding the following default values to make it easy when compare the
-			// existing object from store and the new built object
+			// existing object from the store and the newly built object
 			"marked_for_delete": data.NewBooleanValue(false),
 			"overridden":        data.NewBooleanValue(false),
 		},

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -1470,6 +1470,25 @@ func Test_buildRuleServiceEntries(t *testing.T) {
 				)
 			}(),
 		},
+		{
+			name: "zero port (ANY)",
+			port: v1alpha1.SecurityPolicyPort{
+				Protocol: "TCP",
+			},
+			expected: func() *data.StructValue {
+				return data.NewStructValue(
+					"",
+					map[string]data.DataValue{
+						"source_ports":      data.NewListValue(),
+						"destination_ports": data.NewListValue(),
+						"l4_protocol":       data.NewStringValue("TCP"),
+						"resource_type":     data.NewStringValue("L4PortSetServiceEntry"),
+						"marked_for_delete": data.NewBooleanValue(false),
+						"overridden":        data.NewBooleanValue(false),
+					},
+				)
+			}(),
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -428,9 +428,13 @@ func (service *SecurityPolicyService) convertNetworkPolicyPeerToSecurityPolicyPe
 }
 
 func (service *SecurityPolicyService) convertNetworkPolicyPortToSecurityPolicyPort(npPort *networkingv1.NetworkPolicyPort) (*v1alpha1.SecurityPolicyPort, error) {
-	spPort := &v1alpha1.SecurityPolicyPort{
-		Protocol: *npPort.Protocol,
-		Port:     *npPort.Port,
+	spPort := &v1alpha1.SecurityPolicyPort{}
+	if npPort.Protocol != nil {
+		spPort.Protocol = *npPort.Protocol
+	}
+
+	if npPort.Port != nil {
+		spPort.Port = *npPort.Port
 	}
 	if npPort.EndPort != nil {
 		spPort.EndPort = int(*npPort.EndPort)

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -3366,3 +3366,70 @@ func Test_gcInfraSharesGroups(t *testing.T) {
 		})
 	}
 }
+
+func Test_convertNetworkPolicyPortToSecurityPolicyPort(t *testing.T) {
+	fakeService := fakeSecurityPolicyService()
+
+	tests := []struct {
+		name    string
+		npPort  *networkingv1.NetworkPolicyPort
+		want    *v1alpha1.SecurityPolicyPort
+		wantErr bool
+	}{
+		{
+			name: "with protocol and port",
+			npPort: &networkingv1.NetworkPolicyPort{
+				Protocol: func() *corev1.Protocol {
+					proto := corev1.ProtocolTCP
+					return &proto
+				}(),
+				Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 80},
+			},
+			want: &v1alpha1.SecurityPolicyPort{
+				Protocol: corev1.ProtocolTCP,
+				Port:     intstr.IntOrString{Type: intstr.Int, IntVal: 80},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with protocol only",
+			npPort: &networkingv1.NetworkPolicyPort{
+				Protocol: func() *corev1.Protocol {
+					proto := corev1.ProtocolTCP
+					return &proto
+				}(),
+			},
+			want: &v1alpha1.SecurityPolicyPort{
+				Protocol: corev1.ProtocolTCP,
+			},
+			wantErr: false,
+		},
+		{
+			name: "with port only",
+			npPort: &networkingv1.NetworkPolicyPort{
+				Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 80},
+			},
+			want: &v1alpha1.SecurityPolicyPort{
+				Port: intstr.IntOrString{Type: intstr.Int, IntVal: 80},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "with nil port",
+			npPort:  &networkingv1.NetworkPolicyPort{},
+			want:    &v1alpha1.SecurityPolicyPort{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fakeService.convertNetworkPolicyPortToSecurityPolicyPort(tt.npPort)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("convertNetworkPolicyPortToSecurityPolicyPort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
When create a networkpolicy without port.port
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: np-ingress-egress-allow-all-ns
  namespace: vc1-wcpcluster1-np-ns-5
  annotations:
    ncp/log_traffic: "ALL"
spec:
  podSelector:
    matchLabels:
      app: tea
  ingress:
  - from:
    - namespaceSelector:
        matchLabels:
          app: tea
    - namespaceSelector:
        matchLabels:
          app: coffee
    ports:
    - protocol: TCP
  egress:
  - to:
    - podSelector: {}
    ports:
    - protocol: UDP
```

```2025-06-25 03:01:05.346	INFO	networkpolicy/networkpolicy_controller.go:82	Reconciling NetworkPolicy	{"networkpolicy": {"name":"np-ingress-egress-allow-all-ns","namespace":"ns1"}}
2025-06-25 03:01:05.346	INFO	networkpolicy/networkpolicy_controller.go:106	Reconciling CR to create or update networkPolicy	{"networkPolicy": {"name":"np-ingress-egress-allow-all-ns","namespace":"ns1"}}
2025-06-25 03:01:05.346	INFO	networkpolicy/networkpolicy_controller.go:85	Finished reconciling NetworkPolicy	{"networkpolicy": {"name":"np-ingress-egress-allow-all-ns","namespace":"ns1"}, "duration(ms)": 0}
2025-06-25 03:01:05.347	ERROR	runtime/signal_unix.go:900	Observed a panic	{"controller": "networkpolicy", "controllerGroup": "networking.k8s.io", "controllerKind": "NetworkPolicy", "NetworkPolicy": {"name":"np-ingress-egress-allow-all-ns","namespace":"ns1"}, "namespace": "ns1", "name": "np-ingress-egress-allow-all-ns", "reconcileID": "26b417c1-905e-4be6-b021-1bf0abd9af8e", "panic": "runtime error: invalid memory address or nil pointer dereference", "panicGoValue": "\"invalid memory address or nil pointer dereference\"", "stacktrace": "goroutine 785 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x2b01c88, 0xc0016784e0}, {0x22a82e0, 0x3e579d0})\n\t/root/go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/runtime/runtime.go:107 +0xbc\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:105 +0x114\npanic({0x22a82e0?, 0x3e579d0?})\n\t/usr/local/go/src/runtime/panic.go:785 +0x132\ngithub.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy.(*SecurityPolicyService).convertNetworkPolicyPortToSecurityPolicyPort(...)\n\t/root/nsx-operator/pkg/nsx/services/securitypolicy/firewall.go:433\ngithub.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy.(*SecurityPolicyService).populateRulesForAllowSection(0xc0003d8780, 0xc0014e6c60, 0xc001b4aa80)\n\t/root/nsx-operator/pkg/nsx/services/securitypolicy/firewall.go:274 +0xc0e\ngithub.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy.(*SecurityPolicyService).convertNetworkPolicyToInternalSecurityPolicies(0xc0003d8780, 0xc001b4aa80)\n\t/root/nsx-operator/pkg/nsx/services/securitypolicy/firewall.go:371 +0x66\ngithub.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy.(*SecurityPolicyService).CreateOrUpdateSecurityPolicy(0xc0003d8780, {0x26e3b80, 0xc001b4aa80})\n\t/root/nsx-operator/pkg/nsx/services/securitypolicy/firewall.go:233 +0x8a\ngithub.com/vmware-tanzu/nsx-operator/pkg/controllers/networkpolicy.(*NetworkPolicyReconciler).Reconcile(0xc0001ff3b0, {0x2b01c88, 0xc0016784e0}, {{{0xc000b16d29, 0x3}, {0xc0011fe4a0, 0x1e}}})\n\t/root/nsx-operator/pkg/controllers/networkpolicy/networkpolicy_controller.go:108 +0x625\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc001678450?, {0x2b01c88?, 0xc0016784e0?}, {{{0xc000b16d29?, 0x0?}, {0xc0011fe4a0?, 0x0?}}})\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:116 +0xbf\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x2b124c0, {0x2b01cc0, 0xc0003b7180}, {{{0xc000b16d29, 0x3}, {0xc0011fe4a0, 0x1e}}})\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:303 +0x398\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x2b124c0, {0x2b01cc0, 0xc0003b7180})\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263 +0x20e\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2()\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224 +0x85\ncreated by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2 in goroutine 367\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:220 +0x490\n"}
2025-06-25 03:01:05.347	ERROR	controller/controller.go:316	Reconciler error	{"controller": "networkpolicy", "controllerGroup": "networking.k8s.io", "controllerKind": "NetworkPolicy", "NetworkPolicy": {"name":"np-ingress-egress-allow-all-ns","namespace":"ns1"}, "namespace": "ns1", "name": "np-ingress-egress-allow-all-ns", "reconcileID": "26b417c1-905e-4be6-b021-1bf0abd9af8e", "error": "panic: runtime error: invalid memory address or nil pointer dereference [recovered]"}

```

After this fix, the result is as expected

<img width="1154" alt="image" src="https://github.com/user-attachments/assets/50f46fd5-1557-4b76-9b5e-31bdd5b66f71" />
