### PR TITLE
Add network error when service endpoint statuses are unknown

### DIFF
--- a/pkg/nsx/services/inventory/build_test.go
+++ b/pkg/nsx/services/inventory/build_test.go
@@ -1267,7 +1267,7 @@ func TestBuildService(t *testing.T) {
 		assert.Equal(t, NetworkStatusUnhealthy, containerApplication.NetworkStatus)
 
 		// Verify network errors
-		assert.Equal(t, 3, len(containerApplication.NetworkErrors))
+		assert.Equal(t, 4, len(containerApplication.NetworkErrors))
 
 		// Create a map of error messages for easier verification
 		errorMessages := make(map[string]bool)

--- a/pkg/nsx/services/inventory/retrieval.go
+++ b/pkg/nsx/services/inventory/retrieval.go
@@ -14,7 +14,7 @@ func GetPodIDsFromEndpoint(ctx context.Context, c client.Client, name string, na
 	podIDs = []string{}
 	hasAddr = false
 
-	// Get the endpoints object corresponding to the service
+	// Get the endpoint object corresponding to the service
 	endpoint := &v1.Endpoints{}
 	err := c.Get(ctx, types.NamespacedName{
 		Name:      name,
@@ -30,7 +30,7 @@ func GetPodIDsFromEndpoint(ctx context.Context, c client.Client, name string, na
 	for _, subset := range endpoint.Subsets {
 		for _, address := range subset.Addresses {
 			hasAddr = true
-			if address.TargetRef != nil && address.TargetRef.Kind == "Pod" {
+			if address.TargetRef != nil && (address.TargetRef.Kind == "Pod" || address.TargetRef.Kind == "VirtualMachine") {
 				podIDs = append(podIDs, string(address.TargetRef.UID))
 			}
 		}
@@ -73,7 +73,7 @@ func GetServicesUIDByPodUID(ctx context.Context, c client.Client, podUID types.U
 
 	var serviceUIDs []string
 	for _, svc := range serviceList.Items {
-		// Get the endpoints object associated with the service
+		// Get the endpoint object associated with the service
 		endpoints := &v1.Endpoints{}
 		err := c.Get(ctx, types.NamespacedName{Name: svc.Name, Namespace: namespace}, endpoints)
 		if err != nil {


### PR DESCRIPTION
Fix the bug where networking status of service "UNHEALTHY" but the error message is empty, and annotation of it is empty

Before
![image](https://github.com/user-attachments/assets/2d6de19b-9b32-4a36-9317-9c4520d0218b)

After
![image](https://github.com/user-attachments/assets/0593fdf5-0dd4-4c8f-a656-542b378e3eeb)

