### PR TITLE
Use status instead of annotation to show Pod restore

### DIFF
--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -8,12 +8,14 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"time"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -127,7 +129,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 				log.Error(err, "Failed to update restore annotation on Pod", "Namespace", pod.Namespace, "Pod", pod.Name)
 				return err != nil
 			}, func() error {
-				return common.UpdateReconfigureNicAnnotation(r.Client, ctx, pod, "true")
+				return setReconfigureNicStatus(r.Client, ctx, pod)
 			})
 		}
 	} else {
@@ -146,6 +148,67 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		r.StatusUpdater.DeleteSuccess(req.NamespacedName, pod)
 	}
 	return common.ResultNormal, nil
+}
+
+// Set PodNetworkRestore condition to false in Pod to inform spherelet the SubnetPort is restored with another vif ID
+func setReconfigureNicStatus(client client.Client, ctx context.Context, obj client.Object) error {
+	pod := obj.(*v1.Pod)
+	newConditions := []v1.PodCondition{
+		{
+			Type:               v1.PodConditionType("PodNetworkRestore"),
+			Status:             v1.ConditionFalse,
+			Reason:             "ReconfigureNic",
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+	return updatePodStatusConditions(client, ctx, pod, newConditions)
+}
+
+func updatePodStatusConditions(client client.Client, ctx context.Context, pod *v1.Pod, newConditions []v1.PodCondition) error {
+	conditionsUpdated := false
+	for i := range newConditions {
+		if mergePodStatusCondition(pod, &newConditions[i]) {
+			conditionsUpdated = true
+		}
+	}
+
+	if conditionsUpdated {
+		err := client.Status().Update(ctx, pod)
+		if err != nil {
+			log.Error(err, "Failed to update Pod status", "Name", pod.Name, "Namespace", pod.Namespace)
+			return err
+		}
+		log.Trace("Updated pod", "Name", pod.Name, "Namespace", pod.Namespace,
+			"New Conditions", newConditions)
+	}
+	return nil
+}
+
+func mergePodStatusCondition(pod *v1.Pod, newCondition *v1.PodCondition) bool {
+	matchedCondition := getExistingConditionOfType(newCondition.Type, pod.Status.Conditions)
+
+	if reflect.DeepEqual(matchedCondition, newCondition) {
+		log.Trace("Conditions already match", "New Condition", newCondition, "Existing Condition", matchedCondition)
+		return false
+	}
+
+	if matchedCondition != nil {
+		matchedCondition.Reason = newCondition.Reason
+		matchedCondition.Message = newCondition.Message
+		matchedCondition.Status = newCondition.Status
+	} else {
+		pod.Status.Conditions = append(pod.Status.Conditions, *newCondition)
+	}
+	return true
+}
+
+func getExistingConditionOfType(conditionType v1.PodConditionType, existingConditions []v1.PodCondition) *v1.PodCondition {
+	for i := range existingConditions {
+		if existingConditions[i].Type == conditionType {
+			return &existingConditions[i]
+		}
+	}
+	return nil
 }
 
 func (r *PodReconciler) GetNodeByName(nodeName string) (*model.HostTransportNode, error) {


### PR DESCRIPTION
Spherelet does not have the permission to edit Pod annotation
thus we use Status instead to inform the Spherelet when the
SubnetPort for Pod is restored.
This PR adds a new Condition of type PodNetworkRestore in Pod Status
and after restore, this condition will be false with reason ReconfigureNic.

Testing done:
Simulated the Pod restore and observed after Operator restore the Pod status is updated
```
  status:
    conditions:
    - lastProbeTime: null
      lastTransitionTime: "2025-11-26T08:51:54Z"
      status: "True"
      type: PodScheduled
    - lastProbeTime: null
      lastTransitionTime: "2025-11-26T08:54:19Z"
      status: "True"
      type: Initialized
    - lastProbeTime: null
      lastTransitionTime: "2025-11-26T08:54:19Z"
      status: "True"
      type: ContainersReady
    - lastProbeTime: null
      lastTransitionTime: "2025-11-26T08:54:19Z"
      status: "True"
      type: Ready
    - lastProbeTime: null
      lastTransitionTime: "2025-11-27T02:46:24Z"
      reason: ReconfigureNic
      status: "False"
      type: PodNetworkRestore   <--------- this condition is added after restore
```