### PR TITLE
Check inventory flag while cleaning up

### DIFF
--- a/pkg/clean/clean.go
+++ b/pkg/clean/clean.go
@@ -189,10 +189,13 @@ func InitializeCleanupService(cf *config.NSXOperatorConfig, nsxClient *nsx.Clien
 		AddCleanupService(wrapInitializeStaticRoute(commonService)).
 		AddCleanupService(wrapInitializeVPC(commonService)).
 		AddCleanupService(wrapInitializeIPAddressAllocation(commonService)).
-		AddCleanupService(wrapInitializeInventory(commonService)).
 		AddCleanupService(wrapInitializeLBInfraCleaner(commonService)).
 		AddCleanupService(wrapInitializeHealthCleaner(commonService)).
 		AddCleanupService(wrapInitializeNSXServiceAccount(commonService))
+
+	if cf.EnableInventory {
+		cleanupService = cleanupService.AddCleanupService(wrapInitializeInventory(commonService))
+	}
 
 	return cleanupService, nil
 }


### PR DESCRIPTION
Currently, the default value of enable_inventory is false. 
Check inventory flag while cleaning up

Test Done:
1. run ./clean -cluster d21ae847-b87e-47b2-a9b3-bd18bbb59238 -mgr-ip 10.192.33.204 -vc-passwd '(ZgbH7J^`;c*~92$zUmK' -vc-user wcp-cluster-user-d21ae847-b87e-47b2-a9b3-bd18bbb59238-8fefcd47-2654-43f3-a094-2e7abc6b22b0@vsphere.local -thumbprint 99:4B:F5:D3:AD:63:9C:24:1E:F4:A7:05:CA:6F:3B:BE:9A:D6:FC:5E -vc-sso-domain vsphere.local -vc-endpoint lvn-dvm-10-192-37-70.dvm.lvn.broadcom.net
2. check if cleanup show "Cleanup NSX resources successfully"