### PR TITLE
Update svc status if has error annotation

### DIFF
--- a/pkg/nsx/services/inventory/build_test.go
+++ b/pkg/nsx/services/inventory/build_test.go
@@ -1303,8 +1303,8 @@ func TestBuildService(t *testing.T) {
 		assert.Contains(t, inventoryService.pendingAdd, "service-uid-123")
 
 		containerApplication := inventoryService.pendingAdd["service-uid-123"].(*containerinventory.ContainerApplication)
-		assert.Equal(t, InventoryStatusUnknown, containerApplication.Status)
-		assert.Equal(t, NetworkStatusHealthy, containerApplication.NetworkStatus)
+		assert.Equal(t, InventoryStatusDown, containerApplication.Status)
+		assert.Equal(t, NetworkStatusUnhealthy, containerApplication.NetworkStatus)
 	})
 
 	t.Run("NoEndpointsNoAddress", func(t *testing.T) {

--- a/pkg/nsx/services/inventory/builder.go
+++ b/pkg/nsx/services/inventory/builder.go
@@ -363,16 +363,18 @@ func (s *InventoryService) BuildService(service *corev1.Service) (retry bool) {
 		status = InventoryStatusUp
 	}
 
-	// Get network errors from service annotations
-	if status != InventoryStatusUp {
-		// Check for NCP errors in service annotations
-		for key, value := range service.Annotations {
-			if util.Contains(ServiceNCPErrors, key) {
-				networkErrors = append(networkErrors, common.NetworkError{
-					ErrorMessage: key + ":" + value,
-				})
-			}
+	// Check for NCP errors in service annotations
+	for key, value := range service.Annotations {
+		if util.Contains(ServiceNCPErrors, key) {
+			networkErrors = append(networkErrors, common.NetworkError{
+				ErrorMessage: key + ":" + value,
+			})
 		}
+	}
+
+	if len(networkErrors) > 0 {
+		status = InventoryStatusDown
+		netStatus = NetworkStatusUnhealthy
 	}
 
 	// Update the Pods' service IDs, which are related to this service


### PR DESCRIPTION
Fix the svc network status/status not uploading issue if svc has ep

Test Done:
1. create pod tea
2. create svc with labels: app: tea which VIP has been used
3. check inventory if networkstatus is DOWN, status is DOWN, error is reported