### PR TITLE
Add inventory check to health check

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -123,7 +123,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 	}
 
 	// Initialize and start the system health reporter
-	if cf.CoeConfig.EnableVPCNetwork {
+	if cf.CoeConfig.EnableVPCNetwork && cf.EnableInventory {
 		health.Start(nsxClient, cf, mgr.GetClient())
 	}
 


### PR DESCRIPTION
Test Done

Manually replace image on live testbed

Only when cf.CoeConfig.EnableVPCNetwork and cf.EnableInventory  are true, the health checker report will run.