### PR TITLE
Refactor the logic for port's allocate_addresses and fix issues in some cases

### DIFF
--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -69,6 +69,8 @@ func TestBuildSubnetPort(t *testing.T) {
 		expectedError error
 	}{
 		{
+			// DHCP/DHCPRelay - Y; StaticIPAllocation Enabled - N;
+			// AddressBinding exists - N
 			name: "build-NSX-port-for-subnetport",
 			obj: &v1alpha1.SubnetPort{
 				TypeMeta: metav1.TypeMeta{
@@ -125,6 +127,8 @@ func TestBuildSubnetPort(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			// DHCP/DHCPRelay - Y; StaticIPAllocation Enabled - N;
+			// AddressBinding exists - Y (restore); MAC in NSX MAC pool - N
 			name: "build-NSX-port-for-restore-subnetport",
 			obj: &v1alpha1.SubnetPort{
 				TypeMeta: metav1.TypeMeta{
@@ -196,6 +200,8 @@ func TestBuildSubnetPort(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - Y;
+			// AddressBinding exists - Y; MAC in NSX MAC pool - N
 			name: "build-NSX-port-for-subnetport-outside-nsx-mac-pool",
 			obj: &v1alpha1.SubnetPort{
 				ObjectMeta: metav1.ObjectMeta{
@@ -268,6 +274,8 @@ func TestBuildSubnetPort(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - Y;
+			// AddressBinding exists - Y; MAC in NSX MAC pool - Y
 			name: "build-NSX-port-for-subnetport-inside-nsx-mac-pool",
 			obj: &v1alpha1.SubnetPort{
 				ObjectMeta: metav1.ObjectMeta{
@@ -340,6 +348,8 @@ func TestBuildSubnetPort(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - Y;
+			// AddressBinding exists - N (pod)
 			name: "build-NSX-port-for-pod",
 			obj: &corev1.Pod{
 				TypeMeta: metav1.TypeMeta{
@@ -353,8 +363,13 @@ func TestBuildSubnetPort(t *testing.T) {
 				},
 			},
 			nsxSubnet: &model.VpcSubnet{
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					StaticIpAllocation: &model.StaticIpAllocation{
+						Enabled: common.Bool(true),
+					},
+				},
 				SubnetDhcpConfig: &model.SubnetDhcpConfig{
-					Mode: common.String("DHCP_SERVER"),
+					Mode: common.String("DHCP_DEACTIVATED"),
 				},
 				Path: common.String("fake_path"),
 			},
@@ -399,7 +414,7 @@ func TestBuildSubnetPort(t *testing.T) {
 				Path:       common.String("fake_path/ports/fake_pod_phoia"),
 				ParentPath: common.String("fake_path"),
 				Attachment: &model.PortAttachment{
-					AllocateAddresses: common.String("NONE"),
+					AllocateAddresses: common.String("BOTH"),
 					Type_:             common.String("STATIC"),
 					TrafficTag:        common.Int64(0),
 					AppId:             common.String("c5db1800-ce4c-11de-a935-8105ba7ace78"),
@@ -409,6 +424,8 @@ func TestBuildSubnetPort(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - Y;
+			// AddressBinding exists - N (restore pod)
 			name: "build-NSX-port-for-restore-pod",
 			obj: &corev1.Pod{
 				TypeMeta: metav1.TypeMeta{
@@ -419,7 +436,7 @@ func TestBuildSubnetPort(t *testing.T) {
 					UID:         "c5db1800-ce4c-11de-a935-8105ba7ace78",
 					Name:        "fake_pod",
 					Namespace:   "fake_ns",
-					Annotations: map[string]string{common.AnnotationPodMAC: "11:22:33:44:55:66"},
+					Annotations: map[string]string{common.AnnotationPodMAC: "04:50:56:00:fa:00"},
 				},
 				Status: corev1.PodStatus{
 					PodIP: "10.0.0.1",
@@ -427,7 +444,12 @@ func TestBuildSubnetPort(t *testing.T) {
 			},
 			nsxSubnet: &model.VpcSubnet{
 				SubnetDhcpConfig: &model.SubnetDhcpConfig{
-					Mode: common.String("DHCP_SERVER"),
+					Mode: common.String("DHCP_DEACTIVATED"),
+				},
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					StaticIpAllocation: &model.StaticIpAllocation{
+						Enabled: common.Bool(true),
+					},
 				},
 				Path: common.String("fake_path"),
 			},
@@ -472,7 +494,7 @@ func TestBuildSubnetPort(t *testing.T) {
 				Path:       common.String("fake_path/ports/fake_pod_phoia"),
 				ParentPath: common.String("fake_path"),
 				Attachment: &model.PortAttachment{
-					AllocateAddresses: common.String("NONE"),
+					AllocateAddresses: common.String("BOTH"),
 					Type_:             common.String("STATIC"),
 					TrafficTag:        common.Int64(0),
 					AppId:             common.String("c5db1800-ce4c-11de-a935-8105ba7ace78"),
@@ -481,7 +503,7 @@ func TestBuildSubnetPort(t *testing.T) {
 				AddressBindings: []model.PortAddressBindingEntry{
 					{
 						IpAddress:  common.String("10.0.0.1"),
-						MacAddress: common.String("11:22:33:44:55:66"),
+						MacAddress: common.String("04:50:56:00:fa:00"),
 					},
 				},
 			},
@@ -489,6 +511,8 @@ func TestBuildSubnetPort(t *testing.T) {
 			restore:       true,
 		},
 		{
+			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - N;
+			// AddressBinding exists - N
 			name: "build-NSX-port-for-subnetport-no-ip",
 			obj: &v1alpha1.SubnetPort{
 				TypeMeta: metav1.TypeMeta{
@@ -550,6 +574,8 @@ func TestBuildSubnetPort(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - N;
+			// AddressBinding exists - N
 			name: "build-NSX-port-for-subnetport-no-ip-2",
 			obj: &v1alpha1.SubnetPort{
 				TypeMeta: metav1.TypeMeta{
@@ -604,6 +630,228 @@ func TestBuildSubnetPort(t *testing.T) {
 					AllocateAddresses: common.String("NONE"),
 					Type_:             common.String("STATIC"),
 					TrafficTag:        common.Int64(0),
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - N;
+			// AddressBinding exists - Y; MAC in NSX MAC pool - Y
+			name: "build-NSX-port-in-subnet-no-ip-but-binding-in-nsx-mac-pool",
+			obj: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
+					Name:      "fake_subnetport",
+					Namespace: "fake_ns",
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					Subnet: "subnet-1",
+					AddressBindings: []v1alpha1.PortAddressBinding{
+						{
+							IPAddress:  "192.168.1.100",
+							MACAddress: "04:50:56:00:fa:00",
+						},
+					},
+				},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				SubnetDhcpConfig: &model.SubnetDhcpConfig{
+					Mode: common.String("DHCP_DEACTIVATED"),
+				},
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					StaticIpAllocation: &model.StaticIpAllocation{
+						Enabled: common.Bool(false),
+					},
+				},
+				Path: common.String("fake_path"),
+			},
+			contextID: "fake_context_id",
+			labelTags: nil,
+			expectedPort: &model.VpcSubnetPort{
+				DisplayName: common.String("fake_subnetport"),
+				Id:          common.String("fake_subnetport_phoia"),
+				Tags: []model.Tag{
+					{
+						Scope: common.String("nsx-op/cluster"),
+						Tag:   common.String("fake_cluster"),
+					},
+					{
+						Scope: common.String("nsx-op/version"),
+						Tag:   common.String("1.0.0"),
+					},
+					{
+						Scope: common.String("nsx-op/namespace"),
+						Tag:   common.String("fake_ns"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_name"),
+						Tag:   common.String("fake_subnetport"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_uid"),
+						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+					},
+				},
+				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
+				ParentPath: common.String("fake_path"),
+				Attachment: &model.PortAttachment{
+					AllocateAddresses: common.String("MAC_POOL"),
+					Type_:             common.String("STATIC"),
+					TrafficTag:        common.Int64(0),
+				},
+				AddressBindings: []model.PortAddressBindingEntry{
+					{
+						IpAddress:  common.String("192.168.1.100"),
+						MacAddress: common.String("04:50:56:00:fa:00"),
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - N;
+			// AddressBinding exists - Y; MAC in NSX MAC pool - N
+			name: "build-NSX-port-in-subnet-no-ip-but-binding-outside-nsx-mac-pool",
+			obj: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
+					Name:      "fake_subnetport",
+					Namespace: "fake_ns",
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					Subnet: "subnet-1",
+					AddressBindings: []v1alpha1.PortAddressBinding{
+						{
+							IPAddress:  "192.168.1.100",
+							MACAddress: "00:50:56:00:fa:00",
+						},
+					},
+				},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				SubnetDhcpConfig: &model.SubnetDhcpConfig{
+					Mode: common.String("DHCP_DEACTIVATED"),
+				},
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					StaticIpAllocation: &model.StaticIpAllocation{
+						Enabled: common.Bool(false),
+					},
+				},
+				Path: common.String("fake_path"),
+			},
+			contextID: "fake_context_id",
+			labelTags: nil,
+			expectedPort: &model.VpcSubnetPort{
+				DisplayName: common.String("fake_subnetport"),
+				Id:          common.String("fake_subnetport_phoia"),
+				Tags: []model.Tag{
+					{
+						Scope: common.String("nsx-op/cluster"),
+						Tag:   common.String("fake_cluster"),
+					},
+					{
+						Scope: common.String("nsx-op/version"),
+						Tag:   common.String("1.0.0"),
+					},
+					{
+						Scope: common.String("nsx-op/namespace"),
+						Tag:   common.String("fake_ns"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_name"),
+						Tag:   common.String("fake_subnetport"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_uid"),
+						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+					},
+				},
+				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
+				ParentPath: common.String("fake_path"),
+				Attachment: &model.PortAttachment{
+					AllocateAddresses: common.String("NONE"),
+					Type_:             common.String("STATIC"),
+					TrafficTag:        common.Int64(0),
+				},
+				AddressBindings: []model.PortAddressBindingEntry{
+					{
+						IpAddress:  common.String("192.168.1.100"),
+						MacAddress: common.String("00:50:56:00:fa:00"),
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			// DHCP/DHCPRelay - Y; StaticIPAllocation Enabled - N;
+			// AddressBinding exists - Y; MAC in NSX MAC pool - Y
+			name: "build-NSX-port-in-subnet-dhcp-with-binding-in-nsx-mac-pool",
+			obj: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
+					Name:      "fake_subnetport",
+					Namespace: "fake_ns",
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					Subnet: "subnet-1",
+					AddressBindings: []v1alpha1.PortAddressBinding{
+						{
+							IPAddress:  "192.168.1.100",
+							MACAddress: "04:50:56:00:fa:00",
+						},
+					},
+				},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				SubnetDhcpConfig: &model.SubnetDhcpConfig{
+					Mode: common.String("DHCP_DEACTIVATED"),
+				},
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					StaticIpAllocation: &model.StaticIpAllocation{
+						Enabled: common.Bool(false),
+					},
+				},
+				Path: common.String("fake_path"),
+			},
+			contextID: "fake_context_id",
+			labelTags: nil,
+			expectedPort: &model.VpcSubnetPort{
+				DisplayName: common.String("fake_subnetport"),
+				Id:          common.String("fake_subnetport_phoia"),
+				Tags: []model.Tag{
+					{
+						Scope: common.String("nsx-op/cluster"),
+						Tag:   common.String("fake_cluster"),
+					},
+					{
+						Scope: common.String("nsx-op/version"),
+						Tag:   common.String("1.0.0"),
+					},
+					{
+						Scope: common.String("nsx-op/namespace"),
+						Tag:   common.String("fake_ns"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_name"),
+						Tag:   common.String("fake_subnetport"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_uid"),
+						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+					},
+				},
+				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
+				ParentPath: common.String("fake_path"),
+				Attachment: &model.PortAttachment{
+					AllocateAddresses: common.String("MAC_POOL"),
+					Type_:             common.String("STATIC"),
+					TrafficTag:        common.Int64(0),
+				},
+				AddressBindings: []model.PortAddressBindingEntry{
+					{
+						IpAddress:  common.String("192.168.1.100"),
+						MacAddress: common.String("04:50:56:00:fa:00"),
+					},
 				},
 			},
 			expectedError: nil,

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -443,6 +443,13 @@ func NSXSubnetDHCPEnabled(nsxSubnet *model.VpcSubnet) bool {
 	return nsxSubnet.SubnetDhcpConfig != nil && nsxSubnet.SubnetDhcpConfig.Mode != nil && *nsxSubnet.SubnetDhcpConfig.Mode != nsxutil.ParseDHCPMode(v1alpha1.DHCPConfigModeDeactivated)
 }
 
+func NSXSubnetStaticIPAllocationEnabled(nsxSubnet *model.VpcSubnet) bool {
+	if nsxSubnet.AdvancedConfig == nil || nsxSubnet.AdvancedConfig.StaticIpAllocation == nil || nsxSubnet.AdvancedConfig.StaticIpAllocation.Enabled == nil || !*nsxSubnet.AdvancedConfig.StaticIpAllocation.Enabled {
+		return false
+	}
+	return true
+}
+
 func CRSubnetDHCPEnabled(obj client.Object) bool {
 	mode := ""
 	switch o := obj.(type) {


### PR DESCRIPTION
This patch will make the following change for SubnetPort's property `allocate_addresses` to fix the issues in some cases.


DHCP Enabled?[1] | StaticIPAllocation Enabled? | AddressBinding Exists?[2] | MAC in NSX MAC pool? | allocate_addresses in NSX API
-- | -- | -- | -- | --
y | y | y | y | INVALID
y | y | y | n | INVALID
y | y | n | - | INVALID
y | n | y | y | NONE->MAC_POOL
y | n | y | n | NONE
y | n | n | - | NONE
n | y | y | y | BOTH
n | y | y | n | IP_POOL
n | y | n | - | BOTH
n | n | y | y | NONE->MAC_POOL
n | n | y | n | IP_POOL->NONE
n | n | n | - | NONE

[1] DHCP Enabled means Subnet's DHCP mode is DHCPServer or DHCPRelay.
[2] When AddressBinding exists, it means both the IP and MAC are specified.
In some case, only specifying IP is allowed, but we won't pay particular attention
to this case now.

Testing done:
```
1. Create a SubnetPort on the DHCP Subnet and specify the address binding:
  addressBindings:
  - ipAddress: 172.26.0.20
    macAddress: 04:50:56:00:24:00
the NSX SubnetPort's allocate_addresses is MAC_POOL and next when we create a port with the same MAC, the new SubnetPort CR will the the following error:
/orgs/default/projects/project-quality/vpcs/ns-sunq-00_nu0o0/subnets/subnet-debug-dhcp-03_nu0o0/ports/subnetport-debug-check-34_nu0o0 realized with errors: [Id 04:50:56:00:24:00 is already allocated.]

2. Create a SubnetPort on the Subnet with DHCPDeactivated and IPAM disabled, the address binding is as follows:
  addressBindings:
  - ipAddress: 172.26.0.20
    macAddress: 04:50:56:00:25:00
the created NSX SubnetPort has allocate_addresses=MAC_POOL

3. Create a SubnetPort on the Subnet with DHCPDeactivated and IPAM disabled, the address binding is as follows:
  addressBindings:
  - ipAddress: 172.26.0.20
    macAddress: 00:50:56:00:25:00
the created NSX SubnetPort has allocate_addresses=NONE
...
All the cases listed in the table are covered in the test.
```