### PR TITLE
Use HAPI for SubnetIPReservation cleanup

### DIFF
--- a/cmd_clean/main.go
+++ b/cmd_clean/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"time"
 
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
 	"github.com/vmware-tanzu/nsx-operator/pkg/clean"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
@@ -80,6 +82,7 @@ func main() {
 	defer cancel()
 	log = logger.ZapCustomLogger(cf.DefaultConfig.Debug, config.LogLevel)
 	logger.Log = log
+	logf.SetLogger(log.Logger)
 	err := clean.Clean(ctx, cf, &log.Logger, cf.DefaultConfig.Debug, config.LogLevel)
 	if err != nil {
 		log.Error(err, "Failed to clean nsx resources")

--- a/pkg/nsx/services/subnetipreservation/cleanup_test.go
+++ b/pkg/nsx/services/subnetipreservation/cleanup_test.go
@@ -4,17 +4,27 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
+	orgroot_mocks "github.com/vmware-tanzu/nsx-operator/pkg/mock/orgrootclient"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
 func TestCleanupBeforeVPCDeletion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRootClient := orgroot_mocks.NewMockOrgRootClient(ctrl)
+	mockRootClient.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil)
+
 	service := createFakeService()
+	builder, _ := common.PolicyPathVpcSubnetDynamicIPReservation.NewPolicyTreeBuilder()
+	service.builder = builder
+	service.NSXClient.OrgRootClient = mockRootClient
 	service.IPReservationStore.Apply(&model.DynamicIpAddressReservation{
-		Id:   common.String("ipr-1"),
-		Path: common.String("/orgs/default/projects/default/vpcs/ns-1/subnets/subnet-1/dynamic-ip-reservations/ipr-1"),
+		Id: common.String("ipr-1"),
 	})
 
 	err := service.CleanupBeforeVPCDeletion(context.TODO())


### PR DESCRIPTION
Add back using HAPI for SubnetIPReservation cleanup as NSX side now fix the HAPI bug

Testing done:
Ran cleanup and got the following log
`2025-09-22 02:54:32.000 INFO main.go:86 Cleanup NSX resources successfully`

Observed the NSX Subnet IPReservations are deleted