### PR TITLE
Enhance the validation for Subnet ipAddresses

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
@@ -142,8 +142,6 @@ spec:
               rule: '!has(oldSelf.ipv4SubnetSize) || has(self.ipv4SubnetSize)'
             - message: accessMode is required once set
               rule: '!has(oldSelf.accessMode) || has(self.accessMode)'
-            - message: ipAddresses is required once set
-              rule: '!has(oldSelf.ipAddresses) || has(self.ipAddresses)'
           status:
             description: SubnetStatus defines the observed state of Subnet.
             properties:

--- a/pkg/apis/vpc/v1alpha1/subnet_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnet_types.go
@@ -27,7 +27,6 @@ const (
 // +kubebuilder:validation:XValidation:rule="has(oldSelf.subnetDHCPConfig)==has(self.subnetDHCPConfig) || (has(oldSelf.subnetDHCPConfig) && !has(self.subnetDHCPConfig) && (!has(oldSelf.subnetDHCPConfig.mode) || oldSelf.subnetDHCPConfig.mode=='DHCPDeactivated')) || (!has(oldSelf.subnetDHCPConfig) && has(self.subnetDHCPConfig) && (!has(self.subnetDHCPConfig.mode) || self.subnetDHCPConfig.mode=='DHCPDeactivated'))", message="subnetDHCPConfig mode can only switch between DHCPServer and DHCPRelay"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.ipv4SubnetSize) || has(self.ipv4SubnetSize)", message="ipv4SubnetSize is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.accessMode) || has(self.accessMode)", message="accessMode is required once set"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.ipAddresses) || has(self.ipAddresses)", message="ipAddresses is required once set"
 type SubnetSpec struct {
 	// VPC name of the Subnet.
 	VPCName string `json:"vpcName,omitempty"`

--- a/pkg/controllers/subnet/subnet_webhook.go
+++ b/pkg/controllers/subnet/subnet_webhook.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
@@ -88,6 +89,9 @@ func (v *SubnetValidator) Handle(ctx context.Context, req admission.Request) adm
 			if oldSubnet.Spec.AdvancedConfig.EnableVLANExtension != subnet.Spec.AdvancedConfig.EnableVLANExtension {
 				return admission.Denied(fmt.Sprintf("Subnet %s/%s: spec.enableVLANExtension can only be updated by NSX Operator", subnet.Namespace, subnet.Name))
 			}
+		}
+		if !nsxutil.CompareArraysWithoutOrder(oldSubnet.Spec.IPAddresses, subnet.Spec.IPAddresses) {
+			return admission.Denied("ipAddresses is immutable")
 		}
 	case admissionv1.Delete:
 		oldSubnet := &v1alpha1.Subnet{}


### PR DESCRIPTION
There are 2 issues in the current Subnet validation
- ipAddresses with empty array is not supported
- ipAddresses can be changed from empty to a value

The PR leverages the webhook to make sure subnet.ipAddresses is immutable that
- ipAddresses with empty array and no ipAddresses will be consider as the same
- ipAddresses cannot be set from empty to a value or set from a value to empty

Testing done:

Created the following Subnet CR and observed it is realized.
```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: subnet-1
spec:
  accessMode: PrivateTGW
  ipAddresses: []
  ipv4SubnetSize: 16
  subnetDHCPConfig:
    mode: DHCPServer
```

Updated the above Subnet with the following
```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: subnet-1
spec:
  accessMode: PrivateTGW
  ipAddresses:
  - "172.0.0.0/28"
  ipv4SubnetSize: 16
  subnetDHCPConfig:
    mode: DHCPServer
```

it will be blocked with the message:
```
Error from server (Forbidden): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"crd.nsx.vmware.com/v1alpha1\",\"kind\":\"Subnet\",\"metadata\":{\"annotations\":{},\"name\":\"subnet-1\",\"namespace\":\"workload-ns-1\"},\"spec\":{\"accessMode\":\"PrivateTGW\",\"ipAddresses\":[\"172.0.0.0/28\"],\"ipv4SubnetSize\":16,\"subnetDHCPConfig\":{\"mode\":\"DHCPServer\"}}}\n"}},"spec":{"ipAddresses":["172.0.0.0/28"]}}
to:
Resource: "crd.nsx.vmware.com/v1alpha1, Resource=subnets", GroupVersionKind: "crd.nsx.vmware.com/v1alpha1, Kind=Subnet"
Name: "subnet-1", Namespace: "workload-ns-1"
for: "subnet.yaml": admission webhook "subnet.validating.crd.nsx.vmware.com" denied the request: ipAddresses is immutable
```

Created a Subnet with ipAddresses
```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: subnet-1
spec:
  accessMode: PrivateTGW
  ipAddresses:
  - "10.246.0.32/28"
  ipv4SubnetSize: 16
  subnetDHCPConfig:
    mode: DHCPServer
```
Updated the above Subnet with the following
```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: subnet-1
spec:
  accessMode: PrivateTGW
  ipv4SubnetSize: 16
  subnetDHCPConfig:
    mode: DHCPServer
```

it will be blocked with the message:
```
Error from server (Forbidden): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"crd.nsx.vmware.com/v1alpha1\",\"kind\":\"Subnet\",\"metadata\":{\"annotations\":{},\"name\":\"subnet-1\",\"namespace\":\"workload-ns-1\"},\"spec\":{\"accessMode\":\"PrivateTGW\",\"ipAddresses\":null,\"ipv4SubnetSize\":16,\"subnetDHCPConfig\":{\"mode\":\"DHCPServer\"}}}\n"}},"spec":{"ipAddresses":null}}
to:
Resource: "crd.nsx.vmware.com/v1alpha1, Resource=subnets", GroupVersionKind: "crd.nsx.vmware.com/v1alpha1, Kind=Subnet"
Name: "subnet-1", Namespace: "workload-ns-1"
for: "subnet.yaml": admission webhook "subnet.validating.crd.nsx.vmware.com" denied the request: ipAddresses is immutable
```

