### PR TITLE
Remove TLS configuration from webhook server

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"os"
@@ -216,12 +215,6 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			hookServer = webhook.NewServer(webhook.Options{
 				Port:    config.WebhookServerPort,
 				CertDir: config.WebhookCertDir,
-				TLSOpts: []func(*tls.Config){
-					func(cfg *tls.Config) {
-						cfg.MinVersion = tls.VersionTLS12
-						cfg.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA}
-					},
-				},
 			})
 			if err := mgr.Add(hookServer); err != nil {
 				log.Error(err, "Failed to add hook server")


### PR DESCRIPTION
Align with https://gitreview-vcfnet.lvn.broadcom.net/c/nsx-ujo/+/745757 
`crypto/tls/fipsonly` will ensure FIPS compliance