### PR TITLE
Create DHCP static binding for SubnetPort

### DIFF
--- a/build/yaml/samples/nsx_v1alpha1_subnetport.yaml
+++ b/build/yaml/samples/nsx_v1alpha1_subnetport.yaml
@@ -49,7 +49,7 @@ metadata:
   name: subnetport-sample-c
 spec:
   subnet: vm-subnet
-  address_bindings:
+  addressBindings:
   - ipAddress: 172.26.0.3
     macAddress: 04:50:56:00:94:00
 status:

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -528,7 +528,7 @@ func (r *SubnetPortReconciler) CollectGarbage(ctx context.Context) error {
 	log.Info("subnetport garbage collector started")
 	nsxSubnetPortSet := r.SubnetPortService.ListNSXSubnetPortIDForCR()
 	if len(nsxSubnetPortSet) == 0 {
-		return nil
+		log.V(2).Info("There is no SubnetPort in store")
 	}
 
 	crSubnetPortIDsSet, err := r.SubnetPortService.ListSubnetPortIDsFromCRs(ctx)
@@ -549,6 +549,25 @@ func (r *SubnetPortReconciler) CollectGarbage(ctx context.Context) error {
 			r.StatusUpdater.IncreaseDeleteSuccessTotal()
 		}
 	}
+
+	// In case of there are still some DHCP static bindings for SubnetPort CR in store
+	nsxStaticBindingIdSet := r.SubnetPortService.ListIDsFromDhcpStaticBindingStore()
+	if len(nsxStaticBindingIdSet) == 0 {
+		log.V(2).Info("There is no Dhcp Static Binding in store")
+	}
+	diffSet = nsxStaticBindingIdSet.Difference(crSubnetPortIDsSet)
+	for elem := range diffSet {
+		log.V(1).Info("GC collected SubnetPort CR", "UID", elem)
+		r.StatusUpdater.IncreaseDeleteTotal()
+		err = r.SubnetPortService.DeleteSubnetPortById(elem)
+		if err != nil {
+			errList = append(errList, err)
+			r.StatusUpdater.IncreaseDeleteFailTotal()
+		} else {
+			r.StatusUpdater.IncreaseDeleteSuccessTotal()
+		}
+	}
+
 	addressBindingUIDSet, err := r.getAddressBindingCRUIDSet(ctx)
 	if err != nil {
 		return err

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -458,6 +458,14 @@ func TestSubnetPortReconciler_GarbageCollector(t *testing.T) {
 			return a
 		})
 	defer patchesListNSXSubnetPortIDForCR.Reset()
