### PR TITLE
Fix Subnet CR not updating when NSX subnet is recreated with different properties

### DIFF
--- a/pkg/controllers/staticroute/staticroute_controller_test.go
+++ b/pkg/controllers/staticroute/staticroute_controller_test.go
@@ -408,7 +408,9 @@ func TestStaticRouteReconciler_deleteStaticRouteByName(t *testing.T) {
 		},
 	}
 
+	mockClient := mock_client.NewMockClient(mockCtl)
 	r := &StaticRouteReconciler{
+		Client:  mockClient,
 		Scheme:  nil,
 		Service: service,
 	}

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -102,6 +102,10 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	if !subnetCR.DeletionTimestamp.IsZero() {
+		// If it's a shared subnet, and it is deleted on the NSX side
+		if servicecommon.IsSharedSubnetNotFindNSX(subnetCR) {
+			return ResultNormal, nil
+		}
 		r.StatusUpdater.IncreaseDeleteTotal()
 		bindingsOnNSX := r.getNSXSubnetBindingsBySubnet(string(subnetCR.UID))
 		if len(bindingsOnNSX) > 0 {
@@ -273,7 +277,7 @@ func (r *SubnetReconciler) handleSharedSubnet(ctx context.Context, subnetCR *v1a
 	// Get NSX subnet from cache or API
 	nsxSubnet, err := r.SubnetService.GetNSXSubnetFromCacheOrAPI(associatedResource)
 	if err != nil {
-		r.updateSharedSubnetWithError(ctx, namespacedName, err, "Failed to get NSX Subnet for associated resource")
+		r.updateSharedSubnetWithError(ctx, namespacedName, err, servicecommon.ErrorMsgFailedToGetNSXSubnet)
 		return ResultRequeue, err
 	}
 
@@ -281,8 +285,18 @@ func (r *SubnetReconciler) handleSharedSubnet(ctx context.Context, subnetCR *v1a
 	statusList, err := r.SubnetService.GetSubnetStatusFromCacheOrAPI(nsxSubnet, associatedResource)
 	if err != nil {
 		// Use updateSharedSubnetWithError for consistency with pollAllSharedSubnets
-		r.updateSharedSubnetWithError(ctx, namespacedName, err, "NSX subnet status")
+		r.updateSharedSubnetWithError(ctx, namespacedName, err, servicecommon.ErrorMsgFailedToGetNSXSubnetStatus)
 		return ResultRequeue, err
+	}
+
+	// Check and handle subnet recreation if needed.
+	// This is to handle the case where the shared subnet is deleted and recreated in NSX with the same name.
+	// AccessMode may be changed in the recreation, and CRD doesn't allow it to be changed, so we have to delete and recreate the Subnet CR.
+	if servicecommon.IsSharedSubnetNotFindNSX(subnetCR) {
+		subnetCR, err = r.deleteAndRecreateSubnetIfNeeded(ctx, subnetCR, namespacedName, associatedResource)
+		if err != nil {
+			return ResultRequeue, err
+		}
 	}
 
 	// Update the status with the NSX subnet information and set shared to true

--- a/pkg/nsx/services/common/builder.go
+++ b/pkg/nsx/services/common/builder.go
@@ -24,6 +24,11 @@ var (
 	orgId = "default"
 )
 
+const (
+	ErrorMsgFailedToGetNSXSubnet       = "Failed to get NSX Subnet for associated resource"
+	ErrorMsgFailedToGetNSXSubnetStatus = "Failed to get NSX subnet status"
+)
+
 func QueryTagCondition(resourceType, cluster string) string {
 	return fmt.Sprintf("%s:%s AND tags.scope:%s AND tags.tag:%s",
 		ResourceType, resourceType,
@@ -98,6 +103,16 @@ func IsSharedSubnet(subnet *v1alpha1.Subnet) bool {
 	}
 	_, exists := subnet.Annotations[AnnotationAssociatedResource]
 	return exists
+}
+
+func IsSharedSubnetNotFindNSX(subnet *v1alpha1.Subnet) bool {
+	for _, condition := range subnet.Status.Conditions {
+		if strings.Contains(condition.Message, ErrorMsgFailedToGetNSXSubnet) {
+			log.Info("Found condition with ErrorMsgFailedToGetNSXSubnet", "Subnet", subnet)
+			return true
+		}
+	}
+	return false
 }
 
 // GetVPCFullID returns the formatted VPC full naIDme based on project and VPC IDs

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -622,6 +623,33 @@ func (service *SubnetService) MapNSXSubnetStatusToSubnetCRStatus(subnetCR *v1alp
 			subnetCR.Status.VLANExtension = vlanExtension
 		}
 	}
+}
+
+// CreateSubnetCRInK8s creates the Subnet CR in Kubernetes
+func (service *SubnetService) CreateSubnetCRInK8s(ctx context.Context, client client.Client, subnetCR *v1alpha1.Subnet) error {
+	err := client.Create(ctx, subnetCR)
+	if err != nil {
+		// If the Subnet CR already exists with the same name, try using generateName
+		if apierrors.IsAlreadyExists(err) {
+			log.Info("Subnet CR with the same name already exists, using generateName",
+				"Namespace", subnetCR.Namespace, "Name", subnetCR.Name)
+
+			// Create a new Subnet CR with generateName
+			// subnetCR.ObjectMeta.Name will be subnetName + "-" + randomSuffix
+			subnetCR.GenerateName = subnetCR.Name + "-"
+			subnetCR.Name = ""
+
+			err = client.Create(ctx, subnetCR)
+			if err != nil {
+				return fmt.Errorf("failed to create Subnet CR with generateName: %w", err)
+			}
+		} else {
+			log.Error(err, "Failed to create Subnet CR", "Namespace", subnetCR.Namespace, "Name", subnetCR.Name)
+			return fmt.Errorf("failed to create Subnet CR: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // BuildSubnetCR creates a Subnet CR object with the given parameters


### PR DESCRIPTION
### ✨ What's Changed
* Fix Subnet CR synchronization when NSX subnet is recreated with different properties
* Add detection logic for subnet recreation with changed configuration  
* Implement proper subnet CR update mechanism when NSX subnet ID changes
* Enhanced error handling for deleted and recreated subnets

### 🎯 Motivation
**Bug #3562099**: When a shared subnet is deleted and recreated in NSX with different properties (e.g., changed from Public to Private), the Kubernetes Subnet CR does not update its configuration to match the new NSX subnet properties. This causes:

- **Configuration Drift**: Subnet CR shows stale configuration (old access mode, IP addresses)
- **Network Inconsistency**: Workloads may use incorrect network settings
- **Operational Issues**: Subnet appears ready but has wrong properties
- **Security Concerns**: Access mode mismatch could lead to unexpected network exposure

The current logic didn't detect when an NSX subnet was recreated with the same name but different ID and properties, leading to stale configuration in Kubernetes.

### ✅ Testing
* All existing unit tests pass
* Manual testing with subnet recreation scenario:
  - ✅ Public subnet deleted → Subnet CR becomes `SubnetNotReady`
```
status:
  conditions:
  - lastTransitionTime: "2025-08-14T06:09:00Z"
    message: 'Error occurred while processing the Subnet CR. Please check the config
      and try again. Error: com.vmware.vapi.std.errors.not_found Failed to get NSX
      Subnet for associated resource'
    reason: SubnetNotReady
    status: "False"
    type: Ready
  shared: true
  vlanExtension: {}
```
  - ✅ Private subnet recreated with same name → Subnet CR updates configuration
  - ✅ Access mode correctly changes from `Public` to `Private`
  - ✅ IP addresses update from `40.90.1.192/26` to `172.26.1.0/27`
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  annotations:
    nsx.vmware.com/associated-resource: project-quality:ns1_oqg7p:subnet2
  creationTimestamp: "2025-08-14T08:56:27Z"
  generation: 2
  name: subnetc
  namespace: ns2
  resourceVersion: "889332"
  uid: 8332432e-0f4f-429a-aa51-c2d329c48634
spec:
  accessMode: Private   <----  updated
  advancedConfig:
    connectivityState: Disconnected
    enableVLANExtension: false
    staticIPAllocation:
      enabled: true
  ipAddresses:
  - 172.26.1.0/27
  ipv4SubnetSize: 1024
  subnetDHCPConfig:
    dhcpServerAdditionalConfig: {}
    mode: DHCPDeactivated
  vpcName: project-quality:ns1_oqg7p
status:
  conditions:
  - lastTransitionTime: "2025-08-14T08:56:27Z"
    message: NSX Subnet with DHCPDeactivated has been successfully created/updated
    reason: SubnetReady
    status: "True"
    type: Ready
  gatewayAddresses:
  - 172.26.1.9/27   <---- updated
  networkAddresses:
  - 172.26.1.0/27   <---- updated
  shared: true
  vlanExtension: {}
```
* Test coverage updated:
  - ✅ Subnet controller tests enhanced
  - ✅ Subnet share controller tests modified
  - ✅ Static route controller tests added


### 📝 Modified Files
- `pkg/controllers/subnet/subnet_controller.go` - Added subnet recreation detection
- `pkg/controllers/subnet/subnet_poll.go` - Enhanced polling for ID changes
- `pkg/nsx/services/subnet/subnet.go` - Added subnet recreation methods
- `pkg/nsx/services/common/builder.go` - Added comparison utilities
- `pkg/controllers/namespace/subnet_share_controller.go` - Simplified share logic
- `pkg/controllers/common/utils.go` - Updated utility functions

### 📎 Additional Notes
* **Bug ID**: 3562099
* **Severity**: High (Configuration drift, security implications)
* **Component**: NSX Operator - Subnet Controller
* Zero breaking changes - only fixes incorrect subnet synchronization
* Maintains backward compatibility for existing subnet CRs
* Prevents configuration drift between NSX and Kubernetes
* Ensures proper network connectivity for workloads after subnet recreation
