### PR TITLE
Enhance the SubnetPort requeue logic

### DIFF
--- a/pkg/controllers/ratelimiter/ratelimiter.go
+++ b/pkg/controllers/ratelimiter/ratelimiter.go
@@ -1,0 +1,26 @@
+package ratelimiter
+
+import (
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+)
+
+var (
+	log = logger.Log
+)
+
+type LoggingRateLimiter struct {
+	workqueue.TypedRateLimiter[reconcile.Request]
+}
+
+func (l *LoggingRateLimiter) When(item reconcile.Request) time.Duration {
+	duration := l.TypedRateLimiter.When(item)
+	requeues := l.TypedRateLimiter.NumRequeues(item)
+	// If the request is requeued will error=nil, e.g. "return ResultRequeueAfter60sec, nil", it won't be logged here.
+	log.Debug("RateLimiter: Item has been requeued and will be delayed", "item", item, "requeues", requeues, "duration", duration)
+	return duration
+}

--- a/pkg/controllers/ratelimiter/ratelimiter_test.go
+++ b/pkg/controllers/ratelimiter/ratelimiter_test.go
@@ -1,0 +1,38 @@
+package ratelimiter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestLoggingRateLimiter_When(t *testing.T) {
+	baseRateLimiter := workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]()
+
+	loggingRateLimiter := &LoggingRateLimiter{
+		TypedRateLimiter: baseRateLimiter,
+	}
+
+	testRequest := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "test-namespace",
+			Name:      "test-name",
+		},
+	}
+
+	duration1 := loggingRateLimiter.When(testRequest)
+	assert.Greater(t, duration1, time.Duration(0), "First requeue duration should be greater than 0")
+
+	numRequeues1 := loggingRateLimiter.NumRequeues(testRequest)
+	assert.Equal(t, 1, numRequeues1, "Number of requeues should be 1 after first call")
+
+	duration2 := loggingRateLimiter.When(testRequest)
+	assert.Greater(t, duration2, duration1, "Second requeue duration should be greater than first")
+
+	numRequeues2 := loggingRateLimiter.NumRequeues(testRequest)
+	assert.Equal(t, 2, numRequeues2, "Number of requeues should be 2 after second call")
+}

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnet"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 type fakeRecorder struct {
@@ -250,6 +251,55 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		k8sClient.EXPECT().Status().Return(fakewriter)
 		_, ret := r.Reconcile(ctx, req)
 		assert.Equal(t, err, ret)
+	})
+
+	// CreateOrUpdateSubnetPort fails with RealizeStateError
+	t.Run("failed with CreateOrUpdateSubnetPort", func(t *testing.T) {
+		sp := &v1alpha1.SubnetPort{}
+		patchesGetVirtualMachine := gomonkey.ApplyFunc((*SubnetPortReconciler).getVirtualMachine,
+			func(r *SubnetPortReconciler, ctx context.Context, obj *v1alpha1.SubnetPort) (*vmv1alpha1.VirtualMachine, string, error) {
+				return nil, "", nil
+			})
+		defer patchesGetVirtualMachine.Reset()
+		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, error) {
+				return true, false, "", nil, nil, nil
+			})
+		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
+		patchesGetByUID := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
+			func(s *subnetport.SubnetPortStore, uid types.UID) (*model.VpcSubnetPort, error) {
+				return &model.VpcSubnetPort{Id: servicecommon.String("port1")}, nil
+			})
+		defer patchesGetByUID.Reset()
+		patchesVmMapFunc := gomonkey.ApplyFunc((*SubnetPortReconciler).vmMapFunc,
+			func(r *SubnetPortReconciler, _ context.Context, vm client.Object) []reconcile.Request {
+				requests := []reconcile.Request{}
+				return requests
+			})
+		defer patchesVmMapFunc.Reset()
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
+			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+				v1sp := obj.(*v1alpha1.SubnetPort)
+				v1sp.Spec.Subnet = "subnet1"
+				return nil
+			})
+		patchesIsSharedSubnetPath := gomonkey.ApplyFunc(common.IsSharedSubnetPath, func(ctx context.Context, client client.Client, path string, ns string) (bool, error) {
+			return false, nil
+		})
+		defer patchesIsSharedSubnetPath.Reset()
+		err := util.NewRealizeStateError("CreateOrUpdateSubnetPort failed", 0)
+		patchesCreateOrUpdateSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
+			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
+				return nil, false, err
+			})
+		defer patchesCreateOrUpdateSubnetPort.Reset()
+		patchesGetAddressBindingBySubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).GetAddressBindingBySubnetPort, func(_ *subnetport.SubnetPortService, _ *v1alpha1.SubnetPort) *v1alpha1.AddressBinding {
+			return nil
+		})
+		defer patchesGetAddressBindingBySubnetPort.Reset()
+		k8sClient.EXPECT().Status().Return(fakewriter)
+		_, ret := r.Reconcile(ctx, req)
+		assert.Equal(t, nil, ret)
 	})
 
 	// happy path

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -105,10 +105,11 @@ const (
 	ConnectorUnderline                 string = "_"
 	ConnectorHyphen                    string = "-"
 
-	GCInterval       = 10 * 60 * time.Second
-	SubnetGCInterval = 60 * time.Second
-	DefaultSNATID    = "DEFAULT"
-	AVISubnetLBID    = "_services"
+	GCInterval           = 10 * 60 * time.Second
+	SubnetGCInterval     = 60 * time.Second
+	SubnetPortGCInterval = 60 * time.Second
+	DefaultSNATID        = "DEFAULT"
+	AVISubnetLBID        = "_services"
 
 	NSXServiceAccountFinalizerName = "nsxserviceaccount.nsx.vmware.com/finalizer"
 	T1SecurityPolicyFinalizerName  = "securitypolicy.nsx.vmware.com/finalizer"

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -176,7 +176,11 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 	}
 	nsxSubnetPortState, err := service.CheckSubnetPortState(obj, *nsxSubnet.Path)
 	if err != nil {
-		log.Error(err, "check and update NSX subnet port state failed, would retry exponentially", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)
+		if nsxutil.IsRealizeStateError(err) {
+			log.Error(err, "check and update NSX subnet port state failed, would retry with delay", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)
+		} else {
+			log.Error(err, "check and update NSX subnet port state failed, would retry exponentially", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)
+		}
 		return nil, false, err
 	}
 	createdNSXSubnetPort, err := service.NSXClient.PortClient.Get(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, *nsxSubnetPort.Id)

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/golang/mock/gomock"
@@ -15,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -28,6 +30,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/ipaddressallocation"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
 var (
@@ -323,6 +326,31 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 					Values: gomonkey.Params{model.GenericPolicyRealizedResourceListResult{}, nsxutil.NewRealizeStateError("realized state error", 0)},
 					Times:  1,
 				}})
