### PR TITLE
Decide network errors by the service itself skip ci

### DIFF
--- a/pkg/nsx/services/inventory/build_test.go
+++ b/pkg/nsx/services/inventory/build_test.go
@@ -1605,7 +1605,7 @@ func TestBuildService(t *testing.T) {
 		assert.Equal(t, NetworkStatusUnhealthy, containerApplication.NetworkStatus)
 
 		// Verify network errors
-		assert.Equal(t, 4, len(containerApplication.NetworkErrors))
+		assert.Equal(t, 3, len(containerApplication.NetworkErrors))
 
 		// Create a map of error messages for easier verification
 		errorMessages := make(map[string]bool)

--- a/pkg/nsx/services/inventory/builder.go
+++ b/pkg/nsx/services/inventory/builder.go
@@ -433,18 +433,8 @@ func (s *InventoryService) determineServiceStatus(podIDs []string, hasAddr bool,
 		status = InventoryStatusUp
 	} else if hasAddr {
 		status = InventoryStatusUnknown
-		errorMessage := "Service endpoint status is unknown"
-		uniqueErrors[errorMessage] = true
-		*networkErrors = append(*networkErrors, common.NetworkError{
-			ErrorMessage: errorMessage,
-		})
 	} else {
 		status = InventoryStatusDown
-		errorMessage := "Failed to get endpoints for Service"
-		uniqueErrors[errorMessage] = true
-		*networkErrors = append(*networkErrors, common.NetworkError{
-			ErrorMessage: errorMessage,
-		})
 	}
 
 	return status, netStatus


### PR DESCRIPTION
Eliminate the error message generated by endpoints for the service to ensure compliance with NCP requirements.

Change-Id: I2e586753a950458a4ab0289ea30e068157338192