### PR TITLE
Add cleanup for ClusterControlPlane

### DIFF
--- a/pkg/clean/clean.go
+++ b/pkg/clean/clean.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/inventory"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/ipaddressallocation"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/nsxserviceaccount"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy"
 	sr "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/staticroute"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnet"
@@ -172,6 +173,11 @@ func InitializeCleanupService(cf *config.NSXOperatorConfig, nsxClient *nsx.Clien
 			return NewHealthCleaner(service, log, nsxClient, clusterUUID), nil
 		}
 	}
+	wrapInitializeNSXServiceAccount := func(service common.Service) cleanupFunc {
+		return func() (interface{}, error) {
+			return nsxserviceaccount.InitializeNSXServiceAccount(service)
+		}
+	}
 
 	cleanupService.vpcService = vpcService
 	// TODO: initialize other CR services
@@ -185,7 +191,8 @@ func InitializeCleanupService(cf *config.NSXOperatorConfig, nsxClient *nsx.Clien
 		AddCleanupService(wrapInitializeIPAddressAllocation(commonService)).
 		AddCleanupService(wrapInitializeInventory(commonService)).
 		AddCleanupService(wrapInitializeLBInfraCleaner(commonService)).
-		AddCleanupService(wrapInitializeHealthCleaner(commonService))
+		AddCleanupService(wrapInitializeHealthCleaner(commonService)).
+		AddCleanupService(wrapInitializeNSXServiceAccount(commonService))
 
 	return cleanupService, nil
 }

--- a/pkg/clean/clean_test.go
+++ b/pkg/clean/clean_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/inventory"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/ipaddressallocation"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/nsxserviceaccount"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/securitypolicy"
 	sr "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/staticroute"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnet"
@@ -191,6 +192,9 @@ func TestInitializeCleanupService_Success(t *testing.T) {
 	patches.ApplyFunc(inventory.InitializeService, func(service common.Service, _ bool) (*inventory.InventoryService, error) {
 		return &inventory.InventoryService{}, nil
 	})
+	patches.ApplyFunc(nsxserviceaccount.InitializeNSXServiceAccount, func(service common.Service) (*nsxserviceaccount.NSXServiceAccountService, error) {
+		return &nsxserviceaccount.NSXServiceAccountService{}, nil
+	})
 
 	// Mock the NewHealthCleaner function to avoid nil pointer dereference
 	patches.ApplyFunc(NewHealthCleaner, func(service common.Service, log *logr.Logger, nsxClient *nsx.Client, clusterID string) *HealthCleaner {
@@ -205,7 +209,7 @@ func TestInitializeCleanupService_Success(t *testing.T) {
 	cleanupService, err := InitializeCleanupService(cf, nsxClient, &log)
 	assert.NoError(t, err)
 	assert.NotNil(t, cleanupService)
-	assert.Len(t, cleanupService.vpcPreCleaners, 4)
+	assert.Len(t, cleanupService.vpcPreCleaners, 5)
 	assert.Len(t, cleanupService.vpcChildrenCleaners, 5)
 	assert.Len(t, cleanupService.infraCleaners, 2)
 }


### PR DESCRIPTION
After Supervisor cluster is decommissioned, the ClusterControlPlane resources on NSX are left stale.
Add code to delete stale ClusterControlPlane resources on NSX.

Testing steps - 
1. Generate clean binary `make build-clean`
2. Create a WCP testbed with NSX VPC.
3. Created a dummy ClusterControlPlane on NSX with tag.
```
curl -ku '<user>:<passwd>' -X PUT -H 'content-type: application/json' -d @ccp.json  https://<NSXMgrIP>/policy/api/v1/infra/sites/default/enforcement-points/default/cluster-control-planes/kind
```
ccp.json
```
{
  "vhc_path" : "/orgs/default/projects/bea072ec-a1f7-4296-ada8-42385570a8be/vpcs/default",
  "certificate" : "-----BEGIN CERTIFICATE-----#########-----END CERTIFICATE-----\n",
  "node_type" : "ANTREA_NODE",
  "resource_type" : "ClusterControlPlane",
  "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "bea072ec-a1f7-4296-ada8-42385570a8be" <----- supervisorID
    } ]
}
```
4. Get it to verify created ClusterControlPlane exists.
```
curl -sku '<user>:<passwd>' https://<NSXMgrIP>/policy/api/v1/infra/sites/default/enforcement-points/default/cluster-control-planes
{
  "results" : [ {
    "node_id" : "0780a10d-24b8-48a9-8a11-94434aebf663",
    "vhc_path" : "/orgs/default/projects/bea072ec-a1f7-4296-ada8-42385570a8be/vpcs/default",
    "certificate" : "-----BEGIN CERTIFICATE-----###########-----END CERTIFICATE-----\n",
    "node_type" : "ANTREA_NODE",
    "resource_type" : "ClusterControlPlane",
    "id" : "kind",
    "display_name" : "kind",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "bea072ec-a1f7-4296-ada8-42385570a8be"
    } ],
    "path" : "/infra/sites/default/enforcement-points/default/cluster-control-planes/kind",
    "relative_path" : "kind",
    "parent_path" : "/infra/sites/default/enforcement-points/default",
    "remote_path" : "",
    "unique_id" : "84dacebe-3b01-421b-8630-417b7b99da1f",
    "realization_id" : "84dacebe-3b01-421b-8630-417b7b99da1f",
    "owner_id" : "c9ea103e-3a39-4cbf-8f14-2bddbb022842",
    "marked_for_delete" : false,
    "overridden" : false,
    "_system_owned" : false,
    "_protection" : "NOT_PROTECTED",
    "_create_time" : 1753362805328,
    "_create_user" : "admin",
    "_last_modified_time" : 1753362805328,
    "_last_modified_user" : "admin",
    "_revision" : 0
  } ],
  "result_count" : 1,
  "sort_by" : "display_name",
  "sort_ascending" : true
```
5. Run the clean script (from step 1) on VC.
```
./clean -cluster bea072ec-a1f7-4296-ada8-42385570a8be -mgr-ip <NSXMgrIP> -vc-passwd <passwd> -vc-user <user> -vc-sso-domain <sso-domain> -vc-endpoint <endpoint> -thumbprint <NSX thumbprint> -log-level 1
2025-07-24 13:13:50.584	INFO	clean/clean.go:55	Starting NSX cleanup
...
2025-07-24 13:13:59.469	INFO	common/store.go:192	Initialized store	{"resourceType": "clustercontrolplane", "count": 1}
2025-07-24 13:13:59.469	INFO	nsxserviceaccount/cluster.go:644	Send request to NSX to delete cluster control plane	{"ClusterControlPlane": "kind"}
2025-07-24 13:13:59.469	INFO	subnetbinding/cleanup.go:13	Cleaning up SubnetConnectionBindingMaps	{"Count": 0}
...

```
6. Get CCP to check it doesn't exist.
```
curl -sku '<user>:<passwd>' https://<IP>/policy/api/v1/infra/sites/default/enforcement-points/default/cluster-control-planes
{
  "results" : [ ],
  "result_count" : 0,
  "sort_by" : "display_name",
  "sort_ascending" : true
```