+	patchesListSubnetPortCRIDsFromDhcpStaticBindingStore := gomonkey.ApplyFunc((*subnetport.SubnetPortService).ListIDsFromDhcpStaticBindingStore,
+		func(s *subnetport.SubnetPortService) sets.Set[string] {
+			a := sets.New[string]()
+			a.Insert("sp3456")
+			a.Insert("sp4567")
+			return a
+		})
+	defer patchesListSubnetPortCRIDsFromDhcpStaticBindingStore.Reset()
 	patchesGetVpcSubnetPortByUID := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
 		func(s *subnetport.SubnetPortStore, uid types.UID) (*model.VpcSubnetPort, error) {
 			if uid == "sp1234" {
@@ -466,6 +474,7 @@ func TestSubnetPortReconciler_GarbageCollector(t *testing.T) {
 			return nil, nil
 		})
 	defer patchesGetVpcSubnetPortByUID.Reset()
+
 	patchesDeleteSubnetPortById := gomonkey.ApplyFunc((*subnetport.SubnetPortService).DeleteSubnetPortById,
 		func(s *subnetport.SubnetPortService, uid string) error {
 			return nil

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -108,6 +108,7 @@ type Client struct {
 	SubnetConnectionBindingMapsClient subnets.SubnetConnectionBindingMapsClient
 	NsxApiClient                      *nsxt.APIClient
 	MacPoolsClient                    pools.MacPoolsClient
+	DhcpStaticBindingConfigsClient    subnets.DhcpStaticBindingConfigsClient
 
 	NSXChecker    NSXHealthChecker
 	NSXVerChecker NSXVersionChecker
@@ -217,6 +218,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 
 	nsxApiClient, _ := CreateNsxtApiClient(cf, cluster.client)
 	macPoolsClient := pools.NewMacPoolsClient(connector)
+	dhcpStaticBindingConfigsClient := subnets.NewDhcpStaticBindingConfigsClient(connector)
 
 	nsxChecker := &NSXHealthChecker{
 		cluster: cluster,
@@ -279,6 +281,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 		LbMonitorProfilesClient:           lbMonitorProfilesClient,
 		NsxApiClient:                      nsxApiClient,
 		MacPoolsClient:                    macPoolsClient,
+		DhcpStaticBindingConfigsClient:    dhcpStaticBindingConfigsClient,
 	}
 	// NSX version check will be restarted during SecurityPolicy reconcile
 	// So, it's unnecessary to exit even if failed in the first time

--- a/pkg/nsx/services/common/policy_tree.go
+++ b/pkg/nsx/services/common/policy_tree.go
@@ -56,6 +56,8 @@ func getNSXResourcePath[T any](obj T) *string {
 		return v.Path
 	case *model.Domain:
 		return v.Path
+	case *model.DhcpV4StaticBindingConfig:
+		return v.Path
 	default:
 		log.Error(nil, "Get NSX resource path", "unknown NSX resource type", v)
 		return nil
@@ -96,6 +98,8 @@ func getNSXResourceId[T any](obj T) *string {
 		return v.Id
 	case *model.Domain:
 		return v.Id
+	case *model.DhcpV4StaticBindingConfig:
+		return v.Id
 	default:
 		log.Error(nil, "Get NSX resource ID", "unknown NSX resource type", v)
 		return nil
@@ -134,6 +138,8 @@ func leafWrapper[T any](obj T) (*data.StructValue, error) {
 		return WrapCertificate(v)
 	case *model.Domain:
 		return WrapDomain(v)
+	case *model.DhcpV4StaticBindingConfig:
+		return WrapDhcpV4StaticBindingConfig(v)
 	default:
 		log.Error(nil, "Leaf wrapper", "unknown NSX resource type", v)
 		return nil, fmt.Errorf("unsupported NSX resource type %v", v)
@@ -206,6 +212,7 @@ var (
 	PolicyResourceStaticRoutes                  = PolicyResourceType{ModelKey: ResourceTypeStaticRoutes, PathKey: "static-routes"}
 	PolicyResourceVpcSubnet                     = PolicyResourceType{ModelKey: ResourceTypeSubnet, PathKey: "subnets"}
 	PolicyResourceVpcSubnetPort                 = PolicyResourceType{ModelKey: ResourceTypeSubnetPort, PathKey: "ports"}
+	PolicyResourceDhcpStaticBinding             = PolicyResourceType{ModelKey: ResourceTypeDhcpV4StaticBindingConfig, PathKey: "dhcp-static-binding-configs"}
 	PolicyResourceVpcSubnetConnectionBindingMap = PolicyResourceType{ModelKey: ResourceTypeSubnetConnectionBindingMap, PathKey: "subnet-connection-binding-maps"}
 	PolicyResourceVpcLBService                  = PolicyResourceType{ModelKey: ResourceTypeLBService, PathKey: "vpc-lbs"}
 	PolicyResourceVpcLBPool                     = PolicyResourceType{ModelKey: ResourceTypeLBPool, PathKey: "vpc-lb-pools"}
@@ -225,6 +232,7 @@ var (
 	PolicyPathVpcSubnet                     PolicyResourcePath[*model.VpcSubnet]                  = []PolicyResourceType{PolicyResourceOrg, PolicyResourceProject, PolicyResourceVpc, PolicyResourceVpcSubnet}
 	PolicyPathVpcSubnetConnectionBindingMap PolicyResourcePath[*model.SubnetConnectionBindingMap] = []PolicyResourceType{PolicyResourceOrg, PolicyResourceProject, PolicyResourceVpc, PolicyResourceVpcSubnet, PolicyResourceVpcSubnetConnectionBindingMap}
 	PolicyPathVpcSubnetPort                 PolicyResourcePath[*model.VpcSubnetPort]              = []PolicyResourceType{PolicyResourceOrg, PolicyResourceProject, PolicyResourceVpc, PolicyResourceVpcSubnet, PolicyResourceVpcSubnetPort}
+	PolicyPathDhcpStaticBinding             PolicyResourcePath[*model.DhcpV4StaticBindingConfig]  = []PolicyResourceType{PolicyResourceOrg, PolicyResourceProject, PolicyResourceVpc, PolicyResourceVpcSubnet, PolicyResourceDhcpStaticBinding}
 	PolicyPathVpcLBPool                     PolicyResourcePath[*model.LBPool]                     = []PolicyResourceType{PolicyResourceOrg, PolicyResourceProject, PolicyResourceVpc, PolicyResourceVpcLBPool}
 	PolicyPathVpcLBService                  PolicyResourcePath[*model.LBService]                  = []PolicyResourceType{PolicyResourceOrg, PolicyResourceProject, PolicyResourceVpc, PolicyResourceVpcLBService}
 	PolicyPathVpcLBVirtualServer            PolicyResourcePath[*model.LBVirtualServer]            = []PolicyResourceType{PolicyResourceOrg, PolicyResourceProject, PolicyResourceVpc, PolicyResourceVpcLBVirtualServer}

--- a/pkg/nsx/services/common/policy_tree_test.go
+++ b/pkg/nsx/services/common/policy_tree_test.go
@@ -183,6 +183,15 @@ func testVPCResources(t *testing.T) {
 				ResourceType: String(ResourceTypeSubnetPort),
 			}},
 		}, {
+			name: "delete DhcpV4StaticBindingConfig",
+			objects: []*model.DhcpV4StaticBindingConfig{{
+				Id:           String("staticBinding1"),
+				Path:         String("/orgs/default/projects/p1/vpcs/vpc1/subnets/subnet1/dhcp-static-binding-configs/staticBinding1"),
+				ResourceType: ResourceTypeDhcpV4StaticBindingConfig,
+				IpAddress:    String("172.26.0.3"),
+				MacAddress:   String("04:50:56:00:94:00"),
+			}},
+		}, {
 			name: "delete SubnetConnectionBindingMap",
 			objects: []*model.SubnetConnectionBindingMap{{
 				Id:           String("bm1"),
@@ -277,6 +286,9 @@ func testVPCResources(t *testing.T) {
 				case []*model.VpcSubnetPort:
 					res := tc.objects.([]*model.VpcSubnetPort)
 					err = testPolicyPathBuilderDeletion(t, PolicyPathVpcSubnetPort, res, nsxClient)
+				case []*model.DhcpV4StaticBindingConfig:
+					res := tc.objects.([]*model.DhcpV4StaticBindingConfig)
+					err = testPolicyPathBuilderDeletion(t, PolicyPathDhcpStaticBinding, res, nsxClient)
 				case []*model.SubnetConnectionBindingMap:
 					res := tc.objects.([]*model.SubnetConnectionBindingMap)
 					err = testPolicyPathBuilderDeletion(t, PolicyPathVpcSubnetConnectionBindingMap, res, nsxClient)

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -190,6 +190,7 @@ var (
 	ResourceTypeLBVirtualServer                 = "LBVirtualServer"
 	ResourceTypeLBPool                          = "LBPool"
 	ResourceTypeSubnetConnectionBindingMap      = "SubnetConnectionBindingMap"
+	ResourceTypeDhcpV4StaticBindingConfig       = "DhcpV4StaticBindingConfig"
 
 	// ResourceTypeClusterControlPlane is used by NSXServiceAccountController
 	ResourceTypeClusterControlPlane = "clustercontrolplane"

--- a/pkg/nsx/services/common/wrap.go
+++ b/pkg/nsx/services/common/wrap.go
@@ -309,6 +309,40 @@ func WrapDomain(domain *model.Domain) (*data.StructValue, error) {
 	return dataValue.(*data.StructValue), nil
 }
 
+func WrapDhcpV4StaticBindingConfig(staticBinding *model.DhcpV4StaticBindingConfig) (*data.StructValue, error) {
+	tags := data.NewListValue()
+	for index := range staticBinding.Tags {
+		dataValue := data.NewStructValue(
+			"",
+			map[string]data.DataValue{
+				"scope": data.NewStringValue(*staticBinding.Tags[index].Scope),
+				"tag":   data.NewStringValue(*staticBinding.Tags[index].Tag),
+			})
+		tags.Add(dataValue)
+	}
+	staticBindingStruct := data.NewStructValue(
+		"",
+		map[string]data.DataValue{
+			"id":            data.NewStringValue(*staticBinding.Id),
+			"resource_type": data.NewStringValue(staticBinding.ResourceType),
+			"ip_address":    data.NewStringValue(*staticBinding.IpAddress),
+			"mac_address":   data.NewStringValue(*staticBinding.MacAddress),
+			"tags":          tags,
+		},
+	)
+	childStaticBinding := model.ChildDhcpStaticBindingConfig{
+		Id:                      staticBinding.Id,
+		MarkedForDelete:         staticBinding.MarkedForDelete,
+		ResourceType:            "ChildDhcpStaticBindingConfig",
+		DhcpStaticBindingConfig: staticBindingStruct,
+	}
+	dataValue, errs := NewConverter().ConvertToVapi(childStaticBinding, childStaticBinding.GetType__())
+	if len(errs) > 0 {
+		return nil, errs[0]
+	}
+	return dataValue.(*data.StructValue), nil
+}
+
 func buildInfraFromChildren(children []*data.StructValue) *model.Infra {
 	// This is the outermost layer of the hierarchy infra client.
 	// It doesn't need ID field.

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	mp_model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	corev1 "k8s.io/api/core/v1"
@@ -59,14 +60,15 @@ func TestBuildSubnetPort(t *testing.T) {
 		}).AnyTimes()
 
 	tests := []struct {
-		name          string
-		obj           interface{}
-		nsxSubnet     *model.VpcSubnet
-		contextID     string
-		labelTags     *map[string]string
-		restore       bool
-		expectedPort  *model.VpcSubnetPort
-		expectedError error
+		name                  string
+		obj                   interface{}
+		nsxSubnet             *model.VpcSubnet
+		contextID             string
+		labelTags             *map[string]string
+		restore               bool
+		expectedPort          *model.VpcSubnetPort
+		expectedStaticBinding *model.DhcpV4StaticBindingConfig
+		expectedError         error
 	}{
 		{
 			name: "build-NSX-port-for-subnetport",
@@ -608,19 +610,117 @@ func TestBuildSubnetPort(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		{
+			name: "build-NSX-port-for-subnetport-on-DHCPServer-subnet",
+			obj: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
+					Name:      "fake_subnetport",
+					Namespace: "fake_ns",
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					Subnet: "subnet-1",
+					AddressBindings: []v1alpha1.PortAddressBinding{
+						{
+							IPAddress:  "10.0.0.1",
+							MACAddress: "aa:bb:cc:dd:ee:ff",
+						},
+					},
+				},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				SubnetDhcpConfig: &model.SubnetDhcpConfig{
+					Mode: common.String("DHCP_SERVER"),
+				},
+				Path: common.String("fake_path"),
+			},
+			contextID: "fake_context_id",
+			labelTags: nil,
+			expectedPort: &model.VpcSubnetPort{
+				DisplayName: common.String("fake_subnetport"),
+				Id:          common.String("fake_subnetport_phoia"),
+				Tags: []model.Tag{
+					{
+						Scope: common.String("nsx-op/cluster"),
+						Tag:   common.String("fake_cluster"),
+					},
+					{
+						Scope: common.String("nsx-op/version"),
+						Tag:   common.String("1.0.0"),
+					},
+					{
+						Scope: common.String("nsx-op/namespace"),
+						Tag:   common.String("fake_ns"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_name"),
+						Tag:   common.String("fake_subnetport"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_uid"),
+						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+					},
+				},
+				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
+				ParentPath: common.String("fake_path"),
+				Attachment: &model.PortAttachment{
+					AllocateAddresses: common.String("NONE"),
+					Type_:             common.String("STATIC"),
+					TrafficTag:        common.Int64(0),
+				},
+				AddressBindings: []model.PortAddressBindingEntry{
+					{
+						IpAddress:  common.String("10.0.0.1"),
+						MacAddress: common.String("aa:bb:cc:dd:ee:ff"),
+					},
+				},
+			},
+			expectedStaticBinding: &model.DhcpV4StaticBindingConfig{
+				Id:           common.String("fake_subnetport_phoia"),
+				ResourceType: "DhcpV4StaticBindingConfig",
+				IpAddress:    common.String("10.0.0.1"),
+				MacAddress:   common.String("aa:bb:cc:dd:ee:ff"),
+				Tags: []model.Tag{
+					{
+						Scope: common.String("nsx-op/cluster"),
+						Tag:   common.String("fake_cluster"),
+					},
+					{
+						Scope: common.String("nsx-op/version"),
+						Tag:   common.String("1.0.0"),
+					},
+					{
+						Scope: common.String("nsx-op/namespace"),
+						Tag:   common.String("fake_ns"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_name"),
+						Tag:   common.String("fake_subnetport"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_uid"),
+						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+					},
+				},
+			},
+			expectedError: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			observedPort, err := service.buildSubnetPort(tt.obj, tt.nsxSubnet, tt.contextID, tt.labelTags, false, tt.restore)
+			observedPort, observedStaticBinding, err := service.buildSubnetPort(tt.obj, tt.nsxSubnet, tt.contextID, tt.labelTags, false, tt.restore)
 			// Ignore attachment id as it is random
 			if tt.expectedError != nil {
 				assert.Equal(t, tt.expectedError, err)
 			} else {
 				assert.Nil(t, err)
 				tt.expectedPort.Attachment.Id = observedPort.Attachment.Id
-				assert.Equal(t, tt.expectedPort, observedPort)
-				assert.Equal(t, common.CompareResource(SubnetPortToComparable(tt.expectedPort), SubnetPortToComparable(observedPort)), false)
+				require.Equal(t, tt.expectedPort, observedPort)
+				require.Equal(t, common.CompareResource(SubnetPortToComparable(tt.expectedPort), SubnetPortToComparable(observedPort)), false)
+				if tt.expectedStaticBinding != nil {
+					require.Equal(t, tt.expectedStaticBinding, observedStaticBinding)
+				}
 			}
 		})
 	}

--- a/pkg/nsx/services/subnetport/cleanup.go
+++ b/pkg/nsx/services/subnetport/cleanup.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (service *SubnetPortService) CleanupBeforeVPCDeletion(ctx context.Context) error {
+	if err := service.CleanupDHCPStaticBinding(ctx); err != nil {
+		log.Error(err, "Failed to clean up DHCPV4StaticBindings")
+		return err
+	}
 	objs := service.SubnetPortStore.List()
 	log.Info("Cleaning up VpcSubnetPorts", "Count", len(objs))
 	if len(objs) == 0 {
@@ -24,5 +28,24 @@ func (service *SubnetPortService) CleanupBeforeVPCDeletion(ctx context.Context) 
 	}
 	return service.builder.PagingUpdateResources(ctx, ports, common.DefaultHAPIChildrenCount, service.NSXClient, func(delObjs []*model.VpcSubnetPort) {
 		service.SubnetPortStore.DeleteMultipleObjects(delObjs)
+	})
+}
+
+func (service *SubnetPortService) CleanupDHCPStaticBinding(ctx context.Context) error {
+	objs := service.DHCPStaticBindingStore.List()
+	log.Info("Cleaning up DHCPV4StaticBindingStore", "Count", len(objs))
+	if len(objs) == 0 {
+		return nil
+	}
+
+	// Mark the resources for delete.
+	staticBindings := make([]*model.DhcpV4StaticBindingConfig, len(objs))
+	for i, obj := range objs {
+		staticBinding := obj.(*model.DhcpV4StaticBindingConfig)
+		staticBinding.MarkedForDelete = &MarkedForDelete
+		staticBindings[i] = staticBinding
+	}
+	return service.staticBindingBuilder.PagingUpdateResources(ctx, staticBindings, common.DefaultHAPIChildrenCount, service.NSXClient, func(delObjs []*model.DhcpV4StaticBindingConfig) {
+		service.DHCPStaticBindingStore.DeleteMultipleObjects(delObjs)
 	})
 }

--- a/pkg/nsx/services/subnetport/cleanup_test.go
+++ b/pkg/nsx/services/subnetport/cleanup_test.go
@@ -1,0 +1,85 @@
+package subnetport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	mock_org_root "github.com/vmware-tanzu/nsx-operator/pkg/mock/orgrootclient"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+func TestCleanupBeforeVPCDeletion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	subnetPort := &model.VpcSubnetPort{
+		Id:   &subnetPortId1,
+		Path: &subnetPortPath1,
+	}
+	subnetPort2 := &model.VpcSubnetPort{
+		Id:   &subnetPortId2,
+		Path: &subnetPortPath2,
+	}
+	staticBinding := &model.DhcpV4StaticBindingConfig{
+		Id:         &subnetPortId1,
+		IpAddress:  common.String("172.26.0.4"),
+		MacAddress: common.String("04:50:56:00:94:00"),
+	}
+
+	for _, tc := range []struct {
+		name           string
+		subnetPorts    []*model.VpcSubnetPort
+		staticBindings []*model.DhcpV4StaticBindingConfig
+	}{
+		{
+			name:           "clean up nothing",
+			subnetPorts:    nil,
+			staticBindings: nil,
+		},
+		{
+			name:           "clean up only SubnetPorts",
+			subnetPorts:    []*model.VpcSubnetPort{subnetPort},
+			staticBindings: nil,
+		},
+		{
+			name:           "clean up only DhcpStaticBindings",
+			subnetPorts:    nil,
+			staticBindings: []*model.DhcpV4StaticBindingConfig{staticBinding},
+		},
+		{
+			name:           "clean up with all resources",
+			subnetPorts:    []*model.VpcSubnetPort{subnetPort, subnetPort2},
+			staticBindings: []*model.DhcpV4StaticBindingConfig{staticBinding},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := createSubnetPortService(t)
+			if tc.subnetPorts != nil {
+				for _, port := range tc.subnetPorts {
+					svc.SubnetPortStore.Add(port)
+				}
+				assert.Equal(t, len(tc.subnetPorts), len(svc.SubnetPortStore.List()))
+			}
+			if tc.staticBindings != nil {
+				for _, port := range tc.staticBindings {
+					svc.DHCPStaticBindingStore.Add(port)
+				}
+				assert.Equal(t, len(tc.staticBindings), len(svc.DHCPStaticBindingStore.List()))
+			}
+			orgRootClient := mock_org_root.NewMockOrgRootClient(ctrl)
+			orgRootClient.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			svc.Service.NSXClient.OrgRootClient = orgRootClient
+
+			ctx := context.Background()
+			err := svc.CleanupBeforeVPCDeletion(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, 0, len(svc.SubnetPortStore.List()))
+			assert.Equal(t, 0, len(svc.DHCPStaticBindingStore.List()))
+		})
+	}
+}

--- a/pkg/nsx/services/subnetport/compare.go
+++ b/pkg/nsx/services/subnetport/compare.go
@@ -8,7 +8,8 @@ import (
 )
 
 type (
-	SubnetPort model.VpcSubnetPort
+	SubnetPort        model.VpcSubnetPort
+	DhcpStaticBinding model.DhcpV4StaticBindingConfig
 )
 
 type Comparable = common.Comparable
@@ -36,6 +37,14 @@ func (sp *SubnetPort) Value() data.DataValue {
 			Type_:             sp.Attachment.AllocateAddresses,
 		}
 	}
+	if sp.AddressBindings != nil {
+		s.AddressBindings = []model.PortAddressBindingEntry{
+			{
+				IpAddress:  sp.AddressBindings[0].IpAddress,
+				MacAddress: sp.AddressBindings[0].MacAddress,
+			},
+		}
+	}
 	if sp.ExternalAddressBinding != nil {
 		s.ExternalAddressBinding = &model.ExternalAddressBinding{AllocatedExternalIpPath: sp.ExternalAddressBinding.AllocatedExternalIpPath}
 	}
@@ -49,4 +58,28 @@ func SubnetPortToComparable(sp *model.VpcSubnetPort) Comparable {
 
 func ComparableToSubnetPort(sp Comparable) *model.VpcSubnetPort {
 	return (*model.VpcSubnetPort)(sp.(*SubnetPort))
+}
+
+func (binding *DhcpStaticBinding) Key() string {
+	return *binding.Id
+}
+
+func (binding *DhcpStaticBinding) Value() data.DataValue {
+	s := &DhcpStaticBinding{
+		Id:         binding.Id,
+		Tags:       binding.Tags,
+		IpAddress:  binding.IpAddress,
+		MacAddress: binding.MacAddress,
+	}
+
+	dataValue, _ := ComparableToDhcpStaticBinding(s).GetDataValue__()
+	return dataValue
+}
+
+func DhcpStaticBindingToComparable(binding *model.DhcpV4StaticBindingConfig) Comparable {
+	return (*DhcpStaticBinding)(binding)
+}
+
+func ComparableToDhcpStaticBinding(binding Comparable) *model.DhcpV4StaticBindingConfig {
+	return (*model.DhcpV4StaticBindingConfig)(binding.(*DhcpStaticBinding))
 }

--- a/pkg/nsx/services/subnetport/store.go
+++ b/pkg/nsx/services/subnetport/store.go
@@ -16,6 +16,8 @@ func keyFunc(obj interface{}) (string, error) {
 	switch v := obj.(type) {
 	case *model.VpcSubnetPort:
 		return *v.Id, nil
+	case *model.DhcpV4StaticBindingConfig:
+		return *v.Id, nil
 	case types.UID:
 		return string(v), nil
 	case string:
@@ -169,4 +171,66 @@ func (subnetPortStore *SubnetPortStore) GetVpcSubnetPortByUID(uid types.UID) (*m
 		return nil, nil
 	}
 	return subnetPort, nil
+}
+
+// staticBindingIndexByCRUID is used to get index of a resource, usually, which is the UID of the CR controller reconciles,
+// index is used to filter out resources which are related to the CR
+func staticBindingIndexByCRUID(obj interface{}) ([]string, error) {
+	switch o := obj.(type) {
+	case *model.DhcpV4StaticBindingConfig:
+		return filterTag(o.Tags, common.TagScopeSubnetPortCRUID), nil
+	default:
+		return nil, errors.New("staticBindingIndexByCRUID doesn't support unknown type")
+	}
+}
+
+// DHCPStaticBindingStore is a store for DHCPStaticBindings
+type DHCPStaticBindingStore struct {
+	common.ResourceStore
+}
+
+func (staticBindingStore *DHCPStaticBindingStore) Apply(i interface{}) error {
+	if i == nil {
+		return nil
+	}
+	staticBinding := i.(*model.DhcpV4StaticBindingConfig)
+	if staticBinding.MarkedForDelete != nil && *staticBinding.MarkedForDelete {
+		err := staticBindingStore.Delete(staticBinding)
+		log.V(1).Info("delete DhcpV4StaticBindingConfig from store", "staticBinding", staticBinding)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := staticBindingStore.Add(staticBinding)
+		log.V(1).Info("add DhcpV4StaticBindingConfig to store", "staticBinding", staticBinding)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (staticBindingStore *DHCPStaticBindingStore) GetByKey(key string) *model.DhcpV4StaticBindingConfig {
+	var staticBinding *model.DhcpV4StaticBindingConfig
+	obj := staticBindingStore.ResourceStore.GetByKey(key)
+	if obj != nil {
+		staticBinding = obj.(*model.DhcpV4StaticBindingConfig)
+	}
+	return staticBinding
+}
+
+func (staticBindingStore *DHCPStaticBindingStore) GetByIndex(key string, value string) []*model.DhcpV4StaticBindingConfig {
+	staticBindings := make([]*model.DhcpV4StaticBindingConfig, 0)
+	objs := staticBindingStore.ResourceStore.GetByIndex(key, value)
+	for _, staticBinding := range objs {
+		staticBindings = append(staticBindings, staticBinding.(*model.DhcpV4StaticBindingConfig))
+	}
+	return staticBindings
+}
+
+func (staticBindingStore *DHCPStaticBindingStore) DeleteMultipleObjects(staticBindings []*model.DhcpV4StaticBindingConfig) {
+	for _, staticBinding := range staticBindings {
+		staticBindingStore.Delete(staticBinding)
+	}
 }

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	mp_model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	v1 "k8s.io/api/core/v1"
@@ -36,36 +38,51 @@ var (
 type SubnetPortService struct {
 	servicecommon.Service
 	SubnetPortStore            *SubnetPortStore
+	DHCPStaticBindingStore     *DHCPStaticBindingStore
 	VPCService                 servicecommon.VPCServiceProvider
 	IpAddressAllocationService servicecommon.IPAddressAllocationServiceProvider
 	builder                    *servicecommon.PolicyTreeBuilder[*model.VpcSubnetPort]
+	staticBindingBuilder       *servicecommon.PolicyTreeBuilder[*model.DhcpV4StaticBindingConfig]
 	macPool                    *mp_model.MacPool
 }
 
 // InitializeSubnetPort sync NSX resources.
 func InitializeSubnetPort(service servicecommon.Service, vpcService servicecommon.VPCServiceProvider, ipAddressAllocationService servicecommon.IPAddressAllocationServiceProvider) (*SubnetPortService, error) {
 	builder, _ := servicecommon.PolicyPathVpcSubnetPort.NewPolicyTreeBuilder()
+	staticBindingBuilder, _ := servicecommon.PolicyPathDhcpStaticBinding.NewPolicyTreeBuilder()
 
 	wg := sync.WaitGroup{}
 	wgDone := make(chan bool)
-	fatalErrors := make(chan error)
+	fatalErrors := make(chan error, 2)
 
-	wg.Add(1)
+	wg.Add(2)
 
 	subnetPortService := &SubnetPortService{
 		Service:                    service,
 		VPCService:                 vpcService,
 		IpAddressAllocationService: ipAddressAllocationService,
 		builder:                    builder,
+		staticBindingBuilder:       staticBindingBuilder,
 	}
 
 	subnetPortService.SubnetPortStore = setupStore()
+
+	subnetPortService.DHCPStaticBindingStore = &DHCPStaticBindingStore{
+		ResourceStore: servicecommon.ResourceStore{
+			Indexer: cache.NewIndexer(
+				keyFunc,
+				cache.Indexers{
+					servicecommon.TagScopeSubnetPortCRUID: staticBindingIndexByCRUID,
+				}),
+			BindingType: model.DhcpV4StaticBindingConfigBindingType(),
+		}}
 
 	if err := subnetPortService.loadNSXMacPool(); err != nil {
 		return subnetPortService, err
 	}
 
 	go subnetPortService.InitializeResourceStore(&wg, fatalErrors, ResourceTypeSubnetPort, nil, subnetPortService.SubnetPortStore)
+	go subnetPortService.InitializeResourceStore(&wg, fatalErrors, servicecommon.ResourceTypeDhcpV4StaticBindingConfig, nil, subnetPortService.DHCPStaticBindingStore)
 	go func() {
 		wg.Wait()
 		close(wgDone)
@@ -122,10 +139,36 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 		uid = string(o.UID)
 	}
 	log.Info("creating or updating subnetport", "nsxSubnetPort.Id", uid, "nsxSubnetPath", *nsxSubnet.Path)
-	nsxSubnetPort, err := service.buildSubnetPort(obj, nsxSubnet, contextID, tags, isVmSubnetPort, restoreMode)
+	nsxSubnetPort, staticBinding, err := service.buildSubnetPort(obj, nsxSubnet, contextID, tags, isVmSubnetPort, restoreMode)
 	if err != nil {
 		log.Error(err, "failed to build NSX subnet port", "nsxSubnetPort.Id", uid, "*nsxSubnet.Path", *nsxSubnet.Path, "contextID", contextID)
 		return nil, false, err
+	}
+	subnetInfo, err := servicecommon.ParseVPCResourcePath(*nsxSubnet.Path)
+	if err != nil {
+		return nil, false, err
+	}
+	// create DHCP static binding if needed
+	if staticBinding != nil {
+		existingStaticBinding := service.DHCPStaticBindingStore.GetByKey(*nsxSubnetPort.Id)
+		isChanged := true
+		if existingStaticBinding != nil {
+			isChanged = servicecommon.CompareResource(DhcpStaticBindingToComparable(existingStaticBinding), DhcpStaticBindingToComparable(staticBinding))
+		}
+		if !isChanged {
+			log.Info("DHCP static binding not changed, skipping the update", "staticBinding.Id", staticBinding.Id, "staticBinding.IpAddress", staticBinding.IpAddress)
+		} else {
+			log.Info("Creating or updating DHCP static binding", "staticBinding.Id", staticBinding.Id, "staticBinding.IpAddress", staticBinding.IpAddress)
+			err = service.CreateDHCPStaticBinding(staticBinding, subnetInfo)
+			if err != nil {
+				return nil, true, err
+			}
+			// check DHCP static binding realization state
+			log.Info("Checking DHCP static binding realization state", "staticBinding.Id", staticBinding.Id)
+			if err = service.CheckDHCPStaticBindingRealizationState(staticBinding, subnetInfo); err != nil {
+				return nil, true, err
+			}
+		}
 	}
 	existingSubnetPort := service.SubnetPortStore.GetByKey(*nsxSubnetPort.Id)
 	isChanged := true
@@ -135,10 +178,6 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 			nsxSubnetPort.Attachment.Id = existingSubnetPort.Attachment.Id
 		}
 		isChanged = servicecommon.CompareResource(SubnetPortToComparable(existingSubnetPort), SubnetPortToComparable(nsxSubnetPort))
-	}
-	subnetInfo, err := servicecommon.ParseVPCResourcePath(*nsxSubnet.Path)
-	if err != nil {
-		return nil, false, err
 	}
 	if !isChanged {
 		log.Info("NSX subnet port not changed, skipping the update", "nsxSubnetPort.Id", nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)
@@ -179,9 +218,80 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 	if isChanged {
 		log.Info("successfully created or updated subnetport", "nsxSubnetPort.Id", *nsxSubnetPort.Id)
 	} else {
-		log.Info("subnetport already existed", "subnetport", *nsxSubnetPort.Id)
+		log.Info("Subnetport already existed", "subnetport", *nsxSubnetPort.Id)
 	}
 	return nsxSubnetPortState, enableDHCP, nil
+}
+
+// CreateDHCPStaticBinding will create DHCP static binding.
+func (service *SubnetPortService) CreateDHCPStaticBinding(staticBinding *model.DhcpV4StaticBindingConfig, subnetInfo servicecommon.VPCResourceInfo) error {
+	tags := data.NewListValue()
+	for index := range staticBinding.Tags {
+		dataValue := data.NewStructValue(
+			"",
+			map[string]data.DataValue{
+				"scope": data.NewStringValue(*staticBinding.Tags[index].Scope),
+				"tag":   data.NewStringValue(*staticBinding.Tags[index].Tag),
+			})
+		tags.Add(dataValue)
+	}
+	staticBindingStruct := data.NewStructValue(
+		"",
+		map[string]data.DataValue{
+			"id":            data.NewStringValue(*staticBinding.Id),
+			"resource_type": data.NewStringValue(staticBinding.ResourceType),
+			"ip_address":    data.NewStringValue(*staticBinding.IpAddress),
+			"mac_address":   data.NewStringValue(*staticBinding.MacAddress),
+			"tags":          tags,
+		},
+	)
+	err := service.NSXClient.DhcpStaticBindingConfigsClient.Patch(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, *staticBinding.Id, staticBindingStruct)
+	if err != nil {
+		err = nsxutil.TransNSXApiError(err)
+		log.Error(err, "Failed to create or update DHCP static binding", "staticBinding.Id", *staticBinding.Id, "subnetInfo.ID", subnetInfo.ID)
+		return err
+	}
+	return nil
+}
+
+// CheckDHCPStaticBindingRealizationState will check DHCP static binding realization state.
+// Delete Policy intent of DHCP static binding if realized with failure or add in
+// DHCPStaticBindingStore if realized successfully.
+func (service *SubnetPortService) CheckDHCPStaticBindingRealizationState(staticBinding *model.DhcpV4StaticBindingConfig, subnetInfo servicecommon.VPCResourceInfo) error {
+	// Get DHCP static binding from NSX after patch operation as NSX renders several fields like `path`/`parent_path`.
+	staticBindingStruct, err := service.NSXClient.DhcpStaticBindingConfigsClient.Get(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, *staticBinding.Id)
+	if err != nil {
+		err = nsxutil.TransNSXApiError(err)
+		return err
+	}
+	staticBindingPath, err := staticBindingStruct.Field("path")
+	if err != nil {
+		err = nsxutil.TransNSXApiError(err)
+		return err
+	}
+	if staticBindingPathVal, ok := staticBindingPath.(*data.StringValue); ok {
+		realizeService := realizestate.InitializeRealizeState(service.Service)
+		if err = realizeService.CheckRealizeState(util.NSXTRealizeRetry, staticBindingPathVal.Value(), []string{}); err != nil {
+			log.Error(err, "Failed to check DHCP static binding realization state", "Path", staticBindingPathVal.Value())
+			// Delete the DHCP static binding if the realization check fails, avoiding creating duplicate DHCP static binding continuously.
+			deleteErr := service.DeleteDHCPStaticBinding(subnetInfo, *staticBinding.Id)
+			if deleteErr != nil {
+				log.Error(deleteErr, "Failed to delete DHCP static binding after realization check failure", "ID", *staticBinding.Id)
+				return fmt.Errorf("realization check failed: %v; deletion failed: %v", err, deleteErr)
+			}
+			return err
+		}
+		staticBinding.Path = servicecommon.String(staticBindingPathVal.Value())
+		err = service.DHCPStaticBindingStore.Apply(staticBinding)
+		if err != nil {
+			return err
+		}
+	} else {
+		// handle if staticBindingStruct "path" field is not StringValue
+		return fmt.Errorf("staticBindingStruct path is not StringValue, type: %s", reflect.TypeOf(staticBindingPath))
+	}
+
+	return nil
 }
 
 // CheckSubnetPortState will check the port realized status then get the port state to prepare the CR status.
@@ -243,6 +353,18 @@ func (service *SubnetPortService) GetSubnetPortState(nsxSubnetPortID string, nsx
 
 func (service *SubnetPortService) DeleteSubnetPort(nsxSubnetPort *model.VpcSubnetPort) error {
 	subnetPortInfo, _ := servicecommon.ParseVPCResourcePath(*nsxSubnetPort.Path)
+	// delete DHCP static binding if needed
+	dhcpStaticBinding := service.DHCPStaticBindingStore.GetByKey(*nsxSubnetPort.Id)
+	if dhcpStaticBinding == nil || dhcpStaticBinding.Id == nil {
+		log.V(2).Info("DHCP static binding is not found in store, skip deleting it")
+	} else {
+		err := service.DeleteDHCPStaticBinding(subnetPortInfo, *dhcpStaticBinding.Id)
+		if err != nil {
+			log.Error(err, "Failed to delete DHCP static binding", "dhcpStaticBinding.Id", dhcpStaticBinding.Id)
+			return err
+		}
+	}
+
 	err := service.NSXClient.PortClient.Delete(subnetPortInfo.OrgID, subnetPortInfo.ProjectID, subnetPortInfo.VPCID, subnetPortInfo.ParentID, *nsxSubnetPort.Id)
 	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
@@ -256,7 +378,34 @@ func (service *SubnetPortService) DeleteSubnetPort(nsxSubnetPort *model.VpcSubne
 	return nil
 }
 
+// DeleteDHCPStaticBinding deletes DHCP static binding.
+func (service *SubnetPortService) DeleteDHCPStaticBinding(subnetPortInfo servicecommon.VPCResourceInfo, bindingId string) error {
+	staticBinding := service.DHCPStaticBindingStore.GetByKey(bindingId)
+	if staticBinding != nil {
+		err := service.NSXClient.DhcpStaticBindingConfigsClient.Delete(subnetPortInfo.OrgID, subnetPortInfo.ProjectID, subnetPortInfo.VPCID, subnetPortInfo.ParentID, bindingId)
+		err = nsxutil.TransNSXApiError(err)
+		if err != nil {
+			log.Error(err, "Failed to delete DHCP static binding", "dhcpStaticBinding.Id", bindingId)
+			return err
+		}
+		service.DHCPStaticBindingStore.Delete(staticBinding)
+	}
+	return nil
+}
+
 func (service *SubnetPortService) DeleteSubnetPortById(portID string) error {
+	// delete DHCP static binding if exists
+	dhcpStaticBinding := service.DHCPStaticBindingStore.GetByKey(portID)
+	if dhcpStaticBinding == nil || dhcpStaticBinding.Id == nil {
+		log.V(2).Info("DHCP static binding is not found in store, skip deleting it")
+	} else {
+		staticBindingInfo, _ := servicecommon.ParseVPCResourcePath(*dhcpStaticBinding.Path)
+		err := service.DeleteDHCPStaticBinding(staticBindingInfo, portID)
+		if err != nil {
+			log.Error(err, "Failed to delete DHCP static binding", "Id", portID)
+			return err
+		}
+	}
 	nsxSubnetPort := service.SubnetPortStore.GetByKey(portID)
 	if nsxSubnetPort == nil || nsxSubnetPort.Id == nil {
 		log.Info("NSX subnet port is not found in store, skip deleting it", "id", portID)
@@ -473,4 +622,14 @@ func (service *SubnetPortService) IsEmptySubnet(id string, path string) bool {
 
 func (service *SubnetPortService) DeletePortCount(path string) {
 	service.SubnetPortStore.PortCountInfo.Delete(path)
+}
+
+func (service *SubnetPortService) ListIDsFromDhcpStaticBindingStore() sets.Set[string] {
+	log.V(2).Info("listing subnet port CR UIDs from DHCPStaticBindingStore")
+	subnetPortSet := sets.New[string]()
+	for _, subnetPortCRUid := range service.DHCPStaticBindingStore.ListIndexFuncValues(servicecommon.TagScopeSubnetPortCRUID).UnsortedList() {
+		subnetPortIDs, _ := service.DHCPStaticBindingStore.IndexKeys(servicecommon.TagScopeSubnetPortCRUID, subnetPortCRUid)
+		subnetPortSet.Insert(subnetPortIDs...)
+	}
+	return subnetPortSet
 }


### PR DESCRIPTION
Create DHCP static binding for SubnetPort

For SubnetPort which connected to DHCP Server mode Subnet,
if SubnetPort with IP and MAC address, create DHCP static
binding on the Subnet.

Tests Done:
1. create DHCP Subnet with reserved_ip_ranges
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: subnet-sample-b
spec:
  accessMode: Private
  ipAddresses:
  - 172.26.2.0/28
  subnetDHCPConfig:
    mode: DHCPServer
    dhcpServerAdditionalConfig:
      reservedIPRanges:
      - 172.26.2.4-172.26.2.10
```
2. create SubnetPort with IP “172.26.0.5” in addressBindings
```
root@42326d5a4bd077edf014b0526ecec7d1 [ ~ ]# k -n test1 get subnetport subnetport-sample-b -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetPort","metadata":{"annotations":{},"name":"subnetpo
apiVersion: crd.nsx.vmware.com/v1alpha1
rt-sample-b","namespace":"test1"},"spec":{"addressBindings":[{"ipAddress":"172.26.0.5","macAddress":"04:50:56:00:94:00"}],"subnet":"subnet-sample-b"}}
  creationTimestamp: "2025-07-23T08:35:52Z"
  generation: 1
  name: subnetport-sample-b
  namespace: test1
  resourceVersion: "3866837"
  uid: bec7044b-9414-478e-bfd5-9ade59d12ab9
spec:
  addressBindings:
  - ipAddress: 172.26.0.5
    macAddress: 04:50:56:00:94:00
  subnet: subnet-sample-b
status:
  attachment: {}
  conditions:
  - lastTransitionTime: "2025-07-23T08:35:55Z"
    message: 'error occurred while processing the SubnetPort CR. Error: nsx error
      code: 503216, message: DHCP static IP address 172.26.0.5 does not belong to
      subnet 172.26.2.0/28., details: , related error: nil'
    reason: SubnetPortNotReady
    status: "False"
    type: Ready
  networkInterfaceConfig: {}
```
3. create SubnetPort with IP “172.26.2.3” in addressBindings
```
root@42326d5a4bd077edf014b0526ecec7d1 [ ~ ]# k -n test1 get subnetport subnetport-sample-b -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetPort","metadata":{"annotations":{},"name":"subnetport-sample-b","namespace":"test1"},"spec":{"addressBindings":[{"ipAddress":"172.26.2.3","macAddress":"04:50:56:00:94:00"}],"subnet":"subnet-sample-b"}}
  creationTimestamp: "2025-07-23T08:35:52Z"
  generation: 2
  name: subnetport-sample-b
  namespace: test1
  resourceVersion: "3867315"
  uid: bec7044b-9414-478e-bfd5-9ade59d12ab9
spec:
  addressBindings:
  - ipAddress: 172.26.2.3
    macAddress: 04:50:56:00:94:00
  subnet: subnet-sample-b
status:
  attachment: {}
  conditions:
  - lastTransitionTime: "2025-07-23T08:35:55Z"
    message: 'error occurred while processing the SubnetPort CR. Error: nsx error
      code: 508145, message: Configuring DHCP static binding config for VPC subnet
      path=[/orgs/default/projects/project-quality/vpcs/test1_a5983f65-795f-465e-854f-b8503a4b5d3d/subnets/subnet-sample-b_s3pw4]
      is not allowed. Static IP address 172.26.2.3 does not belong to subnet reserved
      ip ranges [172.26.2.4-172.26.2.10]., details: , related error: nil'
    reason: SubnetPortNotReady
    status: "False"
    type: Ready
  networkInterfaceConfig: {}
```
4. create SubnetPort with IP “172.26.2.6” in addressBindings which belong in reservedIPRanges
```
root@42326d5a4bd077edf014b0526ecec7d1 [ ~ ]# k -n test1 get subnetport subnetport-sample-b -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetPort","metadata":{"annotations":{},"name":"subnetport-sample-b","namespace":"test1"},"spec":{"addressBindings":[{"ipAddress":"172.26.2.6","macAddress":"04:50:56:00:94:00"}],"subnet":"subnet-sample-b"}}
  creationTimestamp: "2025-07-23T08:35:52Z"
  generation: 3
  name: subnetport-sample-b
  namespace: test1
  resourceVersion: "3867564"
  uid: bec7044b-9414-478e-bfd5-9ade59d12ab9
spec:
  addressBindings:
  - ipAddress: 172.26.2.6
    macAddress: 04:50:56:00:94:00
  subnet: subnet-sample-b
status:
  attachment:
    id: 846eaa28-d6d9-54e6-8684-34d276ec346b
  conditions:
  - lastTransitionTime: "2025-07-23T08:36:54Z"
    message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    ipAddresses:
    - gateway: 172.26.2.1
    logicalSwitchUUID: bc5285ac-f214-4543-8738-aaf58c3bdfaa
```
5. check NSX SubnetPort created， also dhcp-static-binding created on Subnet
```
GET https://10.70.195.222/policy/api/v1/orgs/default/projects/project-quality/vpcs/test1_a5983f65-795f-465e-854f-b8503a4b5d3d/subnets/subnet-sample-b_s3pw4/dhcp-static-binding-configs/subnetport-sample-b_s3pw4
{
  "ip_address": "172.26.2.6",
  "mac_address": "04:50:56:00:94:00",
  "lease_time": 86400,
  "resource_type": "DhcpV4StaticBindingConfig",
  "id": "subnetport-sample-b_s3pw4",
  "display_name": "subnetport-sample-b_s3pw4",
  "tags": [
    {
      "scope": "nsx-op/cluster",
      "tag": "07efe2b1-8c68-4e8a-ace2-5407f2f3ccd8"
    },
    {
      "scope": "nsx-op/version",
      "tag": "1.0.0"
    },
    {
      "scope": "nsx-op/vm_namespace",
      "tag": "test1"
    },
    {
      "scope": "nsx-op/vm_namespace_uid",
      "tag": "b8090fa6-f6ea-4593-aed4-45c6a06073b3"
    },
    {
      "scope": "nsx-op/subnetport_name",
      "tag": "subnetport-sample-b"
    },
    {
      "scope": "nsx-op/subnetport_uid",
      "tag": "bec7044b-9414-478e-bfd5-9ade59d12ab9"
    }
  ],
  "path": "/orgs/default/projects/project-quality/vpcs/test1_a5983f65-795f-465e-854f-b8503a4b5d3d/subnets/subnet-sample-b_s3pw4/dhcp-static-binding-configs/subnetport-sample-b_s3pw4",
  "relative_path": "subnetport-sample-b_s3pw4",
  "parent_path": "/orgs/default/projects/project-quality/vpcs/test1_a5983f65-795f-465e-854f-b8503a4b5d3d/subnets/subnet-sample-b_s3pw4",
  "remote_path": "",
  "unique_id": "cb876442-84f6-4a60-822a-97160b42119c",
  "realization_id": "cb876442-84f6-4a60-822a-97160b42119c",
  "owner_id": "e7e210f2-dec3-46a4-b941-eca5c7b79bad",
  "marked_for_delete": false,
  "overridden": false,
  "_system_owned": false,
  "_protection": "REQUIRE_OVERRIDE",
  "_create_time": 1753259812782,
  "_create_user": "wcp-cluster-user-07efe2b1-8c68-4e8a-ace2-5407f2f3ccd8-9571e374-c712-45df-9d66-f8ebc23ed26c",
  "_last_modified_time": 1753259812782,
  "_last_modified_user": "wcp-cluster-user-07efe2b1-8c68-4e8a-ace2-5407f2f3ccd8-9571e374-c712-45df-9d66-f8ebc23ed26c",
  "_revision": 0
}
```
6. delete the SubnetPort CR "k -n test1 delete subnetport subnetport-sample-b"
7. check NSX SubnetPort was deleted, as well as the DHCP static binding created for the SubnetPort
```
GET https://10.70.195.222/policy/api/v1/orgs/default/projects/project-quality/vpcs/test1_a5983f65-795f-465e-854f-b8503a4b5d3d/subnets/subnet-sample-b_s3pw4/dhcp-static-binding-configs
{
  "results": [],
  "result_count": 0,
  "sort_by": "display_name",
  "sort_ascending": true
}
```
8. first create SubnetPort with "addressBindings:
  - ipAddress: 172.26.1.8
    macAddress: 04:50:56:00:94:01", then update SubnetPort to "addressBindings:
  - ipAddress: 172.26.1.6
    macAddress: 04:50:56:00:94:02",
after update,
SubnetPort CR:
```
root@42077980f5112755a157f1aacadf72fb [ ~ ]# k -n test-exec-ns get subnetport subnetport-sample-b -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetPort","metadata":{"annotations":{},"name":"subnetport-sample-b","namespace":"test-exec-ns"},"spec":{"addressBindings":[{"ipAddress":"172.26.1.8","macAddress":"04:50:56:00:94:01"}],"subnet":"subnet-sample-b"}}
  creationTimestamp: "2025-08-08T06:44:24Z"
  generation: 4
  name: subnetport-sample-b
  namespace: test-exec-ns
  resourceVersion: "4423683"
  uid: 3ee8a74a-ad51-424e-9146-3c0ddc821a04
spec:
  addressBindings:
  - ipAddress: 172.26.1.6
    macAddress: 04:50:56:00:94:02
  subnet: subnet-sample-b
status:
  attachment:
    id: e86f624e-482e-5948-b6a1-e40fa9df69ee
  conditions:
  - lastTransitionTime: "2025-08-08T06:47:58Z"
    message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    ipAddresses:
    - gateway: 172.26.1.1
    logicalSwitchUUID: 936c51b0-4fc9-4591-82a7-90d46bb23dfc
```

GET https://10.70.195.222/policy/api/v1/orgs/default/projects/project-quality/vpcs/test1_a5983f65-795f-465e-854f-b8503a4b5d3d/subnets/subnet-sample-b_s3pw4/dhcp-static-binding-configs
```
{
  "results": [
    {
      "ip_address": "172.26.1.6",
      "mac_address": "04:50:56:00:94:02",
      "lease_time": 86400,
      "resource_type": "DhcpV4StaticBindingConfig",
      "id": "subnetport-sample-b_sxy26",
      "display_name": "subnetport-sample-b_sxy26",
      "tags": [
        {
          "scope": "nsx-op/cluster",
          "tag": "57c81a40-4eed-4dc4-ac30-d92ebd7a83d4"
        },
        {
          "scope": "nsx-op/version",
          "tag": "1.0.0"
        },
        {
          "scope": "nsx-op/vm_namespace",
          "tag": "test-exec-ns"
        },
        {
          "scope": "nsx-op/vm_namespace_uid",
          "tag": "cda3f2e1-50e7-4156-aad0-b34a924d7626"
        },
        {
          "scope": "nsx-op/subnetport_name",
          "tag": "subnetport-sample-b"
        },
        {
          "scope": "nsx-op/subnetport_uid",
          "tag": "3ee8a74a-ad51-424e-9146-3c0ddc821a04"
        }
      ],
      "path": "/orgs/default/projects/project-quality/vpcs/test-exec-ns_sxy26/subnets/subnet-sample-b_sxy26/dhcp-static-binding-configs/subnetport-sample-b_sxy26",
      "relative_path": "subnetport-sample-b_sxy26",
      "parent_path": "/orgs/default/projects/project-quality/vpcs/test-exec-ns_sxy26/subnets/subnet-sample-b_sxy26",
      "remote_path": "",
      "unique_id": "57a91593-b65f-4166-8483-f4e8f451a6fd",
      "realization_id": "57a91593-b65f-4166-8483-f4e8f451a6fd",
      "owner_id": "ff208705-dbec-4bea-9275-d141d0f99982",
      "marked_for_delete": false,
      "overridden": false,
      "_system_owned": false,
      "_protection": "REQUIRE_OVERRIDE",
      "_create_time": 1754635465348,
      "_create_user": "wcp-cluster-user-57c81a40-4eed-4dc4-ac30-d92ebd7a83d4-0b84912c-64d4-44a6-96cc-b8b2cdcbd967",
      "_last_modified_time": 1754988066847,
      "_last_modified_user": "wcp-cluster-user-57c81a40-4eed-4dc4-ac30-d92ebd7a83d4-0b84912c-64d4-44a6-96cc-b8b2cdcbd967",
      "_revision": 3
    }
  ],
  "result_count": 1,
  "sort_by": "display_name",
  "sort_ascending": true
}
```
9. Create a SubnetPort with " - ipAddress: 172.26.2.6
    macAddress: 04:50:56:00:94:00" first, then try to create a SubnetPort with the same IP and MAC address,
```
k -n ns1 get subnetport subnetport-sample-c -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetPort","metadata":{"annotations":{},"name":"subnetport-sample-c","namespace":"ns1"},"spec":{"addressBindings":[{"ipAddress":"172.26.2.6","macAddress":"04:50:56:00:94:00"}],"subnet":"subnet-sample-b"}}
  creationTimestamp: "2025-08-23T23:43:41Z"
  generation: 1
  name: subnetport-sample-c
  namespace: ns1
  resourceVersion: "303462"
  uid: a2232b0b-ca11-4072-a0b7-01b169fafab2
spec:
  addressBindings:
  - ipAddress: 172.26.2.6
    macAddress: 04:50:56:00:94:00
  subnet: subnet-sample-b
status:
  attachment: {}
  conditions:
  - lastTransitionTime: "2025-08-23T23:43:41Z"
    message: 'error occurred while processing the SubnetPort CR. Error: nsx error
      code: 503224, message: Duplicate MAC address value 04:50:56:00:94:00 specified
      in DHCP static binding.'
    reason: SubnetPortNotReady
    status: "False"
    type: Ready
  networkInterfaceConfig: {}
```
change MAC address but with the same IP, check correct error message on the SubnetPort CR.
```
k -n ns1 get subnetport subnetport-sample-c -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetPort","metadata":{"annotations":{},"name":"subnetport-sample-c","namespace":"ns1"},"spec":{"addressBindings":[{"ipAddress":"172.26.2.6","macAddress":"04:50:56:00:94:01"}],"subnet":"subnet-sample-b"}}
  creationTimestamp: "2025-08-23T23:43:41Z"
  generation: 2
  name: subnetport-sample-c
  namespace: ns1
  resourceVersion: "304052"
  uid: a2232b0b-ca11-4072-a0b7-01b169fafab2
spec:
  addressBindings:
  - ipAddress: 172.26.2.6
    macAddress: 04:50:56:00:94:01
  subnet: subnet-sample-b
status:
  attachment: {}
  conditions:
  - lastTransitionTime: "2025-08-23T23:43:41Z"
    message: 'error occurred while processing the SubnetPort CR. Error: nsx error
      code: 503224, message: Duplicate IP address value 172.26.2.6 specified in DHCP
      static binding.'
    reason: SubnetPortNotReady
    status: "False"
    type: Ready
  networkInterfaceConfig: {}
```
10. Test Garbage collector
1) Create a SubnetPort CR, check both port and dhcp-static-binding-configs created successfully.
Stop NCP pod, and delete SubnetPort CR, then start NCP pod again, checked on NSX both port and dhcp-static-binding-configs were deleted by GC successfully.
2) Create a SubnetPort CR, check both port and dhcp-static-binding-configs created successfully.
Stop NCP pod, and delete SubnetPort CR, and delete NSX Subnet Port from NSX, then start NCP pod again, checked on NSX dhcp-static-binding-configs were deleted by GC successfully.
3) Create a SubnetPort CR, check both port and dhcp-static-binding-configs created successfully.
Stop NCP pod, and delete SubnetPort CR, and delete DHCP static binding from NSX, then start NCP pod again, checked on NSX SubnetPort were deleted by GC successfully.

11. Test Cleanup binary
Create SubnetPort with addressbindings, then test the clean binary can delete both the SubnetPort and DHCP static bindings.