+				return patches
+			},
+			wantErr:   true,
+			nsxSubnet: nsxSubnet1,
+		},
+		{
+			name: "NoRealizeFailure",
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+					namespaceCR := &corev1.Namespace{}
+					namespaceCR.UID = "ns1"
+					return nil
+				})
+				orgRootClient.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.RealizedEntitiesClient), "List", func(_ *fakeRealizedEntitiesClient, intentPathParam string, sitePathParam *string) (model.GenericPolicyRealizedResourceListResult, error) {
+					return model.GenericPolicyRealizedResourceListResult{}, fmt.Errorf("failed to check realized state")
+				})
+				// Mock NSXTRealizeRetry with shorter backoff: 2 retries, 50ms interval
+				patches.ApplyGlobalVar(&util.NSXTRealizeRetry, wait.Backoff{
+					Steps:    2,
+					Duration: 50 * time.Millisecond,
+					Factor:   1.0,
+					Jitter:   0.0,
+				})
 				return patches
 			},
 			wantErr:   true,


### PR DESCRIPTION
In some cases, when the subnetport_controller hits the RealizeStateError, it may update the SubnetPort status with detailed NSX SubnetPort path, which will trigger another reconcile in the subnetport_controller, that may make the wait time for requeue increase to a extreme long time in several seconds. So that the SubnetPort may need many minutes (up to 1000s) to be ready. This patch will alleviate this issue with the following fine tunings:

1. Shorten SubnetPort GC interval from 600s to 60s, to make the stale SubnetPorts to be GCed more quickly, in case to block the new SubnetPort's realization with the same IP.
2. Make the retry for RealizeStateError smoother, i.e. the ResultRequeueAfter60sec won't trigger the backoff of the wait time.

This patch also adds a custom RateLimiter to facilitate troubleshooting such issues in the future.

