### PR TITLE
Fix the SecurityPolicyPeer lost issue during deduplicating the IP blocks

### DIFF
--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -982,6 +982,7 @@ func (service *SecurityPolicyService) dedupBlocks(rulePeers []v1alpha1.SecurityP
 	deduplicatedRulePeers := make([]v1alpha1.SecurityPolicyPeer, 0, len(rulePeers))
 	for _, rulePeer := range rulePeers {
 		if len(rulePeer.IPBlocks) == 0 {
+			deduplicatedRulePeers = append(deduplicatedRulePeers, rulePeer)
 			continue
 		}
 		var dedupBlocks []v1alpha1.IPBlock

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -1609,7 +1609,7 @@ func Test_dedupBlocks(t *testing.T) {
 		expected []v1alpha1.SecurityPolicyPeer
 	}{
 		{
-			name: "no deduplicated",
+			name: "no deduplicated without selector",
 			input: []v1alpha1.SecurityPolicyPeer{
 				{
 					IPBlocks: []v1alpha1.IPBlock{
@@ -1631,6 +1631,55 @@ func Test_dedupBlocks(t *testing.T) {
 					IPBlocks: []v1alpha1.IPBlock{
 						{
 							CIDR: "1.2.3.0/24",
+						},
+					},
+				},
+				{
+					IPBlocks: []v1alpha1.IPBlock{
+						{
+							CIDR: "2.3.4.0/24",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no deduplicated with selector",
+			input: []v1alpha1.SecurityPolicyPeer{
+				{
+					IPBlocks: []v1alpha1.IPBlock{
+						{
+							CIDR: "1.2.3.0/24",
+						},
+					},
+				},
+				{
+					PodSelector: &v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"key1": "value1",
+						},
+					},
+				},
+				{
+					IPBlocks: []v1alpha1.IPBlock{
+						{
+							CIDR: "2.3.4.0/24",
+						},
+					},
+				},
+			},
+			expected: []v1alpha1.SecurityPolicyPeer{
+				{
+					IPBlocks: []v1alpha1.IPBlock{
+						{
+							CIDR: "1.2.3.0/24",
+						},
+					},
+				},
+				{
+					PodSelector: &v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"key1": "value1",
 						},
 					},
 				},


### PR DESCRIPTION
Testing done:
create the SecurityPolicy with the following yaml

```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SecurityPolicy
metadata:
  name: sp-with-dup-ipblocks
spec:
  priority: 20
  appliedTo:
    - vmSelector: {}
  rules:
    - direction: in
      action: allow
      sources:
        - podSelector:
            matchLabels:
              user: internal
        - ipBlocks:
          - cidr: 192.161.0.0/26
          - cidr: 112.171.0.0/26
        - ipBlocks:
          - cidr: 192.161.0.0/26
          - cidr: 112.171.0.0/26
    - direction: out
      action: drop
      destinations:
        - ipBlocks:
          - cidr: 1.2.3.0/24
          - cidr: 1.2.3.0/24
          - cidr: 2.3.4.0/24
```
then confirm the NSX SecurityPolicy is created as expected:
1. allow rule has group with IP Addresses `["192.161.0.0/26", "112.171.0.0/26"]` and the following membership critera:
```
Subnet Port Tag Equals 76c0a4f6-04ba-45fd-a275-049a79e5ddc8 Scope Equals nsx-op/cluster
        AND Tag Equals 480fbfc3-cd54-4262-88b0-214f30fff94d Scope Equals nsx-op/namespace_uid
        AND Tag Equals internal Scope Equals user
```
2. drop rule has group with IP Addresses `["1.2.3.0/24", "2.3.4.0/24"]`