### PR TITLE
Refactor the service status in the inventory

### DIFF
--- a/pkg/nsx/services/inventory/build_test.go
+++ b/pkg/nsx/services/inventory/build_test.go
@@ -1512,7 +1512,7 @@ func TestBuildService(t *testing.T) {
 
 		containerApplication := inventoryService.pendingAdd["service-uid-123"].(*containerinventory.ContainerApplication)
 		assert.Equal(t, InventoryStatusDown, containerApplication.Status)
-		assert.Equal(t, NetworkStatusUnhealthy, containerApplication.NetworkStatus)
+		assert.Equal(t, NetworkStatusHealthy, containerApplication.NetworkStatus)
 	})
 
 	t.Run("UpdateExistingService", func(t *testing.T) {


### PR DESCRIPTION
Align the service status in the inventory with ncp

To be brief,
- network status is determined by service error annotation
  - network status is healthy if no error annotation
  - network status is unhealthy if error annotation exists
- status is determined by endpoints
  - status is up if endpoints has pod/vm in targetref
  - status is unknown if endpoints has no pod/vm in targetref but has address
  - status is down if endpoints has no address