### PR TITLE
Fix AddressBinding webhook validation for default interface

### DIFF
--- a/pkg/controllers/subnetport/addressbinding_webhook.go
+++ b/pkg/controllers/subnetport/addressbinding_webhook.go
@@ -46,8 +46,17 @@ func (v *AddressBindingValidator) Handle(ctx context.Context, req admission.Requ
 			log.Error(err, "failed to list AddressBinding from cache", "indexValue", abIndexValue)
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
+		hasDefault := ab.Spec.InterfaceName == ""
+		if !hasDefault {
+			for _, existingAddressBinding := range existingAddressBindingList.Items {
+				if existingAddressBinding.Spec.InterfaceName == "" {
+					hasDefault = true
+					break
+				}
+			}
+		}
 		for _, existingAddressBinding := range existingAddressBindingList.Items {
-			if ab.Name != existingAddressBinding.Name && ab.Spec.InterfaceName == existingAddressBinding.Spec.InterfaceName {
+			if ab.Name != existingAddressBinding.Name && (hasDefault || ab.Spec.InterfaceName == existingAddressBinding.Spec.InterfaceName) {
 				return admission.Denied("interface already has AddressBinding")
 			}
 		}

--- a/pkg/controllers/subnetport/addressbinding_webhook_test.go
+++ b/pkg/controllers/subnetport/addressbinding_webhook_test.go
@@ -52,6 +52,15 @@ func TestAddressBindingValidator_Handle(t *testing.T) {
 			InterfaceName: "inf2",
 		},
 	})
+	req2d, _ := json.Marshal(&v1alpha1.AddressBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "ab2",
+		},
+		Spec: v1alpha1.AddressBindingSpec{
+			VMName: "vm1",
+		},
+	})
 	req3, _ := json.Marshal(&v1alpha1.AddressBinding{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: "ns1",
@@ -61,6 +70,16 @@ func TestAddressBindingValidator_Handle(t *testing.T) {
 			VMName:                  "vm1",
 			InterfaceName:           "inf3",
 			IPAddressAllocationName: "ip1",
+		},
+	})
+	req4, _ := json.Marshal(&v1alpha1.AddressBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "ab3",
+		},
+		Spec: v1alpha1.AddressBindingSpec{
+			VMName:        "vm2",
+			InterfaceName: "inf2",
 		},
 	})
 	type args struct {
@@ -101,6 +120,16 @@ func TestAddressBindingValidator_Handle(t *testing.T) {
 		{
 			name: "create dup",
 			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Create, Object: runtime.RawExtension{Raw: req2}}}},
+			want: admission.Denied("interface already has AddressBinding"),
+		},
+		{
+			name: "create dup with default",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Create, Object: runtime.RawExtension{Raw: req2d}}}},
+			want: admission.Denied("interface already has AddressBinding"),
+		},
+		{
+			name: "create dup with existing default",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: admissionv1.Create, Object: runtime.RawExtension{Raw: req4}}}},
 			want: admission.Denied("interface already has AddressBinding"),
 		},
 		{
@@ -263,6 +292,15 @@ func TestAddressBindingValidator_Handle(t *testing.T) {
 				Spec: v1alpha1.AddressBindingSpec{
 					VMName:        "vm1",
 					InterfaceName: "inf2",
+				},
+			})
+			client.Create(ctx, &v1alpha1.AddressBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "ns1",
+					Name:      "ab3a",
+				},
+				Spec: v1alpha1.AddressBindingSpec{
+					VMName: "vm2",
 				},
 			})
 			if tt.prepareFunc != nil {


### PR DESCRIPTION
Testing done:
```
root@422df4dbea4c38c7dd45af0238d16b69 [ ~ ]# cat ab1
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: AddressBinding
metadata:
  name: gran1
  namespace: default
spec:
  vmName: vm1
---
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: AddressBinding
metadata:
  name: gran2
  namespace: default
spec:
  vmName: vm1
  interfaceName: inf1

root@422df4dbea4c38c7dd45af0238d16b69 [ ~ ]# kubectl create -f ab1
addressbinding.crd.nsx.vmware.com/gran1 created
Error from server (Forbidden): error when creating "ab1": admission webhook "addressbinding.validating.crd.nsx.vmware.com" denied the request: interface already has AddressBinding
root@422df4dbea4c38c7dd45af0238d16b69 [ ~ ]# kubectl delete -f ab1
addressbinding.crd.nsx.vmware.com "gran1" deleted
Error from server (NotFound): error when deleting "ab1": addressbindings.crd.nsx.vmware.com "gran2" not found


root@422df4dbea4c38c7dd45af0238d16b69 [ ~ ]# vi ab1
root@422df4dbea4c38c7dd45af0238d16b69 [ ~ ]# cat ab1
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: AddressBinding
metadata:
  name: gran1
  namespace: default
spec:
  vmName: vm1
  interfaceName: inf1
---
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: AddressBinding
metadata:
  name: gran2
  namespace: default
spec:
  vmName: vm1

root@422df4dbea4c38c7dd45af0238d16b69 [ ~ ]# kubectl create -f ab1
addressbinding.crd.nsx.vmware.com/gran1 created
Error from server (Forbidden): error when creating "ab1": admission webhook "addressbinding.validating.crd.nsx.vmware.com" denied the request: interface already has AddressBinding

```