### PR TITLE
[cherry-pick]Block SubnetPort allocation on an IP exhausted Subnet (#1033)

### DIFF
--- a/pkg/nsx/services/realizestate/realize_state.go
+++ b/pkg/nsx/services/realizestate/realize_state.go
@@ -65,8 +65,11 @@ func (service *RealizeStateService) CheckRealizeState(backoff wait.Backoff, inte
 					if nsxutil.IsRetryRealizeError(alarm) {
 						return nsxutil.NewRetryRealizeError(fmt.Sprintf("%s not realized with errors: %s", intentPath, errMsg))
 					}
+					if nsxutil.IsIPAllocationError(alarm) {
+						return nsxutil.NewRealizeStateError(fmt.Sprintf("%s realized with errors: %s", intentPath, errMsg), nsxutil.IPAllocationErrorCode)
+					}
 				}
-				return nsxutil.NewRealizeStateError(fmt.Sprintf("%s realized with errors: %s", intentPath, errMsg))
+				return nsxutil.NewRealizeStateError(fmt.Sprintf("%s realized with errors: %s", intentPath, errMsg), 0)
 			}
 		}
 		// extraIdsRealized can be greater than extraIds length as id is not unique in result list.

--- a/pkg/nsx/services/realizestate/realize_state_test.go
+++ b/pkg/nsx/services/realizestate/realize_state_test.go
@@ -230,4 +230,37 @@ func TestRealizeStateService_CheckRealizeState(t *testing.T) {
 	assert.Equal(t, ok, false)
 	patches.Reset()
 
+	// for subnetport, realized with IPAllocationError
+	patches = gomonkey.ApplyFunc((*fakeRealizedEntitiesClient).List, func(c *fakeRealizedEntitiesClient, intentPathParam string, sitePathParam *string) (model.GenericPolicyRealizedResourceListResult, error) {
+		return model.GenericPolicyRealizedResourceListResult{
+			Results: []model.GenericPolicyRealizedResource{
+				{
+					State: common.String(model.GenericPolicyRealizedResource_STATE_ERROR),
+					Alarms: []model.PolicyAlarmResource{
+						{
+							Message: common.String("Realization failure"),
+							ErrorDetails: &model.PolicyApiError{
+								ErrorCode:    common.Int64(nsxutil.IPAllocationErrorCode),
+								ErrorMessage: common.String("Realization failure"),
+							},
+						},
+					},
+					EntityType: common.String("GenericPolicyRealizedResource"),
+				},
+			},
+		}, nil
+	})
+
+	backoff = wait.Backoff{
+		Duration: 10 * time.Millisecond,
+		Factor:   1,
+		Jitter:   0,
+		Steps:    1,
+	}
+	err = s.CheckRealizeState(backoff, "/orgs/default/projects/default/vpcs/vpc/vpc-lbs/default", []string{})
+	assert.NotEqual(t, err, nil)
+	realizedError, ok := err.(*nsxutil.RealizeStateError)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, nsxutil.IPAllocationErrorCode, realizedError.GetCode())
+	patches.Reset()
 }

--- a/pkg/nsx/services/subnet/subnet_test.go
+++ b/pkg/nsx/services/subnet/subnet_test.go
@@ -482,7 +482,7 @@ func TestSubnetService_createOrUpdateSubnet(t *testing.T) {
 			prepareFunc: func() *gomonkey.Patches {
 				patches := gomonkey.ApplyFunc((*realizestate.RealizeStateService).CheckRealizeState,
 					func(_ *realizestate.RealizeStateService, _ wait.Backoff, _ string, _ []string) error {
-						return nsxutil.NewRealizeStateError("mocked realized error")
+						return nsxutil.NewRealizeStateError("mocked realized error", 0)
 					})
 				patches.ApplyFunc((*SubnetService).DeleteSubnet, func(_ *SubnetService, _ model.VpcSubnet) error {
 					return errors.New("mocked deletion error")

--- a/pkg/nsx/services/subnetport/store.go
+++ b/pkg/nsx/services/subnetport/store.go
@@ -3,6 +3,7 @@ package subnetport
 import (
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"k8s.io/apimachinery/pkg/types"
@@ -98,8 +99,9 @@ type CountInfo struct {
 	// dirtyCount defines the number of SubnetPorts under creation in the Subnet
 	dirtyCount int
 	lock       sync.Mutex
-	// totalIp defines the number of available IP in the Subnet
-	totalIp int
+	// totalIP defines the number of available IP in the Subnet
+	totalIP            int
+	exhaustedCheckTime time.Time
 }
 
 func (vs *SubnetPortStore) Apply(i interface{}) error {

--- a/pkg/nsx/util/errors.go
+++ b/pkg/nsx/util/errors.go
@@ -12,6 +12,7 @@ import (
 const (
 	InvalidLicenseErrorCode   = 505
 	ProviderNotReadyErrorCode = 500042
+	IPAllocationErrorCode     = 8212
 )
 
 type NsxError interface {
@@ -607,14 +608,19 @@ var (
 
 type RealizeStateError struct {
 	message string
+	code    int
 }
 
 func (e *RealizeStateError) Error() string {
 	return e.message
 }
 
-func NewRealizeStateError(msg string) *RealizeStateError {
-	return &RealizeStateError{message: msg}
+func (e *RealizeStateError) GetCode() int {
+	return e.code
+}
+
+func NewRealizeStateError(msg string, code int) *RealizeStateError {
+	return &RealizeStateError{message: msg, code: code}
 }
 
 func IsRealizeStateError(err error) bool {
@@ -638,6 +644,14 @@ func IsRetryRealizeError(alarm model.PolicyAlarmResource) bool {
 	// The ProviderNotReady error indicates NSX get timeout when waiting for the dependencies
 	// and may become Realized after retry.
 	if alarm.ErrorDetails != nil && alarm.ErrorDetails.ErrorCode != nil && *alarm.ErrorDetails.ErrorCode == ProviderNotReadyErrorCode {
+		return true
+	}
+	return false
+}
+
+func IsIPAllocationError(alarm model.PolicyAlarmResource) bool {
+	// The IPAllocationErrorCode error indicates there is no valid IP in Subnet.
+	if alarm.ErrorDetails != nil && alarm.ErrorDetails.ErrorCode != nil && *alarm.ErrorDetails.ErrorCode == IPAllocationErrorCode {
 		return true
 	}
 	return false


### PR DESCRIPTION
For Pod case, we will create and delete SubnetPort for image fetcher. As the IP release needs 2 minutes, it may happen that the SubnetPort number on the Subnet is less than capacity but larger than the number of available IPs. For this condition, we will get IP exhausted error when creating the SubnetPort, and we would like to avoid allocating more SubnetPorts on this IP-exhausted Subnet in the following 2 minutes.

Testing done:
Create 16 pods, delete them and re-create them. Check the log that once the Subnet is found as IP-exhausted, the following SubnetPort will be allocated on other Subnets.