### PR TITLE
Fix UUID empty bug

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -194,8 +194,11 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			log.Error(err, "Failed to initialize SubnetConnectionBindingMap commonService")
 			os.Exit(1)
 		}
-		inventoryService := inventoryservice.NewInventoryService(commonService)
-		inventoryService.Initialize(false)
+		inventoryService, err := inventoryservice.InitializeService(commonService, false)
+		if err != nil {
+			log.Error(err, "Failed to initialize inventory commonService", "controller", "Inventory")
+			os.Exit(1)
+		}
 
 		if _, err := os.Stat(config.WebhookCertDir); errors.Is(err, os.ErrNotExist) {
 			log.Error(err, "Server cert not found, disabling webhook server", "cert", config.WebhookCertDir)

--- a/pkg/nsx/services/inventory/build_test.go
+++ b/pkg/nsx/services/inventory/build_test.go
@@ -30,6 +30,10 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
+var (
+	clusterUUID string
+)
+
 func createService(t *testing.T) (*InventoryService, *mockClient.MockClient) {
 	clusterUUID = util.GetClusterUUID("k8scl-one:test").String()
 	config2 := nsx.NewConfig("localhost", "1", "1", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, []string{"127.0.0.1"})

--- a/pkg/nsx/services/inventory/builder.go
+++ b/pkg/nsx/services/inventory/builder.go
@@ -197,17 +197,17 @@ func (s *InventoryService) BuildInventoryCluster() containerinventory.ContainerC
 		ScopeType: "CONTAINER_CLUSTER"}
 
 	clusterType := InventoryClusterTypeSupervisor
-	clusterName := util.GetClusterUUID(s.NSXConfig.Cluster).String()
+	clusterUUID := util.GetClusterUUID(s.NSXConfig.Cluster).String()
 	// Initialize as an empty slice to ensure NSX receives [] instead of null when clearing errors
 	networkErrors := make([]common.NetworkError, 0)
 	infra := &containerinventory.ContainerInfrastructureInfo{}
 	infra.InfraType = InventoryInfraTypeVsphere
 	newContainerCluster := containerinventory.ContainerCluster{
-		DisplayName:    clusterName,
+		DisplayName:    s.NSXConfig.Cluster,
 		ResourceType:   string(ContainerCluster),
 		Scope:          []containerinventory.DiscoveredResourceScope{scope},
 		ClusterType:    clusterType,
-		ExternalId:     util.GetClusterUUID(s.NSXConfig.Cluster).String(),
+		ExternalId:     clusterUUID,
 		NetworkErrors:  networkErrors,
 		NetworkStatus:  NetworkStatusHealthy,
 		Infrastructure: infra,

--- a/pkg/nsx/services/inventory/cluster.go
+++ b/pkg/nsx/services/inventory/cluster.go
@@ -4,16 +4,19 @@ import (
 	"context"
 
 	"github.com/vmware/go-vmware-nsxt/containerinventory"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
 func (s *InventoryService) GetContainerCluster() (containerinventory.ContainerCluster, error) {
+	clusterUUID := util.GetClusterUUID(s.NSXConfig.Cluster).String()
 	log.Info("Send request to NSX to get inventory cluster", "Cluster id", clusterUUID)
 	containerCluster, _, err := s.NSXClient.NsxApiClient.ContainerClustersApi.GetContainerCluster(context.TODO(), clusterUUID)
 	return containerCluster, err
 }
 
 func (s *InventoryService) AddContainerCluster(cluster containerinventory.ContainerCluster) (containerinventory.ContainerCluster, error) {
-	log.Info("Send request to NSX to create inventory cluster", "Cluster", clusterUUID)
+	log.Info("Send request to NSX to create inventory cluster", "Cluster", cluster)
 	cluster.ClusterType = InventoryClusterTypeSupervisor
 	cluster, _, err := s.NSXClient.NsxApiClient.ContainerClustersApi.AddContainerCluster(context.TODO(), cluster)
 	return cluster, err

--- a/pkg/nsx/services/inventory/inventory.go
+++ b/pkg/nsx/services/inventory/inventory.go
@@ -18,8 +18,7 @@ import (
 )
 
 var (
-	log         = &logger.Log
-	clusterUUID string
+	log = &logger.Log
 )
 
 type InventoryService struct {
@@ -42,7 +41,6 @@ type InventoryService struct {
 func InitializeService(service commonservice.Service, cleanup bool) (*InventoryService, error) {
 	inventoryService := NewInventoryService(service)
 	err := inventoryService.Initialize(cleanup)
-	clusterUUID = util.GetClusterUUID(inventoryService.NSXConfig.Cluster).String()
 	return inventoryService, err
 }
 
@@ -89,7 +87,8 @@ func (s *InventoryService) Initialize(cleanup bool) error {
 	if cleanup {
 		return nil
 	}
-	err = s.SyncInventoryStoreByType(s.NSXConfig.Cluster)
+	clusterUUID := util.GetClusterUUID(s.NSXConfig.Cluster).String()
+	err = s.SyncInventoryStoreByType(clusterUUID)
 	if err != nil {
 		return err
 	}
@@ -132,7 +131,7 @@ func (s *InventoryService) initContainerCluster(cleanup bool) error {
 	return nil
 }
 
-func (s *InventoryService) SyncInventoryStoreByType(clusterId string) error {
+func (s *InventoryService) SyncInventoryStoreByType(clusterUUID string) error {
 	log.Info("Populating inventory object from NSX")
 	err := s.initContainerProject(clusterUUID)
 	if err != nil {
@@ -295,7 +294,7 @@ func (s *InventoryService) sendNSXRequestAndUpdateInventoryStore(ctx context.Con
 		log.V(1).Info("Send update to NSX clusterId ", "ContainerInventoryData", s.requestBuffer)
 		// TODO, check the context.TODO() be replaced by NsxApiClient related todo
 		resp, err := s.NSXClient.NsxApiClient.ContainerInventoryApi.AddContainerInventoryUpdateUpdates(ctx,
-			clusterUUID,
+			util.GetClusterUUID(s.NSXConfig.Cluster).String(),
 			containerinventory.ContainerInventoryData{ContainerInventoryObjects: s.requestBuffer})
 
 		// Update NSX Inventory store when the request succeeds.


### PR DESCRIPTION
Call InitializeService instead of NewInventoryService.
Call GetClusterUUID instead of global clusterUUID.
To comply with NCP, cluster display name is cluster id from configmap,
 cluster externa id is cluster uuid

Test Done:
1. delete the old cluster, replace the manager binary and restart
2. check the inventory cluster
root@421e584c66974cb1f27030f2174101cb [ ~ ]# curl -k -u 'admin:B7!WzqoPH2C9E7Gb' https://10.192.40.157/api/v1/fabric/container-clusters/
{
  "results" : [ {
    "external_id" : "b791c163-a230-548d-86c8-f7c88edfc632", <-- cluster uuid
    "cluster_type" : "SupervisorCluster",
    "infrastructure" : {
      "infra_type" : "vSphere"
    },
    "origin_properties" : [ ],
    "network_status" : "HEALTHY",
    "cni_type" : "NCP",
    "resource_type" : "ContainerCluster",
    "display_name" : "f3280d48-e03f-4435-8d2f-b06782a945c7",  <-- cluster id
    "scope" : [ {
      "scope_id" : "b791c163-a230-548d-86c8-f7c88edfc632",
      "scope_type" : "CONTAINER_CLUSTER"
    } ],
    "_last_sync_time" : 1753779606098
  } ],
  
  3. check if inventory object have been reported