### PR TITLE
Remove the validation for DHCP mode on Subnet and SubnetSet

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
@@ -134,18 +134,8 @@ spec:
                     - DHCPRelay
                     - DHCPDeactivated
                     type: string
-                    x-kubernetes-validations:
-                    - message: subnetDHCPConfig mode can only switch between DHCPServer
-                        and DHCPRelay
-                      rule: oldSelf!='DHCPDeactivated' && self!='DHCPDeactivated'
-                        || oldSelf==self
                 type: object
                 x-kubernetes-validations:
-                - message: subnetDHCPConfig mode can only switch between DHCPServer
-                    and DHCPRelay
-                  rule: has(oldSelf.mode)==has(self.mode) || (has(oldSelf.mode) &&
-                    !has(self.mode)  && oldSelf.mode=='DHCPDeactivated') || (!has(oldSelf.mode)
-                    && has(self.mode) && self.mode=='DHCPDeactivated')
                 - message: DHCPServerAdditionalConfig must be cleared when Subnet
                     has DHCP relay enabled or DHCP is deactivated.
                   rule: (!has(self.mode)|| self.mode=='DHCPDeactivated' || self.mode=='DHCPRelay'
@@ -159,13 +149,6 @@ spec:
             x-kubernetes-validations:
             - message: vpcName is immutable after set
               rule: '!has(oldSelf.vpcName) || self.vpcName == oldSelf.vpcName'
-            - message: subnetDHCPConfig mode can only switch between DHCPServer and
-                DHCPRelay
-              rule: has(oldSelf.subnetDHCPConfig)==has(self.subnetDHCPConfig) || (has(oldSelf.subnetDHCPConfig)
-                && !has(self.subnetDHCPConfig) && (!has(oldSelf.subnetDHCPConfig.mode)
-                || oldSelf.subnetDHCPConfig.mode=='DHCPDeactivated')) || (!has(oldSelf.subnetDHCPConfig)
-                && has(self.subnetDHCPConfig) && (!has(self.subnetDHCPConfig.mode)
-                || self.subnetDHCPConfig.mode=='DHCPDeactivated'))
             - message: ipv4SubnetSize is required once set
               rule: '!has(oldSelf.ipv4SubnetSize) || has(self.ipv4SubnetSize)'
             - message: accessMode is required once set

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
@@ -94,18 +94,8 @@ spec:
                     - DHCPRelay
                     - DHCPDeactivated
                     type: string
-                    x-kubernetes-validations:
-                    - message: subnetDHCPConfig mode can only switch between DHCPServer
-                        and DHCPRelay
-                      rule: oldSelf!='DHCPDeactivated' && self!='DHCPDeactivated'
-                        || oldSelf==self
                 type: object
                 x-kubernetes-validations:
-                - message: subnetDHCPConfig mode can only switch between DHCPServer
-                    and DHCPRelay
-                  rule: has(oldSelf.mode)==has(self.mode) || (has(oldSelf.mode) &&
-                    !has(self.mode)  && oldSelf.mode=='DHCPDeactivated') || (!has(oldSelf.mode)
-                    && has(self.mode) && self.mode=='DHCPDeactivated')
                 - message: DHCPServerAdditionalConfig must be cleared when Subnet
                     has DHCP relay enabled or DHCP is deactivated.
                   rule: (!has(self.mode)|| self.mode=='DHCPDeactivated' || self.mode=='DHCPRelay'
@@ -114,13 +104,6 @@ spec:
                     || has(self.mode) && self.mode=='DHCPServer'
             type: object
             x-kubernetes-validations:
-            - message: subnetDHCPConfig mode can only switch between DHCPServer and
-                DHCPRelay
-              rule: has(oldSelf.subnetDHCPConfig)==has(self.subnetDHCPConfig) || (has(oldSelf.subnetDHCPConfig)
-                && !has(self.subnetDHCPConfig) && (!has(oldSelf.subnetDHCPConfig.mode)
-                || oldSelf.subnetDHCPConfig.mode=='DHCPDeactivated')) || (!has(oldSelf.subnetDHCPConfig)
-                && has(self.subnetDHCPConfig) && (!has(self.subnetDHCPConfig.mode)
-                || self.subnetDHCPConfig.mode=='DHCPDeactivated'))
             - message: accessMode is required once set
               rule: '!has(oldSelf.accessMode) || has(self.accessMode)'
             - message: ipv4SubnetSize is required once set

--- a/pkg/apis/vpc/v1alpha1/subnet_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnet_types.go
@@ -24,7 +24,6 @@ const (
 
 // SubnetSpec defines the desired state of Subnet.
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.vpcName) || self.vpcName == oldSelf.vpcName",message="vpcName is immutable after set"
-// +kubebuilder:validation:XValidation:rule="has(oldSelf.subnetDHCPConfig)==has(self.subnetDHCPConfig) || (has(oldSelf.subnetDHCPConfig) && !has(self.subnetDHCPConfig) && (!has(oldSelf.subnetDHCPConfig.mode) || oldSelf.subnetDHCPConfig.mode=='DHCPDeactivated')) || (!has(oldSelf.subnetDHCPConfig) && has(self.subnetDHCPConfig) && (!has(self.subnetDHCPConfig.mode) || self.subnetDHCPConfig.mode=='DHCPDeactivated'))", message="subnetDHCPConfig mode can only switch between DHCPServer and DHCPRelay"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.ipv4SubnetSize) || has(self.ipv4SubnetSize)", message="ipv4SubnetSize is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.accessMode) || has(self.accessMode)", message="accessMode is required once set"
 // +kubebuilder:validation:XValidation:rule="!(has(oldSelf.advancedConfig) && has(oldSelf.advancedConfig.staticIPAllocation) && has(oldSelf.advancedConfig.staticIPAllocation.enabled) && (!has(self.advancedConfig.staticIPAllocation.enabled) || oldSelf.advancedConfig.staticIPAllocation.enabled != self.advancedConfig.staticIPAllocation.enabled))", message="staticIPAllocation enabled cannot be changed once set"
@@ -141,13 +140,11 @@ type DHCPServerAdditionalConfig struct {
 }
 
 // SubnetDHCPConfig is DHCP configuration for Subnet.
-// +kubebuilder:validation:XValidation:rule="has(oldSelf.mode)==has(self.mode) || (has(oldSelf.mode) && !has(self.mode)  && oldSelf.mode=='DHCPDeactivated') || (!has(oldSelf.mode) && has(self.mode) && self.mode=='DHCPDeactivated')", message="subnetDHCPConfig mode can only switch between DHCPServer and DHCPRelay"
 // +kubebuilder:validation:XValidation:rule="(!has(self.mode)|| self.mode=='DHCPDeactivated' || self.mode=='DHCPRelay' ) && (!has(self.dhcpServerAdditionalConfig) || !has(self.dhcpServerAdditionalConfig.reservedIPRanges) || size(self.dhcpServerAdditionalConfig.reservedIPRanges)==0) || has(self.mode) && self.mode=='DHCPServer'", message="DHCPServerAdditionalConfig must be cleared when Subnet has DHCP relay enabled or DHCP is deactivated."
 type SubnetDHCPConfig struct {
 	// DHCP Mode. DHCPDeactivated will be used if it is not defined.
 	// It cannot switch from DHCPDeactivated to DHCPServer or DHCPRelay.
 	// +kubebuilder:validation:Enum=DHCPServer;DHCPRelay;DHCPDeactivated
-	// +kubebuilder:validation:XValidation:rule="oldSelf!='DHCPDeactivated' && self!='DHCPDeactivated' || oldSelf==self", message="subnetDHCPConfig mode can only switch between DHCPServer and DHCPRelay"
 	Mode DHCPConfigMode `json:"mode,omitempty"`
 	// Additional DHCP server config for a VPC Subnet.
 	DHCPServerAdditionalConfig DHCPServerAdditionalConfig `json:"dhcpServerAdditionalConfig,omitempty"`

--- a/pkg/apis/vpc/v1alpha1/subnetset_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetset_types.go
@@ -8,7 +8,6 @@ import (
 )
 
 // SubnetSetSpec defines the desired state of SubnetSet.
-// +kubebuilder:validation:XValidation:rule="has(oldSelf.subnetDHCPConfig)==has(self.subnetDHCPConfig) || (has(oldSelf.subnetDHCPConfig) && !has(self.subnetDHCPConfig) && (!has(oldSelf.subnetDHCPConfig.mode) || oldSelf.subnetDHCPConfig.mode=='DHCPDeactivated')) || (!has(oldSelf.subnetDHCPConfig) && has(self.subnetDHCPConfig) && (!has(self.subnetDHCPConfig.mode) || self.subnetDHCPConfig.mode=='DHCPDeactivated'))", message="subnetDHCPConfig mode can only switch between DHCPServer and DHCPRelay"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.accessMode) || has(self.accessMode)", message="accessMode is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.ipv4SubnetSize) || has(self.ipv4SubnetSize)", message="ipv4SubnetSize is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(self.subnetDHCPConfig) || has(self.subnetDHCPConfig) && !has(self.subnetDHCPConfig.dhcpServerAdditionalConfig) || has(self.subnetDHCPConfig) && has(self.subnetDHCPConfig.dhcpServerAdditionalConfig) && !has(self.subnetDHCPConfig.dhcpServerAdditionalConfig.reservedIPRanges)", message="reservedIPRanges is not supported in SubnetSet"


### PR DESCRIPTION
The NSX API allows the DHCP mode change on the Subnet. So the NSX operator
also will allow the change to align with NSX API.

Testing done:
1. Create subnet with static_ip_allocation=false and dhcp_mode=DHCPServer,
then change dhcp_mode to DHCPDeactivated, the change is not blocked by the K8s
validation. The following handling failed with NSX error 640901, will be
enhanced in the future.
2. Create subnet with static_ip_allocation=false and dhcp_mode=DHCPDeactivated,
then change dhcp_mode to DHCPServer, the change succeeds.
3. Create subnet with static_ip_allocation=false and dhcp_mode=DHCPRelay,
then change dhcp_mode to DHCPDeactivated, the change succeeds.
4. Create subnet with static_ip_allocation=false and dhcp_mode=DHCPDeactivated,
then change dhcp_mode to DHCPRelay, the change succeeds.
5. Check the cases similar to 1-4 on the SubnetSet CR and the CR changes pass.