### PR TITLE
Enhancement on the SubnetPort realization performance

### DIFF
--- a/pkg/controllers/namespace/subnet_share_controller.go
+++ b/pkg/controllers/namespace/subnet_share_controller.go
@@ -76,7 +76,7 @@ func (r *NamespaceReconciler) createSharedSubnetCR(ctx context.Context, ns strin
 		return err
 	}
 
-	_, err = r.SubnetService.GetNSXSubnetFromCacheOrAPI(associatedName)
+	_, err = r.SubnetService.GetNSXSubnetFromCacheOrAPI(associatedName, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -279,7 +279,7 @@ func (r *SubnetReconciler) handleSharedSubnet(ctx context.Context, subnetCR *v1a
 	log.Info("Subnet has associated-resource annotation, skipping NSX Subnet creation", "Subnet", namespacedName, "AssociatedResource", associatedResource)
 
 	// Get NSX subnet from cache or API
-	nsxSubnet, err := r.SubnetService.GetNSXSubnetFromCacheOrAPI(associatedResource)
+	nsxSubnet, err := r.SubnetService.GetNSXSubnetFromCacheOrAPI(associatedResource, false)
 	if err != nil {
 		r.updateSharedSubnetWithError(ctx, namespacedName, err, "Failed to get NSX Subnet for associated resource")
 		return ResultRequeue, err

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -108,7 +108,9 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 	req := controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "dummy", Name: "dummy"}}
 	patchesGetSubnetByPath := gomonkey.ApplyFunc((*subnet.SubnetService).GetSubnetByPath,
 		func(s *subnet.SubnetService, nsxSubnetPath string, sharedSubnet bool) (*model.VpcSubnet, error) {
-			nsxSubnet := &model.VpcSubnet{}
+			nsxSubnet := &model.VpcSubnet{
+				Id: ptr.To("subnet-1"),
+			}
 			return nsxSubnet, nil
 		})
 	defer patchesGetSubnetByPath.Reset()
@@ -1159,7 +1161,7 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 
 func TestSubnetPortReconciler_updateSubnetStatusOnSubnetPort(t *testing.T) {
 	patchesGetGatewayPrefixForSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).GetGatewayPrefixForSubnetPort,
-		func(s *subnetport.SubnetPortService, obj *v1alpha1.SubnetPort, nsxSubnetPath string) (string, int, error) {
+		func(s *subnetport.SubnetPortService, obj *model.VpcSubnet) (string, int, error) {
 			return "10.0.0.1", 28, nil
 		})
 	defer patchesGetGatewayPrefixForSubnetPort.Reset()
@@ -1176,7 +1178,7 @@ func TestSubnetPortReconciler_updateSubnetStatusOnSubnetPort(t *testing.T) {
 		SubnetPortService: &subnetport.SubnetPortService{},
 		SubnetService:     &subnet.SubnetService{},
 	}
-	err := r.updateSubnetStatusOnSubnetPort(sp, "subnet-path-1", &model.VpcSubnet{
+	err := r.updateSubnetStatusOnSubnetPort(sp, &model.VpcSubnet{
 		RealizationId: servicecommon.String("realization-id-1"),
 	})
 	assert.Nil(t, err)

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -99,7 +99,7 @@ func (m *MockSubnetServiceProvider) GetSubnetByCR(subnet *v1alpha1.Subnet) (*mod
 	return nil, nil
 }
 
-func (m *MockSubnetServiceProvider) GetNSXSubnetFromCacheOrAPI(associate string) (*model.VpcSubnet, error) {
+func (m *MockSubnetServiceProvider) GetNSXSubnetFromCacheOrAPI(associate string, forceAPI bool) (*model.VpcSubnet, error) {
 	return nil, nil
 }
 

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -33,7 +33,7 @@ type SubnetServiceProvider interface {
 	ListSubnetByName(ns, name string) []*model.VpcSubnet
 	ListSubnetBySubnetSetName(ns, subnetSetName string) []*model.VpcSubnet
 	GetSubnetByCR(subnet *v1alpha1.Subnet) (*model.VpcSubnet, error)
-	GetNSXSubnetFromCacheOrAPI(associatedResource string) (*model.VpcSubnet, error)
+	GetNSXSubnetFromCacheOrAPI(associatedResource string, forceAPI bool) (*model.VpcSubnet, error)
 }
 
 type SubnetPortServiceProvider interface {

--- a/pkg/nsx/services/ipblocksinfo/ipblocksinfo.go
+++ b/pkg/nsx/services/ipblocksinfo/ipblocksinfo.go
@@ -252,7 +252,7 @@ func (s *IPBlocksInfoService) getSharedSubnetsCIDRs(vpcConfigList []v1alpha1.VPC
 			continue
 		}
 		associate := fmt.Sprintf("%s:%s:%s", vpcInfo.ProjectID, vpcInfo.VPCID, vpcInfo.ID)
-		subnet, err := s.subnetService.GetNSXSubnetFromCacheOrAPI(associate)
+		subnet, err := s.subnetService.GetNSXSubnetFromCacheOrAPI(associate, false)
 		if err != nil {
 			log.Warn("failed to get nsx subnet: err", err, "subnetPath", associate)
 			continue

--- a/pkg/nsx/services/ipblocksinfo/ipblocksinfo_test.go
+++ b/pkg/nsx/services/ipblocksinfo/ipblocksinfo_test.go
@@ -510,7 +510,7 @@ func TestIPBlocksInfoService_getSharedSubnetsCIDRs(t *testing.T) {
 		associatePrivateTgwSubnet = "default:vpc1:private-tgw-subnet"
 	)
 
-	getSubnetPatch := gomonkey.ApplyMethod(reflect.TypeOf(service.subnetService), "GetNSXSubnetFromCacheOrAPI", func(_ *subnet.SubnetService, associate string) (*model.VpcSubnet, error) {
+	getSubnetPatch := gomonkey.ApplyMethod(reflect.TypeOf(service.subnetService), "GetNSXSubnetFromCacheOrAPI", func(_ *subnet.SubnetService, associate string, forceAPI bool) (*model.VpcSubnet, error) {
 		public := "Public"
 		privateTgw := "Private_TGW"
 
@@ -574,7 +574,7 @@ func TestIPBlocksInfoService_getSharedSubnetsCIDRs(t *testing.T) {
 
 	// Test: SearchResource returns error
 	getSubnetPatch.Reset()
-	getSubnetPatch = gomonkey.ApplyMethod(reflect.TypeOf(service.subnetService), "GetNSXSubnetFromCacheOrAPI", func(_ *subnet.SubnetService, associate string) (*model.VpcSubnet, error) {
+	getSubnetPatch = gomonkey.ApplyMethod(reflect.TypeOf(service.subnetService), "GetNSXSubnetFromCacheOrAPI", func(_ *subnet.SubnetService, associate string, forceAPI bool) (*model.VpcSubnet, error) {
 		return nil, fmt.Errorf("get subnet error")
 	})
 	defer getSubnetPatch.Reset()

--- a/pkg/nsx/services/subnet/subnet_test.go
+++ b/pkg/nsx/services/subnet/subnet_test.go
@@ -380,7 +380,7 @@ func TestSubnetService_GetSubnetByCR(t *testing.T) {
 		{
 			name: "sharedSubnet",
 			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc((*SubnetService).GetNSXSubnetFromCacheOrAPI, func(s *SubnetService, associatedResource string) (*model.VpcSubnet, error) {
+				patches := gomonkey.ApplyFunc((*SubnetService).GetNSXSubnetFromCacheOrAPI, func(s *SubnetService, associatedResource string, forceAPI bool) (*model.VpcSubnet, error) {
 					return &model.VpcSubnet{Id: common.String("subnet-1")}, nil
 				})
 				return patches
@@ -472,7 +472,7 @@ func TestSubnetService_GetSubnetByPath(t *testing.T) {
 		{
 			name: "sharedSubnet",
 			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc((*SubnetService).GetNSXSubnetFromCacheOrAPI, func(s *SubnetService, associatedResource string) (*model.VpcSubnet, error) {
+				patches := gomonkey.ApplyFunc((*SubnetService).GetNSXSubnetFromCacheOrAPI, func(s *SubnetService, associatedResource string, forceAPI bool) (*model.VpcSubnet, error) {
 					return &model.VpcSubnet{Id: common.String("subnet-1")}, nil
 				})
 				return patches
@@ -1433,7 +1433,7 @@ func TestGetNSXSubnetFromCacheOrAPI(t *testing.T) {
 			}
 
 			// Call the function being tested
-			subnet, err := service.GetNSXSubnetFromCacheOrAPI(tt.associatedResource)
+			subnet, err := service.GetNSXSubnetFromCacheOrAPI(tt.associatedResource, false)
 
 			// Check the result
 			if tt.expectedError != "" {

--- a/test/e2e/nsx_subnet_test.go
+++ b/test/e2e/nsx_subnet_test.go
@@ -515,17 +515,20 @@ func conditionSubnetPortRealized(subnetPort *v1alpha1.SubnetPort, args ...string
 	if len(args) > 0 {
 		expectedIP := args[0]
 		if len(subnetPort.Status.NetworkInterfaceConfig.IPAddresses) == 0 || !strings.Contains(subnetPort.Status.NetworkInterfaceConfig.IPAddresses[0].IPAddress, expectedIP+"/") {
+			log.Debug("SubnetPort IP address does not match", "expectedIP", expectedIP, "subnetPort.Status.NetworkInterfaceConfig.IPAddresses", subnetPort.Status.NetworkInterfaceConfig.IPAddresses)
 			return false, nil
 		}
 	}
 	if len(args) == 2 {
 		expectedMAC := args[1]
 		if !strings.Contains(subnetPort.Status.NetworkInterfaceConfig.MACAddress, expectedMAC) {
+			log.Debug("SubnetPort MAC address does not match", "expected", expectedMAC, "actual", subnetPort.Status.NetworkInterfaceConfig.MACAddress)
 			return false, nil
 		}
 	}
 	for _, con := range subnetPort.Status.Conditions {
 		if con.Type == v1alpha1.Ready && con.Status == corev1.ConditionTrue {
+			log.Debug("SubnetPort is ready", "subnetPort", subnetPort.Name)
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Enhancement on the SubnetPort realization performance
1. Avoid the uncessary SubnetPort state check if the stauts indicates that
the port has been realized successfully.
2. Get the Subnet's gateway address from Subnet store instead of Subnet
status API to reduce the frequency of NSX API calls.

Testing done:
1. Created 3000 ports in the single Subnet (ipv4SubnetSize=4096), it took
34 minutes to complete the realization(previously the time is > 90 minutes).
2. Created 3000 ports in the defualt SubnetSet (ipv4SubnetSize=32), it took
36 minutes to complete the realization.