### PR TITLE
Fix race in SubnetPort UT

### DIFF
--- a/hack/test-unit.sh
+++ b/hack/test-unit.sh
@@ -163,7 +163,7 @@ FAILURE_DETAILS=""
 # Run the exact command from user's rule but capture output
 echo -e "${PURPLE}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo "Executing complete test command:"
-echo "GOARCH=amd64 KUBEBUILDER_ASSETS=${KUBEBUILDER_ASSETS} go test -gcflags=all=-l \\"
+echo "GOARCH=amd64 KUBEBUILDER_ASSETS=${KUBEBUILDER_ASSETS} go test -race -gcflags=all=-l \\"
 echo "  -coverpkg=\"${COVERPKG}\" \\"
 echo "  -covermode=atomic \\"
 echo "  -v -coverprofile $(pwd)/.coverage/coverage-unit.out "
@@ -174,7 +174,7 @@ echo -e "${PURPLE}${BOLD}━━━━━━━━━━━━━━━━━━�
 echo ""
 
 # Execute the command and capture both output and errors
-if GOARCH=amd64 KUBEBUILDER_ASSETS="$KUBEBUILDER_ASSETS" go test -gcflags=all=-l \
+if GOARCH=amd64 KUBEBUILDER_ASSETS="$KUBEBUILDER_ASSETS" go test -race -gcflags=all=-l \
     -coverpkg="$COVERPKG" -covermode=atomic \
     ${PACKAGES} -v -coverprofile "$(pwd)/.coverage/coverage-unit.out" 2>&1 | \
     tee "$TEMP_OUTPUT" | \

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -92,6 +92,7 @@ func InitializeSubnetPort(service servicecommon.Service, vpcService servicecommo
 	case <-wgDone:
 		break
 	case err := <-fatalErrors:
+		wg.Wait()
 		close(fatalErrors)
 		return subnetPortService, err
 	}

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -169,9 +169,9 @@ func Test_InitializeSubnetPort(t *testing.T) {
 		{
 			name: "searchResourceError",
 			prepareFunc: func(t *testing.T, s *common.Service, ctx context.Context) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethodSeq(s.NSXClient.QueryClient, "List", []gomonkey.OutputCell{
-					{Values: gomonkey.Params{model.SearchResponse{}, fmt.Errorf("mock error")}},
-					{Values: gomonkey.Params{model.SearchResponse{}, nil}}})
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(&fakeQueryClient{}), "List", func(_ *fakeQueryClient, _ string, _ *string, _ *string, _ *int64, _ *bool, _ *string) (model.SearchResponse, error) {
+					return model.SearchResponse{}, fmt.Errorf("mock error")
+				})
 				patches.ApplyMethodSeq(s.NSXClient.MacPoolsClient, "List", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{mp_model.MacPoolListResult{
 						Results: []mp_model.MacPool{
@@ -189,9 +189,9 @@ func Test_InitializeSubnetPort(t *testing.T) {
 		{
 			name: "success",
 			prepareFunc: func(t *testing.T, s *common.Service, ctx context.Context) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethodSeq(s.NSXClient.QueryClient, "List", []gomonkey.OutputCell{
-					{Values: gomonkey.Params{model.SearchResponse{}, nil}},
-					{Values: gomonkey.Params{model.SearchResponse{}, nil}}})
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(&fakeQueryClient{}), "List", func(_ *fakeQueryClient, _ string, _ *string, _ *string, _ *int64, _ *bool, _ *string) (model.SearchResponse, error) {
+					return model.SearchResponse{}, nil
+				})
 				return patches
 			},
 			wantErr: false,


### PR DESCRIPTION
The PR includes the 2 changes below:
- Avoid closing fatalErros channel before all go routines which may result in race in search calls.
- Replace the mock function for search without specifying number of calls.

Testing done:
After the fix, go test with -race can pass
```
go test -race github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport -gcflags=all=-l
ok  	github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport
```