### PR TITLE
Use id for Subnet vpcName

### DIFF
--- a/pkg/controllers/namespace/subnet_share_controller.go
+++ b/pkg/controllers/namespace/subnet_share_controller.go
@@ -47,7 +47,7 @@ func (r *NamespaceReconciler) createSharedSubnetCR(ctx context.Context, ns strin
 		return err
 	}
 
-	vpcFullName, err := servicecommon.GetVPCFullName(orgID, projectID, vpcID, r.VPCService)
+	vpcFullID, err := servicecommon.GetVPCFullID(orgID, projectID, vpcID, r.VPCService)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func (r *NamespaceReconciler) createSharedSubnetCR(ctx context.Context, ns strin
 	subnetName := *nsxSubnet.DisplayName
 
 	// Create the Subnet CR object
-	subnetCR := r.SubnetService.BuildSubnetCR(ns, subnetName, vpcFullName, associatedName)
+	subnetCR := r.SubnetService.BuildSubnetCR(ns, subnetName, vpcFullID, associatedName)
 
 	// Create the Subnet CR in Kubernetes
 	err = r.createSubnetCRInK8s(ctx, subnetCR)

--- a/pkg/controllers/namespace/subnet_share_controller_test.go
+++ b/pkg/controllers/namespace/subnet_share_controller_test.go
@@ -923,18 +923,6 @@ func TestCreateSharedSubnetCR(t *testing.T) {
 						return "default", "proj-1", "vpc-1", "subnet-1", nil
 					})
 
-				// Mock GetProjectName
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetProjectName",
-					func(_ servicecommon.VPCServiceProvider, orgID, projID string) (string, error) {
-						return "project-1", nil
-					})
-
-				// Mock GetVPCName
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCName",
-					func(_ servicecommon.VPCServiceProvider, orgID, projID, vpcID string) (string, error) {
-						return "vpc-1", nil
-					})
-
 				// Mock IsDefaultNSXProject
 				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "IsDefaultNSXProject",
 					func(_ servicecommon.VPCServiceProvider, orgID, projectID string) (bool, error) {
@@ -957,7 +945,7 @@ func TestCreateSharedSubnetCR(t *testing.T) {
 
 				// Mock BuildSubnetCR
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "BuildSubnetCR",
-					func(_ *subnet.SubnetService, ns, subnetName, vpcFullName, associatedName string) *v1alpha1.Subnet {
+					func(_ *subnet.SubnetService, ns, subnetName, vpcFullID, associatedName string) *v1alpha1.Subnet {
 						return &v1alpha1.Subnet{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      subnetName,
@@ -967,7 +955,7 @@ func TestCreateSharedSubnetCR(t *testing.T) {
 								},
 							},
 							Spec: v1alpha1.SubnetSpec{
-								VPCName: vpcFullName,
+								VPCName: vpcFullID,
 							},
 						}
 					})
@@ -996,52 +984,6 @@ func TestCreateSharedSubnetCR(t *testing.T) {
 			expectedErrString: "invalid subnet path format",
 		},
 		{
-			name:             "Error getting project name",
-			sharedSubnetPath: "/orgs/default/projects/proj-1/vpcs/vpc-1/subnets/subnet-1",
-			setupMocks: func(r *NamespaceReconciler) *gomonkey.Patches {
-				// Mock ExtractSubnetPath
-				patches := gomonkey.ApplyFunc(servicecommon.ExtractSubnetPath,
-					func(path string) (string, string, string, string, error) {
-						return "default", "proj-1", "vpc-1", "subnet-1", nil
-					})
-
-				// Mock GetProjectName to return an error
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetProjectName",
-					func(_ servicecommon.VPCServiceProvider, orgID, projID string) (string, error) {
-						return "", fmt.Errorf("failed to get project name")
-					})
-
-				return patches
-			},
-			expectedErrString: "failed to get project name",
-		},
-		{
-			name:             "Error getting VPC name",
-			sharedSubnetPath: "/orgs/default/projects/proj-1/vpcs/vpc-1/subnets/subnet-1",
-			setupMocks: func(r *NamespaceReconciler) *gomonkey.Patches {
-				// Mock ExtractSubnetPath
-				patches := gomonkey.ApplyFunc(servicecommon.ExtractSubnetPath,
-					func(path string) (string, string, string, string, error) {
-						return "default", "proj-1", "vpc-1", "subnet-1", nil
-					})
-
-				// Mock GetProjectName
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetProjectName",
-					func(_ servicecommon.VPCServiceProvider, orgID, projID string) (string, error) {
-						return "project-1", nil
-					})
-
-				// Mock GetVPCName to return an error
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCName",
-					func(_ servicecommon.VPCServiceProvider, orgID, projID, vpcID string) (string, error) {
-						return "", fmt.Errorf("failed to get VPC name")
-					})
-
-				return patches
-			},
-			expectedErrString: "failed to get VPC name",
-		},
-		{
 			name:             "Error checking if project is default",
 			sharedSubnetPath: "/orgs/default/projects/proj-1/vpcs/vpc-1/subnets/subnet-1",
 			setupMocks: func(r *NamespaceReconciler) *gomonkey.Patches {
@@ -1049,18 +991,6 @@ func TestCreateSharedSubnetCR(t *testing.T) {
 				patches := gomonkey.ApplyFunc(servicecommon.ExtractSubnetPath,
 					func(path string) (string, string, string, string, error) {
 						return "default", "proj-1", "vpc-1", "subnet-1", nil
-					})
-
-				// Mock GetProjectName
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetProjectName",
-					func(_ servicecommon.VPCServiceProvider, orgID, projID string) (string, error) {
-						return "project-1", nil
-					})
-
-				// Mock GetVPCName
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCName",
-					func(_ servicecommon.VPCServiceProvider, orgID, projID, vpcID string) (string, error) {
-						return "vpc-1", nil
 					})
 
 				// Mock IsDefaultNSXProject to return an error
@@ -1081,18 +1011,6 @@ func TestCreateSharedSubnetCR(t *testing.T) {
 				patches := gomonkey.ApplyFunc(servicecommon.ExtractSubnetPath,
 					func(path string) (string, string, string, string, error) {
 						return "default", "proj-1", "vpc-1", "subnet-1", nil
-					})
-
-				// Mock GetProjectName
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetProjectName",
-					func(_ servicecommon.VPCServiceProvider, orgID, projID string) (string, error) {
-						return "project-1", nil
-					})
-
-				// Mock GetVPCName
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCName",
-					func(_ servicecommon.VPCServiceProvider, orgID, projID, vpcID string) (string, error) {
-						return "vpc-1", nil
 					})
 
 				// Mock IsDefaultNSXProject
