### PR TITLE
Add webhook for ipaddressallocation

### DIFF
--- a/build/yaml/webhook/manifests.yaml
+++ b/build/yaml/webhook/manifests.yaml
@@ -68,3 +68,24 @@ webhooks:
     resources:
     - subnets
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: vmware-system-nsx-operator-webhook-service
+      namespace: vmware-system-nsx
+      path: /validate-crd-nsx-vmware-com-v1alpha1-ipaddressallocation
+  failurePolicy: Fail
+  name: ipaddressallocation.validating.crd.nsx.vmware.com
+  rules:
+  - apiGroups:
+    - crd.nsx.vmware.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - ipaddressallocations
+  sideEffects: None

--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook.go
@@ -1,0 +1,87 @@
+/* Copyright © 2025 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package ipaddressallocation
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+)
+
+// +kubebuilder:webhook:path=/validate-crd-nsx-vmware-com-v1alpha1-ipaddressallocation,mutating=false,failurePolicy=fail,sideEffects=None,groups=crd.nsx.vmware.com,resources=ipaddressallocations,verbs=delete,versions=v1alpha1,name=ipaddressallocation.validating.crd.nsx.vmware.com,admissionReviewVersions=v1
+
+type IPAddressAllocationValidator struct {
+	Client  client.Client
+	decoder admission.Decoder
+}
+
+// Handle handles admission requests.
+func (v *IPAddressAllocationValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	log.Info("Handling ipaddressallocation request", "user", req.UserInfo.Username, "operation", req.Operation)
+	// Only care about DELETE operations
+	if req.Operation != admissionv1.Delete {
+		return admission.Allowed("operation is not DELETE")
+	}
+
+	// Decode the old object from the request
+	ipAlloc := &v1alpha1.IPAddressAllocation{}
+	err := v.decoder.DecodeRaw(req.OldObject, ipAlloc)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// If conditions are missing or not Ready — allow delete
+	if len(ipAlloc.Status.Conditions) == 0 || ipAlloc.Status.Conditions[0].Type != "Ready" {
+		return admission.Allowed("allocation not ready, safe to delete")
+	}
+
+	// Parse allocation IPs — assuming comma-separated or space-separated string
+	allocationIPs := ipAlloc.Status.AllocationIPs
+
+	// List Services in the same namespace
+	var svcList corev1.ServiceList
+	if err := v.Client.List(ctx, &svcList, client.InNamespace(req.Namespace)); err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	// Check if any Service uses one of the allocated IPs
+	for _, svc := range svcList.Items {
+		if svc.Spec.LoadBalancerIP != "" {
+			if v.ifIPUsed(svc.Spec.LoadBalancerIP, allocationIPs) { // IP in use — reject delete
+				msg := fmt.Sprintf("cannot delete IPAddressAllocation %s: IP %s is still in use by Service %s", ipAlloc.Name, svc.Spec.LoadBalancerIP, svc.Name)
+				return admission.Denied(msg)
+			}
+		}
+	}
+
+	// No conflicting Service found — allow delete
+	return admission.Allowed("no services using allocated IPs, safe to delete")
+}
+
+func (v *IPAddressAllocationValidator) ifIPUsed(loadBalancerIP string, ipRange string) bool {
+	ip := net.ParseIP(loadBalancerIP)
+	if ip == nil {
+		return false // invalid input
+	}
+	// Try parsing ipRange as CIDR first
+	if _, ipNet, err := net.ParseCIDR(ipRange); err == nil {
+		return ipNet.Contains(ip)
+	}
+
+	// If not CIDR, try parsing as single IP
+	rangeIP := net.ParseIP(ipRange)
+	if rangeIP == nil {
+		return false // invalid input
+	}
+
+	return ip.Equal(rangeIP)
+}

--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook_test.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook_test.go
@@ -1,0 +1,210 @@
+package ipaddressallocation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	mockClient "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
+)
+
+func TestIPAddressAllocationValidator_Handle(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mockClient.NewMockClient(mockCtl)
+	defer mockCtl.Finish()
+
+	scheme := clientgoscheme.Scheme
+	_ = v1alpha1.AddToScheme(scheme)
+	decoder := admission.NewDecoder(scheme)
+	v := &IPAddressAllocationValidator{
+		Client:  k8sClient,
+		decoder: decoder,
+	}
+
+	// Ready allocation with IPs
+	ipAlloc := &v1alpha1.IPAddressAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-1",
+			Name:      "alloc-1",
+		},
+		Status: v1alpha1.IPAddressAllocationStatus{
+			Conditions:    []v1alpha1.Condition{{Type: "Ready"}},
+			AllocationIPs: "192.168.1.2/32",
+		},
+	}
+	rawAlloc, _ := json.Marshal(ipAlloc)
+
+	type args struct {
+		req admission.Request
+	}
+	tests := []struct {
+		name        string
+		args        args
+		prepareFunc func(t *testing.T)
+		want        admission.Response
+	}{
+
+		{
+			name: "DeleteAllowed_NotReady",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{Raw: func() []byte {
+					alloc := *ipAlloc
+					alloc.Status.Conditions = nil
+					b, _ := json.Marshal(&alloc)
+					return b
+				}()},
+			}}},
+
+			want: admission.Allowed("allocation not ready, safe to delete"),
+		},
+
+		{
+			name: "DeleteDenied_IPInUse",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{Raw: rawAlloc},
+			}}},
+			prepareFunc: func(t *testing.T) {
+				ipAlloc.Status.Conditions = []v1alpha1.Condition{{Type: "Ready"}}
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					svcList := list.(*corev1.ServiceList)
+					svcList.Items = append(svcList.Items, corev1.Service{
+						ObjectMeta: metav1.ObjectMeta{Name: "svc-1"},
+						Spec: corev1.ServiceSpec{
+							LoadBalancerIP: "192.168.1.2",
+						},
+					})
+					return nil
+				})
+			},
+			want: admission.Denied(fmt.Sprintf("cannot delete IPAddressAllocation %s: IP %s is still in use by Service %s", ipAlloc.Name, "192.168.1.2", "svc-1")),
+		},
+		{
+			name: "DeleteAllowed_NoIPInUse",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{Raw: rawAlloc},
+			}}},
+			prepareFunc: func(t *testing.T) {
+				ipAlloc.Status.Conditions = []v1alpha1.Condition{{Type: "Ready"}}
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					svcList := list.(*corev1.ServiceList)
+					svcList.Items = append(svcList.Items, corev1.Service{
+						ObjectMeta: metav1.ObjectMeta{Name: "svc-1"},
+						Spec: corev1.ServiceSpec{
+							LoadBalancerIP: "10.0.0.1",
+						},
+					})
+					return nil
+				})
+			},
+			want: admission.Allowed("no services using allocated IPs, safe to delete"),
+		},
+		{
+			name: "Delete_ListServiceError",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{Raw: rawAlloc},
+			}}},
+			prepareFunc: func(t *testing.T) {
+				ipAlloc.Status.Conditions = []v1alpha1.Condition{{Type: "Ready"}}
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("list error"))
+			},
+			want: admission.Errored(http.StatusInternalServerError, errors.New("list error")),
+		},
+		{
+			name: "NotDeleteOperation",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+			}}},
+			want: admission.Allowed("operation is not DELETE"),
+		},
+		{
+			name: "DecodeOldObjectError",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{Raw: []byte("invalid")},
+			}}},
+			want: admission.Response{AdmissionResponse: admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Code: http.StatusBadRequest,
+				},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.prepareFunc != nil {
+				tt.prepareFunc(t)
+			}
+			res := v.Handle(context.TODO(), tt.args.req)
+			if tt.want.Result != nil && tt.want.Result.Code != 0 {
+				assert.Equal(t, tt.want.Result.Code, res.Result.Code)
+			} else {
+				assert.Equal(t, tt.want, res)
+			}
+		})
+	}
+}
+
+func TestIfIPUsed(t *testing.T) {
+	validator := &IPAddressAllocationValidator{}
+
+	tests := []struct {
+		name           string
+		loadBalancerIP string
+		ipRange        string
+		want           bool
+	}{
+		{
+			name:           "IP in CIDR range",
+			loadBalancerIP: "192.168.1.5",
+			ipRange:        "192.168.1.0/24",
+			want:           true,
+		},
+		{
+			name:           "IP not in CIDR range",
+			loadBalancerIP: "192.168.2.5",
+			ipRange:        "192.168.1.0/24",
+			want:           false,
+		},
+		{
+			name:           "IP equals single IP",
+			loadBalancerIP: "10.0.0.1",
+			ipRange:        "10.0.0.1",
+			want:           true,
+		},
+		{
+			name:           "IP not equals single IP",
+			loadBalancerIP: "10.0.0.2",
+			ipRange:        "10.0.0.1",
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validator.ifIPUsed(tt.loadBalancerIP, tt.ipRange)
+			if got != tt.want {
+				t.Errorf("ifIPUsed(%q, %q) = %v, want %v", tt.loadBalancerIP, tt.ipRange, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Search all the service under the same namespace. If the ip has been used in the service, operator will reject the deletion of ipaddressallocation

Test Done:
1. create an ipaddressallocation with ip 192.168.0.50
2. update svc with loadBalancerIP: 192.168.0.50
3. wait for svc ready
4. delete the ipaddressallocation
5. check if return error like: Error from server (Forbidden): admission webhook
"ipaddressallocation.validating.crd.nsx.vmware.com" denied the request: cannot delete IPAddressAllocation ip2: IP 192.168.0.50 is still in use by Service milk-svc