### PR TITLE
Update api doc for SubnetIPReservation.spec.subnet

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetipreservations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetipreservations.yaml
@@ -62,7 +62,9 @@ spec:
                 - message: NumberOfIPs is immutable
                   rule: self == oldSelf
               subnet:
-                description: Subnet specifies the Subnet to reserve IPs from.
+                description: |-
+                  Subnet specifies the Subnet to reserve IPs from.
+                  The Subnet needs to have static IP allocation activated.
                 type: string
                 x-kubernetes-validations:
                 - message: Subnet is immutable

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -703,9 +703,11 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `connectivityState` _[ConnectivityState](#connectivitystate)_ | Connectivity status of the Subnet from other Subnets of the VPC.<br />Default value is "Connected". | Connected | Enum: [Connected Disconnected] <br /> |
+| `connectivityState` _[ConnectivityState](#connectivitystate)_ | Connectivity status of the Subnet from other Subnets of the VPC.<br />The default value is "Connected". | Connected | Enum: [Connected Disconnected] <br /> |
 | `enableVLANExtension` _boolean_ | Whether this Subnet enabled VLAN extension.<br />Default value is false. | false |  |
 | `staticIPAllocation` _[StaticIPAllocation](#staticipallocation)_ | Static IP allocation for VPC Subnet Ports. |  |  |
+| `gatewayAddresses` _string array_ | GatewayAddresses specifies custom gateway IP addresses for the Subnet. |  | MaxItems: 1 <br /> |
+| `dhcpServerAddresses` _string array_ | DHCPServerAddresses specifies custom DHCP server IP addresses for the Subnet. |  | MaxItems: 1 <br /> |
 
 
 #### SubnetConnectionBindingMap
@@ -766,7 +768,7 @@ _Appears in:_
 
 
 
-SubnetDHCPConfig is DHCP configuration for Subnet.
+SubnetDHCPConfig is a DHCP configuration for Subnet.
 
 
 
@@ -812,7 +814,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `subnet` _string_ | Subnet specifies the Subnet to reserve IPs from. |  | Required: \{\} <br /> |
+| `subnet` _string_ | Subnet specifies the Subnet to reserve IPs from.<br />The Subnet needs to have static IP allocation activated. |  | Required: \{\} <br /> |
 | `numberOfIPs` _integer_ | NumberOfIPs defines number of IPs requested to be reserved. |  | Maximum: 100 <br />Minimum: 1 <br />Required: \{\} <br /> |
 
 

--- a/pkg/apis/vpc/v1alpha1/subnetipreservation_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetipreservation_types.go
@@ -10,6 +10,7 @@ import (
 // SubnetIPReservationSpec defines the desired state of SubnetIPReservation
 type SubnetIPReservationSpec struct {
 	// Subnet specifies the Subnet to reserve IPs from.
+	// The Subnet needs to have static IP allocation activated.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Subnet is immutable"
 	Subnet string `json:"subnet"`


### PR DESCRIPTION
Add API doc to indicate user that SubnetIPReservation CR can only be created on Subnet with subnet.advancedConfig.staticIPAllocation.enabled: true. User can also check error message under SubnetIPReservation.status if Subnet does not meet the above requirement.