### PR TITLE
Fix validation rule for SubnetSet

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
@@ -125,9 +125,10 @@ spec:
               rule: '!has(oldSelf.accessMode) || has(self.accessMode)'
             - message: ipv4SubnetSize is required once set
               rule: '!has(oldSelf.ipv4SubnetSize) || has(self.ipv4SubnetSize)'
-            - message: dhcpServerAdditionalConfig is not supported in SubnetSet
+            - message: reservedIPRanges is not supported in SubnetSet
               rule: '!has(self.subnetDHCPConfig) || has(self.subnetDHCPConfig) &&
-                !has(self.subnetDHCPConfig.dhcpServerAdditionalConfig)'
+                !has(self.subnetDHCPConfig.dhcpServerAdditionalConfig) || has(self.subnetDHCPConfig)
+                && has(self.subnetDHCPConfig.dhcpServerAdditionalConfig) && !has(self.subnetDHCPConfig.dhcpServerAdditionalConfig.reservedIPRanges)'
           status:
             description: SubnetSetStatus defines the observed state of SubnetSet.
             properties:

--- a/pkg/apis/vpc/v1alpha1/subnetset_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetset_types.go
@@ -11,7 +11,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="has(oldSelf.subnetDHCPConfig)==has(self.subnetDHCPConfig) || (has(oldSelf.subnetDHCPConfig) && !has(self.subnetDHCPConfig) && (!has(oldSelf.subnetDHCPConfig.mode) || oldSelf.subnetDHCPConfig.mode=='DHCPDeactivated')) || (!has(oldSelf.subnetDHCPConfig) && has(self.subnetDHCPConfig) && (!has(self.subnetDHCPConfig.mode) || self.subnetDHCPConfig.mode=='DHCPDeactivated'))", message="subnetDHCPConfig mode can only switch between DHCPServer and DHCPRelay"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.accessMode) || has(self.accessMode)", message="accessMode is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.ipv4SubnetSize) || has(self.ipv4SubnetSize)", message="ipv4SubnetSize is required once set"
-// +kubebuilder:validation:XValidation:rule="!has(self.subnetDHCPConfig) || has(self.subnetDHCPConfig) && !has(self.subnetDHCPConfig.dhcpServerAdditionalConfig)", message="dhcpServerAdditionalConfig is not supported in SubnetSet"
+// +kubebuilder:validation:XValidation:rule="!has(self.subnetDHCPConfig) || has(self.subnetDHCPConfig) && !has(self.subnetDHCPConfig.dhcpServerAdditionalConfig) || has(self.subnetDHCPConfig) && has(self.subnetDHCPConfig.dhcpServerAdditionalConfig) && !has(self.subnetDHCPConfig.dhcpServerAdditionalConfig.reservedIPRanges)", message="reservedIPRanges is not supported in SubnetSet"
 type SubnetSetSpec struct {
 	// Size of Subnet based upon estimated workload count.
 	// +kubebuilder:validation:Maximum:=65536


### PR DESCRIPTION
on SubnetSet, reservedIPRanges is not supported.
Tests Done:
root@423c4d68d047b3d4d16a2c00ac85a4c1 [ ~ ]# cat ss.yml apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetSet
metadata:
  name: subnetset-a
spec:
  accessMode: Private
  ipv4SubnetSize: 16
apiVersion: crd.nsx.vmware.com/v1alpha1
  subnetDHCPConfig:
    dhcpServerAdditionalConfig:
      reservedIPRanges:
      - 192.168.3.4
    mode: DHCPServer
root@423c4d68d047b3d4d16a2c00ac85a4c1 [ ~ ]# k -n kube-system apply -f ss.yml The SubnetSet "subnetset-a" is invalid: spec: Invalid value: "object": reservedIPRanges is not supported in SubnetSet root@423c4d68d047b3d4d16a2c00ac85a4c1 [ ~ ]# vi ss.yml root@423c4d68d047b3d4d16a2c00ac85a4c1 [ ~ ]# cat ss.yml apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetSet
metadata:
  name: subnetset-a
spec:
  accessMode: Private
  ipv4SubnetSize: 16
  subnetDHCPConfig:
    dhcpServerAdditionalConfig:
      reservedIPRanges:
    mode: DHCPServer
root@423c4d68d047b3d4d16a2c00ac85a4c1 [ ~ ]# k -n kube-system apply -f ss.yml subnetset.crd.nsx.vmware.com/subnetset-a created