### PR TITLE
Add namespace webhook to prevent vpc_network_config annotation modification

### DIFF
--- a/build/yaml/webhook/manifests.yaml
+++ b/build/yaml/webhook/manifests.yaml
@@ -11,6 +11,25 @@ webhooks:
     service:
       name: vmware-system-nsx-operator-webhook-service
       namespace: vmware-system-nsx
+      path: /validate-v1-namespace
+  failurePolicy: Fail
+  name: namespace.validating.nsx.vmware.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    resources:
+    - namespaces
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: vmware-system-nsx-operator-webhook-service
+      namespace: vmware-system-nsx
       # kubebuilder webhookpath.
       path: /validate-crd-nsx-vmware-com-v1alpha1-subnetset
   failurePolicy: Fail

--- a/pkg/controllers/namespace/namespace_webhook.go
+++ b/pkg/controllers/namespace/namespace_webhook.go
@@ -1,0 +1,80 @@
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// log variable is defined in namespace_controller.go at the package level
+
+const (
+	// AnnotationVPCNetworkConfig is the annotation key for vpc network config
+	AnnotationVPCNetworkConfig = "nsx.vmware.com/vpc_network_config"
+)
+
+var NSXOperatorSA = "system:serviceaccount:vmware-system-nsx:ncp-svc-account"
+
+// +kubebuilder:webhook:path=/validate-v1-namespace,mutating=false,failurePolicy=fail,sideEffects=None,groups=core,resources=namespaces,verbs=create;update,versions=v1,name=namespace.validating.nsx.vmware.com,admissionReviewVersions=v1
+
+// NamespaceValidator validates Namespace updates to prevent modification of vpc_network_config annotation
+type NamespaceValidator struct {
+	Client  client.Client
+	decoder admission.Decoder
+}
+
+// Handle handles admission requests.
+func (v *NamespaceValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	log.Info("Handling namespace validation request", "user", req.UserInfo.Username, "operation", req.Operation)
+
+	// Skip validation for NSX Operator service account
+	if req.UserInfo.Username == NSXOperatorSA {
+		return admission.Allowed("")
+	}
+
+	namespace := &corev1.Namespace{}
+	err := v.decoder.Decode(req, namespace)
+	if err != nil {
+		log.Error(err, "error while decoding Namespace", "Namespace", req.Name)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// For update operations, check if vpc_network_config annotation is being modified
+	if req.Operation == admissionv1.Update {
+		oldNamespace := &corev1.Namespace{}
+		if err := v.decoder.DecodeRaw(req.OldObject, oldNamespace); err != nil {
+			log.Error(err, "Failed to decode old Namespace", "Namespace", req.Name)
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		// Get annotations from old and new namespace
+		oldAnnotations := oldNamespace.GetAnnotations()
+		newAnnotations := namespace.GetAnnotations()
+
+		// Check if vpc_network_config annotation exists in the old namespace
+		oldVPCNetworkConfig, oldHasAnnotation := oldAnnotations[AnnotationVPCNetworkConfig]
+		if oldHasAnnotation {
+			// Check if the vpc_network_config annotation is being modified or removed
+			newVPCNetworkConfig, newHasAnnotation := newAnnotations[AnnotationVPCNetworkConfig]
+			if !newHasAnnotation {
+				// Annotation is being removed
+				log.Info("Denying removal of vpc_network_config annotation", "Namespace", req.Name)
+				return admission.Denied(fmt.Sprintf("Namespace %s: annotation %s cannot be removed once set", req.Name, AnnotationVPCNetworkConfig))
+			} else if oldVPCNetworkConfig != newVPCNetworkConfig {
+				// Annotation value is being changed
+				log.Info("Denying modification of vpc_network_config annotation",
+					"Namespace", req.Name,
+					"oldValue", oldVPCNetworkConfig,
+					"newValue", newVPCNetworkConfig)
+				return admission.Denied(fmt.Sprintf("Namespace %s: annotation %s cannot be modified once set", req.Name, AnnotationVPCNetworkConfig))
+			}
+		}
+	}
+
+	return admission.Allowed("")
+}

--- a/pkg/controllers/namespace/namespace_webhook_test.go
+++ b/pkg/controllers/namespace/namespace_webhook_test.go
@@ -1,0 +1,180 @@
+package namespace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/golang/mock/gomock"
+
+	mockClient "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
+)
+
+func TestNamespaceValidator_Handle(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mockClient.NewMockClient(mockCtl)
+	defer mockCtl.Finish()
+
+	scheme := clientgoscheme.Scheme
+	decoder := admission.NewDecoder(scheme)
+	v := &NamespaceValidator{
+		Client:  k8sClient,
+		decoder: decoder,
+	}
+
+	// Create namespace objects for testing
+	nsWithAnnotation := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ns-1",
+			Annotations: map[string]string{
+				AnnotationVPCNetworkConfig: "vpc-config-1",
+			},
+		},
+	}
+	nsWithAnnotationRaw, _ := json.Marshal(nsWithAnnotation)
+
+	nsWithModifiedAnnotation := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ns-1",
+			Annotations: map[string]string{
+				AnnotationVPCNetworkConfig: "vpc-config-2", // Changed value
+			},
+		},
+	}
+	nsWithModifiedAnnotationRaw, _ := json.Marshal(nsWithModifiedAnnotation)
+
+	nsWithoutAnnotation := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ns-1",
+			Annotations: map[string]string{
+				"some-other-annotation": "some-value",
+			},
+		},
+	}
+	nsWithoutAnnotationRaw, _ := json.Marshal(nsWithoutAnnotation)
+
+	nsWithNoAnnotations := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ns-1",
+		},
+	}
+	nsWithNoAnnotationsRaw, _ := json.Marshal(nsWithNoAnnotations)
+
+	invalidJSON := []byte("invalid json")
+
+	tests := []struct {
+		name      string
+		operation admissionv1.Operation
+		object    []byte
+		oldObject []byte
+		username  string
+		nsName    string
+		want      admission.Response
+	}{
+		{
+			name:      "Allow request from NSX Operator service account",
+			operation: admissionv1.Update,
+			object:    nsWithModifiedAnnotationRaw,
+			oldObject: nsWithAnnotationRaw,
+			username:  NSXOperatorSA,
+			nsName:    "test-ns-1",
+			want:      admission.Allowed(""),
+		},
+		{
+			name:      "Allow namespace creation",
+			operation: admissionv1.Create,
+			object:    nsWithAnnotationRaw,
+			username:  "regular-user",
+			nsName:    "test-ns-1",
+			want:      admission.Allowed(""),
+		},
+		{
+			name:      "Allow update without modifying vpc_network_config annotation",
+			operation: admissionv1.Update,
+			object:    nsWithAnnotationRaw,
+			oldObject: nsWithAnnotationRaw,
+			username:  "regular-user",
+			nsName:    "test-ns-1",
+			want:      admission.Allowed(""),
+		},
+		{
+			name:      "Deny removal of vpc_network_config annotation",
+			operation: admissionv1.Update,
+			object:    nsWithoutAnnotationRaw,
+			oldObject: nsWithAnnotationRaw,
+			username:  "regular-user",
+			nsName:    "test-ns-1",
+			want:      admission.Denied("Namespace test-ns-1: annotation nsx.vmware.com/vpc_network_config cannot be removed once set"),
+		},
+		{
+			name:      "Deny modification of vpc_network_config annotation",
+			operation: admissionv1.Update,
+			object:    nsWithModifiedAnnotationRaw,
+			oldObject: nsWithAnnotationRaw,
+			username:  "regular-user",
+			nsName:    "test-ns-1",
+			want:      admission.Denied("Namespace test-ns-1: annotation nsx.vmware.com/vpc_network_config cannot be modified once set"),
+		},
+		{
+			name:      "Allow update when old namespace has no annotations",
+			operation: admissionv1.Update,
+			object:    nsWithAnnotationRaw,
+			oldObject: nsWithNoAnnotationsRaw,
+			username:  "regular-user",
+			nsName:    "test-ns-1",
+			want:      admission.Allowed(""),
+		},
+		{
+			name:      "Error decoding namespace",
+			operation: admissionv1.Update,
+			object:    invalidJSON,
+			username:  "regular-user",
+			nsName:    "test-ns-1",
+			want:      admission.Errored(http.StatusBadRequest, errors.New("couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }")),
+		},
+		{
+			name:      "Error decoding old namespace",
+			operation: admissionv1.Update,
+			object:    nsWithAnnotationRaw,
+			oldObject: invalidJSON,
+			username:  "regular-user",
+			nsName:    "test-ns-1",
+			want:      admission.Errored(http.StatusBadRequest, errors.New("couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: tt.operation,
+					Name:      tt.nsName,
+					Object:    runtime.RawExtension{Raw: tt.object},
+				},
+			}
+
+			if tt.oldObject != nil {
+				req.OldObject = runtime.RawExtension{Raw: tt.oldObject}
+			}
+
+			req.UserInfo.Username = tt.username
+
+			res := v.Handle(context.TODO(), req)
+
+			assert.Equal(t, tt.want.Allowed, res.Allowed)
+			if !res.Allowed && res.Result != nil && tt.want.Result != nil {
+				assert.Equal(t, tt.want.Result.Message, res.Result.Message)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**✨ What's Changed**
- Added namespace webhook to prevent modification of `vpc_network_config` annotation
- Implemented validation logic that blocks removal or modification of the annotation once set
- Added bypass for NSX Operator service account (`system:serviceaccount:vmware-system-nsx:ncp-svc-account`)
- Added comprehensive unit tests with 180 lines of test coverage

**🎯 Motivation**
- Ensure VPC network configurations remain immutable once applied to namespaces
- Prevent accidental or malicious modifications to critical networking annotations
- Maintain consistency and reliability of VPC assignments across namespaces

**✅ Testing**
- Added unit tests covering all validation scenarios
- Test cases include: annotation removal, modification, creation, and service account bypass
- Total changes: 4 files modified with 294 insertions and 1 deletion

Update 
```
root@420cf190774314c26caaf3152d30738f [ ~ ]# kubectl annotate ns default \                            
  nsx.vmware.com/vpc_network_config=test --overwrite
Error from server (Forbidden): admission webhook "namespace.validating.nsx.vmware.com" denied the request: Namespace default: annotation nsx.vmware.com/vpc_network_config cannot be modified once set
```
Delete
```
root@420cf190774314c26caaf3152d30738f [ ~ ]# kubectl annotate ns default nsx.vmware.com/vpc_network_config-
Error from server (Forbidden): admission webhook "namespace.validating.nsx.vmware.com" denied the request: Namespace default: annotation nsx.vmware.com/vpc_network_config cannot be removed once set
```

**🔧 Technical Details**
- Webhook path: `/validate-v1-namespace`
- Validates UPDATE operations on namespaces
- Uses admission webhook framework from controller-runtime
- Implements `NamespaceValidator` struct with validation logic