### PR TITLE
Not print "details: , related error: nil" when the related fields are empty

### DIFF
--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -334,9 +334,20 @@ func NewNSXApiError(apiError *model.ApiError, errorType apierrors.ErrorTypeEnum)
 func (e *NSXApiError) Error() string {
 	if e.ApiError != nil {
 		apierror := e.ApiError
-		return fmt.Sprintf("nsx error code: %d, message: %s, details: %s, related error: %s",
-			safeInt(apierror.ErrorCode), safeString(apierror.ErrorMessage), safeString(apierror.Details),
-			relatedErrorsToString(apierror.RelatedErrors))
+		msg := fmt.Sprintf("nsx error code: %d, message: %s",
+			safeInt(apierror.ErrorCode), safeString(apierror.ErrorMessage))
+
+		details := safeString(apierror.Details)
+		if details != "" {
+			msg += fmt.Sprintf(", details: %s", details)
+		}
+
+		relatedErrStr := relatedErrorsToString(apierror.RelatedErrors)
+		if relatedErrStr != "nil" && relatedErrStr != "[]" {
+			msg += fmt.Sprintf(", related error: %s", relatedErrStr)
+		}
+
+		return msg
 	}
 	return "SDKError: unknown error"
 }
@@ -363,9 +374,18 @@ func relatedErrorToString(err *model.RelatedApiError) string {
 		return "nil"
 	}
 
+	details := safeString(err.Details)
+	if details != "" {
+		return fmt.Sprintf(
+			"{Details: %s, ErrorCode: %d, ErrorMessage: %s, ModuleName: %s}",
+			details,
+			safeInt(err.ErrorCode),
+			safeString(err.ErrorMessage),
+			safeString(err.ModuleName),
+		)
+	}
 	return fmt.Sprintf(
-		"{Details: %s, ErrorCode: %d,  ErrorMessage: %s, ModuleName: %s}",
-		safeString(err.Details),
+		"{ErrorCode: %d, ErrorMessage: %s, ModuleName: %s}",
 		safeInt(err.ErrorCode),
 		safeString(err.ErrorMessage),
 		safeString(err.ModuleName),


### PR DESCRIPTION
Testing done:
Trigger a NSX error for the NSX operator, then observed that there's not "details: , related error: nil" in the status error. Before the change:
```
  Warning  FailUpdate        4s (x10 over 7s)  subnet-controller  nsx error code: 500045, message: An object with the same path=[/orgs/default/projects/project-quality/vpcs/kube-system_grrgk/subnets/subnet-debug-no-ip-public-222_14wia] is marked for deletion. Either use another path or wait for the purge cycle (max 5 minutes) for permanent removal of the object., details: , related error: nil
```
After the change:
```
  Warning  FailUpdate  2s (x10 over 5s)  subnet-controller  nsx error code: 500045, message: An object with the same path=[/orgs/default/projects/project-quality/vpcs/kube-system_grrgk/subnets/subnet-debug-no-ip-public-222_14wia] is marked for deletion. Either use another path or wait for the purge cycle (max 5 minutes) for permanent removal of the object.
```