### PR TITLE
Add ipaddresses from subnet to ipblockinfo

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -187,7 +187,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			log.Error(err, "Failed to initialize staticroute commonService", "controller", "StaticRoute")
 			os.Exit(1)
 		}
-		ipblocksInfoService := ipblocksinfo.InitializeIPBlocksInfoService(commonService)
+		ipblocksInfoService := ipblocksinfo.InitializeIPBlocksInfoService(commonService, subnetService)
 
 		subnetBindingService, err := subnetbindingservice.InitializeService(commonService)
 		if err != nil {

--- a/pkg/controllers/networkinfo/vpcnetworkconfig_handler.go
+++ b/pkg/controllers/networkinfo/vpcnetworkconfig_handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	commontypes "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 // VPCNetworkConfigurationHandler handles VPC NetworkConfiguration event, and reconcile VPC event:
@@ -80,6 +81,14 @@ func (h *VPCNetworkConfigurationHandler) Update(ctx context.Context, e event.Upd
 				},
 			})
 		}
+	}
+	if util.CompareArraysWithoutOrder(oldNc.Spec.Subnets, newNc.Spec.Subnets) {
+		log.V(1).Info("Skip processing VPC NetworkConfig subnets", "newNc", newNc, "oldNc", oldNc)
+		return
+	}
+
+	if err := h.ipBlocksInfoService.UpdateIPBlocksInfo(ctx, newNc); err != nil {
+		log.Error(err, "Failed to update the IPBlocksInfo", "VPCNetworkConfiguration", newNc.Name)
 	}
 }
 

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -99,6 +99,10 @@ func (m *MockSubnetServiceProvider) GetSubnetByCR(subnet *v1alpha1.Subnet) (*mod
 	return nil, nil
 }
 
+func (m *MockSubnetServiceProvider) GetNSXSubnetFromCacheOrAPI(associate string) (*model.VpcSubnet, error) {
+	return nil, nil
+}
+
 type MockSubnetPortServiceProvider struct {
 	mock.Mock
 }

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -33,6 +33,7 @@ type SubnetServiceProvider interface {
 	ListSubnetByName(ns, name string) []*model.VpcSubnet
 	ListSubnetBySubnetSetName(ns, subnetSetName string) []*model.VpcSubnet
 	GetSubnetByCR(subnet *v1alpha1.Subnet) (*model.VpcSubnet, error)
+	GetNSXSubnetFromCacheOrAPI(associatedResource string) (*model.VpcSubnet, error)
 }
 
 type SubnetPortServiceProvider interface {


### PR DESCRIPTION
Need to add the ipaddresses from shared subnet to ipblockinfo.
1. Search the accessmode=Public subnet
2. Search the accessmode=Private_TGW subnet which project is the same Check the ipaddresses of subnet, remove the items which is part of exsiting subnet

Test Done:
case 1:
add subnet which has different public ipblock
1. create subnet1 /orgs/default/projects/project-t2/vpcs/vpc2/subnets/subnet1
2. patch the vpcnetworkconfiguration dev-093f55fb-d89f-450f-a982-fbaed8f4ac0b with the subnet1
3. check ipblocksinfos 
  k get ipblocksinfo -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  externalIPCIDRs:
  - 192.168.0.0/16
  - 192.169.0.0/27

case 2:
add subnet which has different private ipblock
1. create subnet4 /orgs/default/projects/project-quality/vpcs/vpc1/subnets/subnet4
2.  patch the vpcnetworkconfiguration dev-093f55fb-d89f-450f-a982-fbaed8f4ac0b with the subnet4
3. check ipblocksinfos
 k get ipblocksinfo -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  externalIPCIDRs:
  - 192.168.0.0/16
  - 192.169.0.0/27
  privateTGWIPCIDRs:
  - 10.246.0.0/16
  - 10.247.0.32/27
  
 case 3: 
 remove subnet4
 1. remove subnet4 from shared subnets
 2. check the ipblocksinfo
  k get ipblocksinfo -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  externalIPCIDRs:
  - 192.168.0.0/16
  - 192.169.0.0/27
  privateTGWIPCIDRs:
  - 10.246.0.0/16
  
 case 4:
 remove subnet1
 1. remove subnet1 from shared subnets
 2. check the ipblocksinfo
   k get ipblocksinfo -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  externalIPCIDRs:
  - 192.168.0.0/16
  privateTGWIPCIDRs:
  - 10.246.0.0/16
  
case 5:
1. add subnet which created from the same public ipblock subnet1
  192.168.0.32/27
2. add subnet which created from the same private_tgw ipblock subnet2
  10.246.0.32/27
3. check the ipblocksinfo
  k get ipblocksinfo -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  externalIPCIDRs:
  - 192.168.0.0/16
  privateTGWIPCIDRs:
  - 10.246.0.0/16