### PR TITLE
Check enable_inventory before init inventory service

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -124,6 +124,7 @@ type NsxConfig struct {
 	NSXLBSize                 string   `ini:"service_size"`
 	InventoryBatchPeriod      int      `ini:"inventory_batch_period"`
 	InventoryBatchSize        int      `ini:"inventory_batch_size"`
+	EnableInventory           bool     `ini:"enable_inventory"`
 }
 
 type K8sConfig struct {


### PR DESCRIPTION
Check enable_inventory before init inventory service

Test Done:
Case 1:
1. set enable_inventory to false
2. reset nsx-ncp pod
3. check if no inventory service running

Case 2:
1. set enable_inventory to true
2. reset nsx-ncp pod
3. check if inventory service running

