### PR TITLE
Add ReservedIpRanges support for DHCP Subnet

### DIFF
--- a/build/yaml/samples/nsx_v1alpha1_subnet.yaml
+++ b/build/yaml/samples/nsx_v1alpha1_subnet.yaml
@@ -6,6 +6,7 @@ spec:
   accessMode: Private
   ipv4SubnetSize: 64
 ---
+# Subnet CR sample for DHCP Service mode Subnet with reservedIPRanges
 apiVersion: crd.nsx.vmware.com/v1alpha1
 kind: Subnet
 metadata:
@@ -13,13 +14,12 @@ metadata:
 spec:
   accessMode: Private
   ipAddresses:
-  - 172.26.0.0/28
-  ipv4SubnetSize: 16
+  - 172.26.2.0/28
   subnetDHCPConfig:
+    mode: DHCPServer
     dhcpServerAdditionalConfig:
       reservedIPRanges:
-      - 172.26.0.4-172.26.0.10
-    mode: DHCPServer
+      - 172.26.2.4-172.26.2.10
 ---
 # Subnet CR sample for assigned VLAN extension Subnet
 apiVersion: crd.nsx.vmware.com/v1alpha1

--- a/pkg/controllers/subnet/subnet_poll.go
+++ b/pkg/controllers/subnet/subnet_poll.go
@@ -176,8 +176,21 @@ func (r *SubnetReconciler) hasStatusChanged(originalStatus, newStatus *v1alpha1.
 
 // hasSubnetSpecChanged checks if the subnet spec has changed
 func (r *SubnetReconciler) hasSubnetSpecChanged(originalSpec, newSpec *v1alpha1.SubnetSpec) bool {
-	return originalSpec.AdvancedConfig.ConnectivityState != newSpec.AdvancedConfig.ConnectivityState ||
-		originalSpec.SubnetDHCPConfig.Mode != newSpec.SubnetDHCPConfig.Mode
+	if originalSpec.AdvancedConfig.ConnectivityState != newSpec.AdvancedConfig.ConnectivityState ||
+		originalSpec.SubnetDHCPConfig.Mode != newSpec.SubnetDHCPConfig.Mode {
+		return true
+	}
+	// Check for changes in DHCPServerAdditionalConfig.ReservedIPRanges
+	origReservedIPRanges := originalSpec.SubnetDHCPConfig.DHCPServerAdditionalConfig.ReservedIPRanges
+	newReservedIPRanges := newSpec.SubnetDHCPConfig.DHCPServerAdditionalConfig.ReservedIPRanges
+
+	// If both are nil or both are not nil with the same value, no change
+	if (origReservedIPRanges == nil && newReservedIPRanges == nil) ||
+		(origReservedIPRanges != nil && newReservedIPRanges != nil && reflect.DeepEqual(origReservedIPRanges, newReservedIPRanges)) {
+		return false
+	}
+	// Otherwise, there's a change
+	return true
 }
 
 func (r *SubnetReconciler) clearSubnetAddresses(obj client.Object) {

--- a/pkg/controllers/subnet/subnet_poll_test.go
+++ b/pkg/controllers/subnet/subnet_poll_test.go
@@ -75,6 +75,92 @@ func TestHasSubnetSpecChanged(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "ReservedIPRanges not changed",
+			originalSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					ConnectivityState: v1alpha1.ConnectivityStateConnected,
+				},
+				SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
+					DHCPServerAdditionalConfig: v1alpha1.DHCPServerAdditionalConfig{
+						ReservedIPRanges: []string{"172.26.0.4-172.26.0.10"},
+					},
+				},
+			},
+			newSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					ConnectivityState: v1alpha1.ConnectivityStateConnected,
+				},
+				SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
+					DHCPServerAdditionalConfig: v1alpha1.DHCPServerAdditionalConfig{
+						ReservedIPRanges: []string{"172.26.0.4-172.26.0.10"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "ReservedIPRanges changed from nil to value",
+			originalSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					ConnectivityState: v1alpha1.ConnectivityStateConnected,
+				},
+			},
+			newSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					ConnectivityState: v1alpha1.ConnectivityStateConnected,
+				},
+				SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
+					DHCPServerAdditionalConfig: v1alpha1.DHCPServerAdditionalConfig{
+						ReservedIPRanges: []string{"172.26.0.4-172.26.0.10"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "ReservedIPRanges changed from value to nil",
+			originalSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					ConnectivityState: v1alpha1.ConnectivityStateConnected,
+				},
+				SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
+					DHCPServerAdditionalConfig: v1alpha1.DHCPServerAdditionalConfig{
+						ReservedIPRanges: []string{"172.26.0.4-172.26.0.10"},
+					},
+				},
+			},
+			newSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					ConnectivityState: v1alpha1.ConnectivityStateConnected,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "ReservedIPRanges changed value",
+			originalSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					ConnectivityState: v1alpha1.ConnectivityStateConnected,
+				},
+				SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
+					DHCPServerAdditionalConfig: v1alpha1.DHCPServerAdditionalConfig{
+						ReservedIPRanges: []string{"172.26.0.4-172.26.0.10"},
+					},
+				},
+			},
+			newSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					ConnectivityState: v1alpha1.ConnectivityStateConnected,
+				},
+				SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
+					DHCPServerAdditionalConfig: v1alpha1.DHCPServerAdditionalConfig{
+						ReservedIPRanges: []string{"172.26.0.4-172.26.0.10", "172.26.0.13"},
+					},
+				},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -91,7 +91,12 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag, i
 		if dhcpMode == "" {
 			dhcpMode = v1alpha1.DHCPConfigModeDeactivated
 		}
