### PR TITLE
Add envoy support for inventory clean

### DIFF
--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -142,7 +142,6 @@ func (cluster *Cluster) CreateServerUrl(host string, scheme string) string {
 		index := strings.Index(host, ":")
 		mgrIP := ""
 		if index == -1 {
-			log.Info("No port provided, use default port 443", "host", host)
 			mgrIP = host + "/443"
 		} else {
 			mgrIP = strings.ReplaceAll(host, ":", "/")
@@ -385,6 +384,17 @@ func (cluster *Cluster) HttpGet(url string) (map[string]interface{}, error) {
 	respJson := make(map[string]interface{})
 	err, _ = util.HandleHTTPResponse(resp, &respJson, true)
 	return respJson, err
+}
+
+// HttpGetAndDecode sends an http GET request to the cluster and decode the response to result
+func (cluster *Cluster) HttpGetAndDecode(url string, result interface{}) error {
+	resp, err := cluster.httpAction(url, "GET")
+	if err != nil {
+		log.Error(err, "Failed to do HTTP GET operation")
+		return err
+	}
+	err, _ = util.HandleHTTPResponse(resp, result, true)
+	return err
 }
 
 func (cluster *Cluster) httpAction(url, method string, requestBody ...interface{}) (*http.Response, error) {

--- a/pkg/nsx/services/inventory/cluster_test.go
+++ b/pkg/nsx/services/inventory/cluster_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	nsxt "github.com/vmware/go-vmware-nsxt"
 	"github.com/vmware/go-vmware-nsxt/containerinventory"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 func TestInventoryService_GetContainerCluster(t *testing.T) {
@@ -18,10 +21,42 @@ func TestInventoryService_GetContainerCluster(t *testing.T) {
 	patches := gomonkey.ApplyMethod(reflect.TypeOf(clusterApiService), "GetContainerCluster", func(_ *nsxt.ManagementPlaneApiFabricContainerClustersApiService, _ context.Context, _ string) (containerinventory.ContainerCluster, *http.Response, error) {
 		return containerinventory.ContainerCluster{}, nil, nil
 	})
-	defer patches.Reset()
-	_, err := inventoryService.GetContainerCluster()
+	_, err := inventoryService.GetContainerCluster(false)
+	patches.Reset()
 	assert.Nil(t, err)
 
+	// Simulate a 404 response, cleanup false
+	patches = gomonkey.ApplyMethod(reflect.TypeOf(clusterApiService), "GetContainerCluster", func(_ *nsxt.ManagementPlaneApiFabricContainerClustersApiService, _ context.Context, _ string) (containerinventory.ContainerCluster, *http.Response, error) {
+		resp := &http.Response{StatusCode: http.StatusNotFound}
+		return containerinventory.ContainerCluster{}, resp, nil
+	})
+	_, err = inventoryService.GetContainerCluster(false)
+	patches.Reset()
+	assert.Equal(t, util.HttpNotFoundError, err)
+
+	// Simulate a successful response, cleanup true
+	patches = gomonkey.ApplyMethod(reflect.TypeOf(inventoryService.NSXClient.Cluster), "HttpGetAndDecode", func(_ *nsx.Cluster, url string, result interface{}) error {
+		if result, ok := result.(*containerinventory.ContainerCluster); ok {
+			*result = containerinventory.ContainerCluster{DisplayName: "Cluster1", ClusterType: "WCP"}
+		}
+		return nil
+	})
+	cluster, err := inventoryService.GetContainerCluster(true)
+	patches.Reset()
+	assert.Nil(t, err)
+	assert.Equal(t, cluster.DisplayName, "Cluster1")
+	assert.Equal(t, cluster.ClusterType, "WCP")
+
+	// Simulate a 404 response, cleanup false
+	patches = gomonkey.ApplyMethod(reflect.TypeOf(inventoryService.NSXClient.Cluster), "HttpGetAndDecode", func(_ *nsx.Cluster, url string, result interface{}) error {
+		if result, ok := result.(*containerinventory.ContainerCluster); ok {
+			*result = containerinventory.ContainerCluster{DisplayName: "Cluster1", ClusterType: "WCP"}
+		}
+		return util.HttpNotFoundError
+	})
+	cluster, err = inventoryService.GetContainerCluster(true)
+	patches.Reset()
+	assert.Equal(t, util.HttpNotFoundError, err)
 }
 
 func TestInventoryService_AddContainerCluster(t *testing.T) {
@@ -34,4 +69,22 @@ func TestInventoryService_AddContainerCluster(t *testing.T) {
 	defer patches.Reset()
 	_, err1 := inventoryService.AddContainerCluster(cluster1)
 	assert.Nil(t, err1)
+}
+
+func TestInventoryService_DeleteContainerCluster(t *testing.T) {
+	inventoryService, _ := createService(t)
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(inventoryService.NSXClient.Cluster), "HttpDelete", func(_ *nsx.Cluster, url string) error {
+		return nil
+	})
+	defer patches.Reset()
+	err := inventoryService.DeleteContainerCluster(baseUrl, context.TODO())
+	assert.Nil(t, err)
+	patches.Reset()
+
+	patches = gomonkey.ApplyMethod(reflect.TypeOf(inventoryService.NSXClient.Cluster), "HttpDelete", func(_ *nsx.Cluster, url string) error {
+		return util.HttpNotFoundError
+	})
+	defer patches.Reset()
+	err = inventoryService.DeleteContainerCluster(baseUrl, context.TODO())
+	assert.Equal(t, util.HttpNotFoundError, err)
 }

--- a/pkg/nsx/services/inventory/inventory_test.go
+++ b/pkg/nsx/services/inventory/inventory_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	commonservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
@@ -57,13 +58,13 @@ func TestInventoryService_initContainerCluster(t *testing.T) {
 		// "not found" will return nil
 		patches.Reset()
 		patches = gomonkey.ApplyMethod(inventoryService, "GetContainerCluster", func(*InventoryService) (containerinventory.ContainerCluster, error) {
-			return containerinventory.ContainerCluster{}, errors.New("Not Found")
+			return containerinventory.ContainerCluster{}, util.HttpNotFoundError
 		})
 		patches.ApplyMethod(inventoryService, "AddContainerCluster", func(_ *InventoryService, _ containerinventory.ContainerCluster) (containerinventory.ContainerCluster, error) {
 			return containerinventory.ContainerCluster{}, nil
 		})
 		defer patches.Reset()
-		err = inventoryService.initContainerCluster(true)
+		err = inventoryService.initContainerCluster(false)
 		assert.Nil(t, err)
 	})
 


### PR DESCRIPTION
Inventory clean using the NSXClient.NsxApiClient.ContainerClustersApi which doesn't support envoy option.
Using the HttpGet function to add envoy support for inventory cleanup

Test Done:
Case 1:
1. run ./clean -cluster=3bbd3e92-e441-424d-96a1-a64dc4be8a38 -nsx-user=admin -nsx-passwd='I5+UotiLcaRHUEfp' -mgr-ip=10.162.25.228 -envoyhost=localhost -envoyport=1080 -log-level=1 -thumbprint=7A5BC851A2B376BABA79841BC125D7ACB701C8BC
2. check if the clean output 'Cleanup NSX resources successfully' and inventory deleted

Case 2:
1. run ./clean -cluster=3bbd3e92-e441-424d-96a1-a64dc4be8a38 -nsx-user=admin -nsx-passwd='I5+UotiLcaRHUEfp' -mgr-ip=10.162.25.228 -envoyhost=localhost -envoyport=1080 -log-level=1 -thumbprint=7A5BC851A2B376BABA79841BC125D7ACB701C8BC
2. check if log show "No existing container cluster found", "Cleanup NSX resources successfully"
