### PR TITLE
Remove cleaning sharedresource

### DIFF
--- a/pkg/clean/clean_lb_infra.go
+++ b/pkg/clean/clean_lb_infra.go
@@ -59,14 +59,12 @@ func (s *LBInfraCleaner) CleanupInfraResources(ctx context.Context) error {
 		s.log.Error(err, "Failed to clean up DLB virtual servers")
 		return err
 	}
-	// SharedResource has dependencies on Group, so we can't delete sharedResources and groups in parallel.
-	if err := s.cleanupInfraSharedResources(ctx); err != nil {
-		s.log.Error(err, "Failed to clean up infra SharedResources")
+	if err := s.cleanupInfraShares(ctx); err != nil {
+		s.log.Error(err, "Failed to clean up infra Shareds")
 		return err
 	}
 
 	parallelCleaners := []func(ctx context.Context) error{
-		s.cleanupInfraShares,
 		s.cleanupInfraDLBPools,
 		s.cleanupInfraDLBServices,
 		s.cleanupInfraDLBGroups,

--- a/pkg/nsx/services/common/policy_tree.go
+++ b/pkg/nsx/services/common/policy_tree.go
@@ -456,8 +456,8 @@ func (b *PolicyTreeBuilder[T]) UpdateMultipleResourcesOnNSX(objects []T, nsxClie
 			return err
 		}
 		if err = nsxClient.OrgRootClient.Patch(*orgRoot, &enforceRevisionCheckParam); err != nil {
-			log.Error(err, "Failed to delete multiple resources on NSX with HAPI", "resourceType", b.leafType)
 			err = util.TransNSXApiError(err)
+			log.Error(err, "Failed to delete multiple resources on NSX with HAPI", "resourceType", b.leafType)
 			return err
 		}
 		return nil
@@ -469,8 +469,8 @@ func (b *PolicyTreeBuilder[T]) UpdateMultipleResourcesOnNSX(objects []T, nsxClie
 		return err
 	}
 	if err = nsxClient.InfraClient.Patch(*infraRoot, &enforceRevisionCheckParam); err != nil {
-		log.Error(err, "Failed to delete multiple resources on NSX with HAPI", "resourceType", b.leafType)
 		err = util.TransNSXApiError(err)
+		log.Error(err, "Failed to delete multiple resources on NSX with HAPI", "resourceType", b.leafType)
 		return err
 	}
 


### PR DESCRIPTION
In the clean procedure, there was error 'unknown NSX resource type' for sharedresource since leafWrapper didn't handle it. There is no need to handle sharedresource. Clean could use HAPI to delete the shares which could delete the sharedresource. 
Remove cleaning sharedresource

Test Done:
Using binary to run:
root@420e7a7539ff3819db289540206320fc [ ~ ]# ./clean -cluster b855119d-fb45-41be-a44a-6e78589b3db8 -mgr-ip 10.162.169.7 -vc-passwd '>*@VAse=@+>k>-=@Kv1~' -vc-user wcp-cluster-user-b855119d-fb45-41be-a44a-6e78589b3db8-53435f97-8cca-47a3-9c69-6bbade565f70@vsphere.local -thumbprint 41:56:F7:00:D3:7F:49:8F:D3:89:02:07:D9:A2:EC:C3:D8:7E:CE:D8 -vc-sso-domain vsphere.local -vc-endpoint lvn-dvm-10-162-175-44.dvm.lvn.broadcom.net

2025-06-27 08:47:30.443	INFO	clean/clean_service.go:221	Completed to clean up the pre-created VPCs' child resources
2025-06-27 08:47:30.542	INFO	clean/clean_lb_infra.go:191	Cleaning up DLB virtual servers	{"Count": 63}
2025-06-27 08:47:33.347	INFO	clean/clean_lb_infra.go:130	Cleaning up shares	{"Count": 1}
2025-06-27 08:47:35.272	INFO	clean/clean_lb_infra.go:227	Cleaning up DLB services	{"Count": 1}
2025-06-27 08:47:35.595	INFO	clean/clean_lb_infra.go:209	Cleaning up DLB pools	{"Count": 63}
2025-06-27 08:47:35.627	INFO	clean/clean_lb_infra.go:294	Cleaning up lbAppProfiles	{"Count": 3}
2025-06-27 08:47:35.730	INFO	clean/clean_lb_infra.go:320	Cleaning up lbPersistenceProfiles	{"Count": 2}
2025-06-27 08:47:35.823	INFO	clean/clean_lb_infra.go:346	Cleaning up lbMonitorProfiles	{"Count": 0}
2025-06-27 08:47:35.823	INFO	clean/clean_lb_infra.go:364	Completed to clean up NCP created lbMonitorProfiles
2025-06-27 08:47:36.478	INFO	clean/clean_lb_infra.go:340	Completed to clean up NCP created lbPersistenceProfiles
2025-06-27 08:47:36.558	INFO	clean/clean_lb_infra.go:147	Cleaning up certificates	{"Count": 1}
2025-06-27 08:47:36.563	INFO	clean/clean_lb_infra.go:245	Cleaning up DLB groups	{"Count": 1}
2025-06-27 08:47:36.618	INFO	clean/clean_lb_infra.go:314	Completed to clean up NCP created lbAppProfiles
2025-06-27 08:47:38.090	INFO	clean/clean.go:95	Cleanup NSX resources successfully

