### PR TITLE
Refactor SecurityPolicy deletion logic for non-default project

### DIFF
--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -212,6 +212,7 @@ func (service *SecurityPolicyService) buildPolicyGroup(obj *v1alpha1.SecurityPol
 	if err != nil {
 		return nil, "", err
 	}
+	policyAppliedGroup.Path = String(policyAppliedGroupPath)
 
 	log.V(1).Info("Built policy target group", "policyAppliedGroup", policyAppliedGroup)
 	return &policyAppliedGroup, policyAppliedGroupPath, nil
@@ -740,6 +741,7 @@ func (service *SecurityPolicyService) buildRuleAppliedGroupByRule(obj *v1alpha1.
 		Id:          &ruleAppliedGroupID,
 		DisplayName: &ruleAppliedGroupName,
 		Tags:        targetTags,
+		Path:        &ruleAppliedGroupPath,
 	}
 
 	ruleGroupCriteriaCount, ruleGroupTotalExprCount := 0, 0
@@ -895,6 +897,7 @@ func (service *SecurityPolicyService) buildRulePeerGroup(obj *v1alpha1.SecurityP
 		Id:          &rulePeerGroupID,
 		DisplayName: &rulePeerGroupName,
 		Tags:        peerTags,
+		Path:        &rulePeerGroupPath,
 	}
 
 	rulePeerGroupCriteriaCount, rulePeerGroupTotalExprCount := 0, 0

--- a/pkg/nsx/services/securitypolicy/expand.go
+++ b/pkg/nsx/services/securitypolicy/expand.go
@@ -147,6 +147,8 @@ func (service *SecurityPolicyService) expandRuleByService(obj *v1alpha1.Security
 		if err != nil {
 			return nil, nil, err
 		}
+		ruleIPSetGroup.Path = String(IPSetGroupPath)
+
 		nsxRule.DestinationGroups = []string{IPSetGroupPath}
 		log.V(1).Info("Built ruleIPSetGroup", "ruleIPSetGroup", ruleIPSetGroup)
 		nsxGroups = append(nsxGroups, ruleIPSetGroup)

--- a/pkg/nsx/services/securitypolicy/expand_test.go
+++ b/pkg/nsx/services/securitypolicy/expand_test.go
@@ -308,7 +308,7 @@ var secPolicy = &v1alpha1.SecurityPolicy{
 func Test_ExpandRule(t *testing.T) {
 	ruleTagsFn := func(policyType string) []model.Tag {
 		return []model.Tag{
-			{Scope: common.String("nsx-op/cluster"), Tag: common.String("")},
+			{Scope: common.String("nsx-op/cluster"), Tag: common.String("k8scl-one")},
 			{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
 			{Scope: common.String("nsx-op/namespace"), Tag: common.String("ns1")},
 			{Scope: common.String("nsx-op/namespace_uid"), Tag: common.String("ns1-uid")},
@@ -370,9 +370,13 @@ func Test_ExpandRule(t *testing.T) {
 			{Scope: common.String("nsx-op/selector_hash"), Tag: common.String("2be88ca4242c76e8253ac62474851065032d6833")},
 		}
 		groupTags = append(groupTags, ruleTagsFn(policyType)...)
+
+		path := fmt.Sprintf("/infra/domains/k8scl-one/groups/%s", id)
+
 		if isVPC {
 			groupTags = append(groupTags,
 				model.Tag{Scope: common.String("nsx-op/nsx_share_created_for"), Tag: common.String("notShared")})
+			path = fmt.Sprintf("/orgs/default/projects/pro1/vpcs/vpc1/groups/%s", id)
 		}
 
 		addresses := data.NewListValue()
@@ -382,6 +386,7 @@ func Test_ExpandRule(t *testing.T) {
 			Id:          common.String(id),
 			DisplayName: common.String(displayName),
 			Tags:        groupTags,
+			Path:        common.String(path),
 			Expression: []*data.StructValue{
 				data.NewStructValue(
 					"",
@@ -517,7 +522,7 @@ func Test_ExpandRule(t *testing.T) {
 					Services:          []string{"ANY"},
 					ServiceEntries:    []*data.StructValue{getRuleServiceEntries(8080, 0, "TCP")},
 					Tags:              spT1RuleTags,
-					DestinationGroups: []string{"/infra/domains//groups/sp_uid1_94b44028488f3e719879abbc27c75e5cb44872b7_2_0_0_ipset"},
+					DestinationGroups: []string{"/infra/domains/k8scl-one/groups/sp_uid1_94b44028488f3e719879abbc27c75e5cb44872b7_2_0_0_ipset"},
 				}, {
 					Id:             common.String("sp_uid1_94b44028488f3e719879abbc27c75e5cb44872b7_2_1_0"),
 					DisplayName:    common.String("TCP.http_UDP.1236.1237.UDP.1236.1237_ingress_allow"),
@@ -545,7 +550,10 @@ func Test_ExpandRule(t *testing.T) {
 				Service: common.Service{
 					Client: k8sClient,
 					NSXConfig: &config.NSXOperatorConfig{
-						CoeConfig: &config.CoeConfig{EnableVPCNetwork: tc.vpcEnabled},
+						CoeConfig: &config.CoeConfig{
+							EnableVPCNetwork: tc.vpcEnabled,
+							Cluster:          "k8scl-one",
+						},
 					},
 				},
 				vpcService: &mockVPCService,

--- a/pkg/nsx/services/securitypolicy/store.go
+++ b/pkg/nsx/services/securitypolicy/store.go
@@ -122,7 +122,10 @@ func (securityPolicyStore *SecurityPolicyStore) Apply(i interface{}) error {
 	if i == nil {
 		return nil
 	}
-	sp := i.(*model.SecurityPolicy)
+	sp, ok := i.(*model.SecurityPolicy)
+	if !ok || sp == nil {
+		return nil
+	}
 	if sp.MarkedForDelete != nil && *sp.MarkedForDelete {
 		err := securityPolicyStore.Delete(sp)
 		log.V(1).Info("Delete security policy from store", "securitypolicy", sp)

--- a/pkg/nsx/services/securitypolicy/store_test.go
+++ b/pkg/nsx/services/securitypolicy/store_test.go
@@ -316,6 +316,8 @@ func Test_SecurityPolicyStore_Apply(t *testing.T) {
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{"1", args{i: &model.SecurityPolicy{Id: String("1")}}, assert.NoError},
+		{"nil untyped interface", args{i: nil}, assert.NoError},
+		{"nil typed interface", args{i: (*model.SecurityPolicy)(nil)}, assert.NoError},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/nsx/services/securitypolicy/wrap.go
+++ b/pkg/nsx/services/securitypolicy/wrap.go
@@ -227,20 +227,22 @@ func (service *SecurityPolicyService) wrapProject(sp *model.SecurityPolicy, gs [
 }
 
 func (service *SecurityPolicyService) wrapVPC(sp *model.SecurityPolicy, gs []model.Group, vpcID string) ([]*data.StructValue, error) {
-	rulesChildren, err := service.wrapRules(sp.Rules)
-	if err != nil {
-		return nil, err
-	}
-	sp.Rules = nil
-	sp.Children = rulesChildren
-	sp.ResourceType = &common.ResourceTypeSecurityPolicy
-
-	securityPolicyChildren, err := service.wrapSecurityPolicy(sp)
-	if err != nil {
-		return nil, err
-	}
 	var resourceReferenceChildren []*data.StructValue
-	resourceReferenceChildren = append(resourceReferenceChildren, securityPolicyChildren...)
+	if sp != nil {
+		rulesChildren, err := service.wrapRules(sp.Rules)
+		if err != nil {
+			return nil, err
+		}
+		sp.Rules = nil
+		sp.Children = rulesChildren
+		sp.ResourceType = &common.ResourceTypeSecurityPolicy
+		securityPolicyChildren, err := service.wrapSecurityPolicy(sp)
+		if err != nil {
+			return nil, err
+		}
+		resourceReferenceChildren = append(resourceReferenceChildren, securityPolicyChildren...)
+	}
+
 	groupsChildren, err := service.wrapGroups(gs)
 	if err != nil {
 		return nil, err
@@ -249,7 +251,6 @@ func (service *SecurityPolicyService) wrapVPC(sp *model.SecurityPolicy, gs []mod
 
 	targetType := common.ResourceTypeVpc
 	resourceType := common.ResourceTypeChildResourceReference
-
 	childVPC := model.ChildResourceReference{
 		Id:           &vpcID,
 		ResourceType: resourceType,


### PR DESCRIPTION
Previously, SecurityPolicy, rules and groups, and shares will be deleted together with one HAPI call. However, if some resources, like a group or a share, are being used by other security policies, the whole deletion will fail, and NSX SecurityPolicy rules remain. But this SecurityPolicy is already deleted in K8s, which leads security leak due to the inconsistency between the K8s SecurityPolicy CR and NSX SecurityPolicy resource.

This patch is to refactor the SecurityPolicy deletion logic for non-default projects, and separate SecurityPolicy/rules deletion from groups/shares. So, NSX SecurityPolicy will be deleted as long as the SecurityPolicy CR is deleted. The groups and shares could be deleted in the GC loop if they failed to be deleted with the NSX SecurityPolicy at the same time.

This refactor logic also applies to the NetworkPolicy internal SecurityPolicy CR deletion logic.

Testing Done:
1. Testing Normal SecurityPolicy CRUD: 
- Create SecurityPolicy and do update/deletion
2. Test SecurityPolicy is deleted and groups is GC:
 - Create SecurityPolicy
 - Create a DFW in NSX to reference the one group created by SecurityPolicy
 - Delete SecurityPolicy CR and verify NSX SecurityPolicy/rules are deleted
 - Remove group references in NSX DFW rule and verify the stale groups/shares will GC
 3. Test GC SecurityPolicy with groups/shares in one time
 - Create SecurityPolicy 
 - Delete SecurityPolicy CR and make nsx-operator restart at the same time, so the NSX SecurityPolicy resources remain
 - Check NSX SecurityPolicy/rules, groups, shares will be GC after restart
 4.  Testing Normal NetworkPolicy CRUD: 
 - Create NetworkPolicy and do update/deletion
 5. Test NetworkPolicy is deleted and groups is GC:
 - Create NetworkPolicy
 - Create a DFW in NSX to reference the one group created by NetworkPolicy
 - Delete NetworkPolicy CR and verify the corresponding NSX SecurityPolicy/rules are deleted
 - Remove group references in NSX DFW rule and verify the stale groups/shares will GC
 6. Test GC NetworkPolicy with groups/shares in one time
 - Create NetworkPolicy 
 - Delete NetworkPolicy CR and make nsx-operator restart at the same time, so the NSX SecurityPolicy resources remain
 - Check NSX SecurityPolicy/rules, groups, shares will be GC after restart