### PR TITLE
Add EnableSha check to system health reporter initialization

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -123,7 +123,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 	}
 
 	// Initialize and start the system health reporter
-	if cf.CoeConfig.EnableVPCNetwork && cf.EnableInventory {
+	if cf.CoeConfig.EnableVPCNetwork && cf.EnableInventory && cf.CoeConfig.EnableSha {
 		health.Start(nsxClient, cf, mgr.GetClient())
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,6 +98,7 @@ type DefaultConfig struct {
 type CoeConfig struct {
 	Cluster          string `ini:"cluster"`
 	EnableVPCNetwork bool   `ini:"enable_vpc_network"`
+	EnableSha        bool   `ini:"enable_sha"`
 }
 
 type NsxConfig struct {


### PR DESCRIPTION
Test done on live testbed, only when 

	cf.CoeConfig.EnableVPCNetwork && cf.EnableInventory && cf.CoeConfig.EnableSha

will trigger health report.

```
nsx-ncp-544799784d-6b8wg nsx-operator 2025-09-22 07:30:51.000 INFO main.go:120 Successfully generated webhook certificates
nsx-ncp-544799784d-6b8wg nsx-operator 2025-09-22 07:30:51.000 INFO healthchecker.go:262 System health reporter started
nsx-ncp-544799784d-6b8wg nsx-operator 2025-09-22 07:30:51.000 INFO client.go:384 Checking NSX license
```