### PR TITLE
Update EnableVlanExtension in Subnet CR spec if it changed

### DIFF
--- a/pkg/controllers/subnet/subnet_poll.go
+++ b/pkg/controllers/subnet/subnet_poll.go
@@ -177,6 +177,7 @@ func (r *SubnetReconciler) hasStatusChanged(originalStatus, newStatus *v1alpha1.
 // hasSubnetSpecChanged checks if the subnet spec has changed
 func (r *SubnetReconciler) hasSubnetSpecChanged(originalSpec, newSpec *v1alpha1.SubnetSpec) bool {
 	if originalSpec.AdvancedConfig.ConnectivityState != newSpec.AdvancedConfig.ConnectivityState ||
+		originalSpec.AdvancedConfig.EnableVLANExtension != newSpec.AdvancedConfig.EnableVLANExtension ||
 		originalSpec.SubnetDHCPConfig.Mode != newSpec.SubnetDHCPConfig.Mode ||
 		!reflect.DeepEqual(originalSpec.AdvancedConfig.GatewayAddresses, newSpec.AdvancedConfig.GatewayAddresses) ||
 		!reflect.DeepEqual(originalSpec.AdvancedConfig.DHCPServerAddresses, newSpec.AdvancedConfig.DHCPServerAddresses) {

--- a/pkg/controllers/subnet/subnet_poll_test.go
+++ b/pkg/controllers/subnet/subnet_poll_test.go
@@ -56,6 +56,46 @@ func TestHasSubnetSpecChanged(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "EnableVLANExtension no changed",
+			originalSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{},
+			},
+			newSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					EnableVLANExtension: false,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "EnableVLANExtension changed from false to true",
+			originalSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					EnableVLANExtension: false,
+				},
+			},
+			newSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					EnableVLANExtension: true,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "EnableVLANExtension changed from true to false",
+			originalSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					EnableVLANExtension: true,
+				},
+			},
+			newSpec: &v1alpha1.SubnetSpec{
+				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+					EnableVLANExtension: false,
+				},
+			},
+			expected: true,
+		},
+		{
 			name: "DHCP Mode changed",
 			originalSpec: &v1alpha1.SubnetSpec{
 				AdvancedConfig: v1alpha1.SubnetAdvancedConfig{


### PR DESCRIPTION
If NSX subnet changes EnableVlanExtension, now it is not reflected in Subnet CR spec.
This patch checks EnableVlanExtension changes and update it in Subnet CR.

Bug number: 3569325