### PR TITLE
Support backup/restore for pre-created VPC/Subnet

### DIFF
--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_controller.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_controller.go
@@ -5,7 +5,6 @@ package ipaddressallocation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
@@ -189,7 +188,7 @@ func (r *IPAddressAllocationReconciler) RestoreReconcile() error {
 		}
 	}
 	if len(errorList) > 0 {
-		return errors.Join(errorList...)
+		return fmt.Errorf("errors found in IPAddressAllocation restore: %v", errorList)
 	}
 	return nil
 }

--- a/pkg/controllers/node/node_controller.go
+++ b/pkg/controllers/node/node_controller.go
@@ -5,7 +5,6 @@ package node
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -113,7 +112,7 @@ func (r *NodeReconciler) RestoreReconcile() error {
 		}
 	}
 	if len(errorList) > 0 {
-		return errors.Join(errorList...)
+		return fmt.Errorf("errors found in Node restore: %v", errorList)
 	}
 	return nil
 }

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -5,7 +5,6 @@ package pod
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -253,7 +252,7 @@ func (r *PodReconciler) RestoreReconcile() error {
 		}
 	}
 	if len(errorList) > 0 {
-		return errors.Join(errorList...)
+		return fmt.Errorf("errors found in Pod restore: %v", errorList)
 	}
 	return nil
 }

--- a/pkg/controllers/subnetset/subnetset_controller_test.go
+++ b/pkg/controllers/subnetset/subnetset_controller_test.go
@@ -156,13 +156,14 @@ func TestReconcile(t *testing.T) {
 	}{
 		{
 			name:      "Create a SubnetSet with find VPCNetworkConfig error",
-			expectRes: ResultRequeue,
+			expectRes: ResultNormal,
 			patches: func(r *SubnetSetReconciler) *gomonkey.Patches {
 				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnetSet", func(_ *SubnetSetReconciler, _ context.Context, _ *v1alpha1.SubnetSet) []v1alpha1.SubnetConnectionBindingMap {
 					return []v1alpha1.SubnetConnectionBindingMap{}
 				})
 				return patches
 			},
