### PR TITLE
Allow Operator to update shared subnet ip

### DIFF
--- a/pkg/controllers/subnet/subnet_webhook.go
+++ b/pkg/controllers/subnet/subnet_webhook.go
@@ -89,10 +89,11 @@ func (v *SubnetValidator) Handle(ctx context.Context, req admission.Request) adm
 			if oldSubnet.Spec.AdvancedConfig.EnableVLANExtension != subnet.Spec.AdvancedConfig.EnableVLANExtension {
 				return admission.Denied(fmt.Sprintf("Subnet %s/%s: spec.enableVLANExtension can only be updated by NSX Operator", subnet.Namespace, subnet.Name))
 			}
+			if !nsxutil.CompareArraysWithoutOrder(oldSubnet.Spec.IPAddresses, subnet.Spec.IPAddresses) {
+				return admission.Denied("ipAddresses is immutable")
+			}
 		}
-		if !nsxutil.CompareArraysWithoutOrder(oldSubnet.Spec.IPAddresses, subnet.Spec.IPAddresses) {
-			return admission.Denied("ipAddresses is immutable")
-		}
+
 	case admissionv1.Delete:
 		oldSubnet := &v1alpha1.Subnet{}
 		if err := v.decoder.DecodeRaw(req.OldObject, oldSubnet); err != nil {


### PR DESCRIPTION
We should only block the ipAddresses change by non-operator user,
otherwise the shared Subnet spec update will fail