### PR TITLE
Get Subnet total IPs

### DIFF
--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -746,8 +746,13 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 		if err != nil {
 			return
 		}
-		if !r.SubnetPortService.AllocatePortFromSubnet(nsxSubnet) {
-			err = fmt.Errorf("no valid IP in Subnet %s", *nsxSubnet.Path)
+		var canAllocate bool
+		canAllocate, err = r.SubnetPortService.AllocatePortFromSubnet(nsxSubnet)
+		if err != nil {
+			return
+		}
+		if !canAllocate {
+			err = fmt.Errorf("Subnet %s is exhausted", *nsxSubnet.Id)
 			return
 		}
 		subnetPath = *nsxSubnet.Path

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -963,8 +963,8 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 						}}
 					})
 				patches.ApplyFunc((*subnetport.SubnetPortService).AllocatePortFromSubnet,
-					func(s *subnetport.SubnetPortService, nsxSubnet *model.VpcSubnet) bool {
-						return true
+					func(s *subnetport.SubnetPortService, nsxSubnet *model.VpcSubnet) (bool, error) {
+						return true, nil
 					})
 				return patches
 			},

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -111,8 +111,8 @@ func (m *MockSubnetPortServiceProvider) GetPortsOfSubnet(nsxSubnetID string) (po
 	return
 }
 
-func (m *MockSubnetPortServiceProvider) AllocatePortFromSubnet(subnet *model.VpcSubnet) bool {
-	return true
+func (m *MockSubnetPortServiceProvider) AllocatePortFromSubnet(subnet *model.VpcSubnet) (bool, error) {
+	return true, nil
 }
 
 func (m *MockSubnetPortServiceProvider) ReleasePortInSubnet(path string) {

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/vpcs/nat"
 	vpc_sp "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/vpcs/security_policies"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/vpcs/subnets"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/vpcs/subnets/dhcp_server_config"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/vpcs/subnets/ip_pools"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/vpcs/subnets/ports"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search"
@@ -92,6 +93,7 @@ type Client struct {
 	PortStateClient                   ports.StateClient
 	IPPoolClient                      subnets.IpPoolsClient
 	IPAllocationClient                ip_pools.IpAllocationsClient
+	DhcpServerConfigStatsClient       dhcp_server_config.StatsClient
 	SubnetsClient                     vpcs.SubnetsClient
 	IPAddressAllocationClient         vpcs.IpAddressAllocationsClient
 	VPCLBSClient                      vpcs.VpcLbsClient
@@ -200,6 +202,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 	portStateClient := ports.NewStateClient(connector)
 	ipPoolClient := subnets.NewIpPoolsClient(connector)
 	ipAllocationClient := ip_pools.NewIpAllocationsClient(connector)
+	statsClient := dhcp_server_config.NewStatsClient(connector)
 	subnetsClient := vpcs.NewSubnetsClient(connector)
 	subnetStatusClient := subnets.NewStatusClient(connector)
 	ipAddressAllocationClient := vpcs.NewIpAddressAllocationsClient(connectorAllowOverwrite)
@@ -271,6 +274,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 		NSXVerChecker:                     *nsxVersionChecker,
 		IPPoolClient:                      ipPoolClient,
 		IPAllocationClient:                ipAllocationClient,
+		DhcpServerConfigStatsClient:       statsClient,
 		SubnetsClient:                     subnetsClient,
 		IPAddressAllocationClient:         ipAddressAllocationClient,
 		TransitGatewayClient:              transitGatewayClient,

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -38,7 +38,7 @@ type SubnetServiceProvider interface {
 
 type SubnetPortServiceProvider interface {
 	GetPortsOfSubnet(nsxSubnetID string) (ports []*model.VpcSubnetPort)
-	AllocatePortFromSubnet(subnet *model.VpcSubnet) bool
+	AllocatePortFromSubnet(subnet *model.VpcSubnet) (bool, error)
 	ReleasePortInSubnet(path string)
 	IsEmptySubnet(id string, path string) bool
 	DeletePortCount(path string)


### PR DESCRIPTION
Get Subnet total IPs from NSX
1. for DHCP deactivated mode Subnet, get Subnet total IPs from static IP pool if staticIpAllocation is enabled.
2. for DHCP server mode Subnet, get Subnet total IPs from dhcp-server-config/stats.
3. for DHCP relay mode Subnet, assume total IPs is CIDR size - 4 since there is no pool.

Testing Done:
Generate nsx-operator binary and replace it on an existing testbed,
1. create a static Subnet CR, then create a SubnetPort CR. checking the logs:
2025-08-08T05:57:12.468000307Z stdout F 2025-08-08 05:57:12.467 ^[[34mINFO^[[0m ^[[33msubnetport/subnetport.go:419^[[0m xiaopp totalIP  {"totalIP": 14}
```
root@42129554f69b8f2b0402d228de234cf3 [ ~ ]# k -n ns1 get subnetport
NAME                  VIFID                                  IPADDRESS       MACADDRESS
subnetport-sample-a   8182421f-86d4-517a-b110-fa7f96f27e6e   172.26.0.2/28   04:50:56:00:88:00
subnetport-sample-b   d9f1667d-331d-5cf6-93d5-46b54a58601a
root@42129554f69b8f2b0402d228de234cf3 [ ~ ]# k -n ns1 get subnetport subnetport-sample-a -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetPort","metadata":{"annotations":{},"name":"subnetport-sample-a","namespace":"ns1"},"spec":{"subnet":"subnet-sample-a"}}
  creationTimestamp: "2025-08-24T02:58:41Z"
  generation: 1
  name: subnetport-sample-a
  namespace: ns1
  resourceVersion: "425342"
  uid: d3e14c9a-1258-4c6e-984e-dac8e79aa861
spec:
  subnet: subnet-sample-a
status:
  attachment:
    id: 8182421f-86d4-517a-b110-fa7f96f27e6e
  conditions:
  - lastTransitionTime: "2025-08-24T02:58:43Z"
    message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    ipAddresses:
    - gateway: 172.26.0.1
      ipAddress: 172.26.0.2/28
    logicalSwitchUUID: 303dc39f-c24c-4886-814f-7781cf81ea7c
    macAddress: 04:50:56:00:88:00
```
2. create a static Subnet CR, then create a SubnetPort CR. checking the logs:
2025-08-08T06:22:58.451516378Z stdout F 2025-08-08 06:22:58.451 ^[[34mINFO^[[0m ^[[33msubnetport/subnetport.go:429^[[0m xiaopp totalIP  {"totalIP": 12}
```
root@42129554f69b8f2b0402d228de234cf3 [ ~ ]# k -n ns1 get subnetport subnetport-sample-b -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetPort","metadata":{"annotations":{},"name":"subnetport-sample-b","namespace":"ns1"},"spec":{"subnet":"subnet-sample-b"}}
  creationTimestamp: "2025-08-24T03:00:13Z"
  generation: 1
  name: subnetport-sample-b
  namespace: ns1
  resourceVersion: "426409"
  uid: a1bcbe21-e28d-4c60-a486-bf8d722b588b
spec:
  subnet: subnet-sample-b
status:
  attachment:
    id: d9f1667d-331d-5cf6-93d5-46b54a58601a
  conditions:
  - lastTransitionTime: "2025-08-24T03:00:15Z"
    message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    ipAddresses:
    - gateway: 172.26.2.1
    logicalSwitchUUID: 881a89a7-3990-4352-930a-d50ec6163bc8
```