### PR TITLE
Add sts pod support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/pod"
 	securitypolicycontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/securitypolicy"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/service"
+	statefulsetcontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/statefulset"
 	staticroutecontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/staticroute"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/subnet"
 	subnetbindingcontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/subnetbinding"
@@ -244,6 +245,15 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			subnetbindingcontroller.NewReconciler(mgr, subnetService, subnetBindingService),
 			subnetipreservationcontroller.NewReconciler(mgr, subnetIPReservationService, subnetService),
 		)
+		// StatefulSet controller is always registered so that after NSX upgrades (e.g. to 9.2.0+)
+		// replica/GC logic can run without restarting the operator. Reconcile and CollectGarbage
+		// no-op until NSX version supports STS pods and vpc_wcp_enhance=true in config; delete cleanup still runs.
+		reconcilerList = append(reconcilerList, statefulsetcontroller.NewStatefulSetReconciler(mgr, subnetPortService))
+		if nsx.StatefulSetPodSubnetPortFeatureEnabled(commonService.NSXClient, commonService.NSXConfig) {
+			log.Info("NSX version and config allow StatefulSet Pod feature; StatefulSet controller will run replica/GC work")
+		} else {
+			log.Info("StatefulSet Pod feature gated (NSX version and/or vpc_wcp_enhance!=true); StatefulSet controller registered but replica/GC no-op until enabled")
+		}
 		if cf.EnableInventory {
 			reconcilerList = append(reconcilerList, inventory.NewInventoryController(mgr.GetClient(), inventoryService, cf))
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -126,6 +126,9 @@ type NsxConfig struct {
 	InventoryBatchPeriod      int      `ini:"inventory_batch_period"`
 	InventoryBatchSize        int      `ini:"inventory_batch_size"`
 	EnableInventory           bool     `ini:"enable_inventory"`
+	// VpcWcpEnhance controls StatefulSet pod SubnetPort behavior together with NSX version.
+	// When omitted (nil), treated as false; only an explicit true enables the enhancement path.
+	VpcWcpEnhance *bool `ini:"vpc_wcp_enhance"`
 }
 
 type K8sConfig struct {
@@ -398,6 +401,15 @@ func (nsxConfig *NsxConfig) validateCert() error {
 		}
 	}
 	return nil
+}
+
+// VpcWcpEnhanceEnabled reports whether WCP VPC enhancement for StatefulSet pod subnet ports is allowed by config.
+// Missing or nil key defaults to false; only an explicit true enables.
+func (nsxConfig *NsxConfig) VpcWcpEnhanceEnabled() bool {
+	if nsxConfig == nil || nsxConfig.VpcWcpEnhance == nil {
+		return false
+	}
+	return *nsxConfig.VpcWcpEnhance
 }
 
 func (nsxConfig *NsxConfig) validate(enableVPC bool) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -187,6 +187,16 @@ func TestNSXOperatorConfig_GetCACert(t *testing.T) {
 	}
 }
 
+func TestNsxConfig_VpcWcpEnhanceEnabled(t *testing.T) {
+	f := false
+	tr := true
+	assert.False(t, (*NsxConfig)(nil).VpcWcpEnhanceEnabled())
+	assert.False(t, (&NsxConfig{}).VpcWcpEnhanceEnabled())
+	assert.False(t, (&NsxConfig{VpcWcpEnhance: nil}).VpcWcpEnhanceEnabled())
+	assert.True(t, (&NsxConfig{VpcWcpEnhance: &tr}).VpcWcpEnhanceEnabled())
+	assert.False(t, (&NsxConfig{VpcWcpEnhance: &f}).VpcWcpEnhanceEnabled())
+}
+
 func TestNsxConfig_GetServiceSize(t *testing.T) {
 	type fields struct {
 		ServiceSize string

--- a/pkg/controllers/common/types.go
+++ b/pkg/controllers/common/types.go
@@ -24,6 +24,7 @@ const (
 	MetricResTypePod                        = "pod"
 	MetricResTypeNode                       = "node"
 	MetricResTypeServiceLb                  = "servicelb"
+	MetricResTypeStatefulSet                = "statefulset"
 	MaxConcurrentReconciles                 = 8
 	NSXOperatorError                        = "nsx-op/error"
 	//sync the error with NCP side

--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -592,3 +592,13 @@ func IsTepLessMode(k8sClient k8sclient.Client, ctx context.Context, ns string) (
 	}
 	return false, nil
 }
+
+// PodIsDeleted reports whether the Pod has reached a terminal phase (Succeeded / Failed).
+// Used by the Pod reconciler and StatefulSet subnet-port cleanup for aligned release semantics.
+func PodIsDeleted(pod *v1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	return pod.Status.Phase == v1.PodSucceeded ||
+		pod.Status.Phase == v1.PodFailed
+}

--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -1150,3 +1150,27 @@ func TestGetDefaultAccessMode(t *testing.T) {
 		})
 	}
 }
+
+func TestPodIsDeleted(t *testing.T) {
+	now := metav1.Now()
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want bool
+	}{
+		{"nil", nil, false},
+		{"running", &v1.Pod{Status: v1.PodStatus{Phase: v1.PodRunning}}, false},
+		{"pending", &v1.Pod{Status: v1.PodStatus{Phase: v1.PodPending}}, false},
+		{"terminating_running", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now, Finalizers: []string{"x"}},
+			Status:     v1.PodStatus{Phase: v1.PodRunning},
+		}, false},
+		{"succeeded", &v1.Pod{Status: v1.PodStatus{Phase: v1.PodSucceeded}}, true},
+		{"failed", &v1.Pod{Status: v1.PodStatus{Phase: v1.PodFailed}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, PodIsDeleted(tt.pod))
+		})
+	}
+}

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
@@ -83,7 +84,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return common.ResultNormal, nil
 	}
 
-	if !podIsDeleted(pod) {
+	if !common.PodIsDeleted(pod) {
 		r.StatusUpdater.IncreaseUpdateTotal()
 		isExisting, nsxSubnetPath, subnetSetUID, subnetSetLock, err := r.GetSubnetPathForPod(ctx, pod)
 		if subnetSetLock != nil {
@@ -145,6 +146,11 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return common.ResultRequeue, err
 		}
 		if subnetPort != nil {
+			if nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig) && r.isStatefulSetSubnetPort(subnetPort) {
+				log.Info("Ignoring subnet port deletion for StatefulSet pod",
+					"pod", subnetPort.DisplayName, "statefulset-uid", r.getStsUID(subnetPort))
+				return common.ResultNormal, nil
+			}
 			if err := r.SubnetPortService.DeleteSubnetPort(subnetPort); err != nil {
 				r.StatusUpdater.DeleteFail(req.NamespacedName, pod, err)
 				return common.ResultRequeue, err
@@ -361,6 +367,18 @@ func (r *PodReconciler) CollectGarbage(ctx context.Context) error {
 	var errList []error
 	diffSet := nsxSubnetPortSet.Difference(PodSet)
 	for elem := range diffSet {
+		// StatefulSet pod ports are keyed in the pod-UID index but may briefly outlive the old Pod
+		// object (crash/replace window). STS SubnetPort lifecycle is owned by the StatefulSet
+		// reconciler when the feature is enabled; do not delete here (same as deleteSubnetPortByPodName).
+		store := r.SubnetPortService.SubnetPortStore
+		if store != nil && store.Indexer != nil {
+			if nsxSubnetPort := store.GetByKey(elem); nsxSubnetPort != nil &&
+				r.SubnetPortService.NSXClient != nil &&
+				nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig) && r.isStatefulSetSubnetPort(nsxSubnetPort) {
+				log.Info("Skipping pod GC for StatefulSet pod subnet port", "NSXSubnetPortID", elem, "statefulset-uid", r.getStsUID(nsxSubnetPort))
+				continue
+			}
+		}
 		log.Debug("GC collected Pod", "NSXSubnetPortID", elem)
 		r.StatusUpdater.IncreaseDeleteTotal()
 		err = r.SubnetPortService.DeleteSubnetPortById(elem)
@@ -418,21 +436,34 @@ func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (b
 	return false, subnetPath, subnetSetUID, subnetSetLock, nil
 }
 
-func podIsDeleted(pod *v1.Pod) bool {
-	return !pod.ObjectMeta.DeletionTimestamp.IsZero() || pod.Status.Phase == "Succeeded" || pod.Status.Phase == "Failed"
-}
-
 func (r *PodReconciler) deleteSubnetPortByPodName(ctx context.Context, ns string, name string) error {
 	// NamespacedName is a unique identity in store as only one worker can deal with the NamespacedName at a time
 	nsxSubnetPorts := r.SubnetPortService.ListSubnetPortByPodName(ns, name)
 
 	for _, nsxSubnetPort := range nsxSubnetPorts {
+		// Check if this subnet port was created for StatefulSet
+		// Only skip if STS feature is enabled (NSX 9.2.0+)
+		if nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig) && r.isStatefulSetSubnetPort(nsxSubnetPort) {
+			log.Info("Ignoring subnet port deletion for StatefulSet pod",
+				"pod", name, "statefulset-uid", r.getStsUID(nsxSubnetPort))
+			continue // Skip deletion
+		}
+
+		// Normal pod: delete the subnet port
 		if err := r.SubnetPortService.DeleteSubnetPort(nsxSubnetPort); err != nil {
 			return err
 		}
 	}
 	log.Info("Successfully deleted nsxSubnetPort for Pod", "Namespace", ns, "Name", name)
 	return nil
+}
+
+func (r *PodReconciler) isStatefulSetSubnetPort(nsxSubnetPort *model.VpcSubnetPort) bool {
+	return r.getStsUID(nsxSubnetPort) != ""
+}
+
+func (r *PodReconciler) getStsUID(nsxSubnetPort *model.VpcSubnetPort) string {
+	return nsxutil.FindTag(nsxSubnetPort.Tags, servicecommon.TagScopeStatefulSetUID)
 }
 
 // PredicateFuncsPod filters out events where pod.Spec.HostNetwork is true

--- a/pkg/controllers/pod/pod_controller_test.go
+++ b/pkg/controllers/pod/pod_controller_test.go
@@ -340,6 +340,10 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 					func(s *subnetport.SubnetPortStore, uid types.UID) (*model.VpcSubnetPort, error) {
 						return &model.VpcSubnetPort{Id: servicecommon.String("port1")}, nil
 					})
+				patchesDeleteSubnetPort.ApplyMethod(reflect.TypeOf(r.SubnetPortService.NSXClient), "NSXCheckVersion",
+					func(_ *nsx.Client, _ int) bool {
+						return false
+					})
 				return patchesDeleteSubnetPort
 			},
 			expectedResult: common.ResultNormal,
@@ -362,6 +366,10 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 				patchesDeleteSubnetPort.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
 					func(s *subnetport.SubnetPortStore, uid types.UID) (*model.VpcSubnetPort, error) {
 						return &model.VpcSubnetPort{Id: servicecommon.String("port1")}, nil
+					})
+				patchesDeleteSubnetPort.ApplyMethod(reflect.TypeOf(r.SubnetPortService.NSXClient), "NSXCheckVersion",
+					func(_ *nsx.Client, _ int) bool {
+						return false
 					})
 				return patchesDeleteSubnetPort
 			},
@@ -749,6 +757,11 @@ func TestPodReconciler_deleteSubnetPortByPodName(t *testing.T) {
 			return nil
 		})
 	defer patchesDeleteSubnetPort.Reset()
+	patchesNSXCheckVersion := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetPortService.NSXClient), "NSXCheckVersion",
+		func(_ *nsx.Client, _ int) bool {
+			return false
+		})
+	defer patchesNSXCheckVersion.Reset()
 	err := r.deleteSubnetPortByPodName(context.TODO(), ns, podName2)
 	assert.Nil(t, err)
 }