@@ -1121,18 +1039,6 @@ func TestCreateSharedSubnetCR(t *testing.T) {
 						return "default", "proj-1", "vpc-1", "subnet-1", nil
 					})
 
-				// Mock GetProjectName
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetProjectName",
-					func(_ servicecommon.VPCServiceProvider, orgID, projID string) (string, error) {
-						return "project-1", nil
-					})
-
-				// Mock GetVPCName
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCName",
-					func(_ servicecommon.VPCServiceProvider, orgID, projID, vpcID string) (string, error) {
-						return "vpc-1", nil
-					})
-
 				// Mock IsDefaultNSXProject
 				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "IsDefaultNSXProject",
 					func(_ servicecommon.VPCServiceProvider, orgID, projectID string) (bool, error) {
@@ -1155,7 +1061,7 @@ func TestCreateSharedSubnetCR(t *testing.T) {
 
 				// Mock BuildSubnetCR
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "BuildSubnetCR",
-					func(_ *subnet.SubnetService, ns, subnetName, vpcFullName, associatedName string) *v1alpha1.Subnet {
+					func(_ *subnet.SubnetService, ns, subnetName, vpcFullID, associatedName string) *v1alpha1.Subnet {
 						return &v1alpha1.Subnet{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      subnetName,
@@ -1165,7 +1071,7 @@ func TestCreateSharedSubnetCR(t *testing.T) {
 								},
 							},
 							Spec: v1alpha1.SubnetSpec{
-								VPCName: vpcFullName,
+								VPCName: vpcFullID,
 							},
 						}
 					})

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -144,13 +144,13 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	if subnetCR.Spec.VPCName == "" {
-		// Get VPC full name
-		vpcFullName, err := servicecommon.GetVPCFullName(vpcInfoList[0].OrgID, vpcInfoList[0].ProjectID, vpcInfoList[0].VPCID, r.VPCService)
+		// Get VPC full ID
+		vpcFullID, err := servicecommon.GetVPCFullID(vpcInfoList[0].OrgID, vpcInfoList[0].ProjectID, vpcInfoList[0].VPCID, r.VPCService)
 		if err != nil {
-			log.Error(err, "Failed to get VPC full name", "Namespace", subnetCR.Namespace)
+			log.Error(err, "Failed to get VPC full ID", "Namespace", subnetCR.Namespace)
 			return ResultRequeue, nil
 		}
-		subnetCR.Spec.VPCName = vpcFullName
+		subnetCR.Spec.VPCName = vpcFullID
 		specChanged = true
 	}
 

--- a/pkg/controllers/subnet/subnet_controller_test.go
+++ b/pkg/controllers/subnet/subnet_controller_test.go
@@ -510,14 +510,6 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 						{OrgID: "org-id", ProjectID: "project-id", VPCID: "vpc-id", ID: "fake-id"},
 					}
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetProjectName", func(_ *vpc.VPCService,
-					orgID, projID string) (string, error) {
-					return "project-name", nil
-				})
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCName", func(_ *vpc.VPCService,
-					orgID, projID, vpcID string) (string, error) {
-					return "vpc-name", nil
-				})
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (*model.VpcSubnet, error) {
 					return nil, errors.New("create or update failed")
 				})
