### PR TITLE
Fix 'unknown NSX resource type' error

### DIFF
--- a/pkg/nsx/services/common/policy_tree.go
+++ b/pkg/nsx/services/common/policy_tree.go
@@ -128,6 +128,8 @@ func leafWrapper[T any](obj T) (*data.StructValue, error) {
 		return WrapLBPool(v)
 	case *model.TlsCertificate:
 		return WrapCertificate(v)
+	case *model.SharedResource:
+		return WrapSharedResource(v)
 	default:
 		log.Error(nil, "Leaf wrapper", "unknown NSX resource type", v)
 		return nil, fmt.Errorf("unsupported NSX resource type %v", v)
@@ -456,8 +458,8 @@ func (b *PolicyTreeBuilder[T]) UpdateMultipleResourcesOnNSX(objects []T, nsxClie
 			return err
 		}
 		if err = nsxClient.OrgRootClient.Patch(*orgRoot, &enforceRevisionCheckParam); err != nil {
-			log.Error(err, "Failed to delete multiple resources on NSX with HAPI", "resourceType", b.leafType)
 			err = util.TransNSXApiError(err)
+			log.Error(err, "Failed to delete multiple resources on NSX with HAPI", "resourceType", b.leafType)
 			return err
 		}
 		return nil
@@ -469,8 +471,8 @@ func (b *PolicyTreeBuilder[T]) UpdateMultipleResourcesOnNSX(objects []T, nsxClie
 		return err
 	}
 	if err = nsxClient.InfraClient.Patch(*infraRoot, &enforceRevisionCheckParam); err != nil {
-		log.Error(err, "Failed to delete multiple resources on NSX with HAPI", "resourceType", b.leafType)
 		err = util.TransNSXApiError(err)
+		log.Error(err, "Failed to delete multiple resources on NSX with HAPI", "resourceType", b.leafType)
 		return err
 	}
 

--- a/pkg/nsx/services/common/wrap.go
+++ b/pkg/nsx/services/common/wrap.go
@@ -219,6 +219,21 @@ func WrapShare(share *model.Share) (*data.StructValue, error) {
 	return dataValue.(*data.StructValue), nil
 }
 
+func WrapSharedResource(sharedResource *model.SharedResource) (*data.StructValue, error) {
+	sharedResource.ResourceType = &ResourceTypeSharedResource
+	childSharedResource := model.ChildSharedResource{
+		ResourceType:    ResourceTypeChildSharedResource,
+		Id:              sharedResource.Id,
+		MarkedForDelete: sharedResource.MarkedForDelete,
+		SharedResource:  sharedResource,
+	}
+	dataValue, errors := NewConverter().ConvertToVapi(childSharedResource, childSharedResource.GetType__())
+	if len(errors) > 0 {
+		return nil, errors[0]
+	}
+	return dataValue.(*data.StructValue), nil
+}
+
 func WrapLBService(lbService *model.LBService) (*data.StructValue, error) {
 	lbService.ResourceType = &ResourceTypeLBService
 	childLBService := model.ChildLBService{


### PR DESCRIPTION
While building resource tree, there was an error "unknown NSX resource type" in leafWrapper function.
Fix the issue by adding model.SharedResource in leafWrapper 
Change the log position to print the dump error