### PR TITLE
Return error if get inventory cluster return error

### DIFF
--- a/pkg/clean/clean_lb_infra_test.go
+++ b/pkg/clean/clean_lb_infra_test.go
@@ -773,6 +773,9 @@ func TestCleanupInfraResources(t *testing.T) {
 				patches.ApplyPrivateMethod(reflect.TypeOf(cleaner), "cleanupLBMonitorProfiles", func(_ *LBInfraCleaner, ctx context.Context) error {
 					return nil
 				})
+				patches.ApplyPrivateMethod(reflect.TypeOf(cleaner), "cleanupInfraDomain", func(_ *LBInfraCleaner, ctx context.Context) error {
+					return nil
+				})
 				return patches
 			},
 		}, {
@@ -816,6 +819,9 @@ func TestCleanupInfraResources(t *testing.T) {
 					return nil
 				})
 				patches.ApplyPrivateMethod(reflect.TypeOf(cleaner), "cleanupLBMonitorProfiles", func(_ *LBInfraCleaner, ctx context.Context) error {
+					return nil
+				})
+				patches.ApplyPrivateMethod(reflect.TypeOf(cleaner), "cleanupInfraDomain", func(_ *LBInfraCleaner, ctx context.Context) error {
 					return nil
 				})
 				return patches

--- a/pkg/nsx/services/common/policy_tree.go
+++ b/pkg/nsx/services/common/policy_tree.go
@@ -54,6 +54,8 @@ func getNSXResourcePath[T any](obj T) *string {
 		return v.Path
 	case *model.SharedResource:
 		return v.Path
+	case *model.Domain:
+		return v.Path
 	default:
 		log.Error(nil, "Get NSX resource path", "unknown NSX resource type", v)
 		return nil
@@ -92,6 +94,8 @@ func getNSXResourceId[T any](obj T) *string {
 		return v.Id
 	case *model.SharedResource:
 		return v.Id
+	case *model.Domain:
+		return v.Id
 	default:
 		log.Error(nil, "Get NSX resource ID", "unknown NSX resource type", v)
 		return nil
@@ -128,6 +132,8 @@ func leafWrapper[T any](obj T) (*data.StructValue, error) {
 		return WrapLBPool(v)
 	case *model.TlsCertificate:
 		return WrapCertificate(v)
+	case *model.Domain:
+		return WrapDomain(v)
 	default:
 		log.Error(nil, "Leaf wrapper", "unknown NSX resource type", v)
 		return nil, fmt.Errorf("unsupported NSX resource type %v", v)
@@ -236,6 +242,7 @@ var (
 	PolicyPathInfraLBVirtualServer          PolicyResourcePath[*model.LBVirtualServer]            = []PolicyResourceType{PolicyResourceInfra, PolicyResourceInfraLBVirtualServer}
 	PolicyPathInfraLBPool                   PolicyResourcePath[*model.LBPool]                     = []PolicyResourceType{PolicyResourceInfra, PolicyResourceInfraLBPool}
 	PolicyPathInfraLBService                PolicyResourcePath[*model.LBService]                  = []PolicyResourceType{PolicyResourceInfra, PolicyResourceInfraLBService}
+	PolicyPathInfraDomain                   PolicyResourcePath[*model.Domain]                     = []PolicyResourceType{PolicyResourceInfra, PolicyResourceDomain}
 )
 
 type hNodeKey struct {

--- a/pkg/nsx/services/common/wrap.go
+++ b/pkg/nsx/services/common/wrap.go
@@ -294,6 +294,21 @@ func WrapCertificate(cert *model.TlsCertificate) (*data.StructValue, error) {
 	return dataValue.(*data.StructValue), nil
 }
 
+func WrapDomain(domain *model.Domain) (*data.StructValue, error) {
+	domain.ResourceType = &ResourceTypeDomain
+	childDomain := model.ChildDomain{
+		Id:              domain.Id,
+		MarkedForDelete: domain.MarkedForDelete,
+		ResourceType:    "ChildDomain",
+		Domain:          domain,
+	}
+	dataValue, errs := NewConverter().ConvertToVapi(childDomain, childDomain.GetType__())
+	if len(errs) > 0 {
+		return nil, errs[0]
+	}
+	return dataValue.(*data.StructValue), nil
+}
+
 func buildInfraFromChildren(children []*data.StructValue) *model.Infra {
 	// This is the outermost layer of the hierarchy infra client.
 	// It doesn't need ID field.


### PR DESCRIPTION
When get inventory cluster during the cleanup, operator will return nil if GET API return error which will make the cleanup ignore the inventory.
Return error so cleanup will retry.
Also delete the domain resource created by NCP.

Test Done:
case 1:
1. run ./clean -cluster c1dc74c5-ad54-4123-8ab5-75bdfac868bd -mgr-ip 10.192.38.87 -vc-passwd 'TkhTq<VOn2J8$j8Q}eut' -vc-user wcp-cluster-user-c1dc74c5-ad54-4123-8ab5-75bdfac868bd-13022d9b-d480-4dfd-a5c8-63c7d212112d@vsphere.local -thumbprint 37:29:00:0B:07:35:6B:04:BB:59:67:D0:C0:9D:5D:6B:E4:E2:B2:3C -vc-sso-domain vsphere.local -vc-endpoint lvn-dvm-10-192-33-98.dvm.lvn.broadcom.net
2. check if inventory and domain has been deleted

case 2:
1.  rerun the command
2. check if cleanup could handle 'not found' error