+			expectErrStr: "failed to locate default NetworkConfig",
 		},
 		{
 			name:      "Create a SubnetSet",
@@ -190,8 +191,8 @@ func TestReconcile(t *testing.T) {
 		{
 			// return nil and requeue when UpdateSubnetSet failed
 			name:         "Create a SubnetSet failed to UpdateSubnetSet",
-			expectRes:    ResultRequeue,
-			expectErrStr: "",
+			expectRes:    ResultNormal,
+			expectErrStr: "failed to get SubnetSet",
 			patches: func(r *SubnetSetReconciler) *gomonkey.Patches {
 				vpcnetworkConfig := &v1alpha1.VPCNetworkConfiguration{Spec: v1alpha1.VPCNetworkConfigurationSpec{DefaultSubnetSize: 32}}
 				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*v1alpha1.VPCNetworkConfiguration, error) {

--- a/pkg/nsx/services/ipaddressallocation/ipaddressallocation.go
+++ b/pkg/nsx/services/ipaddressallocation/ipaddressallocation.go
@@ -115,8 +115,10 @@ func (service *IPAddressAllocationService) CreateOrUpdateIPAddressAllocation(obj
 	}
 	if restoreMode {
 		if obj.Status.AllocationIPs == *allocation_ips {
+			// The status may be updated with error by the previous restore process,
+			// return updated as true to make sure the condition will be updated to ready
 			log.Info("Successfully restored IPAddressAllocation CR", "Name", obj.Name, "Namespace", obj.Namespace)
-			return false, nil
+			return true, nil
 		} else {
 			err = fmt.Errorf("IP mismatches for the restored IPAddressAllocation CR %s: got %s, expecting %s", obj.GetUID(), *allocation_ips, obj.Status.AllocationIPs)
 			return false, err

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -555,6 +555,7 @@ func (service *SubnetService) GetNSXSubnetByAssociatedResource(associatedResourc
 	subnetID := parts[2]
 
 	nsxSubnet, err := service.NSXClient.SubnetsClient.Get(orgID, projectID, vpcID, subnetID)
+	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "Failed to get NSX Subnet", "SubnetName", subnetID)
 		return nil, err


### PR DESCRIPTION
For pre-created VPC/Subnet in backup/restore,
- If the NSX VPC/Subnet does not exist, update Namespace/Subnet condition to show the error but not block the restore
- If there is Subnet/SubnetPort/IPAddressAllocation under pre-created VPC, or SubnetPort under shared Subnet, let NSX Operator keeps retry in restore mode

Testing done:
Case 1:
Created Namespace with pre-created VPC, and created Subnet/SubnetPort/IPAddressAllocation under it.
Stopped ncp and deleted the pre-created VPC and the resources under it on NSX.
Forced restore and observed:
- Namespace status indicates the VPC not exists
```yaml
    status:
      conditions:
      - lastTransitionTime: "2025-11-10T06:53:13Z"
        message: 'Error happened to create or update VPC: pre-created VPC is not found
          in NSX: /orgs/default/projects/project-quality/vpcs/test'
        reason: VPCNotReady
        status: "False"
        type: NamespaceNetworkReady
      phase: Active
```
- Subnet/SubnetPort/IPAddressAllocation under the VPC cannot be restored and block restore mode
```log
2025-11-10 06:55:17.000 ERROR main.go:263 Failed to process restore error="failed to restore resources: [errors found in Subnet restore: [failed to restore Subnet ns-1/subnet-1, error: nsx error code: 524221, message: Object not found /orgs/default/projects/project-quality/vpcs/test.] errors found in SubnetSet restore: [failed to restore SubnetSet ns-1/pod-default, error: nsx error code: 524221, message: Object not found /orgs/default/projects/project-quality/vpcs/test.] errors found in SubnetPort restore: [failed to restore SubnetPort ns-1/subnetport-1, error: empty NSX resource path for Subnet CR subnet-1(6cf97e39-5849-4887-b8f2-58db9fe9e474) failed to restore SubnetPort ns-1/subnetport-2, error: failed to find Subnet matching IP 10.246.0.1] errors found in IPAddressAllocation restore: [failed to restore IPAddressAllocation ns-1/ipa-1, error: error get nsx error code: 600, message: The requested object : /orgs/default/projects/project-quality/vpcs/test/ip-address-allocations/ipa-1_5d04h could not be found. Object identifiers are case sensitive., error patch nsx error code: 500242, message: Parent for the path=[/orgs/default/projects/project-quality/vpcs/test/ip-address-allocations/ipa-1_5d04h] does not exist. Please first create the parent with id test.]]"
```
Recreated the vpc test, observed the Subnet/SubnetPort/IPAddressAllocation under the Namespace can be restored

Case 2:
Created a shared Subnet and created a SubnetPort under it.
Stopped ncp and deleted the shared Subnet and SubnetPort on NSX.
Forced restore and observed:
- Subnet CR status indicates the NSX Subnet not exists
```yaml
      conditions:
        - lastTransitionTime: "2025-11-11T02:43:04Z"
          message: 'Error occurred while processing the Subnet CR. Please check the config
            and try again. Error: nsx error code: 600, message: The requested object :
            /orgs/default/projects/project-quality/vpcs/ns-1_a5pjz/subnets/test could
            not be found. Object identifiers are case sensitive.'
          reason: SubnetNotReady
          status: "False"
          type: Ready
```
- SubnetPort under the Subnet cannot be restored and block restore mode
```log
2025-11-11 03:05:12.000 ERROR main.go:263 Failed to process restore error="failed to restore resources: [errors found in SubnetPort restore: [failed to restore SubnetPort ns-1/subnetport-1, error: nsx error code: 600, message: The requested object : /orgs/default/projects/project-quality/vpcs/ns-1_a5pjz/subnets/test could not be found. Object identifiers are case sensitive.]]"
```
Recreated the Subnet, checked SubnetPort under the it can be restored