```
Testing done:
1. Reproduce the issue by recreating the SubnetPort with same name in NCP downtime,
it can be observed with in about 6 times. We can see that the SubnetPort CR was realized
after a long time:
Events:
  Type     Reason            Age                    From                   Message
  ----     ------            ----                   ----                   -------
  Warning  FailUpdate        29m                    subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_stpqs realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/b741d0bf-7bce-4074-a4be-925b960494be] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/482d2c2f-41ff-4173-8a94-8b9f6a5b30ed]]
  Warning  FailUpdate        29m                    subnetport-controller  nsx error code: 503638, message: Port attachment ID 65613934-3139-4130-ad62-3337382d3436 used by another segment port /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_stpqs.
  Warning  FailUpdate        29m                    subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_o3bkg realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/af0033c0-d8e4-4d3a-9d03-19a573f268ec] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/482d2c2f-41ff-4173-8a94-8b9f6a5b30ed]]
  Warning  FailUpdate        28m                    subnetport-controller  nsx error code: 503638, message: Port attachment ID 65613934-3139-4130-ad62-3337382d3436 used by another segment port /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_o3bkg.
  Warning  FailUpdate        28m                    subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_gzjx9 realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/45134073-2421-4fbd-b5b7-360ab3dd3b2b] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/482d2c2f-41ff-4173-8a94-8b9f6a5b30ed]]
  Warning  FailUpdate        28m                    subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_bwkuf realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/f46e5d3b-05f9-47e0-b4b4-56a1222711ec] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/482d2c2f-41ff-4173-8a94-8b9f6a5b30ed]]
  Warning  FailUpdate        27m                    subnetport-controller  nsx error code: 503638, message: Port attachment ID 65613934-3139-4130-ad62-3337382d3436 used by another segment port /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_bwkuf.
  Warning  FailUpdate        27m                    subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_gh3g9 realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/e356a984-ddbd-42d5-9b92-4c9bca83efe9] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/482d2c2f-41ff-4173-8a94-8b9f6a5b30ed]]
  Warning  FailUpdate        26m                    subnetport-controller  nsx error code: 503638, message: Port attachment ID 65613934-3139-4130-ad62-3337382d3436 used by another segment port /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_gh3g9.
  Warning  FailUpdate        26m (x16 over 26m)     subnetport-controller  (combined from similar events): /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_fze2o realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/9cc95b5e-ab76-4f5b-9a4e-36fc1ffeca29] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/482d2c2f-41ff-4173-8a94-8b9f6a5b30ed]]
  Normal   SuccessfulUpdate  9m54s (x2 over 9m54s)  subnetport-controller  SubnetPort CR has been successfully updated
2. Patch the change, then retry step 1, the port realization
can be completed within shorter time:
Events:
  Type     Reason            Age               From                   Message
  ----     ------            ----              ----                   -------
  Warning  FailUpdate        88s               subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_ewnmn realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/036977a1-1ec4-4ebb-af79-70619034d0f8] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/a49c8e4c-6159-495e-b428-d75d5b9ee036]]
  Warning  FailUpdate        84s               subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_sbo0q realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/85810d82-f7fa-49fc-b32f-8aca152f194a] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/a49c8e4c-6159-495e-b428-d75d5b9ee036]]
  Warning  FailUpdate        81s               subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_owafm realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/19ec74da-3695-4329-8152-4d2777f9be36] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/a49c8e4c-6159-495e-b428-d75d5b9ee036]]
  Warning  FailUpdate        79s               subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_ec08b realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/8d5e495e-dd3c-4787-9a57-b18399414345] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/a49c8e4c-6159-495e-b428-d75d5b9ee036]]
  Warning  FailUpdate        77s               subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_1i31y realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/3eb943ab-9d71-4c10-8ca4-75b41c217d74] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/a49c8e4c-6159-495e-b428-d75d5b9ee036]]
  Warning  FailUpdate        75s               subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_q7uy0 realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/2638d24b-eee8-4106-8e4a-aae0fa08a39d] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/a49c8e4c-6159-495e-b428-d75d5b9ee036]]
  Warning  FailUpdate        74s               subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_77b5w realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/bd738add-cc8d-46e9-a364-9106c7c71a76] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/a49c8e4c-6159-495e-b428-d75d5b9ee036]]
  Warning  FailUpdate        73s               subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_88uti realized with errors: []
  Warning  FailUpdate        72s               subnetport-controller  /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_e73az realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/f7a12d09-f81d-47e5-8062-b79a86719569] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/a49c8e4c-6159-495e-b428-d75d5b9ee036]]
  Warning  FailUpdate        5s (x4 over 71s)  subnetport-controller  (combined from similar events): /orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ports/subnetport-03o-testsq_pcypd realized with errors: [IpAddressAllocation path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/8599c2b6-2356-4b58-9067-e5c9b27d04c7] cannot be created due to the requested IP has been allocated to path=[/orgs/default/projects/project-quality/vpcs/kube-system_5t2au/subnets/vm-default-d13d1cc5_tpv2k/ip-pools/static-ipv4-default/ip-allocations/a49c8e4c-6159-495e-b428-d75d5b9ee036]]
  Normal   SuccessfulUpdate  4s (x2 over 4s)   subnetport-controller  SubnetPort CR has been successfully updated
```

(cherry picked from commit 922e9101b4d34e4bcc0ef7aff8dfe7dfb9dd5574)