### PR TITLE
Remove node checking

### DIFF
--- a/pkg/nsx/services/inventory/builder.go
+++ b/pkg/nsx/services/inventory/builder.go
@@ -39,7 +39,6 @@ func (s *InventoryService) BuildPod(pod *corev1.Pod) (retry bool) {
 		log.Error(err, "Failed to build Pod", "Pod", pod)
 		return
 	}
-
 	node := &corev1.Node{}
 	err = s.Client.Get(context.TODO(), types.NamespacedName{Name: pod.Spec.NodeName}, node)
 	if err != nil {
@@ -48,8 +47,8 @@ func (s *InventoryService) BuildPod(pod *corev1.Pod) (retry bool) {
 			retry = true
 		}
 		log.Error(err, "Cannot find node for Pod", "Pod", pod.Name, "Namespace", pod.Namespace, "Node", pod.Spec.NodeName, "retry", retry)
-		return
 	}
+
 	status := InventoryStatusDown
 	if pod.Status.Phase == corev1.PodRunning {
 		status = InventoryStatusUp


### PR DESCRIPTION
While reporting pod inventory, operator will check if node's ready. But NCP didn't check it. Follow the NCP style and remove the node checking.
Rename build.go to builder.go

Test Done:
1. create a pod with status pending
2. check from UI if pod inventory reported
3. check if networkworking status with error '"0/6 nodes are available: 3 node(s) didn't match Pod's node affinity/selector, 3 node(s) had untolerated taint {node-role.kubernetes.io/control-plane:"
4. check if pod status is 'Down'