### PR TITLE
Add http status_code 401 support

### DIFF
--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -215,6 +215,12 @@ var (
 			"403": &InvalidCredentials{},
 			"505": &InvalidLicense{},
 		},
+		"401": // http.StatusUnauthorized
+		{
+			"98":  &BadXSRFToken{},
+			"403": &InvalidCredentials{},
+			"505": &InvalidLicense{},
+		},
 	}
 
 	errorTable1 = map[string]NsxError{


### PR DESCRIPTION
NSX has upgraded that Spring security. NSX will return 401 instead of 403 when the JWT token expired.
Handle status code 401 to apply for JWT again