@@ -553,15 +545,6 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 						{OrgID: "org-id", ProjectID: "project-id", VPCID: "vpc-id", ID: "fake-id"},
 					}
 				})
-
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetProjectName", func(_ *vpc.VPCService,
-					orgID, projID string) (string, error) {
-					return "project-name", nil
-				})
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCName", func(_ *vpc.VPCService,
-					orgID, projID, vpcID string) (string, error) {
-					return "vpc-name", nil
-				})
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (*model.VpcSubnet, error) {
 					return nil, nil
 				})
@@ -592,7 +575,7 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 			},
 			existingSubnetCR: createNewSubnet(),
 			expectSubnetCR: &v1alpha1.Subnet{
-				Spec: v1alpha1.SubnetSpec{VPCName: "project-name:vpc-name", IPv4SubnetSize: 16, AccessMode: "Private",
+				Spec: v1alpha1.SubnetSpec{VPCName: "project-id:vpc-id", IPv4SubnetSize: 16, AccessMode: "Private",
 					IPAddresses:      []string(nil),
 					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{Mode: v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated)}},
 				Status: v1alpha1.SubnetStatus{},
@@ -622,14 +605,6 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 					}
 				})
 
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetProjectName", func(_ *vpc.VPCService,
-					orgID, projID string) (string, error) {
-					return "project-name", nil
-				})
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCName", func(_ *vpc.VPCService,
-					orgID, projID, vpcID string) (string, error) {
-					return "vpc-name", nil
-				})
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (*model.VpcSubnet, error) {
 					return nil, nil
 				})
@@ -645,7 +620,7 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 			},
 			existingSubnetCR: createNewSubnet(),
 			expectSubnetCR: &v1alpha1.Subnet{
-				Spec: v1alpha1.SubnetSpec{VPCName: "project-name:vpc-name", IPv4SubnetSize: 16, AccessMode: "Private", IPAddresses: []string(nil),
+				Spec: v1alpha1.SubnetSpec{VPCName: "project-id:vpc-id", IPv4SubnetSize: 16, AccessMode: "Private", IPAddresses: []string(nil),
 					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{Mode: v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated)}},
 				Status: v1alpha1.SubnetStatus{},
 			},
@@ -684,14 +659,6 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 					return []common.VPCResourceInfo{
 						{OrgID: "org-id", ProjectID: "project-id", VPCID: "vpc-id", ID: "fake-id"},
 					}
