### PR TITLE
AllocatePortFromSubnet should always return true for no ipam Subnet[skip ci]

### DIFF
--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -1464,6 +1464,16 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			} else {
 				assert.Nil(t, err)
 			}
+			if tt.expectedValue {
+				canAllocate, err = subnetPortService.AllocatePortFromSubnet(tt.subnet)
+				assert.Equal(t, tt.expectedValue, canAllocate)
+				if tt.expectedErr != "" {
+					assert.Contains(t, err.Error(), tt.expectedErr)
+				} else {
+					assert.Nil(t, err)
+				}
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
For static Subnet with staticIPAllocation enabled:false, AllocatePortFromSubnet should always return true instead of reading PortCountInfo from cache.

Testing Done:
On local testbed, 
1. create Subnet with staticIPAllocation enabled: false with subnet size 16
```
root@423b65a9731e776cfc977c648258b458 [ ~ ]# k -n test-exec-ns get subnet subnet-sample-c -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"Subnet","metadata":{"annotations":{},"name":"subnet-sample-c","namespace":"test-exec-ns"},"spec":{"accessMode":"Private","advancedConfig":{"staticIPAllocation":{"enabled":false}},"ipv4SubnetSize":16}}
  creationTimestamp: "2025-08-29T11:50:12Z"
  generation: 2
  name: subnet-sample-c
  namespace: test-exec-ns
  resourceVersion: "3395041"
  uid: 8756e531-b093-4129-be0e-ea3b6759e06a
spec:
  accessMode: Private
  advancedConfig:
    connectivityState: Connected
    enableVLANExtension: false
    staticIPAllocation:
      enabled: false
  ipv4SubnetSize: 16
  subnetDHCPConfig:
    dhcpServerAdditionalConfig: {}
  vpcName: project-quality:test-exec-ns_ocvtx
status:
  conditions:
  - lastTransitionTime: "2025-08-29T11:50:14Z"
    message: NSX Subnet with DHCPDeactivated has been successfully created/updated
    reason: SubnetReady
    status: "True"
    type: Ready
  gatewayAddresses:
  - 172.26.0.65/28
  networkAddresses:
  - 172.26.0.64/28
  shared: false
  vlanExtension: {}
```
2. create Subnetports on the Subnet
```
root@423b65a9731e776cfc977c648258b458 [ ~ ]# k -n test-exec-ns get subnetport subnetport-sample-1 -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetPort","metadata":{"annotations":{},"name":"subnetport-sample-1","namespace":"test-exec-ns"},"spec":{"subnet":"subnet-sample-c"}}
  creationTimestamp: "2025-08-29T11:52:22Z"
  generation: 1
  name: subnetport-sample-1
  namespace: test-exec-ns
  resourceVersion: "3396378"
  uid: 77eb4d6e-0589-4ea7-925b-09d348903454
spec:
  subnet: subnet-sample-c
status:
  attachment:
    id: 93617f98-bcdb-53f5-9df1-c47c5775d184
  conditions:
  - lastTransitionTime: "2025-08-29T11:52:24Z"
    message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    dhcpDeactivatedOnSubnet: true
    ipAddresses:
    - gateway: 172.26.0.65
    logicalSwitchUUID: ee4ecbd4-ed0b-4aea-80cf-d49465be3339
```
Create total 17 Subnetports on the Subnet
```
root@423b65a9731e776cfc977c648258b458 [ ~ ]# k -n test-exec-ns get subnetport
NAME                   VIFID                                  IPADDRESS   MACADDRESS
subnetport-sample-1    93617f98-bcdb-53f5-9df1-c47c5775d184
subnetport-sample-10   6f790112-1629-5d7b-a7d5-7ed5070ac186
subnetport-sample-11   a0face58-d6ed-5363-b2da-f4aee52405ad
subnetport-sample-12   87da3bd6-87c0-5333-addd-a7c7714b8e24
subnetport-sample-13   2f770cef-2ebb-5487-b96c-70aa72b2b5eb
subnetport-sample-14   491b08c8-94c8-53d0-824c-adc485ff789a
subnetport-sample-15   a0a6e699-6892-56e2-aae8-75b4ae9fe639
subnetport-sample-16   de1161ca-41dc-54e8-8ef5-7dd490063bb4
subnetport-sample-17   83eedfc6-11c4-5d57-9f8c-69cf638238c8
subnetport-sample-2    489e44fe-d15d-5f5d-8b7e-061ebbb2242e
subnetport-sample-3    fffba423-679d-5bac-aa96-b64577ae5ae4
subnetport-sample-4    de117c1c-c384-5f6f-862b-8ee42137d0cc
subnetport-sample-5    fe6f990e-13d0-5ac3-846f-66e401874dfc
subnetport-sample-6    beeb8da6-912f-5fd6-b84e-02cccba415bc
subnetport-sample-7    bdc12059-2a64-59d0-aa40-e1e67aa3ba0e
subnetport-sample-8    bddf815f-c6a9-5bf4-b4a6-5482b484793c
subnetport-sample-9    39872d65-6af5-5db1-a6f4-a11d25499dbe
```
Checked on NSX all subnet ports have been created, for example "subnetport-sample-10_ocvtx":
```
GET https://10.162.109.26/policy/api/v1/orgs/default/projects/project-quality/vpcs/test-exec-ns_ocvtx/subnets/subnet-sample-c_ocvtx/ports/subnetport-sample-10_ocvtx/
{
  "resource_type": "VpcSubnetPort",
  "id": "subnetport-sample-10_ocvtx",
  "display_name": "subnetport-sample-10",
  "tags": [
    {
      "scope": "nsx-op/cluster",
      "tag": "b94495ab-2ca7-4034-8696-8de109647ffa"
    },
    {
      "scope": "nsx-op/version",
      "tag": "1.0.0"
    },
    {
      "scope": "nsx-op/vm_namespace",
      "tag": "test-exec-ns"
    },
    {
      "scope": "nsx-op/vm_namespace_uid",
      "tag": "1f9dadae-1fab-46ab-8797-716d0458cf5c"
    },
    {
      "scope": "nsx-op/subnetport_name",
      "tag": "subnetport-sample-10"
    },
    {
      "scope": "nsx-op/subnetport_uid",
      "tag": "d5d44f2b-228c-4844-90c5-48b5ee0c1bfe"
    }
  ],
  "path": "/orgs/default/projects/project-quality/vpcs/test-exec-ns_ocvtx/subnets/subnet-sample-c_ocvtx/ports/subnetport-sample-10_ocvtx",
  "relative_path": "subnetport-sample-10_ocvtx",
  "parent_path": "/orgs/default/projects/project-quality/vpcs/test-exec-ns_ocvtx/subnets/subnet-sample-c_ocvtx",
  "remote_path": "",
  "unique_id": "adb8a427-adae-48ce-b165-b7bac2eead5d",
  "realization_id": "adb8a427-adae-48ce-b165-b7bac2eead5d",
  "owner_id": "e608d994-684a-4726-9f2a-10febcb0bc2d",
  "marked_for_delete": false,
  "overridden": false,
  "attachment": {
    "id": "6f790112-1629-5d7b-a7d5-7ed5070ac186",
    "type": "STATIC",
    "allocate_addresses": "NONE",
    "traffic_tag": 0,
    "hyperbus_mode": "DISABLE"
  },
  "admin_state": "UP",
  "tofu_version": 0,
  "_system_owned": false,
  "_protection": "REQUIRE_OVERRIDE",
  "_create_time": 1756468563526,
  "_create_user": "wcp-cluster-user-b94495ab-2ca7-4034-8696-8de109647ffa-b49e114b-63bd-4618-8915-c04d1386291c",
  "_last_modified_time": 1756468563526,
  "_last_modified_user": "wcp-cluster-user-b94495ab-2ca7-4034-8696-8de109647ffa-b49e114b-63bd-4618-8915-c04d1386291c",
  "_revision": 0
}
```

Bug: 3569804