-		nsxSubnet.SubnetDhcpConfig = service.buildSubnetDHCPConfig(dhcpMode, nil)
+		var dhcpServerAdditionalConfig *model.DhcpServerAdditionalConfig
+		if len(o.Spec.SubnetDHCPConfig.DHCPServerAdditionalConfig.ReservedIPRanges) > 0 {
+			dhcpServerAdditionalConfig = &model.DhcpServerAdditionalConfig{}
+			dhcpServerAdditionalConfig.ReservedIpRanges = o.Spec.SubnetDHCPConfig.DHCPServerAdditionalConfig.ReservedIPRanges
+		}
+		nsxSubnet.SubnetDhcpConfig = service.buildSubnetDHCPConfig(dhcpMode, dhcpServerAdditionalConfig)
 		if len(o.Spec.IPAddresses) > 0 {
 			nsxSubnet.IpAddresses = o.Spec.IPAddresses
 		} else if len(o.Status.NetworkAddresses) > 0 {

--- a/pkg/nsx/services/subnet/builder_test.go
+++ b/pkg/nsx/services/subnet/builder_test.go
@@ -179,8 +179,12 @@ func TestBuildSubnetForSubnet(t *testing.T) {
 			Namespace: "ns-1",
 		},
 		Spec: v1alpha1.SubnetSpec{
+			IPAddresses: []string{"10.0.0.0/28"},
 			SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
 				Mode: v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeServer),
+				DHCPServerAdditionalConfig: v1alpha1.DHCPServerAdditionalConfig{
+					ReservedIPRanges: []string{"10.0.0.4-10.0.0.10"},
+				},
 			},
 			AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
 				StaticIPAllocation: v1alpha1.StaticIPAllocation{
@@ -206,4 +210,5 @@ func TestBuildSubnetForSubnet(t *testing.T) {
 	newSubnet, err := service.buildSubnet(subnet2, tags, []string{})
 	assert.Nil(t, err)
 	assert.NotEqual(t, *subnet.Id, *newSubnet.Id)
+	assert.Equal(t, []string{"10.0.0.4-10.0.0.10"}, subnet.SubnetDhcpConfig.DhcpServerAdditionalConfig.ReservedIpRanges)
 }

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -137,6 +137,7 @@ func (service *SubnetService) RestoreSubnetSet(obj *v1alpha1.SubnetSet, vpcInfo 
 func (service *SubnetService) CreateOrUpdateSubnet(obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (subnet *model.VpcSubnet, err error) {
 	uid := string(obj.GetUID())
 	nsxSubnet, err := service.buildSubnet(obj, tags, []string{})
+
 	if err != nil {
 		log.Error(err, "Failed to build Subnet")
 		return nil, err
@@ -553,6 +554,10 @@ func (service *SubnetService) MapNSXSubnetToSubnetCR(subnetCR *v1alpha1.Subnet, 
 		switch dhcpMode {
 		case "DHCP_SERVER":
 			subnetCR.Spec.SubnetDHCPConfig.Mode = v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeServer)
+			if len(nsxSubnet.SubnetDhcpConfig.DhcpServerAdditionalConfig.ReservedIpRanges) > 0 {
+				subnetCR.Spec.SubnetDHCPConfig.DHCPServerAdditionalConfig.ReservedIPRanges = nsxSubnet.SubnetDhcpConfig.DhcpServerAdditionalConfig.ReservedIpRanges
+			}
+
 		case "DHCP_RELAY":
 			subnetCR.Spec.SubnetDHCPConfig.Mode = v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeRelay)
 		default:

--- a/pkg/nsx/util/errors.go
+++ b/pkg/nsx/util/errors.go
@@ -10,9 +10,11 @@ import (
 )
 
 const (
-	InvalidLicenseErrorCode   = 505
-	ProviderNotReadyErrorCode = 500042
-	IPAllocationErrorCode     = 8212
+	InvalidLicenseErrorCode                   = 505
+	ProviderNotReadyErrorCode                 = 500042
+	IPAllocationErrorCode                     = 8212
+	ReservedIPRangesOverlappedErrorCode       = 508134
+	ReservedIPRangesOutOfSubnetRangeErrorCode = 508135
 )
 
 type NsxError interface {


### PR DESCRIPTION
For DHCP Subnet, add support for user to set ReservedIpRanges.

1. create Subnet with below yml
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: subnetf
spec:
  accessMode: Private
  ipAddresses:
  - 172.26.3.0/28
  subnetDHCPConfig:
    mode: DHCPServer
    dhcpServerAdditionalConfig:
      reservedIPRanges:
      - 172.26.3.4-172.26.3.10
      - 172.26.3.12
```
  
2. check NSX Subnet created 
```
{
  "ipv4_subnet_size": 32,
  "access_mode": "Private",
  "ip_addresses": [
    "172.26.3.0/28"
  ],
  "advanced_config": {
    "static_ip_allocation": {
      "enabled": false
    },
    "connectivity_state": "CONNECTED",
    "gateway_addresses": [
      "172.26.3.1/28"
    ],
    "dhcp_server_addresses": [
      "172.26.3.2/28"
    ],
    "enable_vlan_extension": false
  },
  "ip_blocks": [
    "/orgs/default/projects/project-quality/infra/ip-blocks/test-exec-ns_ed74aab4-8f0c-4e24-821f-d673220cf1ec-172_26_0_0_16"
  ],
  "subnet_dhcp_config": {
    "mode": "DHCP_SERVER",
    "dhcp_server_additional_config": {
      "reserved_ip_ranges": [
        "172.26.3.4-172.26.3.10",
        "172.26.3.12"
      ]
    }
  },
  "resource_type": "VpcSubnet",
  "id": "subnetf_3e283659-77ca-465a-b472-f7c768956f78"
}
```
3. create Subnet CR with reservedIPRanges, then update Subnet CR and removed reservedIPRanges, checked NSX Subnet also removed "reserved_ip_ranges".
``` 
"subnet_dhcp_config": {
    "mode": "DHCP_SERVER",
    "dhcp_server_additional_config": {}
  }
```
4. update Subnet CR again and add reservedIPRanges out of Subnet CIDR range, checked Subnet CR status with error.
```
root@42077980f5112755a157f1aacadf72fb [ ~ ]# k -n test-exec-ns get subnet subnet-sample-c -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"Subnet","metadata":{"annotations":{},"creationTimestamp":"2025-08-14T04:18:13Z","generation":3,"name":"subnet-sample-c","namespace":"test-exec-ns","resourceVersion":"6031825","uid":"82cc4c50-c87e-4bed-8a05-0e702b6ae3f4"},"spec":{"accessMode":"Private","advancedConfig":{"connectivityState":"Connected","enableVLANExtension":false,"staticIPAllocation":{"enabled":false}},"ipAddresses":["172.26.2.0/28"],"ipv4SubnetSize":16,"subnetDHCPConfig":{"dhcpServerAdditionalConfig":{"reservedIPRanges":["172.26.3.4-172.26.3.10"]},"mode":"DHCPServer"},"vpcName":"project-quality:test-exec-ns_sxy26"},"status":{"DHCPServerAddresses":["172.26.2.2/28"],"conditions":[{"lastTransitionTime":"2025-08-14T04:18:15Z","message":"NSX Subnet with DHCPServer has been successfully created/updated","reason":"SubnetReady","status":"True","type":"Ready"}],"gatewayAddresses":["172.26.2.1/28"],"networkAddresses":["172.26.2.0/28"],"shared":false,"vlanExtension":{}}}
  creationTimestamp: "2025-08-14T04:18:13Z"
  generation: 4
  name: subnet-sample-c
  namespace: test-exec-ns
  resourceVersion: "6037332"
  uid: 82cc4c50-c87e-4bed-8a05-0e702b6ae3f4
spec:
  accessMode: Private
  advancedConfig:
    connectivityState: Connected
    enableVLANExtension: false
    staticIPAllocation:
      enabled: false
  ipAddresses:
  - 172.26.2.0/28
  ipv4SubnetSize: 16
  subnetDHCPConfig:
    dhcpServerAdditionalConfig:
      reservedIPRanges:
      - 172.26.3.4-172.26.3.10
    mode: DHCPServer
  vpcName: project-quality:test-exec-ns_sxy26
status:
  DHCPServerAddresses:
  - 172.26.2.2/28
  conditions:
  - lastTransitionTime: "2025-08-14T04:18:15Z"
    message: 'Error occurred while processing the Subnet CR. Please check the config
      and try again. Error: nsx error code: 508135, message: Reserved IP ranges 172.26.3.4-172.26.3.10
      must be within 172.26.2.3-172.26.2.14 for subnet /orgs/default/projects/project-quality/vpcs/test-exec-ns_sxy26/subnets/subnet-sample-c_sxy26.,
      details: , related error: nil'
    reason: SubnetNotReady
    status: "False"
    type: Ready
  gatewayAddresses:
  - 172.26.2.1/28
  networkAddresses:
  - 172.26.2.0/28
  shared: false
  vlanExtension: {}
```
5. update Subnet CR again and check Subnet CR was updated successfully with reservedIPRanges
```
root@42077980f5112755a157f1aacadf72fb [ ~ ]# k -n test-exec-ns get subnet subnet-sample-c -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"Subnet","metadata":{"annotations":{},"creationTimestamp":"2025-08-14T04:18:13Z","generation":3,"name":"subnet-sample-c","namespace":"test-exec-ns","resourceVersion":"6031825","uid":"82cc4c50-c87e-4bed-8a05-0e702b6ae3f4"},"spec":{"accessMode":"Private","advancedConfig":{"connectivityState":"Connected","enableVLANExtension":false,"staticIPAllocation":{"enabled":false}},"ipAddresses":["172.26.2.0/28"],"ipv4SubnetSize":16,"subnetDHCPConfig":{"dhcpServerAdditionalConfig":{"reservedIPRanges":["172.26.3.4-172.26.3.10"]},"mode":"DHCPServer"},"vpcName":"project-quality:test-exec-ns_sxy26"},"status":{"DHCPServerAddresses":["172.26.2.2/28"],"conditions":[{"lastTransitionTime":"2025-08-14T04:18:15Z","message":"NSX Subnet with DHCPServer has been successfully created/updated","reason":"SubnetReady","status":"True","type":"Ready"}],"gatewayAddresses":["172.26.2.1/28"],"networkAddresses":["172.26.2.0/28"],"shared":false,"vlanExtension":{}}}
  creationTimestamp: "2025-08-14T04:18:13Z"
  generation: 5
  name: subnet-sample-c
  namespace: test-exec-ns
  resourceVersion: "6038942"
  uid: 82cc4c50-c87e-4bed-8a05-0e702b6ae3f4
spec:
  accessMode: Private
  advancedConfig:
    connectivityState: Connected
    enableVLANExtension: false
    staticIPAllocation:
      enabled: false
  ipAddresses:
  - 172.26.2.0/28
  ipv4SubnetSize: 16
  subnetDHCPConfig:
    dhcpServerAdditionalConfig:
      reservedIPRanges:
      - 172.26.2.4-172.26.2.10
    mode: DHCPServer
  vpcName: project-quality:test-exec-ns_sxy26
status:
  DHCPServerAddresses:
  - 172.26.2.2/28
  conditions:
  - lastTransitionTime: "2025-08-14T04:18:15Z"
    message: NSX Subnet with DHCPServer has been successfully created/updated
    reason: SubnetReady
    status: "True"
    type: Ready
  gatewayAddresses:
  - 172.26.2.1/28
  networkAddresses:
  - 172.26.2.0/28
  shared: false
  vlanExtension: {}
```