-				})
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetProjectName", func(_ *vpc.VPCService,
-					orgID, projID string) (string, error) {
-					return "project-name", nil
-				})
-				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCName", func(_ *vpc.VPCService,
-					orgID, projID, vpcID string) (string, error) {
-					return "vpc-name", nil
 				})
 
 				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "IsDefaultNSXProject", func(_ *vpc.VPCService, orgID, projectID string) (bool, error) {

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -55,16 +55,6 @@ func (m *MockVPCServiceProvider) GetNetworkconfigNameFromNS(ctx context.Context,
 	return "", nil
 }
 
-func (m *MockVPCServiceProvider) GetProjectName(orgID, projectID string) (string, error) {
-	args := m.Called(orgID, projectID)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockVPCServiceProvider) GetVPCName(orgID, projectID, vpcID string) (string, error) {
-	args := m.Called(orgID, projectID, vpcID)
-	return args.String(0), args.Error(1)
-}
-
 func (m *MockVPCServiceProvider) IsDefaultNSXProject(orgID, projectID string) (bool, error) {
 	args := m.Called(orgID, projectID)
 	return args.Bool(0), args.Error(1)

--- a/pkg/nsx/services/common/builder.go
+++ b/pkg/nsx/services/common/builder.go
@@ -97,30 +97,20 @@ func IsSharedSubnet(subnet *v1alpha1.Subnet) bool {
 	return exists
 }
 
-// GetVPCFullName returns the formatted VPC full name based on project and VPC names
-// If the project is a default NSX project, the format is ":vpcName", otherwise it's "projectName:vpcName"
-func GetVPCFullName(orgID, projectID, vpcID string, vpcService VPCServiceProvider) (string, error) {
-	projectName, err := vpcService.GetProjectName(orgID, projectID)
-	if err != nil {
-		return "", fmt.Errorf("failed to get project name: %w", err)
-	}
-
-	vpcName, err := vpcService.GetVPCName(orgID, projectID, vpcID)
-	if err != nil {
-		return "", fmt.Errorf("failed to get VPC name: %w", err)
-	}
-
-	// Format VPC full name
-	vpcFullName := fmt.Sprintf("%s:%s", projectName, vpcName)
+// GetVPCFullID returns the formatted VPC full naIDme based on project and VPC IDs
+// If the project is a default NSX project, the format is ":vpcId", otherwise it's "projectId:vpcId"
+func GetVPCFullID(orgID, projectID, vpcID string, vpcService VPCServiceProvider) (string, error) {
+	// Format VPC full ID
+	vpcFullID := fmt.Sprintf("%s:%s", projectID, vpcID)
 	isDefault, err := vpcService.IsDefaultNSXProject(orgID, projectID)
 	if err != nil {
 		return "", fmt.Errorf("failed to check if project is default: %w", err)
 	}
 	if isDefault {
-		vpcFullName = fmt.Sprintf(":%s", vpcName)
+		vpcFullID = fmt.Sprintf(":%s", vpcID)
 	}
 
-	return vpcFullName, nil
+	return vpcFullID, nil
 }
 
 func GetSubnetPathFromAssociatedResource(associatedResource string) (string, error) {

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -21,8 +21,6 @@ type VPCServiceProvider interface {
 	GetDefaultNetworkConfig() (*v1alpha1.VPCNetworkConfiguration, error)
 	ListVPCInfo(ns string) []VPCResourceInfo
 	GetNetworkconfigNameFromNS(ctx context.Context, ns string) (string, error)
-	GetProjectName(orgID, projectID string) (string, error)
-	GetVPCName(orgID, projectID, vpcID string) (string, error)
 	IsDefaultNSXProject(orgID, projectID string) (bool, error)
 }
 

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -626,7 +626,7 @@ func (service *SubnetService) MapNSXSubnetStatusToSubnetCRStatus(subnetCR *v1alp
 }
 
 // BuildSubnetCR creates a Subnet CR object with the given parameters
-func (service *SubnetService) BuildSubnetCR(ns, subnetName, vpcFullName, associatedName string) *v1alpha1.Subnet {
+func (service *SubnetService) BuildSubnetCR(ns, subnetName, vpcFullID, associatedName string) *v1alpha1.Subnet {
 	// Create the Subnet CR
 	subnetCR := &v1alpha1.Subnet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -637,7 +637,7 @@ func (service *SubnetService) BuildSubnetCR(ns, subnetName, vpcFullName, associa
 			},
 		},
 		Spec: v1alpha1.SubnetSpec{
-			VPCName: vpcFullName,
+			VPCName: vpcFullID,
 		},
 	}
 	log.Info("Build Subnet CR", "Subnet", subnetCR)

--- a/pkg/nsx/services/subnet/subnet_test.go
+++ b/pkg/nsx/services/subnet/subnet_test.go
@@ -979,7 +979,7 @@ func TestBuildSubnetCR(t *testing.T) {
 		name           string
 		ns             string
 		subnetName     string
-		vpcFullName    string
+		vpcFullID      string
 		associatedName string
 		nsxSubnet      *model.VpcSubnet
 		expectedSubnet *v1alpha1.Subnet
@@ -988,7 +988,7 @@ func TestBuildSubnetCR(t *testing.T) {
 			name:           "Build Subnet CR with NSX Subnet",
 			ns:             "test-ns",
 			subnetName:     "test-subnet",
-			vpcFullName:    "proj-1:vpc-1",
+			vpcFullID:      "proj-1:vpc-1",
 			associatedName: "proj-1:vpc-1:subnet-1",
 			expectedSubnet: &v1alpha1.Subnet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1011,7 +1011,7 @@ func TestBuildSubnetCR(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			service := &SubnetService{}
-			subnetCR := service.BuildSubnetCR(tt.ns, tt.subnetName, tt.vpcFullName, tt.associatedName)
+			subnetCR := service.BuildSubnetCR(tt.ns, tt.subnetName, tt.vpcFullID, tt.associatedName)
 			assert.Equal(t, tt.expectedSubnet, subnetCR)
 		})
 	}

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -45,16 +45,10 @@ var (
 	TypeDistributedVlanConnection = "distributed-vlan-connections"
 )
 
-type nameCache struct {
-	projectNames map[string]string
-	vpcNames     map[string]string
-}
-
 type VPCService struct {
 	common.Service
-	VpcStore  *VPCStore
-	LbsStore  *LBSStore
-	nameCache *nameCache
+	VpcStore *VPCStore
+	LbsStore *LBSStore
 }
 
 func (s *VPCService) GetDefaultNetworkConfig() (*v1alpha1.VPCNetworkConfiguration, error) {
@@ -163,11 +157,6 @@ func InitializeVPC(service common.Service) (*VPCService, error) {
 		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{}),
 		BindingType: model.LBServiceBindingType(),
 	}}
-	VPCService.nameCache = &nameCache{
-		projectNames: make(map[string]string),
-		vpcNames:     make(map[string]string),
-	}
-
 	// Note: waitgroup.Add must be called before its consumptions.
 	wg.Add(2)
 	// initialize vpc store, lbs store
@@ -1010,43 +999,6 @@ func (s *VPCService) cleanupAviSubnetPorts(ctx context.Context) error {
 
 func IsPreCreatedVPC(nc *v1alpha1.VPCNetworkConfiguration) bool {
 	return nc.Spec.VPC != ""
-}
-
-// GetProjectName gets the project name from its ID
-func (s *VPCService) GetProjectName(orgID, projectID string) (string, error) {
-	key := fmt.Sprintf("%s/%s", orgID, projectID)
-	if cachedName, exists := s.nameCache.projectNames[key]; exists {
-		return cachedName, nil
-	}
-
-	proj, err := s.NSXClient.ProjectClient.Get(orgID, projectID, nil)
-	if err != nil {
-		log.Error(err, "Failed to get project", "ProjectID", projectID)
-		return "", err
-	}
-	if proj.DisplayName != nil {
-		s.nameCache.projectNames[key] = *proj.DisplayName
-		return *proj.DisplayName, nil
-	}
-	return "", fmt.Errorf("project %s has no display name", projectID)
-}
-
-// GetVPCName gets the VPC name from its ID
-func (s *VPCService) GetVPCName(orgID, projectID, vpcID string) (string, error) {
-	key := fmt.Sprintf("%s/%s/%s", orgID, projectID, vpcID)
-	if cachedName, exists := s.nameCache.vpcNames[key]; exists {
-		return cachedName, nil
-	}
-	vpc, err := s.NSXClient.VPCClient.Get(orgID, projectID, vpcID)
-	if err != nil {
-		log.Error(err, "Failed to get VPC", "VPCID", vpcID)
-		return "", err
-	}
-	if vpc.DisplayName != nil {
-		s.nameCache.vpcNames[key] = *vpc.DisplayName
-		return *vpc.DisplayName, nil
-	}
-	return "", fmt.Errorf("VPC %s has no display name", vpcID)
 }
 
 // IsDefaultNSXProject checks if the given project is a default project


### PR DESCRIPTION
Change vpcName in Subnet from project-name:vpc-name to project-id:vpc:id to be consistent with VCFA.

Testing done:
- Create a shared Subnet in workload-ns-1, observed vpcName is set as `project-quality:workload-ns-1_d843cda5-e1c8-4785-b18f-feb3ae495565`
- Create an auto-created Subnet in workload-ns-1, observed vpcName is set as ` project-quality:workload-ns-1_d843cda5-e1c8-4785-b18f-feb3ae495565`