### PR TITLE
Create SubnetPort without IP if StaticIpAllocation is nil

### DIFF
--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -119,7 +119,9 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 		// we will get the error `User defined address bindings are not allowed on LogicalPort
 		// InternalLogicalPort/{id} as its VIF AttachmentContext contain IP/MAC Pool {1}.`
 		allocateAddresses = "IP_POOL"
-	} else if nsxSubnet.AdvancedConfig != nil && nsxSubnet.AdvancedConfig.StaticIpAllocation != nil && !*nsxSubnet.AdvancedConfig.StaticIpAllocation.Enabled {
+	} else if nsxSubnet.AdvancedConfig == nil || nsxSubnet.AdvancedConfig.StaticIpAllocation == nil ||
+		nsxSubnet.AdvancedConfig.StaticIpAllocation.Enabled == nil || !*nsxSubnet.AdvancedConfig.StaticIpAllocation.Enabled {
+		// StaticIpAllocation is false by default. Set allocateAddresses to NONE if StaticIpAllocation is not set or disabled.
 		allocateAddresses = "NONE"
 	} else {
 		allocateAddresses = "BOTH"

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -217,6 +217,11 @@ func TestBuildSubnetPort(t *testing.T) {
 				SubnetDhcpConfig: &model.SubnetDhcpConfig{
 					Mode: common.String("DHCP_DEACTIVATED"),
 				},
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					StaticIpAllocation: &model.StaticIpAllocation{
+						Enabled: common.Bool(true),
+					},
+				},
 				Path: common.String("fake_path"),
 			},
 			contextID: "fake_context_id",
@@ -283,6 +288,11 @@ func TestBuildSubnetPort(t *testing.T) {
 			nsxSubnet: &model.VpcSubnet{
 				SubnetDhcpConfig: &model.SubnetDhcpConfig{
 					Mode: common.String("DHCP_DEACTIVATED"),
+				},
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					StaticIpAllocation: &model.StaticIpAllocation{
+						Enabled: common.Bool(true),
+					},
 				},
 				Path: common.String("fake_path"),
 			},
@@ -499,6 +509,65 @@ func TestBuildSubnetPort(t *testing.T) {
 					StaticIpAllocation: &model.StaticIpAllocation{
 						Enabled: common.Bool(false),
 					},
+				},
+				Path: common.String("fake_path"),
+			},
+			contextID: "fake_context_id",
+			labelTags: nil,
+			expectedPort: &model.VpcSubnetPort{
+				DisplayName: common.String("fake_subnetport"),
+				Id:          common.String("fake_subnetport_phoia"),
+				Tags: []model.Tag{
+					{
+						Scope: common.String("nsx-op/cluster"),
+						Tag:   common.String("fake_cluster"),
+					},
+					{
+						Scope: common.String("nsx-op/version"),
+						Tag:   common.String("1.0.0"),
+					},
+					{
+						Scope: common.String("nsx-op/namespace"),
+						Tag:   common.String("fake_ns"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_name"),
+						Tag:   common.String("fake_subnetport"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_uid"),
+						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+					},
+				},
+				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
+				ParentPath: common.String("fake_path"),
+				Attachment: &model.PortAttachment{
+					AllocateAddresses: common.String("NONE"),
+					Type_:             common.String("STATIC"),
+					TrafficTag:        common.Int64(0),
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "build-NSX-port-for-subnetport-no-ip-2",
+			obj: &v1alpha1.SubnetPort{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1alpha1",
+					Kind:       "SubnetPort",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
+					Name:      "fake_subnetport",
+					Namespace: "fake_ns",
+				},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				SubnetDhcpConfig: &model.SubnetDhcpConfig{
+					Mode: common.String("DHCP_DEACTIVATED"),
+				},
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					ConnectivityState: common.String("CONNECTED"),
 				},
 				Path: common.String("fake_path"),
 			},


### PR DESCRIPTION
AdvancedConfig.StaticIpAllocation may be nil for precreated Subnet.
We still need to create SubnetPort with addressbinding as NONE in this case
as the default StaticIpAllocation is false in NSX