@@ -872,4 +885,126 @@ func (m *MockManager) Add(runnable manager.Runnable) error {
 
 func (m *MockManager) Start(context.Context) error {
 	return nil
+}
+
+func TestIsStatefulSetSubnetPort(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []model.Tag
+		want bool
+	}{
+		{
+			name: "StatefulSet subnet port",
+			tags: []model.Tag{
+				{Scope: servicecommon.String(servicecommon.TagScopeStatefulSetUID), Tag: servicecommon.String("sts-uid-123")},
+			},
+			want: true,
+		},
+		{
+			name: "Non-StatefulSet subnet port",
+			tags: []model.Tag{
+				{Scope: servicecommon.String("nsx-op/created_for"), Tag: servicecommon.String("pod")},
+			},
+			want: false,
+		},
+		{
+			name: "No tags",
+			tags: []model.Tag{},
+			want: false,
+		},
+		{
+			name: "Nil tags",
+			tags: nil,
+			want: false,
+		},
+	}
+
+	reconciler := &PodReconciler{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nsxSubnetPort := &model.VpcSubnetPort{
+				Tags: tt.tags,
+			}
+			got := reconciler.isStatefulSetSubnetPort(nsxSubnetPort)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetStsUID(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []model.Tag
+		want string
+	}{
+		{
+			name: "StatefulSet UID tag",
+			tags: []model.Tag{
+				{Scope: servicecommon.String("nsx-op/sts_uid"), Tag: servicecommon.String("sts-uid-123")},
+			},
+			want: "sts-uid-123",
+		},
+		{
+			name: "No sts_uid tag",
+			tags: []model.Tag{
+				{Scope: servicecommon.String("nsx-op/pod_uid"), Tag: servicecommon.String("pod-uid-123")},
+			},
+			want: "",
+		},
+		{
+			name: "Empty tags",
+			tags: []model.Tag{},
+			want: "",
+		},
+		{
+			name: "Nil tags",
+			tags: nil,
+			want: "",
+		},
+	}
+
+	reconciler := &PodReconciler{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nsxSubnetPort := &model.VpcSubnetPort{
+				Tags: tt.tags,
+			}
+			got := reconciler.getStsUID(nsxSubnetPort)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStatefulSetTagScopes(t *testing.T) {
+	assert.Equal(t, "nsx-op/created_for", servicecommon.TagScopeCreatedFor)
+	assert.Equal(t, "nsx-op/sts_name", servicecommon.TagScopeStatefulSetName)
+	assert.Equal(t, "nsx-op/sts_uid", servicecommon.TagScopeStatefulSetUID)
+
+	reconciler := &PodReconciler{}
+
+	stsPort := &model.VpcSubnetPort{
+		Id:          servicecommon.String("sts-port-1"),
+		DisplayName: servicecommon.String("web-0"),
+		Tags: []model.Tag{
+			{Scope: servicecommon.String("nsx-op/sts_name"), Tag: servicecommon.String("web")},
+			{Scope: servicecommon.String("nsx-op/sts_uid"), Tag: servicecommon.String("sts-uid-abc123")},
+			{Scope: servicecommon.String("nsx-op/pod_name"), Tag: servicecommon.String("web-0")},
+			{Scope: servicecommon.String("nsx-op/pod_uid"), Tag: servicecommon.String("pod-uid-xyz789")},
+		},
+	}
+
+	assert.True(t, reconciler.isStatefulSetSubnetPort(stsPort), "Should detect STS port")
+	assert.Equal(t, "sts-uid-abc123", reconciler.getStsUID(stsPort), "Should get correct STS UID")
+
+	regularPort := &model.VpcSubnetPort{
+		Id:          servicecommon.String("regular-port-1"),
+		DisplayName: servicecommon.String("nginx-abc123"),
+		Tags: []model.Tag{
+			{Scope: servicecommon.String("nsx-op/created_for"), Tag: servicecommon.String("pod")},
+			{Scope: servicecommon.String("nsx-op/pod_name"), Tag: servicecommon.String("nginx-abc123")},
+		},
+	}
+	assert.False(t, reconciler.isStatefulSetSubnetPort(regularPort), "Should not detect regular pod as STS")
 }

--- a/pkg/controllers/statefulset/statefulset_controller.go
+++ b/pkg/controllers/statefulset/statefulset_controller.go
@@ -1,0 +1,468 @@
+/* Copyright © 2026 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package statefulset
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	subnetportservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
+)
+
+var (
+	log                      = logger.Log
+	MetricResTypeStatefulSet = common.MetricResTypeStatefulSet
+)
+
+// stsSubnetPortPendingRequeueAfter is used when StatefulSet-related subnet ports cannot be released yet
+// because the backing Pod is still running (scale-down/delete path). Requeue instead of relying only on GC.
+const stsSubnetPortPendingRequeueAfter = 10 * time.Second
+
+type releaseSubnetPortOutcome int
+
+const (
+	releaseSubnetPortNoop releaseSubnetPortOutcome = iota
+	releaseSubnetPortReleased
+	releaseSubnetPortSkippedRunningPod
+)
+
+// StatefulSetReconciler reconciles a StatefulSet object
+type StatefulSetReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	SubnetPortService *subnetportservice.SubnetPortService
+	Recorder          record.EventRecorder
+	StatusUpdater     common.StatusUpdater
+}
+
+// StatefulSetPodFeatureEnabled reports whether the StatefulSet pod SubnetPort feature is active (NSX 9.2.0+ and vpc_wcp_enhance=true in config).
+func (r *StatefulSetReconciler) StatefulSetPodFeatureEnabled() bool {
+	return nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig)
+}
+
+func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log.Info("Reconciling StatefulSet", "StatefulSet", req.NamespacedName)
+	startTime := time.Now()
+	defer func() {
+		log.Info("Finished reconciling StatefulSet", "StatefulSet", req.NamespacedName, "duration", time.Since(startTime))
+	}()
+
+	r.StatusUpdater.IncreaseSyncTotal()
+	if !r.StatefulSetPodFeatureEnabled() {
+		log.Debug("StatefulSet pod NSX feature disabled; skipping reconcile (pod controller owns SubnetPort lifecycle)",
+			"StatefulSet", req.NamespacedName)
+		return common.ResultNormal, nil
+	}
+
+	sts := &appsv1.StatefulSet{}
+	if err := r.Client.Get(ctx, req.NamespacedName, sts); err != nil {
+		if apierrors.IsNotFound(err) {
+			return r.processDelete(ctx, req.NamespacedName, nil)
+		}
+		log.Error(err, "Unable to fetch StatefulSet", "StatefulSet", req.NamespacedName)
+		return common.ResultRequeue, err
+	}
+	if sts.DeletionTimestamp != nil {
+		return r.processDelete(ctx, req.NamespacedName, sts)
+	}
+	// Handle replica changes
+	replicaResult, err := r.handleReplicaChange(ctx, sts)
+	if err != nil {
+		log.Error(err, "Failed to handle replica change", "StatefulSet", req.NamespacedName)
+		r.StatusUpdater.UpdateFail(ctx, sts, err, "", nil)
+		return common.ResultRequeue, err
+	}
+
+	r.StatusUpdater.UpdateSuccess(ctx, sts, nil)
+	if replicaResult.RequeueAfter > 0 {
+		return ctrl.Result{Requeue: true, RequeueAfter: replicaResult.RequeueAfter}, nil
+	}
+	return common.ResultNormal, nil
+}
+
+func (r *StatefulSetReconciler) processDelete(ctx context.Context, namespacedName types.NamespacedName, sts *appsv1.StatefulSet) (ctrl.Result, error) {
+	pendingRunningPod, err := r.releaseSubnetPortsForStatefulSet(ctx, namespacedName.Namespace, namespacedName.Name)
+	if err != nil {
+		// StatusUpdater is a struct, not a pointer/interface. So we check if its Client field is initialized.
+		if r.StatusUpdater.Client != nil {
+			r.StatusUpdater.DeleteFail(namespacedName, sts, err)
+		}
+		return common.ResultRequeue, err
+	}
+	if r.StatusUpdater.Client != nil {
+		r.StatusUpdater.DeleteSuccess(namespacedName, sts)
+	}
+	if pendingRunningPod {
+		return ctrl.Result{Requeue: true, RequeueAfter: stsSubnetPortPendingRequeueAfter}, nil
+	}
+	return common.ResultNormal, nil
+}
+
+func (r *StatefulSetReconciler) handleReplicaChange(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
+	start, end := r.GetOrdinalRange(sts)
+	log.Info("Checking replicas range", "start", start, "end", end, "stsUID", sts.UID, "namespace", sts.Namespace)
+
+	existingPorts := r.SubnetPortService.ListSubnetPortByStsUid(sts.Namespace, string(sts.UID))
+
+	pendingRunningPod := false
+	for _, port := range existingPorts {
+		podName := util.FindTag(port.Tags, servicecommon.TagScopePodName)
+		if podName == "" {
+			continue
+		}
+		idx := stsPodOrdinalFromPort(port)
+		if idx == -1 {
+			continue
+		}
+		if idx < start || idx > end {
+			outcome, err := r.releaseSubnetPortForPod(ctx, sts.Namespace, podName)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if outcome == releaseSubnetPortSkippedRunningPod {
+				pendingRunningPod = true
+			}
+			if outcome == releaseSubnetPortReleased {
+				log.Info("Released out-of-range statefulset subnet port", "index", idx, "port", *port.Id)
+			}
+		}
+	}
+	if pendingRunningPod {
+		return ctrl.Result{RequeueAfter: stsSubnetPortPendingRequeueAfter}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *StatefulSetReconciler) releaseSubnetPortsForStatefulSet(ctx context.Context, namespace, name string) (pendingRunningPod bool, err error) {
+	log.Info("Releasing all subnet ports for StatefulSet", "StatefulSet", namespace+"/"+name)
+
+	subnetPorts := r.SubnetPortService.ListSubnetPortByStsName(namespace, name)
+
+	var errList []error
+	for _, subnetPort := range subnetPorts {
+		podName := util.FindTag(subnetPort.Tags, servicecommon.TagScopePodName)
+		if podName != "" {
+			pod := &corev1.Pod{}
+			if err := r.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: podName}, pod); err == nil {
+				podUid := util.FindTag(subnetPort.Tags, servicecommon.TagScopePodUID)
+				if pod.UID != types.UID(podUid) {
+					log.Info("Pod UID mismatch, deleting subnet port ", "pod", podName, "podUID", pod.UID, "subnetPortUID", podUid)
+				} else if !common.PodIsDeleted(pod) {
+					log.Info("Pod still exists, skipping subnet port deletion", "pod", podName)
+					pendingRunningPod = true
+					continue
+				}
+			}
+		}
+
+		if err := r.SubnetPortService.DeleteSubnetPort(subnetPort); err != nil {
+			log.Error(err, "Failed to delete subnet port",
+				"subnetPort", *subnetPort.Id,
+				"StatefulSet", namespace+"/"+name)
+			errList = append(errList, err)
+		} else {
+			log.Info("Successfully deleted subnet port for StatefulSet",
+				"subnetPort", *subnetPort.Id,
+				"StatefulSet", namespace+"/"+name)
+		}
+	}
+
+	if len(errList) > 0 {
+		return pendingRunningPod, fmt.Errorf("errors found in releasing subnet ports: %v", errList)
+	}
+
+	return pendingRunningPod, nil
+}
+
+func (r *StatefulSetReconciler) releaseSubnetPortForPod(ctx context.Context, namespace, podName string) (releaseSubnetPortOutcome, error) {
+	log.Info("Releasing subnet port for pod", "pod", podName, "namespace", namespace)
+
+	pod := &corev1.Pod{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: podName}, pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Debug("Pod does not exist, releasing subnet port", "pod", podName, "namespace", namespace)
+		} else {
+			log.Error(err, "Failed to get pod", "pod", podName, "namespace", namespace)
+			return releaseSubnetPortNoop, err
+		}
+	} else if !common.PodIsDeleted(pod) {
+		log.Debug("Pod still exists, skipping subnet port release", "pod", podName, "namespace", namespace, "podPhase", pod.Status.Phase)
+		return releaseSubnetPortSkippedRunningPod, nil
+	}
+
+	targetPorts := r.SubnetPortService.ListSubnetPortByPodName(namespace, podName)
+	if len(targetPorts) == 0 {
+		log.Debug("No subnet port found for pod", "pod", podName)
+		return releaseSubnetPortNoop, nil
+	}
+
+	for _, targetPort := range targetPorts {
+		if err := r.SubnetPortService.DeleteSubnetPort(targetPort); err != nil {
+			log.Error(err, "Failed to delete subnet port for pod", "pod", podName)
+			return releaseSubnetPortNoop, err
+		}
+	}
+
+	log.Info("Successfully released subnet port for pod", "pod", podName)
+	return releaseSubnetPortReleased, nil
+}
+
+// stsPodOrdinalFromPort returns the StatefulSet pod ordinal from NSX port tags.
+// It prefers tag apps.kubernetes.io/pod-index when present (e.g. synced from the Pod label).
+// If that tag is missing or invalid, it falls back to parsing the pod name (legacy ports).
+func stsPodOrdinalFromPort(port *model.VpcSubnetPort) int {
+	if port == nil {
+		return -1
+	}
+	if s := util.FindTag(port.Tags, servicecommon.TagScopePodIndex); s != "" {
+		if i, err := strconv.Atoi(s); err == nil {
+			return i
+		}
+	}
+	podName := util.FindTag(port.Tags, servicecommon.TagScopePodName)
+	if podName == "" {
+		return -1
+	}
+	return parseIndexFromPodName(podName)
+}
+
+// parseIndexFromPodName returns the ordinal from default StatefulSet pod naming
+// (<name>-<ordinal>, ordinal in the last '-' segment). Returns -1 if not parseable.
+func parseIndexFromPodName(podName string) int {
+	lastDashIndex := strings.LastIndex(podName, "-")
+	if lastDashIndex == -1 {
+		return -1
+	}
+	indexStr := podName[lastDashIndex+1:]
+	index, err := strconv.Atoi(indexStr)
+	if err != nil {
+		return -1
+	}
+	return index
+}
+
+// CollectGarbage collects StatefulSet subnet ports which have been removed
+func (r *StatefulSetReconciler) CollectGarbage(ctx context.Context) error {
+	if !r.StatefulSetPodFeatureEnabled() {
+		return nil
+	}
+	log.Info("StatefulSet garbage collector started")
+	statefulSetList := &appsv1.StatefulSetList{}
+	err := r.Client.List(ctx, statefulSetList)
+	if err != nil {
+		log.Error(err, "Failed to list StatefulSet")
+		return err
+	}
+
+	var errList []error
+	statefulSetUIDs := sets.New[string]()
+	for _, sts := range statefulSetList.Items {
+		existingPorts := r.SubnetPortService.SubnetPortStore.GetByIndex(servicecommon.TagScopeStatefulSetUID, string(sts.UID))
+		start, end := r.GetOrdinalRange(&sts)
+		log.Debug("StatefulSet garbage collector", "stsUID", sts.UID, "namespace", sts.Namespace, "start", start, "end", end)
+		for _, port := range existingPorts {
+			podName := util.FindTag(port.Tags, servicecommon.TagScopePodName)
+			if podName == "" {
+				continue
+			}
+			idx := stsPodOrdinalFromPort(port)
+			// Match handleReplicaChange: do not treat unparseable ordinals as out-of-range.
+			if idx == -1 {
+				continue
+			}
+			if idx < start || idx > end {
+				if podName != "" {
+					pod := &corev1.Pod{}
+					if err := r.Client.Get(ctx, types.NamespacedName{Namespace: sts.Namespace, Name: podName}, pod); err == nil && !common.PodIsDeleted(pod) {
+						log.Debug("GC: pod still exists, skipping port deletion", "pod", podName)
+						continue
+					}
+				}
+				log.Info("StatefulSet garbage collector: found out-of-range port", "index", idx, "stsUID", sts.UID, "start", start, "end", end, "namespace", sts.Namespace)
+				if err := r.SubnetPortService.DeleteSubnetPort(port); err != nil {
+					log.Error(err, "GC: failed to delete out-of-range subnet port", "port", *port.Id, "stsUID", sts.UID, "namespace", sts.Namespace)
+					errList = append(errList, err)
+				}
+			}
+		}
+		statefulSetUIDs.Insert(string(sts.UID))
+	}
+
+	existingPorts := r.SubnetPortService.SubnetPortStore.GetByIndex(servicecommon.IndexKeyAllStsPorts, servicecommon.StsPortBucket)
+	for _, port := range existingPorts {
+		stsID := util.FindTag(port.Tags, servicecommon.TagScopeStatefulSetUID)
+		if !statefulSetUIDs.Has(stsID) {
+			podName := util.FindTag(port.Tags, servicecommon.TagScopePodName)
+			namespace := util.FindTag(port.Tags, servicecommon.TagScopeNamespace)
+			if podName != "" && namespace != "" {
+				pod := &corev1.Pod{}
+				if err := r.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: podName}, pod); err == nil && !common.PodIsDeleted(pod) {
+					log.Debug("GC: pod still exists, skipping orphaned port deletion", "pod", podName)
+					continue
+				}
+			}
+			log.Debug("Found orphaned subnet port for deleted StatefulSet", "port", *port.Id, "stsUID", stsID)
+			if err := r.SubnetPortService.DeleteSubnetPort(port); err != nil {
+				log.Error(err, "GC: failed to delete orphaned subnet port", "port", *port.Id, "stsUID", stsID)
+				errList = append(errList, err)
+			}
+		}
+	}
+	if len(errList) > 0 {
+		return fmt.Errorf("StatefulSet GC: %d delete error(s): %v", len(errList), errList)
+	}
+	return nil
+}
+
+func (r *StatefulSetReconciler) GetOrdinalRange(sts *appsv1.StatefulSet) (int, int) {
+	start := 0
+	if sts.Spec.Ordinals != nil {
+		// K8s 1.31+ feature, start index can be specified by users, default is 0
+		start = int(sts.Spec.Ordinals.Start)
+	}
+
+	replicas := 0
+	if sts.Spec.Replicas != nil {
+		replicas = int(*sts.Spec.Replicas)
+	}
+
+	if replicas == 0 {
+		// No desired pods: empty ordinal range. Callers treat any idx>=0 as out-of-range
+		// so handleReplicaChange/GC release all STS-tagged ports for this StatefulSet.
+		return -1, -1
+	}
+
+	return start, start + replicas - 1
+}
+
+// PredicateFuncsForStatefulSet limits which StatefulSet watch events reach the reconciler.
+//
+// The reconciler mainly needs to release NSX resources when desired pod ordinals drop out
+// of the active range (scale down or ordinals start moved up). Updates are therefore admitted
+// only when the inclusive ordinal window [start, start+replicas-1] shrinks: either the start
+// moves right (newStart > oldStart) or the end moves left (newEnd < oldEnd). Other updates,
+// including scale-up and unchanged replica/ordinal fields, are ignored.
+//
+// Create and generic events are ignored; subnet wiring for new pods is handled via Pod
+// reconciliation. Delete events are always admitted so the controller can tear down
+// remaining resources for the StatefulSet.
+var PredicateFuncsForStatefulSet = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		oldSts, ok1 := e.ObjectOld.(*appsv1.StatefulSet)
+		newSts, ok2 := e.ObjectNew.(*appsv1.StatefulSet)
+		if !ok1 || !ok2 {
+			log.Error(fmt.Errorf("type assertion failed"), "Failed to cast to StatefulSet in update event")
+			return false
+		}
+
+		oldStart := int32(0)
+		if oldSts.Spec.Ordinals != nil {
+			oldStart = oldSts.Spec.Ordinals.Start
+		}
+		newStart := int32(0)
+		if newSts.Spec.Ordinals != nil {
+			newStart = newSts.Spec.Ordinals.Start
+		}
+
+		// If either has nil replicas, don't trigger.
+		if oldSts.Spec.Replicas == nil || newSts.Spec.Replicas == nil {
+			return false
+		}
+
+		oldRepl := *oldSts.Spec.Replicas
+		oldEnd := oldStart + oldRepl - 1
+
+		newRepl := *newSts.Spec.Replicas
+		newEnd := newStart + newRepl - 1
+
+		// Shrink of desired ordinal range: dropped lower indices and/or dropped upper indices.
+		if newStart > oldStart || newEnd < oldEnd {
+			log.Debug("StatefulSet update event received",
+				"name", oldSts.Name,
+				"namespace", oldSts.Namespace,
+				"oldReplicas", oldSts.Spec.Replicas,
+				"newReplicas", newSts.Spec.Replicas,
+				"oldOrdinalsStart", oldStart,
+				"newOrdinalsStart", newStart)
+			return true
+		}
+		return false
+	},
+	CreateFunc: func(e event.CreateEvent) bool {
+		return false
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return true
+	},
+	GenericFunc: func(e event.GenericEvent) bool {
+		return false
+	},
+}
+
+// setupWithManager sets up the controller with the Manager.
+func (r *StatefulSetReconciler) setupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.StatefulSet{}).
+		WithEventFilter(PredicateFuncsForStatefulSet).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: common.NumReconcile(),
+		}).
+		Complete(r)
+}
+
+func (r *StatefulSetReconciler) StartController(mgr ctrl.Manager, _ webhook.Server) error {
+	if err := r.setupWithManager(mgr); err != nil {
+		log.Error(err, "failed to create controller", "controller", "StatefulSet")
+		return err
+	}
+	go common.GenericGarbageCollector(make(chan bool), servicecommon.GCInterval, r.CollectGarbage)
+	return nil
+}
+
+func NewStatefulSetReconciler(mgr ctrl.Manager, subnetPortService *subnetportservice.SubnetPortService) *StatefulSetReconciler {
+	log.Debug("New StatefulSet Reconciler")
+	reconciler := &StatefulSetReconciler{
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		SubnetPortService: subnetPortService,
+		Recorder:          mgr.GetEventRecorderFor("statefulset-controller"),
+	}
+	reconciler.StatusUpdater = common.NewStatusUpdater(reconciler.Client, reconciler.SubnetPortService.NSXConfig, reconciler.Recorder, MetricResTypeStatefulSet, "SubnetPort", "StatefulSet")
+	return reconciler
+}
+
+// Start starts the controller
+func (r *StatefulSetReconciler) Start(mgr ctrl.Manager) error {
+	return r.setupWithManager(mgr)
+}
+
+// RestoreReconcile implements ReconcilerProvider interface
+func (r *StatefulSetReconciler) RestoreReconcile() error {
+	// StatefulSet controller doesn't need restore reconcile for now
+	return nil
+}

--- a/pkg/controllers/statefulset/statefulset_controller_test.go
+++ b/pkg/controllers/statefulset/statefulset_controller_test.go
@@ -1,0 +1,2081 @@
+/* Copyright © 2026 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package statefulset
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	goruntime "runtime"
+	"testing"
+	"time"
+
+	gomonkey "github.com/agiledragon/gomonkey/v2"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	subnetportservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
+)
+
+type MockManager struct {
+	ctrl.Manager
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+func (m *MockManager) GetClient() client.Client {
+	return m.client
+}
+
+func (m *MockManager) GetScheme() *runtime.Scheme {
+	return m.scheme
+}
+
+func (m *MockManager) GetEventRecorderFor(name string) record.EventRecorder {
+	return nil
+}
+
+func (m *MockManager) Add(runnable manager.Runnable) error {
+	return nil
+}
+
+func (m *MockManager) Start(context.Context) error {
+	return nil
+}
+
+type fakeRecorder struct{}
+
+func (recorder fakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {}
+
+func (recorder fakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+}
+
+func (recorder fakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+}
+
+// patchNSXClientStatefulSetPodVersion replaces (*nsx.Client).NSXCheckVersion for nsx.StatefulSetPod only.
+// Use only in tests that do not combine gomonkey ApplyFunc on SubnetPortService in the same function.
+func patchNSXClientStatefulSetPodVersion(t *testing.T, enabled bool) func() {
+	t.Helper()
+	patches := gomonkey.ApplyMethod(reflect.TypeOf((*nsx.Client)(nil)), "NSXCheckVersion", func(_ *nsx.Client, feature int) bool {
+		if feature == nsx.StatefulSetPod {
+			return enabled
+		}
+		return false
+	})
+	return func() { patches.Reset() }
+}
+
+func testNSXConfigWithStatefulSetPodEnhance() *config.NSXOperatorConfig {
+	on := true
+	return &config.NSXOperatorConfig{
+		NsxConfig: &config.NsxConfig{
+			EnforcementPoint: "vmc-enforcementpoint",
+			VpcWcpEnhance:    &on,
+		},
+	}
+}
+
+func TestParseIndexFromPodName(t *testing.T) {
+	tests := []struct {
+		name    string
+		podName string
+		want    int
+	}{
+		{
+			name:    "valid index",
+			podName: "tea-set-0",
+			want:    0,
+		},
+		{
+			name:    "valid index 5",
+			podName: "tea-set-5",
+			want:    5,
+		},
+		{
+			name:    "no dash",
+			podName: "teaset",
+			want:    -1,
+		},
+		{
+			name:    "invalid index",
+			podName: "tea-set-abc",
+			want:    -1,
+		},
+		{
+			name:    "empty string",
+			podName: "",
+			want:    -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseIndexFromPodName(tt.podName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStsPodOrdinalFromPort(t *testing.T) {
+	podIndexScope := servicecommon.TagScopePodIndex
+	podNameScope := servicecommon.TagScopePodName
+	tests := []struct {
+		name string
+		port *model.VpcSubnetPort
+		want int
+	}{
+		{
+			name: "pod-index tag",
+			port: &model.VpcSubnetPort{
+				Tags: []model.Tag{
+					{Scope: &podIndexScope, Tag: servicecommon.String("9")},
+					{Scope: &podNameScope, Tag: servicecommon.String("web-9")},
+				},
+			},
+			want: 9,
+		},
+		{
+			name: "fallback to pod name",
+			port: &model.VpcSubnetPort{
+				Tags: []model.Tag{
+					{Scope: &podNameScope, Tag: servicecommon.String("tea-set-3")},
+				},
+			},
+			want: 3,
+		},
+		{
+			name: "prefer pod-index over misleading name",
+			port: &model.VpcSubnetPort{
+				Tags: []model.Tag{
+					{Scope: &podIndexScope, Tag: servicecommon.String("2")},
+					{Scope: &podNameScope, Tag: servicecommon.String("custom-template-9")},
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "invalid pod-index falls back to name",
+			port: &model.VpcSubnetPort{
+				Tags: []model.Tag{
+					{Scope: &podIndexScope, Tag: servicecommon.String("not-a-number")},
+					{Scope: &podNameScope, Tag: servicecommon.String("tea-set-1")},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "nil port",
+			port: nil,
+			want: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stsPodOrdinalFromPort(tt.port)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPredicateUpdateFunc(t *testing.T) {
+	tests := []struct {
+		name        string
+		oldReplicas *int32
+		newReplicas *int32
+		want        bool
+	}{
+		{
+			name:        "shrink replicas",
+			oldReplicas: func() *int32 { r := int32(5); return &r }(),
+			newReplicas: func() *int32 { r := int32(3); return &r }(),
+			want:        true,
+		},
+		{
+			name:        "expand replicas",
+			oldReplicas: func() *int32 { r := int32(3); return &r }(),
+			newReplicas: func() *int32 { r := int32(5); return &r }(),
+			want:        false,
+		},
+		{
+			name:        "same replicas",
+			oldReplicas: func() *int32 { r := int32(3); return &r }(),
+			newReplicas: func() *int32 { r := int32(3); return &r }(),
+			want:        false,
+		},
+		{
+			name:        "old nil replicas",
+			oldReplicas: nil,
+			newReplicas: func() *int32 { r := int32(3); return &r }(),
+			want:        false,
+		},
+		{
+			name:        "new nil replicas",
+			oldReplicas: func() *int32 { r := int32(3); return &r }(),
+			newReplicas: nil,
+			want:        false,
+		},
+		{
+			name:        "both nil replicas",
+			oldReplicas: nil,
+			newReplicas: nil,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldSts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: tt.oldReplicas,
+				},
+			}
+			newSts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: tt.newReplicas,
+				},
+			}
+
+			updateEvent := event.UpdateEvent{
+				ObjectOld: oldSts,
+				ObjectNew: newSts,
+			}
+			result := PredicateFuncsForStatefulSet.UpdateFunc(updateEvent)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestPredicateFuncsForStatefulSet(t *testing.T) {
+	createEvent := event.CreateEvent{}
+	assert.False(t, PredicateFuncsForStatefulSet.CreateFunc(createEvent))
+
+	deleteEvent := event.DeleteEvent{}
+	assert.True(t, PredicateFuncsForStatefulSet.DeleteFunc(deleteEvent))
+
+	genericEvent := event.GenericEvent{}
+	assert.False(t, PredicateFuncsForStatefulSet.GenericFunc(genericEvent))
+}
+
+func TestRestoreReconcile(t *testing.T) {
+	reconciler := &StatefulSetReconciler{}
+	err := reconciler.RestoreReconcile()
+	assert.NoError(t, err)
+}
+
+func TestNewStatefulSetReconciler(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects().Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			Client: fakeClient,
+			NSXConfig: &config.NSXOperatorConfig{
+				NsxConfig: &config.NsxConfig{
+					EnforcementPoint: "vmc-enforcementpoint",
+				},
+			},
+		},
+	}
+	mockMgr := &MockManager{scheme: runtime.NewScheme(), client: fakeClient}
+	patches := gomonkey.ApplyFunc((*StatefulSetReconciler).setupWithManager, func(r *StatefulSetReconciler, mgr manager.Manager) error {
+		return nil
+	})
+	defer patches.Reset()
+	r := NewStatefulSetReconciler(mockMgr, subnetPortService)
+	assert.NotNil(t, r)
+}
+
+func TestStatefulSetReconciler_StartController(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects().Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			Client: fakeClient,
+		},
+	}
+	mockMgr := &MockManager{scheme: runtime.NewScheme(), client: fakeClient}
+	patches := gomonkey.ApplyFunc((*StatefulSetReconciler).setupWithManager, func(r *StatefulSetReconciler, mgr manager.Manager) error {
+		return nil
+	})
+	gcEntered := make(chan struct{}, 1)
+	patches.ApplyFunc(common.GenericGarbageCollector, func(cancel chan bool, timeout time.Duration, f func(ctx context.Context) error) {
+		gcEntered <- struct{}{}
+	})
+	defer patches.Reset()
+	r := NewStatefulSetReconciler(mockMgr, subnetPortService)
+	err := r.StartController(mockMgr, nil)
+	assert.Nil(t, err)
+	// Wait until the GC goroutine has entered the patched collector before Reset; otherwise gomonkey
+	// can corrupt unrelated patched methods in later tests.
+	select {
+	case <-gcEntered:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "patched GenericGarbageCollector was not invoked")
+	}
+	goruntime.Gosched()
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestStatefulSetReconciler_Reconcile(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	defer mockCtl.Finish()
+
+	r := &StatefulSetReconciler{
+		Client: k8sClient,
+		SubnetPortService: &subnetportservice.SubnetPortService{
+			Service: servicecommon.Service{
+				NSXClient: &nsx.Client{},
+				NSXConfig: testNSXConfigWithStatefulSetPodEnhance(),
+			},
+			SubnetPortStore: &subnetportservice.SubnetPortStore{},
+		},
+		Recorder: fakeRecorder{},
+	}
+	r.StatusUpdater = common.NewStatusUpdater(k8sClient, r.SubnetPortService.NSXConfig, r.Recorder, MetricResTypeStatefulSet, "SubnetPort", "StatefulSet")
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+
+	tests := []struct {
+		name           string
+		prepareFunc    func(*testing.T, *StatefulSetReconciler) *gomonkey.Patches
+		expectedErr    string
+		expectedResult ctrl.Result
+	}{
+		{
+			name: "StatefulSet not found",
+			prepareFunc: func(t *testing.T, r *StatefulSetReconciler) *gomonkey.Patches {
+				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("not found"))
+				return nil
+			},
+			expectedErr:    "not found",
+			expectedResult: common.ResultRequeue,
+		},
+		{
+			name: "StatefulSet found",
+			prepareFunc: func(t *testing.T, r *StatefulSetReconciler) *gomonkey.Patches {
+				sts := &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-sts",
+						Namespace: "default",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: func() *int32 { r := int32(3); return &r }(),
+					},
+					Status: appsv1.StatefulSetStatus{
+						Replicas: 3,
+					},
+				}
+				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(
+					func(ctx interface{}, key interface{}, obj interface{}, opts ...interface{}) error {
+						sts.DeepCopyInto(obj.(*appsv1.StatefulSet))
+						return nil
+					})
+				patches := gomonkey.ApplyFunc((*StatefulSetReconciler).handleReplicaChange,
+					func(r *StatefulSetReconciler, ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
+						return ctrl.Result{}, nil
+					})
+				return patches
+			},
+			expectedResult: common.ResultNormal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patches := tt.prepareFunc(t, r)
+			if patches != nil {
+				defer patches.Reset()
+			}
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-sts",
+					Namespace: "default",
+				},
+			}
+
+			result, err := r.Reconcile(context.Background(), req)
+			if tt.expectedErr != "" {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+// TestZStatefulSetReconciler_Reconcile_RequeueAfterOutOfRangePortBlockedByPod is named with a Z prefix so it
+// runs after other tests: gomonkey on ListSubnetPortByStsUid here can otherwise break ListSubnetPortByStsName patches.
+func TestZStatefulSetReconciler_Reconcile_RequeueAfterOutOfRangePortBlockedByPod(t *testing.T) {
+	// Register NSX patch before ListSubnetPortByStsUid patch defers so Reset runs in safe order on exit.
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	stsUID := types.UID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-sts", Namespace: "default", UID: stsUID,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(2); return &r }(),
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-sts-2", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sts, pod).Build()
+
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: testNSXConfigWithStatefulSetPodEnhance(),
+		},
+		SubnetPortStore: nil,
+	}
+
+	scope := servicecommon.TagScopePodName
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsUid,
+		func(s *subnetportservice.SubnetPortService, ns string, stsUid string) []*model.VpcSubnetPort {
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port1"),
+					Tags: []model.Tag{{Scope: &scope, Tag: servicecommon.String("test-sts-2")}}},
+			}
+		})
+	defer patches.Reset()
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+		Recorder:          fakeRecorder{},
+	}
+	r.StatusUpdater = common.NewStatusUpdater(fakeClient, r.SubnetPortService.NSXConfig, r.Recorder, MetricResTypeStatefulSet, "SubnetPort", "StatefulSet")
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-sts", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, stsSubnetPortPendingRequeueAfter, res.RequeueAfter)
+	assert.True(t, res.Requeue)
+}
+
+func TestStatefulSetReconciler_CollectGarbage(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	defer mockCtl.Finish()
+
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: testNSXConfigWithStatefulSetPodEnhance(),
+		},
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            k8sClient,
+		SubnetPortService: subnetPortService,
+	}
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+
+	tests := []struct {
+		name        string
+		prepareFunc func(*testing.T, *StatefulSetReconciler) *gomonkey.Patches
+		wantErr     bool
+	}{
+		{
+			name: "list error",
+			prepareFunc: func(t *testing.T, r *StatefulSetReconciler) *gomonkey.Patches {
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(errors.New("list failed"))
+				return nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "list success with empty items",
+			prepareFunc: func(t *testing.T, r *StatefulSetReconciler) *gomonkey.Patches {
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil).Do(
+					func(ctx interface{}, list interface{}, opts ...interface{}) error {
+						list.(*appsv1.StatefulSetList).Items = []appsv1.StatefulSet{}
+						return nil
+					})
+				patches := gomonkey.ApplyFunc(
+					(*subnetportservice.SubnetPortStore).GetByIndex,
+					func(s *subnetportservice.SubnetPortStore, indexKey string, indexValue string) []*model.VpcSubnetPort {
+						return []*model.VpcSubnetPort{}
+					})
+				return patches
+			},
+			wantErr: false,
+		},
+		{
+			name: "list success with StatefulSet - replicas shrink",
+			prepareFunc: func(t *testing.T, r *StatefulSetReconciler) *gomonkey.Patches {
+				sts := &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-sts",
+						Namespace: "default",
+						UID:       "sts-uid-1",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: func() *int32 { r := int32(2); return &r }(),
+					},
+					Status: appsv1.StatefulSetStatus{
+						Replicas: 5,
+					},
+				}
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil).Do(
+					func(ctx interface{}, list interface{}, opts ...interface{}) error {
+						list.(*appsv1.StatefulSetList).Items = []appsv1.StatefulSet{*sts}
+						return nil
+					})
+				callCount := 0
+				patches := gomonkey.ApplyFunc(
+					(*subnetportservice.SubnetPortStore).GetByIndex,
+					func(s *subnetportservice.SubnetPortStore, indexKey string, indexValue string) []*model.VpcSubnetPort {
+						callCount++
+						if callCount == 1 {
+							return []*model.VpcSubnetPort{
+								{DisplayName: servicecommon.String("test-sts-0")},
+								{DisplayName: servicecommon.String("test-sts-1")},
+								{DisplayName: servicecommon.String("test-sts-2")},
+								{DisplayName: servicecommon.String("test-sts-3")},
+								{DisplayName: servicecommon.String("test-sts-4")},
+							}
+						}
+						return []*model.VpcSubnetPort{}
+					})
+				patches.ApplyFunc(
+					(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+					func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+						return nil
+					})
+				return patches
+			},
+			wantErr: false,
+		},
+		{
+			name: "list success - stateful deleted (orphaned ports)",
+			prepareFunc: func(t *testing.T, r *StatefulSetReconciler) *gomonkey.Patches {
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil).Do(
+					func(ctx interface{}, list interface{}, opts ...interface{}) error {
+						list.(*appsv1.StatefulSetList).Items = []appsv1.StatefulSet{}
+						return nil
+					})
+				callCount := 0
+				patches := gomonkey.ApplyFunc(
+					(*subnetportservice.SubnetPortStore).GetByIndex,
+					func(s *subnetportservice.SubnetPortStore, indexKey string, indexValue string) []*model.VpcSubnetPort {
+						callCount++
+						if callCount == 1 {
+							return []*model.VpcSubnetPort{}
+						}
+						portID := servicecommon.String("orphaned-port-1")
+						stsUID := servicecommon.String("deleted-sts-uid")
+						return []*model.VpcSubnetPort{
+							{
+								Id:          portID,
+								DisplayName: servicecommon.String("test-sts-0"),
+								Tags: []model.Tag{
+									{Scope: servicecommon.String(servicecommon.TagScopeStatefulSetUID), Tag: stsUID},
+								},
+							},
+						}
+					})
+				patches.ApplyFunc(
+					(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+					func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+						return nil
+					})
+				return patches
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patches := tt.prepareFunc(t, r)
+			if patches != nil {
+				defer patches.Reset()
+			}
+
+			err := r.CollectGarbage(context.Background())
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStatefulSetReconciler_HandleReplicaChange(t *testing.T) {
+	subnetPortService := &subnetportservice.SubnetPortService{
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		SubnetPortService: subnetPortService,
+	}
+
+	tests := []struct {
+		name             string
+		sts              *appsv1.StatefulSet
+		prepareFunc      func(*testing.T, *StatefulSetReconciler) *gomonkey.Patches
+		wantErr          bool
+		wantRequeueAfter time.Duration
+	}{
+		{
+			name: "replicas decreased",
+			sts: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sts",
+					Namespace: "default",
+					UID:       "test-sts-uid",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: func() *int32 { r := int32(2); return &r }(),
+				},
+				Status: appsv1.StatefulSetStatus{
+					Replicas: 5,
+				},
+			},
+			prepareFunc: func(t *testing.T, r *StatefulSetReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc(
+					(*subnetportservice.SubnetPortService).ListSubnetPortByStsUid,
+					func(s *subnetportservice.SubnetPortService, ns string, stsUid string) []*model.VpcSubnetPort {
+						return []*model.VpcSubnetPort{
+							{Id: servicecommon.String("port1"), DisplayName: servicecommon.String("test-sts-0")},
+							{Id: servicecommon.String("port2"), DisplayName: servicecommon.String("test-sts-1")},
+							{Id: servicecommon.String("port3"), DisplayName: servicecommon.String("test-sts-2")},
+							{Id: servicecommon.String("port4"), DisplayName: servicecommon.String("test-sts-3")},
+							{Id: servicecommon.String("port5"), DisplayName: servicecommon.String("test-sts-4")},
+						}
+					})
+				patches.ApplyFunc((*StatefulSetReconciler).releaseSubnetPortForPod,
+					func(r *StatefulSetReconciler, ctx context.Context, namespace, podName string) (releaseSubnetPortOutcome, error) {
+						return releaseSubnetPortReleased, nil
+					})
+				return patches
+			},
+			wantErr: false,
+		},
+		{
+			name: "replicas increased",
+			sts: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sts",
+					Namespace: "default",
+					UID:       "test-sts-uid",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: func() *int32 { r := int32(5); return &r }(),
+				},
+				Status: appsv1.StatefulSetStatus{
+					Replicas: 3,
+				},
+			},
+			prepareFunc: func(t *testing.T, r *StatefulSetReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc(
+					(*subnetportservice.SubnetPortService).ListSubnetPortByStsUid,
+					func(s *subnetportservice.SubnetPortService, ns string, stsUid string) []*model.VpcSubnetPort {
+						return []*model.VpcSubnetPort{}
+					})
+				return patches
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil replicas spec",
+			sts: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sts",
+					Namespace: "default",
+					UID:       "test-sts-uid",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: nil,
+				},
+				Status: appsv1.StatefulSetStatus{
+					Replicas: 3,
+				},
+			},
+			prepareFunc: func(t *testing.T, r *StatefulSetReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc(
+					(*subnetportservice.SubnetPortService).ListSubnetPortByStsUid,
+					func(s *subnetportservice.SubnetPortService, ns string, stsUid string) []*model.VpcSubnetPort {
+						return []*model.VpcSubnetPort{}
+					})
+				patches.ApplyFunc((*StatefulSetReconciler).releaseSubnetPortForPod,
+					func(r *StatefulSetReconciler, ctx context.Context, namespace, podName string) (releaseSubnetPortOutcome, error) {
+						return releaseSubnetPortReleased, nil
+					})
+				return patches
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var patches *gomonkey.Patches
+			if tt.prepareFunc != nil {
+				patches = tt.prepareFunc(t, r)
+				if patches != nil {
+					defer patches.Reset()
+				}
+			}
+
+			res, err := r.handleReplicaChange(context.Background(), tt.sts)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantRequeueAfter, res.RequeueAfter)
+			}
+		})
+	}
+}
+
+type releaseSubnetPortsAux struct {
+	deleteCalls int
+}
+
+func runReleaseSubnetPortsForStatefulSetCase(t *testing.T, prepare func(*testing.T, *subnetportservice.SubnetPortService, *releaseSubnetPortsAux) *gomonkey.Patches, wantErr bool, wantErrSubstring string, wantDeleteCalls int, wantPending *bool) {
+	t.Helper()
+	fakeClient := fake.NewClientBuilder().Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+	aux := &releaseSubnetPortsAux{}
+	patches := prepare(t, subnetPortService, aux)
+	if patches != nil {
+		defer patches.Reset()
+	}
+
+	pending, err := r.releaseSubnetPortsForStatefulSet(context.Background(), "default", "test-sts")
+	if wantErr {
+		require.Error(t, err)
+		if wantErrSubstring != "" {
+			assert.Contains(t, err.Error(), wantErrSubstring)
+		}
+	} else {
+		require.NoError(t, err)
+	}
+	if wantPending != nil {
+		assert.Equal(t, *wantPending, pending)
+	}
+	if wantDeleteCalls >= 0 {
+		assert.Equal(t, wantDeleteCalls, aux.deleteCalls)
+	}
+}
+
+func TestStatefulSetReconciler_ReleaseSubnetPortsForStatefulSet_noPorts(t *testing.T) {
+	f := false
+	runReleaseSubnetPortsForStatefulSetCase(t, func(t *testing.T, sps *subnetportservice.SubnetPortService, aux *releaseSubnetPortsAux) *gomonkey.Patches {
+		return gomonkey.ApplyFunc(
+			(*subnetportservice.SubnetPortService).ListSubnetPortByStsName,
+			func(s *subnetportservice.SubnetPortService, ns string, stsName string) []*model.VpcSubnetPort {
+				return []*model.VpcSubnetPort{}
+			})
+	}, false, "", -1, &f)
+}
+
+func TestStatefulSetReconciler_ReleaseSubnetPortsForStatefulSet_withPortsDeleteSuccess(t *testing.T) {
+	fp := false
+	runReleaseSubnetPortsForStatefulSetCase(t, func(t *testing.T, sps *subnetportservice.SubnetPortService, aux *releaseSubnetPortsAux) *gomonkey.Patches {
+		patches := gomonkey.ApplyFunc(
+			(*subnetportservice.SubnetPortService).ListSubnetPortByStsName,
+			func(s *subnetportservice.SubnetPortService, ns string, stsName string) []*model.VpcSubnetPort {
+				podNameScope := "nsx-op/pod_name"
+				return []*model.VpcSubnetPort{
+					{Id: servicecommon.String("port1"), DisplayName: servicecommon.String("test-sts-0"),
+						Tags: []model.Tag{{Scope: &podNameScope, Tag: servicecommon.String("test-sts-0")}}},
+					{Id: servicecommon.String("port2"), DisplayName: servicecommon.String("test-sts-1"),
+						Tags: []model.Tag{{Scope: &podNameScope, Tag: servicecommon.String("test-sts-1")}}},
+				}
+			})
+		patches.ApplyFunc(
+			(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+			func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+				return nil
+			})
+		return patches
+	}, false, "", -1, &fp)
+}
+
+func TestStatefulSetReconciler_ReleaseSubnetPortsForStatefulSet_portWithoutPodNameTagStillDeletes(t *testing.T) {
+	fp := false
+	runReleaseSubnetPortsForStatefulSetCase(t, func(t *testing.T, sps *subnetportservice.SubnetPortService, aux *releaseSubnetPortsAux) *gomonkey.Patches {
+		patches := gomonkey.ApplyFunc(
+			(*subnetportservice.SubnetPortService).ListSubnetPortByStsName,
+			func(s *subnetportservice.SubnetPortService, ns, stsName string) []*model.VpcSubnetPort {
+				return []*model.VpcSubnetPort{{Id: servicecommon.String("orphan-id")}}
+			})
+		patches.ApplyFunc(
+			(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+			func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+				aux.deleteCalls++
+				return nil
+			})
+		return patches
+	}, false, "", 1, &fp)
+}
+
+func TestStatefulSetReconciler_ReleaseSubnetPortsForStatefulSet_deleteSubnetPortErrorAggregates(t *testing.T) {
+	fp := false
+	runReleaseSubnetPortsForStatefulSetCase(t, func(t *testing.T, sps *subnetportservice.SubnetPortService, aux *releaseSubnetPortsAux) *gomonkey.Patches {
+		patches := gomonkey.ApplyFunc(
+			(*subnetportservice.SubnetPortService).ListSubnetPortByStsName,
+			func(s *subnetportservice.SubnetPortService, ns, stsName string) []*model.VpcSubnetPort {
+				return []*model.VpcSubnetPort{{Id: servicecommon.String("p1")}}
+			})
+		patches.ApplyFunc(
+			(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+			func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+				return errors.New("nsx delete failed")
+			})
+		return patches
+	}, true, "errors found in releasing subnet ports", -1, &fp)
+}
+
+func runReleaseSubnetPortForPodCase(t *testing.T, prepare func(*testing.T, *subnetportservice.SubnetPortService) *gomonkey.Patches, wantErr bool, wantOutcome releaseSubnetPortOutcome) {
+	t.Helper()
+	fakeClient := fake.NewClientBuilder().Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+	patches := prepare(t, subnetPortService)
+	if patches != nil {
+		defer patches.Reset()
+	}
+	outcome, err := r.releaseSubnetPortForPod(context.Background(), "default", "test-sts-0")
+	if wantErr {
+		assert.Error(t, err)
+	} else {
+		assert.NoError(t, err)
+		assert.Equal(t, wantOutcome, outcome)
+	}
+}
+
+func TestStatefulSetReconciler_ReleaseSubnetPortForPod_noPorts(t *testing.T) {
+	runReleaseSubnetPortForPodCase(t, func(t *testing.T, sps *subnetportservice.SubnetPortService) *gomonkey.Patches {
+		return gomonkey.ApplyFunc(
+			(*subnetportservice.SubnetPortService).ListSubnetPortByPodName,
+			func(s *subnetportservice.SubnetPortService, ns string, name string) []*model.VpcSubnetPort {
+				return []*model.VpcSubnetPort{}
+			})
+	}, false, releaseSubnetPortNoop)
+}
+
+func TestStatefulSetReconciler_ReleaseSubnetPortForPod_withPortsDeleteSuccess(t *testing.T) {
+	runReleaseSubnetPortForPodCase(t, func(t *testing.T, sps *subnetportservice.SubnetPortService) *gomonkey.Patches {
+		patches := gomonkey.ApplyFunc(
+			(*subnetportservice.SubnetPortService).ListSubnetPortByPodName,
+			func(s *subnetportservice.SubnetPortService, ns string, name string) []*model.VpcSubnetPort {
+				return []*model.VpcSubnetPort{
+					{Id: servicecommon.String("port1")},
+				}
+			})
+		patches.ApplyFunc(
+			(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+			func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+				return nil
+			})
+		return patches
+	}, false, releaseSubnetPortReleased)
+}
+
+func TestSetupWithManager(t *testing.T) {
+	reconciler := &StatefulSetReconciler{}
+	err := reconciler.setupWithManager(nil)
+	assert.Error(t, err)
+}
+
+func TestStart(t *testing.T) {
+	reconciler := &StatefulSetReconciler{}
+	err := reconciler.Start(nil)
+	assert.Error(t, err)
+}
+
+func TestGetOrdinalRange(t *testing.T) {
+	tests := []struct {
+		name          string
+		sts           *appsv1.StatefulSet
+		expectedStart int
+		expectedEnd   int
+	}{
+		{
+			name: "default ordinals",
+			sts: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: func() *int32 { r := int32(3); return &r }(),
+				},
+			},
+			expectedStart: 0,
+			expectedEnd:   2,
+		},
+		{
+			name: "custom ordinals start",
+			sts: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Ordinals: &appsv1.StatefulSetOrdinals{Start: 10},
+					Replicas: func() *int32 { r := int32(3); return &r }(),
+				},
+			},
+			expectedStart: 10,
+			expectedEnd:   12,
+		},
+		{
+			name: "zero replicas",
+			sts: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: func() *int32 { r := int32(0); return &r }(),
+				},
+			},
+			expectedStart: -1,
+			expectedEnd:   -1,
+		},
+		{
+			name:          "nil replicas",
+			sts:           &appsv1.StatefulSet{},
+			expectedStart: -1,
+			expectedEnd:   -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &StatefulSetReconciler{}
+			start, end := r.GetOrdinalRange(tt.sts)
+			assert.Equal(t, tt.expectedStart, start)
+			assert.Equal(t, tt.expectedEnd, end)
+		})
+	}
+}
+
+func TestHandleReplicaChange_WithOrdinals(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		// Nil store: if releaseSubnetPortForPod is not monkey-patched, ListSubnetPortByPodName returns
+		// empty without touching an uninitialized indexer (avoids panic; does not affect patched ListSubnetPortByStsUid).
+		SubnetPortStore: nil,
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "default",
+			UID:       "test-sts-uid",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Ordinals: &appsv1.StatefulSetOrdinals{Start: 5},
+			Replicas: func() *int32 { r := int32(3); return &r }(),
+		},
+	}
+
+	scope := servicecommon.TagScopePodName
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsUid,
+		func(s *subnetportservice.SubnetPortService, ns string, stsUid string) []*model.VpcSubnetPort {
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port1"), Tags: []model.Tag{{Scope: &scope, Tag: servicecommon.String("test-sts-0")}}},
+				{Id: servicecommon.String("port2"), Tags: []model.Tag{{Scope: &scope, Tag: servicecommon.String("test-sts-1")}}},
+				{Id: servicecommon.String("port3"), Tags: []model.Tag{{Scope: &scope, Tag: servicecommon.String("test-sts-5")}}},
+				{Id: servicecommon.String("port4"), Tags: []model.Tag{{Scope: &scope, Tag: servicecommon.String("test-sts-6")}}},
+				{Id: servicecommon.String("port5"), Tags: []model.Tag{{Scope: &scope, Tag: servicecommon.String("test-sts-7")}}},
+			}
+		})
+	patches.ApplyFunc((*StatefulSetReconciler).releaseSubnetPortForPod,
+		func(r *StatefulSetReconciler, ctx context.Context, namespace, podName string) (releaseSubnetPortOutcome, error) {
+			return releaseSubnetPortReleased, nil
+		})
+	defer patches.Reset()
+
+	res, err := r.handleReplicaChange(context.Background(), sts)
+	assert.NoError(t, err)
+	assert.Zero(t, res.RequeueAfter)
+}
+
+func TestHandleReplicaChange_WithNilDisplayName(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		SubnetPortStore: nil,
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "default",
+			UID:       "test-sts-uid",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(2); return &r }(),
+		},
+	}
+
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsUid,
+		func(s *subnetportservice.SubnetPortService, ns string, stsUid string) []*model.VpcSubnetPort {
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port1")},
+			}
+		})
+	defer patches.Reset()
+
+	res, err := r.handleReplicaChange(context.Background(), sts)
+	assert.NoError(t, err)
+	assert.Zero(t, res.RequeueAfter)
+}
+
+func TestReleaseSubnetPortForPod_PodExists(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-pod",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}).Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	outcome, err := r.releaseSubnetPortForPod(context.Background(), "default", "existing-pod")
+	assert.NoError(t, err)
+	assert.Equal(t, releaseSubnetPortSkippedRunningPod, outcome)
+}
+
+func TestReleaseSubnetPortsForStatefulSet_PodExists(t *testing.T) {
+	livePodUID := types.UID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	fakeClient := fake.NewClientBuilder().WithObjects(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts-0",
+			Namespace: "default",
+			UID:       livePodUID,
+		},
+	}).Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	var deleteCalls int
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsName,
+		func(s *subnetportservice.SubnetPortService, ns string, stsName string) []*model.VpcSubnetPort {
+			podNameScope := "nsx-op/pod_name"
+			podUIDScope := servicecommon.TagScopePodUID
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port1"), DisplayName: servicecommon.String("test-sts-0"),
+					Tags: []model.Tag{
+						{Scope: &podNameScope, Tag: servicecommon.String("test-sts-0")},
+						{Scope: &podUIDScope, Tag: servicecommon.String(string(livePodUID))},
+					}},
+			}
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+		func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+			deleteCalls++
+			return nil
+		})
+	defer patches.Reset()
+
+	pending, err := r.releaseSubnetPortsForStatefulSet(context.Background(), "default", "test-sts")
+	assert.NoError(t, err)
+	assert.True(t, pending, "caller should requeue while live pod still blocks port deletion")
+	assert.Equal(t, 0, deleteCalls, "port should be retained when pod exists and port pod_uid matches pod.UID")
+}
+
+func TestReleaseSubnetPortsForStatefulSet_PodSucceededAllowsDeleteWithMatchingUID(t *testing.T) {
+	livePodUID := types.UID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+	fakeClient := fake.NewClientBuilder().WithObjects(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts-0",
+			Namespace: "default",
+			UID:       livePodUID,
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+	}).Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	var deleteCalls int
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsName,
+		func(s *subnetportservice.SubnetPortService, ns string, stsName string) []*model.VpcSubnetPort {
+			podNameScope := "nsx-op/pod_name"
+			podUIDScope := servicecommon.TagScopePodUID
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port1"), DisplayName: servicecommon.String("test-sts-0"),
+					Tags: []model.Tag{
+						{Scope: &podNameScope, Tag: servicecommon.String("test-sts-0")},
+						{Scope: &podUIDScope, Tag: servicecommon.String(string(livePodUID))},
+					}},
+			}
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+		func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+			deleteCalls++
+			return nil
+		})
+	defer patches.Reset()
+
+	pending, err := r.releaseSubnetPortsForStatefulSet(context.Background(), "default", "test-sts")
+	assert.NoError(t, err)
+	assert.False(t, pending)
+	assert.Equal(t, 1, deleteCalls, "port should be deleted when pod is Succeeded even if UID still matches")
+}
+
+func TestReleaseSubnetPortsForStatefulSet_PodTerminatingSkipsDeleteWithMatchingUID(t *testing.T) {
+	livePodUID := types.UID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+	now := metav1.Now()
+	fakeClient := fake.NewClientBuilder().WithObjects(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-sts-0",
+			Namespace:         "default",
+			UID:               livePodUID,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test-finalizer"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}).Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	var deleteCalls int
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsName,
+		func(s *subnetportservice.SubnetPortService, ns string, stsName string) []*model.VpcSubnetPort {
+			podNameScope := "nsx-op/pod_name"
+			podUIDScope := servicecommon.TagScopePodUID
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port1"), DisplayName: servicecommon.String("test-sts-0"),
+					Tags: []model.Tag{
+						{Scope: &podNameScope, Tag: servicecommon.String("test-sts-0")},
+						{Scope: &podUIDScope, Tag: servicecommon.String(string(livePodUID))},
+					}},
+			}
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+		func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+			deleteCalls++
+			return nil
+		})
+	defer patches.Reset()
+
+	pending, err := r.releaseSubnetPortsForStatefulSet(context.Background(), "default", "test-sts")
+	assert.NoError(t, err)
+	assert.True(t, pending, "terminating-but-not-terminal pod should defer delete and surface pending for requeue")
+	assert.Equal(t, 0, deleteCalls, "PodIsDeleted is terminal phase only: Running+DeletionTimestamp must not release port when UID still matches")
+}
+
+func TestReleaseSubnetPortsForStatefulSet_PodUIDMismatchDeletesPort(t *testing.T) {
+	livePodUID := types.UID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	stalePortPodUID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	fakeClient := fake.NewClientBuilder().WithObjects(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts-0",
+			Namespace: "default",
+			UID:       livePodUID,
+		},
+	}).Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	var deleteCalls int
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsName,
+		func(s *subnetportservice.SubnetPortService, ns string, stsName string) []*model.VpcSubnetPort {
+			podNameScope := "nsx-op/pod_name"
+			podUIDScope := servicecommon.TagScopePodUID
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port1"), DisplayName: servicecommon.String("test-sts-0"),
+					Tags: []model.Tag{
+						{Scope: &podNameScope, Tag: servicecommon.String("test-sts-0")},
+						{Scope: &podUIDScope, Tag: servicecommon.String(stalePortPodUID)},
+					}},
+			}
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+		func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+			deleteCalls++
+			return nil
+		})
+	defer patches.Reset()
+
+	pending, err := r.releaseSubnetPortsForStatefulSet(context.Background(), "default", "test-sts")
+	assert.NoError(t, err)
+	assert.False(t, pending)
+	assert.Equal(t, 1, deleteCalls, "stale subnet port for same pod name but different pod UID should be deleted")
+}
+
+func TestReleaseSubnetPortForPod_DeleteError(t *testing.T) {
+	// Use fake client (empty cluster) so Get returns NotFound without gomock + gomonkey cross-test interference.
+	fakeClient := fake.NewClientBuilder().Build()
+
+	subnetPortService := &subnetportservice.SubnetPortService{
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByPodName,
+		func(s *subnetportservice.SubnetPortService, ns string, podName string) []*model.VpcSubnetPort {
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port-delete-error"), DisplayName: servicecommon.String("test-sts-0"), Path: servicecommon.String("/path/to/port")},
+			}
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+		func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+			return errors.New("delete subnet port failed")
+		})
+	defer patches.Reset()
+
+	_, err := r.releaseSubnetPortForPod(context.Background(), "default", "test-pod-0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete subnet port failed")
+}
+
+func TestCollectGarbage_OrphanedPortDeleteError(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: testNSXConfigWithStatefulSetPodEnhance(),
+		},
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortStore).GetByIndex,
+		func(s *subnetportservice.SubnetPortStore, indexKey string, indexValue string) []*model.VpcSubnetPort {
+			if indexKey == servicecommon.IndexKeyAllStsPorts {
+				stsUIDScope := "nsx-op/sts_uid"
+				nsScope := "nsx-op/namespace"
+				podNameScope := "nsx-op/pod_name"
+				return []*model.VpcSubnetPort{
+					{Id: servicecommon.String("port-orphan"),
+						Tags: []model.Tag{
+							{Scope: &stsUIDScope, Tag: servicecommon.String("deleted-sts-uid")},
+							{Scope: &nsScope, Tag: servicecommon.String("default")},
+							{Scope: &podNameScope, Tag: servicecommon.String("test-pod-0")},
+						}},
+				}
+			}
+			return []*model.VpcSubnetPort{}
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+		func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+			return errors.New("delete orphaned port failed")
+		})
+	defer patches.Reset()
+
+	err := r.CollectGarbage(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "delete error(s)")
+}
+
+func TestCollectGarbage_MixedErrors(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects(&appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "default",
+			UID:       "test-sts-uid",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(2); return &r }(),
+		},
+	}).Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: testNSXConfigWithStatefulSetPodEnhance(),
+		},
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortStore).GetByIndex,
+		func(s *subnetportservice.SubnetPortStore, indexKey string, indexValue string) []*model.VpcSubnetPort {
+			if indexKey == servicecommon.TagScopeStatefulSetUID && indexValue == "test-sts-uid" {
+				podNameScope := "nsx-op/pod_name"
+				return []*model.VpcSubnetPort{
+					{Id: servicecommon.String("port-oor"), DisplayName: servicecommon.String("test-sts-5"), Tags: []model.Tag{{Scope: &podNameScope, Tag: servicecommon.String("test-sts-5")}}},
+				}
+			}
+			if indexKey == servicecommon.IndexKeyAllStsPorts {
+				stsUIDScope := "nsx-op/sts_uid"
+				nsScope := "nsx-op/namespace"
+				podNameScope := "nsx-op/pod_name"
+				return []*model.VpcSubnetPort{
+					{Id: servicecommon.String("port-orphan"),
+						Tags: []model.Tag{
+							{Scope: &stsUIDScope, Tag: servicecommon.String("deleted-sts-uid")},
+							{Scope: &nsScope, Tag: servicecommon.String("default")},
+							{Scope: &podNameScope, Tag: servicecommon.String("test-pod-0")},
+						}},
+				}
+			}
+			return []*model.VpcSubnetPort{}
+		})
+
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+		func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+			if port.Path == nil {
+				port.Path = servicecommon.String("/orgs/default/projects/default/vpcs/default/subnets/default/ports/default")
+			}
+			if port.Id != nil && *port.Id == "port-oor" {
+				return errors.New("failed to delete out-of-range port")
+			}
+			if port.Id != nil && *port.Id == "port-orphan" {
+				return errors.New("failed to delete orphaned port")
+			}
+			return nil
+		})
+	defer patches.Reset()
+
+	err := r.CollectGarbage(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete out-of-range port")
+	assert.Contains(t, err.Error(), "failed to delete orphaned port")
+}
+
+func TestCollectGarbage_WithNilDisplayName(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects(&appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "default",
+			UID:       "test-sts-uid",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(2); return &r }(),
+		},
+	}).Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: testNSXConfigWithStatefulSetPodEnhance(),
+		},
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortStore).GetByIndex,
+		func(s *subnetportservice.SubnetPortStore, indexKey string, indexValue string) []*model.VpcSubnetPort {
+			if indexKey == servicecommon.TagScopeStatefulSetUID && indexValue == "test-sts-uid" {
+				return []*model.VpcSubnetPort{
+					{Id: servicecommon.String("port1"), DisplayName: nil},
+					{Id: servicecommon.String("port2"), DisplayName: servicecommon.String("test-sts-0")},
+				}
+			}
+			if indexKey == servicecommon.IndexKeyAllStsPorts {
+				return []*model.VpcSubnetPort{}
+			}
+			return []*model.VpcSubnetPort{}
+		})
+	defer patches.Reset()
+
+	err := r.CollectGarbage(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestCollectGarbage_WithInvalidIndexDisplayName(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects(&appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "default",
+			UID:       "test-sts-uid",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(2); return &r }(),
+		},
+	}).Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: testNSXConfigWithStatefulSetPodEnhance(),
+		},
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortStore).GetByIndex,
+		func(s *subnetportservice.SubnetPortStore, indexKey string, indexValue string) []*model.VpcSubnetPort {
+			if indexKey == servicecommon.TagScopeStatefulSetUID && indexValue == "test-sts-uid" {
+				return []*model.VpcSubnetPort{
+					{Id: servicecommon.String("port1"), DisplayName: servicecommon.String("invalid-name")},
+					{Id: servicecommon.String("port2"), DisplayName: servicecommon.String("test-sts-0")},
+				}
+			}
+			if indexKey == servicecommon.IndexKeyAllStsPorts {
+				return []*model.VpcSubnetPort{}
+			}
+			return []*model.VpcSubnetPort{}
+		})
+	defer patches.Reset()
+
+	err := r.CollectGarbage(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestHandleReplicaChange_WithPodStillExists(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts-2",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}).Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		SubnetPortStore: nil,
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts",
+			Namespace: "default",
+			UID:       "test-sts-uid",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(2); return &r }(),
+		},
+	}
+
+	scope := servicecommon.TagScopePodName
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsUid,
+		func(s *subnetportservice.SubnetPortService, ns string, stsUid string) []*model.VpcSubnetPort {
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port1"),
+					Tags: []model.Tag{{Scope: &scope, Tag: servicecommon.String("test-sts-2")}}},
+			}
+		})
+	defer patches.Reset()
+
+	res, err := r.handleReplicaChange(context.Background(), sts)
+	assert.NoError(t, err)
+	assert.Equal(t, stsSubnetPortPendingRequeueAfter, res.RequeueAfter)
+}
+
+// TestHandleReplicaChange_ReplicasZeroWithRunningPod covers GetOrdinalRange (-1,-1): every
+// parseable ordinal is out of range; a still-running Pod forces requeue instead of deleting.
+func TestHandleReplicaChange_ReplicasZeroWithRunningPod(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts-0",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}).Build()
+	subnetPortService := &subnetportservice.SubnetPortService{SubnetPortStore: nil}
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-sts", Namespace: "default", UID: "test-sts-uid",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { z := int32(0); return &z }(),
+		},
+	}
+
+	scope := servicecommon.TagScopePodName
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsUid,
+		func(s *subnetportservice.SubnetPortService, ns string, stsUid string) []*model.VpcSubnetPort {
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port0"),
+					Tags: []model.Tag{{Scope: &scope, Tag: servicecommon.String("test-sts-0")}}},
+			}
+		})
+	defer patches.Reset()
+
+	res, err := r.handleReplicaChange(context.Background(), sts)
+	assert.NoError(t, err)
+	assert.Equal(t, stsSubnetPortPendingRequeueAfter, res.RequeueAfter)
+}
+
+// TestHandleReplicaChange_ReplicasZeroReleasesWhenPodsGone verifies scale-to-zero releases
+// NSX ports once Pods are gone (no requeue when nothing is blocked by a live Pod).
+func TestHandleReplicaChange_ReplicasZeroReleasesWhenPodsGone(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	subnetPortService := &subnetportservice.SubnetPortService{SubnetPortStore: nil}
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-sts", Namespace: "default", UID: "test-sts-uid",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { z := int32(0); return &z }(),
+		},
+	}
+
+	scope := servicecommon.TagScopePodName
+	var deleteCalls int
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsUid,
+		func(s *subnetportservice.SubnetPortService, ns string, stsUid string) []*model.VpcSubnetPort {
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port0"),
+					Tags: []model.Tag{{Scope: &scope, Tag: servicecommon.String("test-sts-0")}}},
+			}
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByPodName,
+		func(s *subnetportservice.SubnetPortService, ns string, name string) []*model.VpcSubnetPort {
+			if name == "test-sts-0" {
+				return []*model.VpcSubnetPort{{Id: servicecommon.String("port0")}}
+			}
+			return nil
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+		func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+			deleteCalls++
+			return nil
+		})
+	defer patches.Reset()
+
+	res, err := r.handleReplicaChange(context.Background(), sts)
+	assert.NoError(t, err)
+	assert.Zero(t, res.RequeueAfter)
+	assert.Equal(t, 1, deleteCalls)
+}
+
+// TestHandleReplicaChange_MixedReleasedAndSkippedRunningPod ensures pendingRunningPod is OR'd:
+// one out-of-range port is released while another is blocked by a running Pod → still requeue.
+func TestHandleReplicaChange_MixedReleasedAndSkippedRunningPod(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts-4",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}).Build()
+	subnetPortService := &subnetportservice.SubnetPortService{SubnetPortStore: nil}
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-sts", Namespace: "default", UID: "test-sts-uid",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(2); return &r }(),
+		},
+	}
+
+	scope := servicecommon.TagScopePodName
+	var deleteCalls int
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsUid,
+		func(s *subnetportservice.SubnetPortService, ns string, stsUid string) []*model.VpcSubnetPort {
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port3"),
+					Tags: []model.Tag{{Scope: &scope, Tag: servicecommon.String("test-sts-3")}}},
+				{Id: servicecommon.String("port4"),
+					Tags: []model.Tag{{Scope: &scope, Tag: servicecommon.String("test-sts-4")}}},
+			}
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByPodName,
+		func(s *subnetportservice.SubnetPortService, ns string, name string) []*model.VpcSubnetPort {
+			switch name {
+			case "test-sts-3":
+				return []*model.VpcSubnetPort{{Id: servicecommon.String("port3")}}
+			case "test-sts-4":
+				return []*model.VpcSubnetPort{{Id: servicecommon.String("port4")}}
+			default:
+				return nil
+			}
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+		func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+			deleteCalls++
+			return nil
+		})
+	defer patches.Reset()
+
+	res, err := r.handleReplicaChange(context.Background(), sts)
+	assert.NoError(t, err)
+	assert.Equal(t, stsSubnetPortPendingRequeueAfter, res.RequeueAfter)
+	assert.Equal(t, 1, deleteCalls, "only the out-of-range Pod with no live Pod should be deleted")
+}
+
+func TestReleaseSubnetPortForPod_ClientGetError(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("apiserver timeout"))
+
+	subnetPortService := &subnetportservice.SubnetPortService{SubnetPortStore: nil}
+	r := &StatefulSetReconciler{
+		Client:            k8sClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	outcome, err := r.releaseSubnetPortForPod(context.Background(), "default", "any-pod")
+	assert.Error(t, err)
+	assert.Equal(t, releaseSubnetPortNoop, outcome)
+}
+
+func TestReleaseSubnetPortForPod_DeleteSubnetPortFails(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	subnetPortService := &subnetportservice.SubnetPortService{SubnetPortStore: nil}
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByPodName,
+		func(s *subnetportservice.SubnetPortService, ns string, name string) []*model.VpcSubnetPort {
+			return []*model.VpcSubnetPort{{Id: servicecommon.String("p1")}}
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+		func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+			return errors.New("nsx delete failed")
+		})
+	defer patches.Reset()
+
+	outcome, err := r.releaseSubnetPortForPod(context.Background(), "default", "gone-pod")
+	assert.Error(t, err)
+	assert.Equal(t, releaseSubnetPortNoop, outcome)
+}
+
+func TestReconcile_PodCacheNotReady(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: testNSXConfigWithStatefulSetPodEnhance(),
+		},
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            k8sClient,
+		SubnetPortService: subnetPortService,
+		Recorder:          fakeRecorder{},
+	}
+	r.StatusUpdater = common.NewStatusUpdater(k8sClient, r.SubnetPortService.NSXConfig, r.Recorder, MetricResTypeStatefulSet, "SubnetPort", "StatefulSet")
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+
+	// Return an arbitrary error from Get to simulate cache not ready
+	k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("cache not ready"))
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-sts", Namespace: "default"}}
+	res, err := r.Reconcile(context.Background(), req)
+
+	assert.Error(t, err)
+	assert.Equal(t, "cache not ready", err.Error())
+	assert.True(t, res.Requeue)
+}
+
+func TestReconcile_WithDeleteAnnotation(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: testNSXConfigWithStatefulSetPodEnhance(),
+		},
+		// No store: ListSubnetPortByStsName returns empty without gomonkey (avoids leaking a global patch).
+		SubnetPortStore: nil,
+	}
+
+	r := &StatefulSetReconciler{
+		Client:            k8sClient,
+		SubnetPortService: subnetPortService,
+		Recorder:          fakeRecorder{},
+	}
+	r.StatusUpdater = common.NewStatusUpdater(k8sClient, r.SubnetPortService.NSXConfig, r.Recorder, MetricResTypeStatefulSet, "SubnetPort", "StatefulSet")
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-sts",
+			Namespace:         "default",
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(2); return &r }(),
+		},
+	}
+
+	k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+			sts.DeepCopyInto(obj.(*appsv1.StatefulSet))
+			return nil
+		})
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-sts", Namespace: "default"}}
+	res, err := r.Reconcile(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, common.ResultNormal, res)
+}
+
+func TestPredicateUpdateFunc_NonStatefulSetObjects(t *testing.T) {
+	ev := event.UpdateEvent{
+		ObjectOld: &corev1.Pod{},
+		ObjectNew: &corev1.Pod{},
+	}
+	assert.False(t, PredicateFuncsForStatefulSet.UpdateFunc(ev))
+}
+
+func TestPredicateUpdateFunc_OrdinalsStartIncreasedShrinksRange(t *testing.T) {
+	oldSts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+		Spec: appsv1.StatefulSetSpec{
+			Ordinals: &appsv1.StatefulSetOrdinals{Start: 5},
+			Replicas: func() *int32 { r := int32(3); return &r }(),
+		},
+	}
+	newSts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+		Spec: appsv1.StatefulSetSpec{
+			Ordinals: &appsv1.StatefulSetOrdinals{Start: 7},
+			Replicas: func() *int32 { r := int32(3); return &r }(),
+		},
+	}
+	assert.True(t, PredicateFuncsForStatefulSet.UpdateFunc(event.UpdateEvent{ObjectOld: oldSts, ObjectNew: newSts}))
+}
+
+func TestReleaseSubnetPortForPod_GetPodError(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("apiserver timeout"))
+
+	subnetPortService := &subnetportservice.SubnetPortService{SubnetPortStore: &subnetportservice.SubnetPortStore{}}
+	r := &StatefulSetReconciler{Client: k8sClient, SubnetPortService: subnetPortService}
+
+	_, err := r.releaseSubnetPortForPod(context.Background(), "default", "pod-0")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "apiserver timeout")
+}
+
+func TestProcessDelete_ReleaseSubnetPortsError(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{EnforcementPoint: "vmc-enforcementpoint"}},
+		},
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+	r := &StatefulSetReconciler{
+		Client:            k8sClient,
+		SubnetPortService: subnetPortService,
+		Recorder:          fakeRecorder{},
+	}
+	r.StatusUpdater = common.NewStatusUpdater(k8sClient, r.SubnetPortService.NSXConfig, r.Recorder, MetricResTypeStatefulSet, "SubnetPort", "StatefulSet")
+
+	// Drive releaseSubnetPortsForStatefulSet failure via NSX delete error (more reliable than patching the reconciler method on darwin/arm64).
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsName,
+		func(s *subnetportservice.SubnetPortService, ns, stsName string) []*model.VpcSubnetPort {
+			return []*model.VpcSubnetPort{{Id: servicecommon.String("p1")}}
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+		func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+			return errors.New("delete failed")
+		})
+	defer patches.Reset()
+
+	res, err := r.processDelete(context.Background(), types.NamespacedName{Namespace: "default", Name: "sts"}, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "errors found in releasing subnet ports")
+	assert.Equal(t, common.ResultRequeue, res)
+}
+
+func TestProcessDelete_PendingRunningPodRequeues(t *testing.T) {
+	livePodUID := types.UID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	fakeClient := fake.NewClientBuilder().WithObjects(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-sts-0", Namespace: "default", UID: livePodUID},
+	}).Build()
+	subnetPortService := &subnetportservice.SubnetPortService{
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+	r := &StatefulSetReconciler{
+		Client:            fakeClient,
+		SubnetPortService: subnetPortService,
+	}
+	podNameScope := "nsx-op/pod_name"
+	podUIDScope := servicecommon.TagScopePodUID
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortService).ListSubnetPortByStsName,
+		func(s *subnetportservice.SubnetPortService, ns, stsName string) []*model.VpcSubnetPort {
+			return []*model.VpcSubnetPort{
+				{Id: servicecommon.String("port1"),
+					Tags: []model.Tag{
+						{Scope: &podNameScope, Tag: servicecommon.String("test-sts-0")},
+						{Scope: &podUIDScope, Tag: servicecommon.String(string(livePodUID))},
+					}},
+			}
+		})
+	defer patches.Reset()
+
+	res, err := r.processDelete(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-sts"}, nil)
+	require.NoError(t, err)
+	assert.True(t, res.Requeue)
+	assert.Equal(t, stsSubnetPortPendingRequeueAfter, res.RequeueAfter)
+}
+
+func TestReconcile_NoOpWhenFeatureDisabled(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{EnforcementPoint: "vmc-enforcementpoint"}},
+		},
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+	r := &StatefulSetReconciler{
+		Client:            k8sClient,
+		SubnetPortService: subnetPortService,
+		Recorder:          fakeRecorder{},
+	}
+	r.StatusUpdater = common.NewStatusUpdater(k8sClient, r.SubnetPortService.NSXConfig, r.Recorder, MetricResTypeStatefulSet, "SubnetPort", "StatefulSet")
+	defer patchNSXClientStatefulSetPodVersion(t, false)()
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "sts"}}
+	res, err := r.Reconcile(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, common.ResultNormal, res)
+}
+
+func TestStatefulSetPodFeatureEnabled_NSXCheckVersion(t *testing.T) {
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+	s := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: testNSXConfigWithStatefulSetPodEnhance(),
+		},
+	}
+	r := &StatefulSetReconciler{SubnetPortService: s}
+	assert.True(t, r.StatefulSetPodFeatureEnabled())
+}
+
+func TestStatefulSetPodFeatureEnabled_DisabledWhenVpcWcpEnhanceUnset(t *testing.T) {
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+	s := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{EnforcementPoint: "vmc-enforcementpoint"}},
+		},
+	}
+	r := &StatefulSetReconciler{SubnetPortService: s}
+	assert.False(t, r.StatefulSetPodFeatureEnabled())
+}
+
+func TestStatefulSetPodFeatureEnabled_DisabledWhenVpcWcpEnhanceFalse(t *testing.T) {
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+	off := false
+	s := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{VpcWcpEnhance: &off}},
+		},
+	}
+	r := &StatefulSetReconciler{SubnetPortService: s}
+	assert.False(t, r.StatefulSetPodFeatureEnabled())
+}
+
+func TestCollectGarbage_GetPodErrorDoesNotSkipDelete(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+
+	subnetPortService := &subnetportservice.SubnetPortService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: testNSXConfigWithStatefulSetPodEnhance(),
+		},
+		SubnetPortStore: &subnetportservice.SubnetPortStore{},
+	}
+	r := &StatefulSetReconciler{Client: k8sClient, SubnetPortService: subnetPortService}
+	defer patchNSXClientStatefulSetPodVersion(t, true)()
+
+	// List StatefulSets: one STS so orphaned path uses second loop with sts not in set
+	k8sClient.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+			list.(*appsv1.StatefulSetList).Items = []appsv1.StatefulSet{
+				{ObjectMeta: metav1.ObjectMeta{Name: "live", Namespace: "ns", UID: "live-uid"}, Spec: appsv1.StatefulSetSpec{Replicas: func() *int32 { r := int32(1); return &r }()}},
+			}
+			return nil
+		})
+	// GC orphan branch: Get pod fails → should not skip delete
+	k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("temporary")).MinTimes(1)
+
+	var deleteCalls int
+	patches := gomonkey.ApplyFunc(
+		(*subnetportservice.SubnetPortStore).GetByIndex,
+		func(s *subnetportservice.SubnetPortStore, indexKey, indexValue string) []*model.VpcSubnetPort {
+			if indexKey == servicecommon.TagScopeStatefulSetUID && indexValue == "live-uid" {
+				return []*model.VpcSubnetPort{}
+			}
+			if indexKey == servicecommon.IndexKeyAllStsPorts {
+				nsScope := servicecommon.TagScopeNamespace
+				podScope := servicecommon.TagScopePodName
+				stsScope := servicecommon.TagScopeStatefulSetUID
+				return []*model.VpcSubnetPort{
+					{Id: servicecommon.String("orph"),
+						Tags: []model.Tag{
+							{Scope: &stsScope, Tag: servicecommon.String("gone-sts-uid")},
+							{Scope: &nsScope, Tag: servicecommon.String("ns")},
+							{Scope: &podScope, Tag: servicecommon.String("pod-0")},
+						}},
+				}
+			}
+			return nil
+		})
+	patches.ApplyFunc(
+		(*subnetportservice.SubnetPortService).DeleteSubnetPort,
+		func(s *subnetportservice.SubnetPortService, port *model.VpcSubnetPort) error {
+			deleteCalls++
+			return nil
+		})
+	defer patches.Reset()
+
+	require.NoError(t, r.CollectGarbage(context.Background()))
+	assert.GreaterOrEqual(t, deleteCalls, 1)
+}

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -55,10 +55,11 @@ const (
 	VTEPLessMode
 	RestoreVIF
 	StaticIPReservation
+	StatefulSetPod
 	AllFeatures
 )
 
-var FeaturesName = [AllFeatures]string{"VPC", "SECURITY_POLICY", "NSX_SERVICE_ACCOUNT", "NSX_SERVICE_ACCOUNT_RESTORE", "NSX_SERVICE_ACCOUNT_CERT_ROTATION", "STATIC_ROUTE", "VPC_PREFERRED_DEFAULT_SNAT_IP", "SUBNET_IP_RESERVATION", "SUBNET_MINIMAL_SIZE_8", "VTEP_LESS_MODE", "RESTORE_VIF", "STATIC_IP_RESERVATION"}
+var FeaturesName = [AllFeatures]string{"VPC", "SECURITY_POLICY", "NSX_SERVICE_ACCOUNT", "NSX_SERVICE_ACCOUNT_RESTORE", "NSX_SERVICE_ACCOUNT_CERT_ROTATION", "STATIC_ROUTE", "VPC_PREFERRED_DEFAULT_SNAT_IP", "SUBNET_IP_RESERVATION", "SUBNET_MINIMAL_SIZE_8", "VTEP_LESS_MODE", "RESTORE_VIF", "STATIC_IP_RESERVATION", "STATEFULSET_POD"}
 
 type Client struct {
 	NsxConfig     *config.NSXOperatorConfig
@@ -131,6 +132,7 @@ var (
 	nsx412Version = [3]int64{4, 1, 2}
 	nsx413Version = [3]int64{4, 1, 3}
 	nsx910Version = [3]int64{9, 1, 0}
+	nsx912Version = [3]int64{9, 1, 2}
 	nsx920Version = [3]int64{9, 2, 0}
 )
 
@@ -304,6 +306,10 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 		NsxApiClient:                      nsxApiClient,
 		VifsClient:                        vifsClient,
 	}
+	nsxClient.Cluster.SetOnNodeVersionChanged(func(oldVer, newVer string) {
+		nsxClient.resetNSXVersionFeatureCache()
+		log.Info("NSX node version changed; cleared cached feature support gates", "oldVersion", oldVer, "newVersion", newVer)
+	})
 	// NSX version check will be restarted during SecurityPolicy reconcile
 	// So, it's unnecessary to exit even if failed in the first time
 	if !nsxClient.NSXCheckVersion(SecurityPolicy) {
@@ -364,6 +370,12 @@ func CreateNsxtApiClient(config *config.NSXOperatorConfig, client *http.Client) 
 	return nsxClient, nil
 }
 
+func (client *Client) resetNSXVersionFeatureCache() {
+	for i := range client.NSXVerChecker.featureSupported {
+		client.NSXVerChecker.featureSupported[i] = false
+	}
+}
+
 func (client *Client) NSXCheckVersion(feature int) bool {
 	// TODO: Remove this once NSX implementation for SubnetPort VIF restore is merged
 	if feature == RestoreVIF {
@@ -385,8 +397,7 @@ func (client *Client) NSXCheckVersion(feature int) bool {
 	}
 
 	if !nsxVersion.featureSupported(feature) {
-		err = errors.New("NSX version check failed")
-		log.Error(err, FeaturesName[feature]+"feature is not supported", "current version", nsxVersion.NodeVersion)
+		log.Warn(FeaturesName[feature]+" feature is not supported", "current NSX version", nsxVersion.NodeVersion)
 		return false
 	}
 	client.NSXVerChecker.featureSupported[feature] = true

--- a/pkg/nsx/client_test.go
+++ b/pkg/nsx/client_test.go
@@ -140,6 +140,17 @@ func TestGetClient(t *testing.T) {
 	assert.True(t, client.NSXCheckVersion(ServiceAccountCertRotation))
 }
 
+func TestClient_resetNSXVersionFeatureCache(t *testing.T) {
+	client := &Client{}
+	for i := range client.NSXVerChecker.featureSupported {
+		client.NSXVerChecker.featureSupported[i] = true
+	}
+	client.resetNSXVersionFeatureCache()
+	for i := range client.NSXVerChecker.featureSupported {
+		assert.False(t, client.NSXVerChecker.featureSupported[i], "featureSupported[%d] should be false after reset", i)
+	}
+}
+
 func IsInstanceOf(objectPtr, typePtr interface{}) bool {
 	return reflect.TypeOf(objectPtr) == reflect.TypeOf(typePtr)
 }

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -61,6 +61,8 @@ type Cluster struct {
 	sync.Mutex
 	nsxVersion         *NsxVersion
 	lastTimeGetVersion time.Time
+	// onNodeVersionChanged is invoked after a successful HTTP refresh when node_version changes (non-empty old and new, and different).
+	onNodeVersionChanged func(oldVersion, newVersion string)
 }
 type NsxVersion struct {
 	NodeVersion string `json:"node_version"`
@@ -356,10 +358,24 @@ func (cluster *Cluster) Health() ClusterHealth {
 	return ORANGE
 }
 
+// SetOnNodeVersionChanged registers a callback run after GetVersion successfully refreshes
+// from NSX and detects a non-empty node_version change. Used to invalidate client-side
+// feature caches. Safe to call once during operator init; fn may be nil to clear.
+func (cluster *Cluster) SetOnNodeVersionChanged(fn func(oldVersion, newVersion string)) {
+	cluster.Mutex.Lock()
+	defer cluster.Mutex.Unlock()
+	cluster.onNodeVersionChanged = fn
+}
+
 func (cluster *Cluster) GetVersion() (*NsxVersion, error) {
 	if cluster.nsxVersion != nil && len(cluster.nsxVersion.NodeVersion) > 0 && time.Since(cluster.lastTimeGetVersion) < GetNsxVersionInterval {
 		log.Debug("Get version from cache", "version", cluster.nsxVersion.NodeVersion)
 		return cluster.nsxVersion, nil
+	}
+
+	oldVersion := ""
+	if cluster.nsxVersion != nil {
+		oldVersion = cluster.nsxVersion.NodeVersion
 	}
 
 	ep := cluster.endpoints[0]
@@ -384,6 +400,18 @@ func (cluster *Cluster) GetVersion() (*NsxVersion, error) {
 	err, _ = util.HandleHTTPResponse(resp, cluster.nsxVersion, true)
 	if err == nil {
 		cluster.lastTimeGetVersion = time.Now()
+		newVersion := ""
+		if cluster.nsxVersion != nil {
+			newVersion = cluster.nsxVersion.NodeVersion
+		}
+		if oldVersion != "" && newVersion != "" && oldVersion != newVersion {
+			cluster.Mutex.Lock()
+			cb := cluster.onNodeVersionChanged
+			cluster.Mutex.Unlock()
+			if cb != nil {
+				cb(oldVersion, newVersion)
+			}
+		}
 	} else {
 		cluster.nsxVersion = &NsxVersion{}
 	}
@@ -536,6 +564,9 @@ func (nsxVersion *NsxVersion) featureSupported(feature int) bool {
 		validFeature = true
 	case StaticIPReservation:
 		minVersion = nsx920Version
+		validFeature = true
+	case StatefulSetPod:
+		minVersion = nsx912Version
 		validFeature = true
 	}
 

--- a/pkg/nsx/cluster_test.go
+++ b/pkg/nsx/cluster_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
@@ -253,6 +254,143 @@ func TestCluster_getVersion(t *testing.T) {
 	nsxVersion, err := cluster.GetVersion()
 	assert.Equal(t, err, nil)
 	assert.Equal(t, nsxVersion.NodeVersion, "3.1.3.3.0.18844962")
+}
+
+func TestCluster_GetVersion_invokesOnNodeVersionChangedWhenNodeVersionChanges(t *testing.T) {
+	var (
+		callbackCalls int
+		gotOld        string
+		gotNew        string
+	)
+	versionCalls := 0
+	resHealth := `{
+					"healthy" : true,
+					"components_health" : "MANAGER:UP, SEARCH:UP, UI:UP, NODE_MGMT:UP"
+					}`
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if strings.Contains(r.URL.Path, "reverse-proxy/node/health") {
+			w.Write([]byte(resHealth))
+			return
+		}
+		if strings.Contains(r.URL.Path, "/api/v1/node/version") {
+			versionCalls++
+			var body string
+			if versionCalls == 1 {
+				body = `{"node_version":"9.1.0.0.0.10000000","product_version":"9.1.0"}`
+			} else {
+				body = `{"node_version":"9.2.0.0.0.20000000","product_version":"9.2.0"}`
+			}
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+	thumbprint := []string{"123"}
+	index := strings.Index(ts.URL, "//")
+	a := ts.URL[index+2:]
+	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
+	cluster, err := NewCluster(config)
+	assert.NoError(t, err)
+
+	cluster.SetOnNodeVersionChanged(func(oldV, newV string) {
+		callbackCalls++
+		gotOld, gotNew = oldV, newV
+	})
+
+	ver1, err := cluster.GetVersion()
+	assert.NoError(t, err)
+	assert.Equal(t, "9.1.0.0.0.10000000", ver1.NodeVersion)
+	assert.Equal(t, 0, callbackCalls, "first successful fetch has no prior node_version, callback must not run")
+
+	cluster.lastTimeGetVersion = time.Now().Add(-40 * time.Minute)
+	ver2, err := cluster.GetVersion()
+	assert.NoError(t, err)
+	assert.Equal(t, "9.2.0.0.0.20000000", ver2.NodeVersion)
+	assert.Equal(t, 1, callbackCalls)
+	assert.Equal(t, "9.1.0.0.0.10000000", gotOld)
+	assert.Equal(t, "9.2.0.0.0.20000000", gotNew)
+}
+
+func TestCluster_GetVersion_noOnNodeVersionChangedWhenVersionUnchanged(t *testing.T) {
+	var callbackCalls int
+	versionCalls := 0
+	resHealth := `{
+					"healthy" : true,
+					"components_health" : "MANAGER:UP, SEARCH:UP, UI:UP, NODE_MGMT:UP"
+					}`
+	const sameVersion = `{"node_version":"9.1.0.0.0.10000000","product_version":"9.1.0"}`
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if strings.Contains(r.URL.Path, "reverse-proxy/node/health") {
+			w.Write([]byte(resHealth))
+			return
+		}
+		if strings.Contains(r.URL.Path, "/api/v1/node/version") {
+			versionCalls++
+			_, _ = w.Write([]byte(sameVersion))
+			return
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+	thumbprint := []string{"123"}
+	index := strings.Index(ts.URL, "//")
+	a := ts.URL[index+2:]
+	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
+	cluster, err := NewCluster(config)
+	assert.NoError(t, err)
+
+	cluster.SetOnNodeVersionChanged(func(_, _ string) {
+		callbackCalls++
+	})
+
+	_, err = cluster.GetVersion()
+	assert.NoError(t, err)
+	cluster.lastTimeGetVersion = time.Now().Add(-40 * time.Minute)
+	_, err = cluster.GetVersion()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, callbackCalls)
+}
+
+func TestCluster_GetVersion_noPanicWhenOnNodeVersionChangedNil(t *testing.T) {
+	versionCalls := 0
+	resHealth := `{
+					"healthy" : true,
+					"components_health" : "MANAGER:UP, SEARCH:UP, UI:UP, NODE_MGMT:UP"
+					}`
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if strings.Contains(r.URL.Path, "reverse-proxy/node/health") {
+			w.Write([]byte(resHealth))
+			return
+		}
+		if strings.Contains(r.URL.Path, "/api/v1/node/version") {
+			versionCalls++
+			if versionCalls == 1 {
+				_, _ = w.Write([]byte(`{"node_version":"4.1.0.0.0.1","product_version":"4.1.0"}`))
+			} else {
+				_, _ = w.Write([]byte(`{"node_version":"4.1.1.0.0.1","product_version":"4.1.1"}`))
+			}
+			return
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+	thumbprint := []string{"123"}
+	index := strings.Index(ts.URL, "//")
+	a := ts.URL[index+2:]
+	config := NewConfig(a, "admin", "passw0rd", []string{}, 10, 3, 20, 20, true, true, true, ratelimiter.AIMD, nil, nil, thumbprint)
+	cluster, err := NewCluster(config)
+	assert.NoError(t, err)
+
+	cluster.SetOnNodeVersionChanged(nil)
+	_, err = cluster.GetVersion()
+	assert.NoError(t, err)
+	cluster.lastTimeGetVersion = time.Now().Add(-40 * time.Minute)
+	_, err = cluster.GetVersion()
+	assert.NoError(t, err)
 }
 
 func TestCluster_CreateServerUrl(t *testing.T) {

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -105,11 +105,15 @@ const (
 	LabelCPVM                          string = "iaas.vmware.com/is-cpvm-subnetport"
 	TagScopePodName                    string = "nsx-op/pod_name"
 	TagScopePodUID                     string = "nsx-op/pod_uid"
-	ValueMajorVersion                  string = "1"
-	ValueMinorVersion                  string = "0"
-	ValuePatchVersion                  string = "0"
-	ConnectorUnderline                 string = "_"
-	ConnectorHyphen                    string = "-"
+	TagScopeStatefulSetName            string = "nsx-op/sts_name"
+	TagScopeStatefulSetUID             string = "nsx-op/sts_uid"
+	// TagScopePodIndex is the NSX tag scope for Pod label apps.kubernetes.io/pod-index when synced onto the port (not set in BuildBasicTags).
+	TagScopePodIndex   string = "apps.kubernetes.io/pod-index"
+	ValueMajorVersion  string = "1"
+	ValueMinorVersion  string = "0"
+	ValuePatchVersion  string = "0"
+	ConnectorUnderline string = "_"
+	ConnectorHyphen    string = "-"
 
 	GCInterval           = 10 * 60 * time.Second
 	SubnetGCInterval     = 60 * time.Second
@@ -125,6 +129,8 @@ const (
 	IndexKeySubnetPath          = "IndexKeySubnetPath"
 	IndexKeyNodeName            = "IndexKeyNodeName"
 	IndexKeyAttachmentID        = "IndexKeyAttachmentID"
+	IndexKeyAllStsPorts         = "IndexKeyAllStsPorts"
+	StsPortBucket               = "allStsPorts"
 	GCValidationInterval uint16 = 720
 
 	RuleIngress            = "ingress"

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -19,7 +20,9 @@ import (
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	controllercommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
@@ -37,6 +40,7 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 	if _, ok := obj.(*corev1.Pod); ok {
 		appId = string(objMeta.UID)
 	}
+	_, stsUID := getStatefulSetInfo(obj)
 	var externalAddressBinding *model.ExternalAddressBinding
 	var err error
 	var addressBindings []model.PortAddressBindingEntry
@@ -127,7 +131,7 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 	}
 	namespaceUid := namespace.UID
 
-	nsxSubnetPortID, nsxSubnetPortName := service.BuildSubnetPortIdAndName(objMeta, namespaceUid)
+	nsxSubnetPortID, nsxSubnetPortName := service.BuildSubnetPortIdAndName(objMeta, namespaceUid, stsUID)
 	nsxSubnetPortPath := fmt.Sprintf("%s/ports/%s", *nsxSubnet.Path, nsxSubnetPortID)
 
 	tags := util.BuildBasicTags(getCluster(service), obj, namespaceUid)
@@ -163,6 +167,7 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 			tagsFiltered = append(tagsFiltered, model.Tag{Scope: common.String(k), Tag: common.String((*labelTags)[k])})
 		}
 	}
+
 	nsxSubnetPort := &model.VpcSubnetPort{
 		DisplayName: String(nsxSubnetPortName),
 		Id:          String(nsxSubnetPortID),
@@ -187,11 +192,43 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 	return nsxSubnetPort, nil
 }
 
-func (service *SubnetPortService) BuildSubnetPortIdAndName(obj *metav1.ObjectMeta, namespaceUID types.UID) (string, string) {
+// getStatefulSetInfo returns the StatefulSet name and UID if the pod's controller
+// is a StatefulSet (matches real API server behavior: the STS sets controller=true).
+func getStatefulSetInfo(obj interface{}) (string, string) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return "", ""
+	}
+	stsKind := appsv1.SchemeGroupVersion.WithKind("StatefulSet").Kind
+	if ref := metav1.GetControllerOf(pod); ref != nil && ref.Kind == stsKind {
+		return ref.Name, string(ref.UID)
+	}
+	return "", ""
+}
+
+func (service *SubnetPortService) BuildSubnetPortIdAndName(obj *metav1.ObjectMeta, namespaceUID types.UID, stsUID string) (string, string) {
 	existingSubnetPort, err := service.SubnetPortStore.GetVpcSubnetPortByUID(obj.GetUID())
 	if err == nil && existingSubnetPort != nil {
 		return *existingSubnetPort.Id, *existingSubnetPort.DisplayName
 	}
+
+	// For StatefulSet pods: check if a SubnetPort with the same StatefulSet UID and pod name exists
+	// Note: STS UID is globally unique, so we only need to check pod name
+	// Only reuse if STS feature is enabled (NSX 9.2.0+ and vpc_wcp_enhance=true)
+	enableStsFeature := nsx.StatefulSetPodSubnetPortFeatureEnabled(service.NSXClient, service.NSXConfig)
+	if enableStsFeature && stsUID != "" {
+		existingPorts := service.SubnetPortStore.GetByIndex(common.TagScopeStatefulSetUID, stsUID)
+		for _, port := range existingPorts {
+			log.Debug("BuildSubnetPortIdAndName", "port", port.Id, "path", port.Path)
+			portName := nsxutil.FindTag(port.Tags, common.TagScopePodName)
+			if portName == obj.Name {
+				log.Info("Reusing existing SubnetPort for StatefulSet pod",
+					"podName", obj.Name, "stsUID", stsUID)
+				return *port.Id, *port.DisplayName
+			}
+		}
+	}
+
 	// Note: we will use the Pod or Subnet CR's name and the Namespace UID to generate the NSX VpcSubnetPort's id.
 	objWithNamespaceUID := &metav1.ObjectMeta{
 		Name: obj.Name,

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
@@ -27,10 +28,11 @@ import (
 func TestBuildSubnetPort(t *testing.T) {
 	mockCtl := gomock.NewController(t)
 	k8sClient := mock_client.NewMockClient(mockCtl)
+	nsxClient := &nsx.Client{}
 	service := &SubnetPortService{
 		Service: common.Service{
 			Client:    k8sClient,
-			NSXClient: &nsx.Client{},
+			NSXClient: nsxClient,
 			NSXConfig: &config.NSXOperatorConfig{
 				NsxConfig: &config.NsxConfig{
 					EnforcementPoint: "vmc-enforcementpoint",
@@ -42,6 +44,13 @@ func TestBuildSubnetPort(t *testing.T) {
 		},
 		SubnetPortStore: setupStore(),
 	}
+
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion",
+		func(_ *nsx.Client, _ int) bool {
+			return false
+		})
+	defer patches.Reset()
+
 	ctx := context.Background()
 	namespace := &corev1.Namespace{}
 	k8sClient.EXPECT().Get(ctx, gomock.Any(), namespace).Return(nil).Do(
@@ -1356,4 +1365,179 @@ func TestBuildExternalAddressBinding(t *testing.T) {
 			assert.Equal(t, tt.expectedAb, actualAb)
 		})
 	}
+}
+
+func TestGetStatefulSetInfo(t *testing.T) {
+	tests := []struct {
+		name         string
+		obj          interface{}
+		expectedName string
+		expectedUID  string
+	}{
+		{
+			name: "StatefulSet pod with controller reference",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "StatefulSet",
+							Name:       "web",
+							UID:        "sts-uid-123",
+							Controller: ptr.To(true),
+						},
+					},
+				},
+			},
+			expectedName: "web",
+			expectedUID:  "sts-uid-123",
+		},
+		{
+			name: "StatefulSet owner but not controller (should ignore)",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "StatefulSet",
+							Name:       "web",
+							UID:        "sts-uid-123",
+							Controller: ptr.To(false),
+						},
+					},
+				},
+			},
+			expectedName: "",
+			expectedUID:  "",
+		},
+		{
+			name: "Deployment pod with owner reference",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "ReplicaSet",
+							Name:       "nginx-7d4c7b8b5",
+						},
+					},
+				},
+			},
+			expectedName: "",
+			expectedUID:  "",
+		},
+		{
+			name: "Standalone pod without owner",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{},
+				},
+			},
+			expectedName: "",
+			expectedUID:  "",
+		},
+		{
+			name:         "SubnetPort CR (not a pod)",
+			obj:          &v1alpha1.SubnetPort{},
+			expectedName: "",
+			expectedUID:  "",
+		},
+		{
+			name:         "Nil object",
+			obj:          nil,
+			expectedName: "",
+			expectedUID:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stsName, stsUID := getStatefulSetInfo(tt.obj)
+			assert.Equal(t, tt.expectedName, stsName)
+			assert.Equal(t, tt.expectedUID, stsUID)
+		})
+	}
+}
+
+func TestBuildSubnetPortIdAndName_existingPortByUID(t *testing.T) {
+	nsxClient := &nsx.Client{}
+	store := &SubnetPortStore{}
+	service := &SubnetPortService{
+		Service: common.Service{
+			NSXClient: nsxClient,
+		},
+		SubnetPortStore: store,
+	}
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(store), "GetVpcSubnetPortByUID",
+		func(s *SubnetPortStore, uid types.UID) (*model.VpcSubnetPort, error) {
+			portID := "existing-port-id"
+			portName := "existing-port-name"
+			return &model.VpcSubnetPort{
+				Id:          &portID,
+				DisplayName: &portName,
+			}, nil
+		})
+	patches.ApplyMethod(reflect.TypeOf(store), "GetByKey",
+		func(s *SubnetPortStore, key string) *model.VpcSubnetPort {
+			return nil
+		})
+	defer patches.Reset()
+	patchesStsFeat := gomonkey.ApplyFunc(nsx.StatefulSetPodSubnetPortFeatureEnabled,
+		func(_ *nsx.Client, _ *config.NSXOperatorConfig) bool {
+			return false
+		})
+	defer patchesStsFeat.Reset()
+
+	objMeta := &metav1.ObjectMeta{Name: "test-pod", UID: "pod-uid-123"}
+	id, name := service.BuildSubnetPortIdAndName(objMeta, types.UID("ns-uid-456"), "")
+	assert.Equal(t, "existing-port-id", id)
+	assert.Equal(t, "existing-port-name", name)
+}
+
+func TestBuildSubnetPortIdAndName_reuseSTSPortByUIDAndPodName(t *testing.T) {
+	nsxClient := &nsx.Client{}
+	store := &SubnetPortStore{}
+	service := &SubnetPortService{
+		Service: common.Service{
+			NSXClient: nsxClient,
+		},
+		SubnetPortStore: store,
+	}
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(store), "GetVpcSubnetPortByUID",
+		func(s *SubnetPortStore, uid types.UID) (*model.VpcSubnetPort, error) {
+			return nil, nil
+		})
+	defer patches.Reset()
+	patches.ApplyMethod(reflect.TypeOf(store), "GetByIndex",
+		func(s *SubnetPortStore, indexKey string, indexValue string) []*model.VpcSubnetPort {
+			if indexKey == common.TagScopeStatefulSetUID && indexValue == "sts-uid-123" {
+				podNameScope := "nsx-op/pod_name"
+				stsPortID := "sts-port-id"
+				stsPortName := "test-pod"
+				return []*model.VpcSubnetPort{
+					{
+						Id:          &stsPortID,
+						DisplayName: &stsPortName,
+						Tags: []model.Tag{
+							{Scope: &podNameScope, Tag: common.String("test-pod")},
+						},
+					},
+				}
+			}
+			return []*model.VpcSubnetPort{}
+		})
+	patches.ApplyMethod(reflect.TypeOf(store), "GetByKey",
+		func(s *SubnetPortStore, key string) *model.VpcSubnetPort {
+			return nil
+		})
+	patchesStsFeat := gomonkey.ApplyFunc(nsx.StatefulSetPodSubnetPortFeatureEnabled,
+		func(_ *nsx.Client, _ *config.NSXOperatorConfig) bool {
+			return true
+		})
+	defer patchesStsFeat.Reset()
+
+	objMeta := &metav1.ObjectMeta{Name: "test-pod", UID: "pod-uid-123"}
+	id, name := service.BuildSubnetPortIdAndName(objMeta, types.UID("ns-uid-456"), "sts-uid-123")
+	assert.Equal(t, "sts-port-id", id)
+	assert.Equal(t, "test-pod", name)
 }

--- a/pkg/nsx/services/subnetport/store.go
+++ b/pkg/nsx/services/subnetport/store.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 // keyFunc is used to get the key of a resource, usually, which is the ID of the resource
@@ -96,6 +97,39 @@ func subnetPortIndexPodNamespace(obj interface{}) ([]string, error) {
 	default:
 		return nil, errors.New("subnetPortIndexPodNamespace doesn't support unknown type")
 	}
+}
+
+func subnetPortIndexByStatefulSetUID(obj interface{}) ([]string, error) {
+	switch o := obj.(type) {
+	case *model.VpcSubnetPort:
+		return filterTag(o.Tags, common.TagScopeStatefulSetUID), nil
+	default:
+		return nil, errors.New("subnetPortIndexByStatefulSetUID doesn't support unknown type")
+	}
+}
+
+func subnetPortIndexByStatefulSetName(obj interface{}) ([]string, error) {
+	switch o := obj.(type) {
+	case *model.VpcSubnetPort:
+		return filterTag(o.Tags, common.TagScopeStatefulSetName), nil
+	default:
+		return nil, errors.New("subnetPortIndexByStatefulSetName doesn't support unknown type")
+	}
+}
+
+func subnetPortIndexBySts(obj interface{}) ([]string, error) {
+	port, ok := obj.(*model.VpcSubnetPort)
+	if !ok {
+		return nil, errors.New("subnetPortIndexBySts doesn't support unknown type")
+	}
+	if port == nil {
+		return nil, nil
+	}
+	stsUID := util.FindTag(port.Tags, common.TagScopeStatefulSetUID)
+	if stsUID != "" {
+		return []string{common.StsPortBucket}, nil
+	}
+	return nil, nil
 }
 
 // SubnetPortStore is a store for SubnetPorts

--- a/pkg/nsx/services/subnetport/store_test.go
+++ b/pkg/nsx/services/subnetport/store_test.go
@@ -222,3 +222,144 @@ func Test_subnetPortIndexByCRUID(t *testing.T) {
 		})
 	}
 }
+
+func Test_subnetPortIndexByStatefulSetUID(t *testing.T) {
+	type args struct {
+		obj interface{}
+	}
+	stsUIDScope := "nsx-op/sts_uid"
+	stsUID := "sts-uid-123"
+	tests := []struct {
+		name           string
+		expectedResult []string
+		expectedErr    string
+		args           args
+	}{
+		{
+			name:           "Success",
+			expectedResult: []string{stsUID},
+			args: args{obj: &model.VpcSubnetPort{
+				Tags: []model.Tag{
+					{
+						Scope: &stsUIDScope,
+						Tag:   &stsUID,
+					},
+				},
+			}},
+		},
+		{
+			name:        "Failure",
+			expectedErr: "subnetPortIndexByStatefulSetUID doesn't support unknown type",
+			args:        args{obj: &stsUID},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := subnetPortIndexByStatefulSetUID(tt.args.obj)
+			if tt.expectedErr != "" {
+				assert.EqualError(t, err, tt.expectedErr)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+func Test_subnetPortIndexByStatefulSetName(t *testing.T) {
+	type args struct {
+		obj interface{}
+	}
+	stsNameScope := "nsx-op/sts_name"
+	stsName := "test-sts"
+	tests := []struct {
+		name           string
+		expectedResult []string
+		expectedErr    string
+		args           args
+	}{
+		{
+			name:           "Success",
+			expectedResult: []string{stsName},
+			args: args{obj: &model.VpcSubnetPort{
+				Tags: []model.Tag{
+					{
+						Scope: &stsNameScope,
+						Tag:   &stsName,
+					},
+				},
+			}},
+		},
+		{
+			name:        "Failure",
+			expectedErr: "subnetPortIndexByStatefulSetName doesn't support unknown type",
+			args:        args{obj: &stsName},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := subnetPortIndexByStatefulSetName(tt.args.obj)
+			if tt.expectedErr != "" {
+				assert.EqualError(t, err, tt.expectedErr)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+func Test_subnetPortIndexBySts(t *testing.T) {
+	type args struct {
+		obj interface{}
+	}
+	stsUIDScope := "nsx-op/sts_uid"
+	stsUID := "sts-uid-123"
+	tests := []struct {
+		name           string
+		expectedResult []string
+		expectedErr    string
+		args           args
+	}{
+		{
+			name:           "STS port - should return bucket",
+			expectedResult: []string{"allStsPorts"},
+			args: args{obj: &model.VpcSubnetPort{
+				Tags: []model.Tag{
+					{
+						Scope: &stsUIDScope,
+						Tag:   &stsUID,
+					},
+				},
+			}},
+		},
+		{
+			name:           "Non-STS port - should return nil",
+			expectedResult: nil,
+			args: args{obj: &model.VpcSubnetPort{
+				Tags: []model.Tag{},
+			}},
+		},
+		{
+			name:           "Nil port",
+			expectedResult: nil,
+			args:           args{obj: (*model.VpcSubnetPort)(nil)},
+		},
+		{
+			name:        "Failure - unknown type",
+			expectedErr: "subnetPortIndexBySts doesn't support unknown type",
+			args:        args{obj: "invalid"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := subnetPortIndexBySts(tt.args.obj)
+			if tt.expectedErr != "" {
+				assert.EqualError(t, err, tt.expectedErr)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			}
+		})
+	}
+}

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -88,7 +88,10 @@ func setupStore() *SubnetPortStore {
 					servicecommon.TagScopeVMNamespace:     subnetPortIndexNamespace,
 					servicecommon.TagScopeNamespace:       subnetPortIndexPodNamespace,
 					// Use Subnet Path instead of Subnet ID as shared Subnet ID on different VPC can be the same
-					servicecommon.IndexKeySubnetPath: subnetPortIndexBySubnetPath,
+					servicecommon.IndexKeySubnetPath:      subnetPortIndexBySubnetPath,
+					servicecommon.TagScopeStatefulSetUID:  subnetPortIndexByStatefulSetUID,
+					servicecommon.TagScopeStatefulSetName: subnetPortIndexByStatefulSetName,
+					servicecommon.IndexKeyAllStsPorts:     subnetPortIndexBySts,
 				}),
 			BindingType: model.VpcSubnetPortBindingType(),
 		}}
@@ -293,6 +296,9 @@ func (service *SubnetPortService) GetSubnetPortState(nsxSubnetPortID string, nsx
 }
 
 func (service *SubnetPortService) DeleteSubnetPort(nsxSubnetPort *model.VpcSubnetPort) error {
+	if nsxSubnetPort.Path == nil {
+		return errors.New("subnet port path is nil")
+	}
 	subnetPortInfo, _ := servicecommon.ParseVPCResourcePath(*nsxSubnetPort.Path)
 	err := service.NSXClient.PortClient.Delete(subnetPortInfo.OrgID, subnetPortInfo.ProjectID, subnetPortInfo.VPCID, subnetPortInfo.ParentID, *nsxSubnetPort.Id)
 	err = nsxutil.TransNSXApiError(err)
@@ -397,6 +403,9 @@ func (service *SubnetPortService) ListSubnetPortByName(ns string, name string) [
 
 func (service *SubnetPortService) ListSubnetPortByPodName(ns string, name string) []*model.VpcSubnetPort {
 	var result []*model.VpcSubnetPort
+	if service.SubnetPortStore == nil {
+		return result
+	}
 	subnetports := service.SubnetPortStore.GetByIndex(servicecommon.TagScopeNamespace, ns)
 	for _, subnetport := range subnetports {
 		tagname := nsxutil.FindTag(subnetport.Tags, servicecommon.TagScopePodName)
@@ -417,6 +426,36 @@ func (service *SubnetPortService) ResetSubnetTotalIP(path string) {
 	info.lock.Lock()
 	defer info.lock.Unlock()
 	info.totalIP = 0
+}
+
+func (service *SubnetPortService) ListSubnetPortByStsName(ns string, stsName string) []*model.VpcSubnetPort {
+	var result []*model.VpcSubnetPort
+	if service.SubnetPortStore == nil {
+		return result
+	}
+	subnetports := service.SubnetPortStore.GetByIndex(servicecommon.TagScopeStatefulSetName, stsName)
+	for _, subnetport := range subnetports {
+		tagname := nsxutil.FindTag(subnetport.Tags, servicecommon.TagScopeNamespace)
+		if tagname == ns {
+			result = append(result, subnetport)
+		}
+	}
+	return result
+}
+
+func (service *SubnetPortService) ListSubnetPortByStsUid(ns string, stsUid string) []*model.VpcSubnetPort {
+	var result []*model.VpcSubnetPort
+	if service.SubnetPortStore == nil {
+		return result
+	}
+	subnetports := service.SubnetPortStore.GetByIndex(servicecommon.TagScopeStatefulSetUID, stsUid)
+	for _, subnetport := range subnetports {
+		tagname := nsxutil.FindTag(subnetport.Tags, servicecommon.TagScopeNamespace)
+		if tagname == ns {
+			result = append(result, subnetport)
+		}
+	}
+	return result
 }
 
 // AllocatePortFromSubnet checks the number of SubnetPorts on the Subnet.

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -178,20 +178,22 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 	k8sClient := mock_client.NewMockClient(mockCtl)
 	defer mockCtl.Finish()
 	orgRootClient := mock_org_root.NewMockOrgRootClient(mockCtl)
-	commonService := common.Service{
-		Client: k8sClient,
-		NSXClient: &nsx.Client{
-			QueryClient:            &fakeQueryClient{},
-			PortClient:             &fakePortClient{},
-			RealizedEntitiesClient: &fakeRealizedEntitiesClient{},
-			PortStateClient:        &fakePortStateClient{},
-			OrgRootClient:          orgRootClient,
-			NsxConfig: &config.NSXOperatorConfig{
-				CoeConfig: &config.CoeConfig{
-					Cluster: "k8scl-one:test",
-				},
+	nsxClient := &nsx.Client{
+		QueryClient:            &fakeQueryClient{},
+		PortClient:             &fakePortClient{},
+		RealizedEntitiesClient: &fakeRealizedEntitiesClient{},
+		PortStateClient:        &fakePortStateClient{},
+		OrgRootClient:          orgRootClient,
+		Cluster:                &nsx.Cluster{},
+		NsxConfig: &config.NSXOperatorConfig{
+			CoeConfig: &config.CoeConfig{
+				Cluster: "k8scl-one:test",
 			},
 		},
+	}
+	commonService := common.Service{
+		Client:    k8sClient,
+		NSXClient: nsxClient,
 		NSXConfig: &config.NSXOperatorConfig{
 			CoeConfig: &config.CoeConfig{
 				Cluster: "k8scl-one:test",
@@ -266,7 +268,10 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 					return nil
 				})
 				orgRootClient.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-				return nil
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+					return false
+				})
+				return patches
 			},
 			wantErr:      false,
 			nsxSubnet:    nsxSubnet1,
@@ -286,6 +291,9 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 					return model.SegmentPortState{
 						RealizedBindings: []model.AddressBindingEntry{{Binding: &model.PacketAddressClassifier{IpAddress: common.String("10.0.0.1")}}},
 					}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+					return false
 				})
 				return patches
 			},
@@ -309,6 +317,9 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 						RealizedBindings: []model.AddressBindingEntry{{Binding: &model.PacketAddressClassifier{IpAddress: common.String("10.0.0.1")}}},
 					}, nil
 				})
+				patches.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+					return false
+				})
 				return patches
 			},
 			wantErr:      false,
@@ -330,7 +341,7 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 						RealizedBindings: []model.AddressBindingEntry{{Binding: &model.PacketAddressClassifier{IpAddress: common.String("10.0.0.1")}}},
 					}, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(service.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+				patches.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
 					return true
 				})
 				return patches
@@ -364,6 +375,9 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 					Values: gomonkey.Params{model.GenericPolicyRealizedResourceListResult{}, nsxutil.NewRealizeStateError("realized state error", 0)},
 					Times:  1,
 				}})
+				patches.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+					return false
+				})
 				return patches
 			},
 			wantErr:   true,
@@ -390,6 +404,9 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 					Factor:   1.0,
 					Jitter:   0.0,
 				})
+				patches.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+					return false
+				})
 				return patches
 			},
 			wantErr:   true,
@@ -409,6 +426,9 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 					Values: gomonkey.Params{model.GenericPolicyRealizedResourceListResult{}, nsxutil.NewRealizeStateError("realized state error", nsxutil.IPAllocationErrorCode)},
 					Times:  1,
 				}})
+				patches.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+					return false
+				})
 				return patches
 			},
 			wantErr:   true,
@@ -427,6 +447,9 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 					Values: gomonkey.Params{fmt.Errorf("mock error")},
 					Times:  1,
 				}})
+				patches.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+					return false
+				})
 				return patches
 			},
 			wantErr:   true,
@@ -445,6 +468,9 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 					Values: gomonkey.Params{model.VpcSubnetPort{}, fmt.Errorf("mock error")},
 					Times:  1,
 				}})
+				patches.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+					return false
+				})
 				return patches
 			},
 			wantErr:   true,
@@ -961,6 +987,176 @@ func TestSubnetPortService_ListSubnetPortByPodName(t *testing.T) {
 	assert.Equal(t, subnetPort2, subnetPorts[0])
 }
 
+func TestSubnetPortService_ListSubnetPortByStsName(t *testing.T) {
+	subnetPortService := createSubnetPortService(t)
+	subnetPort1 := &model.VpcSubnetPort{
+		Id:         &subnetPortId1,
+		Path:       &subnetPortPath1,
+		ParentPath: &subnetPath,
+		Tags: []model.Tag{
+			{
+				Scope: common.String("nsx-op/namespace"),
+				Tag:   common.String("ns-1"),
+			},
+			{
+				Scope: common.String(common.TagScopeStatefulSetName),
+				Tag:   common.String("sts-1"),
+			},
+		},
+	}
+	subnetPort2 := &model.VpcSubnetPort{
+		Id:         &subnetPortId2,
+		Path:       &subnetPortPath2,
+		ParentPath: &subnetPath,
+		Tags: []model.Tag{
+			{
+				Scope: common.String("nsx-op/namespace"),
+				Tag:   common.String("ns-1"),
+			},
+			{
+				Scope: common.String(common.TagScopeStatefulSetName),
+				Tag:   common.String("sts-1"),
+			},
+		},
+	}
+	subnetPortDifferentNS := &model.VpcSubnetPort{
+		Id:         common.String("port-3"),
+		Path:       common.String("/subnet-path-3"),
+		ParentPath: &subnetPath,
+		Tags: []model.Tag{
+			{
+				Scope: common.String("nsx-op/namespace"),
+				Tag:   common.String("ns-2"),
+			},
+			{
+				Scope: common.String(common.TagScopeStatefulSetName),
+				Tag:   common.String("sts-1"),
+			},
+		},
+	}
+	subnetPortService.SubnetPortStore.Add(subnetPort1)
+	subnetPortService.SubnetPortStore.Add(subnetPort2)
+	subnetPortService.SubnetPortStore.Add(subnetPortDifferentNS)
+
+	tests := []struct {
+		name          string
+		ns            string
+		stsName       string
+		expectedCount int
+	}{
+		{
+			name:          "found in ns-1",
+			ns:            "ns-1",
+			stsName:       "sts-1",
+			expectedCount: 2,
+		},
+		{
+			name:          "not found different namespace",
+			ns:            "ns-2",
+			stsName:       "sts-1",
+			expectedCount: 1,
+		},
+		{
+			name:          "not found",
+			ns:            "ns-1",
+			stsName:       "non-existent",
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnetPorts := subnetPortService.ListSubnetPortByStsName(tt.ns, tt.stsName)
+			assert.Equal(t, tt.expectedCount, len(subnetPorts))
+		})
+	}
+}
+
+func TestSubnetPortService_ListSubnetPortByStsUid(t *testing.T) {
+	subnetPortService := createSubnetPortService(t)
+	subnetPort1 := &model.VpcSubnetPort{
+		Id:         &subnetPortId1,
+		Path:       &subnetPortPath1,
+		ParentPath: &subnetPath,
+		Tags: []model.Tag{
+			{
+				Scope: common.String("nsx-op/namespace"),
+				Tag:   common.String("ns-1"),
+			},
+			{
+				Scope: common.String(common.TagScopeStatefulSetUID),
+				Tag:   common.String("sts-uid-123"),
+			},
+		},
+	}
+	subnetPort2 := &model.VpcSubnetPort{
+		Id:         &subnetPortId2,
+		Path:       &subnetPortPath2,
+		ParentPath: &subnetPath,
+		Tags: []model.Tag{
+			{
+				Scope: common.String("nsx-op/namespace"),
+				Tag:   common.String("ns-1"),
+			},
+			{
+				Scope: common.String(common.TagScopeStatefulSetUID),
+				Tag:   common.String("sts-uid-123"),
+			},
+		},
+	}
+	subnetPortDifferentNS := &model.VpcSubnetPort{
+		Id:         common.String("port-3"),
+		Path:       common.String("/subnet-path-3"),
+		ParentPath: &subnetPath,
+		Tags: []model.Tag{
+			{
+				Scope: common.String("nsx-op/namespace"),
+				Tag:   common.String("ns-2"),
+			},
+			{
+				Scope: common.String(common.TagScopeStatefulSetUID),
+				Tag:   common.String("sts-uid-123"),
+			},
+		},
+	}
+	subnetPortService.SubnetPortStore.Add(subnetPort1)
+	subnetPortService.SubnetPortStore.Add(subnetPort2)
+	subnetPortService.SubnetPortStore.Add(subnetPortDifferentNS)
+
+	tests := []struct {
+		name          string
+		ns            string
+		stsUid        string
+		expectedCount int
+	}{
+		{
+			name:          "found in ns-1",
+			ns:            "ns-1",
+			stsUid:        "sts-uid-123",
+			expectedCount: 2,
+		},
+		{
+			name:          "not found different namespace",
+			ns:            "ns-2",
+			stsUid:        "sts-uid-123",
+			expectedCount: 1,
+		},
+		{
+			name:          "not found",
+			ns:            "ns-1",
+			stsUid:        "non-existent",
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnetPorts := subnetPortService.ListSubnetPortByStsUid(tt.ns, tt.stsUid)
+			assert.Equal(t, tt.expectedCount, len(subnetPorts))
+		})
+	}
+}
+
 func TestSubnetPortService_AllocateAndReleasePortFromSubnet(t *testing.T) {
 	subnetPath := "subnet-path-1"
 	subnetId := "subnet-id-1"
@@ -1240,6 +1436,8 @@ func createSubnetPortService(t *testing.T) *SubnetPortService {
 					common.TagScopeVMNamespace:     subnetPortIndexNamespace,
 					common.TagScopeNamespace:       subnetPortIndexPodNamespace,
 					common.IndexKeySubnetPath:      subnetPortIndexBySubnetPath,
+					common.TagScopeStatefulSetUID:  subnetPortIndexByStatefulSetUID,
+					common.TagScopeStatefulSetName: subnetPortIndexByStatefulSetName,
 				}),
 			BindingType: model.VpcSubnetPortBindingType(),
 		}},
@@ -1368,7 +1566,8 @@ func TestSubnetPortService_GetAllVIFs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.prepareFunc(t, subnetPortService, context.Background())
+			patches := tt.prepareFunc(t, subnetPortService, context.Background())
+			defer patches.Reset()
 			_, err := subnetPortService.GetAllVIFs()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetAllVIFs() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/nsx/statefulset_pod_feature.go
+++ b/pkg/nsx/statefulset_pod_feature.go
@@ -1,0 +1,20 @@
+/* Copyright © 2026 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package nsx
+
+import "github.com/vmware-tanzu/nsx-operator/pkg/config"
+
+// StatefulSetPodSubnetPortFeatureEnabled is true when NSX supports StatefulSet pod SubnetPorts
+// and operator nsx_v3 sets vpc_wcp_enhance to true (omitted or false keeps the feature off).
+//
+//go:noinline
+func StatefulSetPodSubnetPortFeatureEnabled(client *Client, operatorConfig *config.NSXOperatorConfig) bool {
+	if client == nil || !client.NSXCheckVersion(StatefulSetPod) {
+		return false
+	}
+	if operatorConfig == nil || operatorConfig.NsxConfig == nil {
+		return false
+	}
+	return operatorConfig.NsxConfig.VpcWcpEnhanceEnabled()
+}

--- a/pkg/nsx/statefulset_pod_feature_test.go
+++ b/pkg/nsx/statefulset_pod_feature_test.go
@@ -1,0 +1,44 @@
+/* Copyright © 2026 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package nsx
+
+import (
+	"reflect"
+	"testing"
+
+	gomonkey "github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+)
+
+func TestStatefulSetPodSubnetPortFeatureEnabled(t *testing.T) {
+	f := false
+	tr := true
+	nsxClient := &Client{}
+
+	t.Run("nil client", func(t *testing.T) {
+		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nil, &config.NSXOperatorConfig{}))
+	})
+
+	t.Run("version supports and vpc_wcp_enhance opt-in", func(t *testing.T) {
+		p := gomonkey.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *Client, feature int) bool {
+			return feature == StatefulSetPod
+		})
+		defer p.Reset()
+		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, nil))
+		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: nil}))
+		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}))
+		assert.True(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{VpcWcpEnhance: &tr}}))
+		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{VpcWcpEnhance: &f}}))
+	})
+
+	t.Run("version does not support", func(t *testing.T) {
+		p := gomonkey.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *Client, feature int) bool {
+			return false
+		})
+		defer p.Reset()
+		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}))
+	})
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -15,6 +15,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/google/uuid"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -383,6 +384,12 @@ func BuildBasicTags(cluster string, obj interface{}, namespaceID types.UID) []mo
 		tags = append(tags, model.Tag{Scope: String(common.TagScopeNamespace), Tag: String(i.ObjectMeta.Namespace)})
 		tags = append(tags, model.Tag{Scope: String(common.TagScopePodName), Tag: String(i.ObjectMeta.Name)})
 		tags = append(tags, model.Tag{Scope: String(common.TagScopePodUID), Tag: String(string(i.UID))})
+		// StatefulSet is the controller ref on pods it creates (see metav1.GetControllerOf).
+		stsKind := appsv1.SchemeGroupVersion.WithKind("StatefulSet").Kind
+		if ref := metav1.GetControllerOf(i); ref != nil && ref.Kind == stsKind {
+			tags = append(tags, model.Tag{Scope: String(common.TagScopeStatefulSetName), Tag: String(ref.Name)})
+			tags = append(tags, model.Tag{Scope: String(common.TagScopeStatefulSetUID), Tag: String(string(ref.UID))})
+		}
 	case *v1alpha1.NetworkInfo:
 		tags = append(tags, model.Tag{Scope: String(common.TagScopeNamespace), Tag: String(i.ObjectMeta.Namespace)})
 	case *v1alpha1.IPAddressAllocation:

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -684,4 +685,69 @@ func TestValidateSubnetSize(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildBasicTagsWithStatefulSetPod(t *testing.T) {
+	cluster := "test-cluster"
+	namespaceID := types.UID("ns-uid-123")
+
+	controller := true
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-0",
+			Namespace: "default",
+			UID:       "pod-uid-123",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       appsv1.SchemeGroupVersion.WithKind("StatefulSet").Kind,
+					Name:       "test-sts",
+					UID:        "sts-uid-123",
+					Controller: &controller,
+				},
+			},
+		},
+	}
+
+	tags := BuildBasicTags(cluster, pod, namespaceID)
+
+	assert.Len(t, tags, 8)
+	foundCluster := false
+	foundVersion := false
+	foundNamespace := false
+	foundPodName := false
+	foundPodUID := false
+	foundStsName := false
+	foundStsUID := false
+
+	for _, tag := range tags {
+		if *tag.Scope == common.TagScopeCluster && *tag.Tag == cluster {
+			foundCluster = true
+		}
+		if *tag.Scope == common.TagScopeVersion {
+			foundVersion = true
+		}
+		if *tag.Scope == common.TagScopeNamespace && *tag.Tag == "default" {
+			foundNamespace = true
+		}
+		if *tag.Scope == common.TagScopePodName && *tag.Tag == "test-pod-0" {
+			foundPodName = true
+		}
+		if *tag.Scope == common.TagScopePodUID && *tag.Tag == "pod-uid-123" {
+			foundPodUID = true
+		}
+		if *tag.Scope == common.TagScopeStatefulSetName && *tag.Tag == "test-sts" {
+			foundStsName = true
+		}
+		if *tag.Scope == common.TagScopeStatefulSetUID && *tag.Tag == "sts-uid-123" {
+			foundStsUID = true
+		}
+	}
+
+	assert.True(t, foundCluster, "should have cluster tag")
+	assert.True(t, foundVersion, "should have version tag")
+	assert.True(t, foundNamespace, "should have namespace tag")
+	assert.True(t, foundPodName, "should have pod name tag")
+	assert.True(t, foundPodUID, "should have pod uid tag")
+	assert.True(t, foundStsName, "should have statefulset name tag")
+	assert.True(t, foundStsUID, "should have statefulset uid tag")
 }


### PR DESCRIPTION
 Add sts pod support

    Not delete subnetport in pod_controller if it's a sts port.
    Rlease subnetport in statefulset_controller if index out of range.
    If the pod reschduled and the port found, reuse the port

    Test Done:

    Test case: upgrade
    1. Create the sts without patch
    2. Check subnet port created without sts related tag
    3. Patch the commit
    4. Check if subunit port has been added new tags

    Test Case: shrink
    1. Create the sts with replicas 2
    2. Update the replicas from 2 to 1
    3. Check if pod controller skip to delete the subnetport
    4. Check if statefulset controller has deleted the subnetport

    Test Case: delete
    1. Create the sts with replicas 2
    2. Delete the sts
    3. Check if subnetports have been deleted
       "statefulset_controller.go:124 Successfully deleted
       subnet port for StatefulSet StatefulSet"

    Test Case: gc
    1. Create a subnetport with sts tag
    2. Restart the nix-operator
    3. Check if the subnetport has been deleted
       "Found orphaned subnet port for deleted StatefulSet"

    Test Case: reuse, same node
    1. create the sts pod
    2. delete one pod
    3. check if the pod created with the same ip in the same node
    4. check if the subnetport id is the same as before
    
    Test Case: reuse, different node
    1. create the sts pod
    2. taint the node
    3. delete the pod
    4. check if the pod created with the same ip
    5. check if the subnetport id of the pod is the same as before
    
    Test Case: Update replicas
    1. create the sts pod with replicas=6
    2. update the replicas=20
    3. check if the pod has been created
    
    Test Case: Delete multiple pods
     1. create the sts with replicas=20
     2. delete some of pod like
        k delete pod web-sts-2,web-sts-6,web-sts-8,web-sts-10,web-sts-15 -nqe
     3. check if all the pod have been created with the same ip
     
    Test Case：NSX 9.1
    1. mock the nsx version 9.1.0.25317852
    2. restart the operator
    3. check if has log:
    2026-04-13 07:17:52.000 INFO main.go:254 NSX version does not yet support StatefulSet Pod feature...
    4. delete one of the pod
    5. check if the previous old port deleted
    6. check if new port allocated
    
    Test case: change nsx version from 9.1 to 9.2
    1. mock the nsx version 9.1.0.25317852
    2. restart the operator
    3. check if has log:
    2026-04-13 07:17:52.000 INFO main.go:254 NSX version does not yet support StatefulSet Pod feature...
    4, delete one of the pod
     5. check if pod controller handle the DELETE event
     6. mock the nsx version 9.2.0.25317852, wait for version checking interval
     7. check if statefulset GC log found
       
   Test case: check cm vpc_wcp_enhance
    1. set the vpc_wcp_enhance true
    2. check if the statefulset feature has been enabled
    3. update the vpc_wcp_enhance false 
    4. restart the nsx-operator
    5. check if the statefulset feature has been disabled
    StatefulSet Pod feature gated (NSX version or vpc_wcp_enhance); StatefulSet controller registered but replica/GC no-op until enabled