### PR TITLE
Add From/To fields in SecurityPolicy

### DIFF
--- a/build/yaml/crd/legacy/nsx.vmware.com_securitypolicies.yaml
+++ b/build/yaml/crd/legacy/nsx.vmware.com_securitypolicies.yaml
@@ -260,8 +260,9 @@ spec:
                         type: object
                       type: array
                     destinations:
-                      description: Destinations defines the endpoints where the traffic
-                        is to. For egress rule only.
+                      description: |-
+                        Deprecated: use To instead.
+                        Destinations defines the endpoints where the traffic is to. For egress rule only.
                       items:
                         description: SecurityPolicyPeer defines the source or destination
                           of traffic.
@@ -429,6 +430,173 @@ spec:
                       description: Direction is the direction of the rule, including
                         'In' or 'Ingress', 'Out' or 'Egress'.
                       type: string
+                    from:
+                      description: |-
+                        From defines the endpoints where the traffic is from. For ingress rule only.
+                        This is the preferred field over the deprecated Sources.
+                      items:
+                        description: SecurityPolicyPeer defines the source or destination
+                          of traffic.
+                        properties:
+                          ipBlocks:
+                            description: IPBlocks is a list of IP CIDRs.
+                            items:
+                              description: IPBlock describes a particular CIDR that
+                                is allowed or denied to/from the workloads matched
+                                by an AppliedTo.
+                              properties:
+                                cidr:
+                                  description: |-
+                                    CIDR is a string representing the IP Block.
+                                    A valid example is "192.168.1.1/24".
+                                  type: string
+                              required:
+                              - cidr
+                              type: object
+                            type: array
+                          namespaceSelector:
+                            description: NamespaceSelector uses label selector to
+                              select Namespaces.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          podSelector:
+                            description: PodSelector uses label selector to select
+                              Pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          vmSelector:
+                            description: VMSelector uses label selector to select
+                              VMs.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
                     name:
                       description: Name is the display name of this rule.
                       type: string
@@ -456,8 +624,176 @@ spec:
                         type: object
                       type: array
                     sources:
-                      description: Sources defines the endpoints where the traffic
-                        is from. For ingress rule only.
+                      description: |-
+                        Deprecated: use From instead.
+                        Sources defines the endpoints where the traffic is from. For ingress rule only.
+                      items:
+                        description: SecurityPolicyPeer defines the source or destination
+                          of traffic.
+                        properties:
+                          ipBlocks:
+                            description: IPBlocks is a list of IP CIDRs.
+                            items:
+                              description: IPBlock describes a particular CIDR that
+                                is allowed or denied to/from the workloads matched
+                                by an AppliedTo.
+                              properties:
+                                cidr:
+                                  description: |-
+                                    CIDR is a string representing the IP Block.
+                                    A valid example is "192.168.1.1/24".
+                                  type: string
+                              required:
+                              - cidr
+                              type: object
+                            type: array
+                          namespaceSelector:
+                            description: NamespaceSelector uses label selector to
+                              select Namespaces.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          podSelector:
+                            description: PodSelector uses label selector to select
+                              Pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          vmSelector:
+                            description: VMSelector uses label selector to select
+                              VMs.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
+                    to:
+                      description: |-
+                        To defines the endpoints where the traffic is to. For egress rule only.
+                        This is the preferred field over the deprecated Destinations.
                       items:
                         description: SecurityPolicyPeer defines the source or destination
                           of traffic.

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_securitypolicies.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_securitypolicies.yaml
@@ -260,8 +260,9 @@ spec:
                         type: object
                       type: array
                     destinations:
-                      description: Destinations defines the endpoints where the traffic
-                        is to. For egress rule only.
+                      description: |-
+                        Deprecated: use To instead.
+                        Destinations defines the endpoints where the traffic is to. For egress rule only.
                       items:
                         description: SecurityPolicyPeer defines the source or destination
                           of traffic.
@@ -429,6 +430,173 @@ spec:
                       description: Direction is the direction of the rule, including
                         'In' or 'Ingress', 'Out' or 'Egress'.
                       type: string
+                    from:
+                      description: |-
+                        From defines the endpoints where the traffic is from. For ingress rule only.
+                        This is the preferred field over the deprecated Sources.
+                      items:
+                        description: SecurityPolicyPeer defines the source or destination
+                          of traffic.
+                        properties:
+                          ipBlocks:
+                            description: IPBlocks is a list of IP CIDRs.
+                            items:
+                              description: IPBlock describes a particular CIDR that
+                                is allowed or denied to/from the workloads matched
+                                by an AppliedTo.
+                              properties:
+                                cidr:
+                                  description: |-
+                                    CIDR is a string representing the IP Block.
+                                    A valid example is "192.168.1.1/24".
+                                  type: string
+                              required:
+                              - cidr
+                              type: object
+                            type: array
+                          namespaceSelector:
+                            description: NamespaceSelector uses label selector to
+                              select Namespaces.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          podSelector:
+                            description: PodSelector uses label selector to select
+                              Pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          vmSelector:
+                            description: VMSelector uses label selector to select
+                              VMs.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
                     name:
                       description: Name is the display name of this rule.
                       type: string
@@ -456,8 +624,176 @@ spec:
                         type: object
                       type: array
                     sources:
-                      description: Sources defines the endpoints where the traffic
-                        is from. For ingress rule only.
+                      description: |-
+                        Deprecated: use From instead.
+                        Sources defines the endpoints where the traffic is from. For ingress rule only.
+                      items:
+                        description: SecurityPolicyPeer defines the source or destination
+                          of traffic.
+                        properties:
+                          ipBlocks:
+                            description: IPBlocks is a list of IP CIDRs.
+                            items:
+                              description: IPBlock describes a particular CIDR that
+                                is allowed or denied to/from the workloads matched
+                                by an AppliedTo.
+                              properties:
+                                cidr:
+                                  description: |-
+                                    CIDR is a string representing the IP Block.
+                                    A valid example is "192.168.1.1/24".
+                                  type: string
+                              required:
+                              - cidr
+                              type: object
+                            type: array
+                          namespaceSelector:
+                            description: NamespaceSelector uses label selector to
+                              select Namespaces.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          podSelector:
+                            description: PodSelector uses label selector to select
+                              Pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          vmSelector:
+                            description: VMSelector uses label selector to select
+                              VMs.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
+                    to:
+                      description: |-
+                        To defines the endpoints where the traffic is to. For egress rule only.
+                        This is the preferred field over the deprecated Destinations.
                       items:
                         description: SecurityPolicyPeer defines the source or destination
                           of traffic.

--- a/build/yaml/samples/nsx_v1alpha1_securitypolicy.yaml
+++ b/build/yaml/samples/nsx_v1alpha1_securitypolicy.yaml
@@ -42,3 +42,40 @@ spec:
       ports:
         - protocol: TCP
           port: 8000
+
+---
+
+# Example using from/to aliases (Kubernetes NetworkPolicy style)
+apiVersion: crd.nsx.vmware.com/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: from-to-policy-1
+  namespace: ns-1
+spec:
+  appliedTo:
+    - podSelector:
+        matchLabels:
+          role: db
+  rules:
+    - direction: Ingress
+      action: Allow
+      from:
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 3306
+    - direction: Out
+      action: Allow
+      to:
+        - podSelector:
+            matchLabels:
+              role: dns
+      ports:
+        - protocol: UDP
+          port: 53
+    - direction: Ingress
+      action: Drop
+    - direction: Out
+      action: Drop

--- a/docs/ref/apis/legacy.md
+++ b/docs/ref/apis/legacy.md
@@ -357,8 +357,10 @@ _Appears in:_
 | `action` _[RuleAction](#ruleaction)_ | Action specifies the action to be applied on the rule. |  |  |
 | `appliedTo` _[SecurityPolicyTarget](#securitypolicytarget) array_ | AppliedTo is a list of rule targets.<br />Policy level 'Applied To' will take precedence over rule level. |  |  |
 | `direction` _[RuleDirection](#ruledirection)_ | Direction is the direction of the rule, including 'In' or 'Ingress', 'Out' or 'Egress'. |  |  |
-| `sources` _[SecurityPolicyPeer](#securitypolicypeer) array_ | Sources defines the endpoints where the traffic is from. For ingress rule only. |  |  |
-| `destinations` _[SecurityPolicyPeer](#securitypolicypeer) array_ | Destinations defines the endpoints where the traffic is to. For egress rule only. |  |  |
+| `sources` _[SecurityPolicyPeer](#securitypolicypeer) array_ | **Deprecated: use `from` instead.** Sources defines the endpoints where the traffic is from. For ingress rule only. |  |  |
+| `destinations` _[SecurityPolicyPeer](#securitypolicypeer) array_ | **Deprecated: use `to` instead.** Destinations defines the endpoints where the traffic is to. For egress rule only. |  |  |
+| `from` _[SecurityPolicyPeer](#securitypolicypeer) array_ | From defines the endpoints where the traffic is from. For ingress rule only. This is the preferred field over the deprecated Sources. |  |  |
+| `to` _[SecurityPolicyPeer](#securitypolicypeer) array_ | To defines the endpoints where the traffic is to. For egress rule only. This is the preferred field over the deprecated Destinations. |  |  |
 | `ports` _[SecurityPolicyPort](#securitypolicyport) array_ | Ports is a list of ports to be matched. |  |  |
 | `name` _string_ | Name is the display name of this rule. |  |  |
 

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -540,8 +540,10 @@ _Appears in:_
 | `action` _[RuleAction](#ruleaction)_ | Action specifies the action to be applied on the rule. |  |  |
 | `appliedTo` _[SecurityPolicyTarget](#securitypolicytarget) array_ | AppliedTo is a list of rule targets.<br />Policy level 'Applied To' will take precedence over rule level. |  |  |
 | `direction` _[RuleDirection](#ruledirection)_ | Direction is the direction of the rule, including 'In' or 'Ingress', 'Out' or 'Egress'. |  |  |
-| `sources` _[SecurityPolicyPeer](#securitypolicypeer) array_ | Sources defines the endpoints where the traffic is from. For ingress rule only. |  |  |
-| `destinations` _[SecurityPolicyPeer](#securitypolicypeer) array_ | Destinations defines the endpoints where the traffic is to. For egress rule only. |  |  |
+| `sources` _[SecurityPolicyPeer](#securitypolicypeer) array_ | **Deprecated: use `from` instead.** Sources defines the endpoints where the traffic is from. For ingress rule only. |  |  |
+| `destinations` _[SecurityPolicyPeer](#securitypolicypeer) array_ | **Deprecated: use `to` instead.** Destinations defines the endpoints where the traffic is to. For egress rule only. |  |  |
+| `from` _[SecurityPolicyPeer](#securitypolicypeer) array_ | From defines the endpoints where the traffic is from. For ingress rule only. This is the preferred field over the deprecated Sources. |  |  |
+| `to` _[SecurityPolicyPeer](#securitypolicypeer) array_ | To defines the endpoints where the traffic is to. For egress rule only. This is the preferred field over the deprecated Destinations. |  |  |
 | `ports` _[SecurityPolicyPort](#securitypolicyport) array_ | Ports is a list of ports to be matched. |  |  |
 | `name` _string_ | Name is the display name of this rule. |  |  |
 

--- a/docs/security-policy.md
+++ b/docs/security-policy.md
@@ -82,6 +82,57 @@ to access through TCP with port 8000. The second rule allows the selected VMs to
 access Pods with label "role: dns" through UDP with port 53. The third and forth
 rules are to drop any other ingress and egress traffic to/from the selected VMs.
 
+### Kubernetes NetworkPolicy style (from/to)
+
+SecurityPolicy supports `from` and `to` fields as the preferred way to specify
+traffic peers, aligning with the standard Kubernetes NetworkPolicy syntax. The
+legacy `sources` and `destinations` fields are deprecated; use `from` and `to`
+instead. The following example is equivalent to the one above:
+
+```yaml
+apiVersion: nsx.vmware.com/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: db-isolation
+  namespace: prod-ns
+spec:
+  priority: 1
+  appliedTo:
+    - vmSelector:
+        matchLabels:
+          role: db
+  rules:
+    - direction: in
+      action: allow
+      from:
+        - namespaceSelector:
+            matchLabels:
+              role: control
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 8000
+    - direction: out
+      action: allow
+      to:
+        - podSelector:
+            matchLabels:
+              role: dns
+      ports:
+        - protocol: UDP
+          port: 53
+      appliedTo:
+        - vmSelector:
+            matchLabels:
+              user: internal
+    - direction: in
+      action: drop
+    - direction: out
+      action: drop
+```
+
 Below are explanations for the fields:
 
 **spec**: defines all the configurations for a SecurityPolicy CR.
@@ -107,21 +158,26 @@ or 'Egress'.
 **ports**: define protocol, specific port or port range. `ports.port` will be treated
 as destination port. More details refer to section `Targeting a range of Ports`
 
-**sources** and **destinations**: defines a list of peers where the traffic is from/to.
+**from** and **to**: defines a list of peers where the traffic is from/to.
 It could be `podSelector`, `vmSelector`, `namespaceSelector` and `ipBlocks`.
 `podSelector` and `namespaceSelector` in the same entry select particular Pods within
 particular Namespaces.
 `vmSelector` and `namespaceSelector` in the same entry select particular VMs within
 particular Namespaces.
-More details refer to section `Behavior of sources and destinations selectors`
+More details refer to section `Behavior of from and to selectors`
+
+**sources** and **destinations** *(deprecated)*: legacy names for `from` and `to`.
+These fields are still accepted for backward compatibility but users should migrate
+to `from`/`to`. If both `sources` and `from` (or `destinations` and `to`) are set
+in the same rule, `from`/`to` takes precedence.
 
 **status**: shows CR realization state. If there is any error during realization,
 nsx-operator will also update status with error message.
 
-## Behavior of sources and destinations selectors
+## Behavior of from and to selectors
 
-There are 6 kinds of selectors that can be specified in an `ingress` `sources` section
-or `egress` `destinations` section:
+There are 6 kinds of selectors that can be specified in an `ingress` `from`
+(or legacy `sources`) section or `egress` `to` (or legacy `destinations`) section:
 
 **podSelector**: This selects particular Pods in the same namespace as the SecurityPolicy
 as ingress sources or egress destinations.
@@ -129,7 +185,7 @@ as ingress sources or egress destinations.
 **namespaceSelector**: This selects particular namespaces for which all Pods and
 VMs as ingress sources or egress destinations.
 
-**namespaceSelector and podSelector**: A single `sources`/`destinations` entry that
+**namespaceSelector and podSelector**: A single `from`/`to` entry that
 specifies both `namespaceSelector` and `podSelector` selects particular Pods within
 particular namespaces. Be careful to use correct YAML syntax; this policy:
 
@@ -138,7 +194,7 @@ particular namespaces. Be careful to use correct YAML syntax; this policy:
   rules:
     - direction: in
       action: allow
-      sources:
+      from:
         - namespaceSelector:
             matchLabels:
               user: alice
@@ -147,7 +203,7 @@ particular namespaces. Be careful to use correct YAML syntax; this policy:
               role: client
   ...
 ```
-contains a single `sources` element allowing connections from Pods with the label
+contains a single `from` element allowing connections from Pods with the label
 `role=client` in namespaces with the label `user=alice`. But this policy:
 
 ```
@@ -155,7 +211,7 @@ contains a single `sources` element allowing connections from Pods with the labe
   rules:
     - direction: in
       action: allow
-      sources:
+      from:
         - namespaceSelector:
             matchLabels:
               user: alice
@@ -164,7 +220,7 @@ contains a single `sources` element allowing connections from Pods with the labe
               role: client
   ...
 ```
-contains two elements in the sources array, and allows connections from Pods in
+contains two elements in the `from` array, and allows connections from Pods in
 the current Namespace with the label `role=client`, or from any Pod in the namespaces
 with the label `user=alice`.
 
@@ -176,7 +232,7 @@ the SecurityPolicy as ingress sources or egress destinations. E.g.
   rules:
     - direction: in
       action: allow
-      sources:
+      from:
         - vmSelector:
             matchLabels:
               role: client
@@ -185,7 +241,7 @@ the SecurityPolicy as ingress sources or egress destinations. E.g.
 allows connections from VirtualMachines with the label `role=client` in the current
 namespace.
 
-**namespaceSelector and vmSelector**: A single `sources`/`destinations` entry that
+**namespaceSelector and vmSelector**: A single `from`/`to` entry that
 specifies both `namespaceSelector` and `vmSelector` selects particular VirtualMachines
 within particular namespaces. E.g.
 
@@ -194,7 +250,7 @@ within particular namespaces. E.g.
   rules:
     - direction: in
       action: allow
-      sources:
+      from:
         - namespaceSelector:
             matchLabels:
               user: alice
@@ -203,7 +259,7 @@ within particular namespaces. E.g.
               role: client
   ...
 ```
-contains a single `sources` element allowing connections from VirtualMachines with
+contains a single `from` element allowing connections from VirtualMachines with
 the label `role=client` in namespaces with the label `user=alice`.
 
 **ipBlocks**: This selects particular IP CIDR ranges to allow as ingress sources
@@ -214,7 +270,7 @@ or egress destinations. E.g.
   rules:
     - direction: ingress
       action: allow
-      sources:
+      from:
         - ipBlocks:
             - cidr: 192.168.0.0/24
 ...
@@ -227,7 +283,7 @@ Particularly, it can be used for single IP by suffix `/32`. E.g.
   rules:
     - direction: ingress
       action: allow
-      sources:
+      from:
         - ipBlocks:
             - cidr: 100.64.232.1/32
 ...
@@ -243,7 +299,7 @@ port. E.g.
   rules:
     - direction: in
       action: allow
-      sources:
+      from:
         - podSelector:
             matchLabels:
               role: ui
@@ -270,17 +326,17 @@ In the same policy, the higher rule has the higher priority. E.g. in the policy:
   rules:
     - direction: in
       action: allow
-      sources:
+      from:
         - podSelector:
             matchLabels:
               role: client
     - direction: in
       action: drop
-      sources:
+      from:
         - podSelector: {}
     - direction: out
       action: drop
-      destinations:
+      to:
         - podSelector: {}
 ...
 ```

--- a/pkg/apis/legacy/v1alpha1/securitypolicy_types.go
+++ b/pkg/apis/legacy/v1alpha1/securitypolicy_types.go
@@ -59,10 +59,18 @@ type SecurityPolicyRule struct {
 	AppliedTo []SecurityPolicyTarget `json:"appliedTo,omitempty"`
 	// Direction is the direction of the rule, including 'In' or 'Ingress', 'Out' or 'Egress'.
 	Direction *RuleDirection `json:"direction"`
+	// Deprecated: use From instead.
 	// Sources defines the endpoints where the traffic is from. For ingress rule only.
 	Sources []SecurityPolicyPeer `json:"sources,omitempty"`
+	// Deprecated: use To instead.
 	// Destinations defines the endpoints where the traffic is to. For egress rule only.
 	Destinations []SecurityPolicyPeer `json:"destinations,omitempty"`
+	// From defines the endpoints where the traffic is from. For ingress rule only.
+	// This is the preferred field over the deprecated Sources.
+	From []SecurityPolicyPeer `json:"from,omitempty"`
+	// To defines the endpoints where the traffic is to. For egress rule only.
+	// This is the preferred field over the deprecated Destinations.
+	To []SecurityPolicyPeer `json:"to,omitempty"`
 	// Ports is a list of ports to be matched.
 	Ports []SecurityPolicyPort `json:"ports,omitempty"`
 	// Name is the display name of this rule.

--- a/pkg/apis/legacy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/legacy/v1alpha1/zz_generated.deepcopy.go
@@ -384,6 +384,20 @@ func (in *SecurityPolicyRule) DeepCopyInto(out *SecurityPolicyRule) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.From != nil {
+		in, out := &in.From, &out.From
+		*out = make([]SecurityPolicyPeer, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.To != nil {
+		in, out := &in.To, &out.To
+		*out = make([]SecurityPolicyPeer, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
 		*out = make([]SecurityPolicyPort, len(*in))

--- a/pkg/apis/vpc/v1alpha1/securitypolicy_types.go
+++ b/pkg/apis/vpc/v1alpha1/securitypolicy_types.go
@@ -59,10 +59,18 @@ type SecurityPolicyRule struct {
 	AppliedTo []SecurityPolicyTarget `json:"appliedTo,omitempty"`
 	// Direction is the direction of the rule, including 'In' or 'Ingress', 'Out' or 'Egress'.
 	Direction *RuleDirection `json:"direction"`
+	// Deprecated: use From instead.
 	// Sources defines the endpoints where the traffic is from. For ingress rule only.
 	Sources []SecurityPolicyPeer `json:"sources,omitempty"`
+	// Deprecated: use To instead.
 	// Destinations defines the endpoints where the traffic is to. For egress rule only.
 	Destinations []SecurityPolicyPeer `json:"destinations,omitempty"`
+	// From defines the endpoints where the traffic is from. For ingress rule only.
+	// This is the preferred field over the deprecated Sources.
+	From []SecurityPolicyPeer `json:"from,omitempty"`
+	// To defines the endpoints where the traffic is to. For egress rule only.
+	// This is the preferred field over the deprecated Destinations.
+	To []SecurityPolicyPeer `json:"to,omitempty"`
 	// Ports is a list of ports to be matched.
 	Ports []SecurityPolicyPort `json:"ports,omitempty"`
 	// Name is the display name of this rule.

--- a/pkg/apis/vpc/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/vpc/v1alpha1/zz_generated.deepcopy.go
@@ -635,6 +635,20 @@ func (in *SecurityPolicyRule) DeepCopyInto(out *SecurityPolicyRule) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.From != nil {
+		in, out := &in.From, &out.From
+		*out = make([]SecurityPolicyPeer, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.To != nil {
+		in, out := &in.To, &out.To
+		*out = make([]SecurityPolicyPeer, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
 		*out = make([]SecurityPolicyPort, len(*in))

--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -89,6 +89,20 @@ func (service *SecurityPolicyService) buildSecurityPolicyIDAndName(obj *v1alpha1
 	return nsxSecurityPolicyID, service.buildSecurityPolicyName(obj)
 }
 
+func getRuleSourcePeers(rule *v1alpha1.SecurityPolicyRule) []v1alpha1.SecurityPolicyPeer {
+	if len(rule.From) > 0 {
+		return rule.From
+	}
+	return rule.Sources //nolint:staticcheck
+}
+
+func getRuleDestinationPeers(rule *v1alpha1.SecurityPolicyRule) []v1alpha1.SecurityPolicyPeer {
+	if len(rule.To) > 0 {
+		return rule.To
+	}
+	return rule.Destinations //nolint:staticcheck
+}
+
 func (service *SecurityPolicyService) buildSecurityPolicy(obj *v1alpha1.SecurityPolicy, createdFor string, vpcInfo *common.VPCResourceInfo, isDefaultProject bool) (*model.SecurityPolicy, *[]model.Group, *[]GroupShare, error) {
 	var nsxRules []model.Rule
 	var nsxGroups []model.Group
@@ -581,7 +595,8 @@ func (service *SecurityPolicyService) buildRuleInGroup(obj *v1alpha1.SecurityPol
 	var nsxRuleSrcGroupPath string
 	var nsxRuleDstGroupPath string
 	var err error
-	if len(rule.Sources) > 0 {
+	sources := getRuleSourcePeers(rule)
+	if len(sources) > 0 {
 		nsxRuleSrcGroup, nsxRuleSrcGroupPath, nsxGroupShare, err = service.buildRulePeerGroup(obj, rule, ruleIdx, ruleBaseID, true, createdFor, vpcInfo, isDefaultProject)
 		if err != nil {
 			return nil, "", "", nil, err
@@ -609,7 +624,8 @@ func (service *SecurityPolicyService) buildRuleOutGroup(obj *v1alpha1.SecurityPo
 	if len(nsxRule.DestinationGroups) > 0 {
 		nsxRuleDstGroupPath = nsxRule.DestinationGroups[0]
 	} else {
-		if len(rule.Destinations) > 0 {
+		destinations := getRuleDestinationPeers(rule)
+		if len(destinations) > 0 {
 			nsxRuleDstGroup, nsxRuleDstGroupPath, nsxGroupShare, err = service.buildRulePeerGroup(obj, rule, ruleIdx, ruleBaseID, false, createdFor, vpcInfo, isDefaultProject)
 			if err != nil {
 				return nil, "", "", nil, err
@@ -863,12 +879,11 @@ func (service *SecurityPolicyService) buildRulePeerGroup(obj *v1alpha1.SecurityP
 	var rulePeers []v1alpha1.SecurityPolicyPeer
 	var ruleDirection string
 	var err error
-
 	if isSource {
-		rulePeers = rule.Sources
+		rulePeers = getRuleSourcePeers(rule)
 		ruleDirection = "source"
 	} else {
-		rulePeers = rule.Destinations
+		rulePeers = getRuleDestinationPeers(rule)
 		ruleDirection = "destination"
 	}
 
@@ -1065,13 +1080,17 @@ func (service *SecurityPolicyService) buildPeerTags(obj *v1alpha1.SecurityPolicy
 	ruleBaseID string, isSource bool, groupScope GroupScope, createdFor string,
 ) []model.Tag {
 	basicTags := service.buildBasicTags(obj, createdFor)
-	groupTypeTag := String(common.TagValueGroupDestination)
-	peers := &rule.Destinations
+	var groupTypeTag *string
+
+	var peers []v1alpha1.SecurityPolicyPeer
 	if isSource {
+		peers = getRuleSourcePeers(rule)
 		groupTypeTag = String(common.TagValueGroupSource)
-		peers = &rule.Sources
+	} else {
+		peers = getRuleDestinationPeers(rule)
+		groupTypeTag = String(common.TagValueGroupDestination)
 	}
-	serializedBytes, _ := json.Marshal(*peers)
+	serializedBytes, _ := json.Marshal(peers)
 
 	peerTags := []model.Tag{
 		{

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -40,19 +40,19 @@ func Test_BuildSecurityPolicyForT1(t *testing.T) {
 	)
 
 	podSelectorRule0Name00 := "rule-with-pod-ns-selector_ingress_allow"
-	podSelectorRule0IDPort000 := "sp_uidA_2c822e90b1377b346014adfa583f08a99dee52a8_0_0_0"
+	podSelectorRule0IDPort000 := "sp_uidA_1e510e8ad94c103f4727e2bfc28bc637cb752831_0_0_0"
 
 	podSelectorRule1Name00 := "rule-with-ns-selector_ingress_allow"
-	podSelectorRule1IDPort000 := "sp_uidA_2a4595d0dd582c2ae5613245ad7b39de5ade2e20_1_0_0"
+	podSelectorRule1IDPort000 := "sp_uidA_304ea84a85a12eae03f799a546ec5bfe1ffaaa64_1_0_0"
 
 	vmSelectorRule0Name00 := "rule-with-VM-selector_egress_isolation"
-	vmSelectorRule0IDPort000 := "sp_uidB_67410606c486d2ba38002ed076a2a4211c9d49b5_0_0_0"
+	vmSelectorRule0IDPort000 := "sp_uidB_db8116ce8304671a055501343fa850eb93b76604_0_0_0"
 
 	vmSelectorRule1Name00 := "rule-with-ns-selector_egress_isolation"
-	vmSelectorRule1IDPort000 := "sp_uidB_7d721f087be35f0bf318f4847b5acdc3d2b91446_1_0_0"
+	vmSelectorRule1IDPort000 := "sp_uidB_52d139ca30855b6286398468ff1fb83b6a80a67a_1_0_0"
 
 	vmSelectorRule2Name00 := "all_egress_isolation"
-	vmSelectorRule2IDPort000 := "sp_uidB_a40c813916cc397fcd2260e48cc773d4c9b08565_2_0_0"
+	vmSelectorRule2IDPort000 := "sp_uidB_1241cf958964f48b167979a831adbae3453dae99_2_0_0"
 
 	tests := []struct {
 		name           string
@@ -216,25 +216,25 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 	defer patches.Reset()
 
 	podSelectorRule0Name00 := "rule-with-pod-ns-selector_ingress_allow"
-	podSelectorRule0IDPort000 := "spA-2c822e90_re0bz_all"
+	podSelectorRule0IDPort000 := "spA-1e510e8a_re0bz_all"
 
 	podSelectorRule1Name00 := "rule-with-ns-selector_ingress_allow"
-	podSelectorRule1IDPort000 := "spA-2a4595d0_re0bz_53"
+	podSelectorRule1IDPort000 := "spA-304ea84a_re0bz_53"
 
 	vmSelectorRule0Name00 := "rule-with-VM-selector_egress_isolation"
-	vmSelectorRule0IDPort000 := "spB-67410606_9u8w9_all"
+	vmSelectorRule0IDPort000 := "spB-db8116ce_9u8w9_all"
 
 	vmSelectorRule1Name00 := "rule-with-ns-selector_egress_isolation"
-	vmSelectorRule1IDPort000 := "spB-7d721f08_9u8w9_all"
+	vmSelectorRule1IDPort000 := "spB-52d139ca_9u8w9_all"
 
 	vmSelectorRule2Name00 := "all_egress_isolation"
-	vmSelectorRule2IDPort000 := "spB-a40c8139_9u8w9_all"
+	vmSelectorRule2IDPort000 := "spB-1241cf95_9u8w9_all"
 
-	vpcRuleTags1 := appendRuleIDAndHashTags(vpcBasicTags, "2c822e90", "spA-2c822e90_re0bz")
-	vpcRuleTags2 := appendRuleIDAndHashTags(vpcBasicTags, "2a4595d0", "spA-2a4595d0_re0bz")
-	vpcRuleTags3 := appendRuleIDAndHashTags(vpcBasicTagsForSpWithVMSelector, "67410606", "spB-67410606_9u8w9")
-	vpcRuleTags4 := appendRuleIDAndHashTags(vpcBasicTagsForSpWithVMSelector, "7d721f08", "spB-7d721f08_9u8w9")
-	vpcRuleTags5 := appendRuleIDAndHashTags(vpcBasicTagsForSpWithVMSelector, "a40c8139", "spB-a40c8139_9u8w9")
+	vpcRuleTags1 := appendRuleIDAndHashTags(vpcBasicTags, "1e510e8a", "spA-1e510e8a_re0bz")
+	vpcRuleTags2 := appendRuleIDAndHashTags(vpcBasicTags, "304ea84a", "spA-304ea84a_re0bz")
+	vpcRuleTags3 := appendRuleIDAndHashTags(vpcBasicTagsForSpWithVMSelector, "db8116ce", "spB-db8116ce_9u8w9")
+	vpcRuleTags4 := appendRuleIDAndHashTags(vpcBasicTagsForSpWithVMSelector, "52d139ca", "spB-52d139ca_9u8w9")
+	vpcRuleTags5 := appendRuleIDAndHashTags(vpcBasicTagsForSpWithVMSelector, "1241cf95", "spB-1241cf95_9u8w9")
 
 	tests := []struct {
 		name             string
@@ -258,10 +258,10 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 						Id:                &podSelectorRule0IDPort000,
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
-						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA-2c822e90-scope_re0bz"},
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA-1e510e8a-scope_re0bz"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-2c822e90-src_re0bz"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-1e510e8a-src_re0bz"},
 						Action:            &nsxRuleActionAllow,
 						Tags:              vpcRuleTags1,
 					},
@@ -273,7 +273,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-2a4595d0-src_re0bz"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-304ea84a-src_re0bz"},
 						Action:            &nsxRuleActionAllow,
 						ServiceEntries:    []*data.StructValue{serviceEntry},
 						Tags:              vpcRuleTags2,
@@ -295,9 +295,9 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule0Name00,
 						Id:                &vmSelectorRule0IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB-67410606-dst_9u8w9"},
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB-db8116ce-dst_9u8w9"},
 						Direction:         &nsxRuleDirectionOut,
-						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB-67410606-scope_9u8w9"},
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB-db8116ce-scope_9u8w9"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
 						SourceGroups:      []string{"ANY"},
@@ -307,7 +307,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule1Name00,
 						Id:                &vmSelectorRule1IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spB-7d721f08-dst_9u8w9"},
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spB-52d139ca-dst_9u8w9"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
@@ -320,7 +320,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule2Name00,
 						Id:                &vmSelectorRule2IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB-a40c8139-dst_9u8w9"},
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB-1241cf95-dst_9u8w9"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq2,
@@ -349,10 +349,10 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 						Id:                &podSelectorRule0IDPort000,
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
-						Scope:             []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spA-2c822e90-scope_re0bz"},
+						Scope:             []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spA-1e510e8a-scope_re0bz"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/infra/domains/default/groups/spA-2c822e90-src_re0bz"},
+						SourceGroups:      []string{"/infra/domains/default/groups/spA-1e510e8a-src_re0bz"},
 						Action:            &nsxRuleActionAllow,
 						Tags:              vpcRuleTags1,
 					},
@@ -364,7 +364,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/infra/domains/default/groups/spA-2a4595d0-src_re0bz"},
+						SourceGroups:      []string{"/infra/domains/default/groups/spA-304ea84a-src_re0bz"},
 						Action:            &nsxRuleActionAllow,
 						ServiceEntries:    []*data.StructValue{serviceEntry},
 						Tags:              vpcRuleTags2,
@@ -387,9 +387,9 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule0Name00,
 						Id:                &vmSelectorRule0IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spB-67410606-dst_9u8w9"},
+						DestinationGroups: []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spB-db8116ce-dst_9u8w9"},
 						Direction:         &nsxRuleDirectionOut,
-						Scope:             []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spB-67410606-scope_9u8w9"},
+						Scope:             []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spB-db8116ce-scope_9u8w9"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
 						SourceGroups:      []string{"ANY"},
@@ -399,7 +399,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule1Name00,
 						Id:                &vmSelectorRule1IDPort000,
-						DestinationGroups: []string{"/infra/domains/default/groups/spB-7d721f08-dst_9u8w9"},
+						DestinationGroups: []string{"/infra/domains/default/groups/spB-52d139ca-dst_9u8w9"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
@@ -412,7 +412,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule2Name00,
 						Id:                &vmSelectorRule2IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spB-a40c8139-dst_9u8w9"},
+						DestinationGroups: []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spB-1241cf95-dst_9u8w9"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq2,
@@ -2110,8 +2110,8 @@ func Test_getRuleIDByUUIDAndRuleHash(t *testing.T) {
 	fakeService.vpcService = &mockVPCService
 	fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
 
-	spRuleTags := appendRuleIDAndHashTags(vpcBasicTags, "2c822e90", "spA-2c822e90_re0bz")
-	npRuleTags := appendRuleIDAndHashTags(npAllowBasicTags, "67410606", "npB-67410606_9u8w9")
+	spRuleTags := appendRuleIDAndHashTags(vpcBasicTags, "1e510e8a", "spA-1e510e8a_re0bz")
+	npRuleTags := appendRuleIDAndHashTags(npAllowBasicTags, "db8116ce", "npB-db8116ce_9u8w9")
 	rules := []model.Rule{
 		{
 			Id:   String("rule-1-80"),
@@ -2140,21 +2140,21 @@ func Test_getRuleIDByUUIDAndRuleHash(t *testing.T) {
 		{
 			name:           "get SecurityPolicy rule by UUID and Rule Hash",
 			uuid:           tagValuePolicyCRUID,
-			hash:           "2c822e90",
+			hash:           "1e510e8a",
 			createdFor:     common.ResourceTypeSecurityPolicy,
-			expectedRuleID: String("spA-2c822e90_re0bz"),
+			expectedRuleID: String("spA-1e510e8a_re0bz"),
 		},
 		{
 			name:           "get NetworkPolicy rule by UUID and Rule Hash",
 			uuid:           string(npWithNsSelecotr.UID + "_allow"),
-			hash:           "67410606",
+			hash:           "db8116ce",
 			createdFor:     common.ResourceTypeNetworkPolicy,
-			expectedRuleID: String("npB-67410606_9u8w9"),
+			expectedRuleID: String("npB-db8116ce_9u8w9"),
 		},
 		{
 			name:           "no matching rules with invalid uuid",
 			uuid:           "invaliduid",
-			hash:           "2c822e90",
+			hash:           "1e510e8a",
 			createdFor:     common.ResourceTypeSecurityPolicy,
 			expectedRuleID: nil,
 		},
@@ -2188,7 +2188,7 @@ func Test_buildRuleID(t *testing.T) {
 				{
 					Action:    &allowAction,
 					Direction: &directionIn,
-					Sources: []v1alpha1.SecurityPolicyPeer{
+					From: []v1alpha1.SecurityPolicyPeer{
 						{
 							PodSelector: &v1.LabelSelector{
 								MatchLabels: map[string]string{"app": "coffee"},
@@ -2217,7 +2217,7 @@ func Test_buildRuleID(t *testing.T) {
 			createdFor: common.ResourceTypeSecurityPolicy,
 			enableVPC:  false,
 			checkFunc: func(t *testing.T, result string) {
-				assert.Equal(t, "sp_uidA_2c822e90b1377b346014adfa583f08a99dee52a8_0", result)
+				assert.Equal(t, "sp_uidA_1e510e8ad94c103f4727e2bfc28bc637cb752831_0", result)
 			},
 		},
 		{
@@ -2229,7 +2229,7 @@ func Test_buildRuleID(t *testing.T) {
 			existingRuleID: nil,
 			checkFunc: func(t *testing.T, result string) {
 				assert.NotEmpty(t, result)
-				assert.Equal(t, "spA-2c822e90_re0bz", result)
+				assert.Equal(t, "spA-1e510e8a_re0bz", result)
 			},
 		},
 		{
@@ -2252,10 +2252,10 @@ func Test_buildRuleID(t *testing.T) {
 			existingRuleID: nil,
 			rebuildRuleID:  true,
 			checkFunc: func(t *testing.T, result string) {
-				assert.NotEqual(t, "spA-2c822e90_re0bz", result)
+				assert.NotEqual(t, "spA-1e510e8a_re0bz", result)
 				parts := strings.Split(result, common.ConnectorUnderline)
 				assert.Equal(t, 2, len(parts))
-				assert.Equal(t, "spA-2c822e90", parts[0])
+				assert.Equal(t, "spA-1e510e8a", parts[0])
 				assert.NotEqual(t, "re0bz", parts[1])
 			},
 		},
@@ -2268,7 +2268,7 @@ func Test_buildRuleID(t *testing.T) {
 			existingRuleID: nil,
 			checkFunc: func(t *testing.T, result string) {
 				assert.NotEmpty(t, result)
-				assert.Equal(t, "np-app-access-allow-a6f6b3bc_aoqj8", result)
+				assert.Equal(t, "np-app-access-allow-3ccf8bbb_aoqj8", result)
 			},
 		},
 		{
@@ -2315,10 +2315,10 @@ func Test_buildRuleID(t *testing.T) {
 					ruleStore.Apply(&rules)
 				} else if tt.rebuildRuleID {
 					// Set up rule store with existing ruleID for rebuild testing
-					// "spA-2c822e90_re0bz" should be the same with spWithPodSelector's first rule generated ID,
+					// "spA-1e510e8a_re0bz" should be the same with spWithPodSelector's first rule generated ID,
 					// so that it will rebuilt it
-					ruleTags := appendRuleIDAndHashTags(vpcBasicTags, "hash", "spA-2c822e90_re0bz")
-					nsxRuleID := String("spA-2c822e90_re0bz" + "portSuffix")
+					ruleTags := appendRuleIDAndHashTags(vpcBasicTags, "hash", "spA-1e510e8a_re0bz")
+					nsxRuleID := String("spA-1e510e8a_re0bz" + "portSuffix")
 					rules := []model.Rule{
 						{
 							Id:   nsxRuleID,

--- a/pkg/nsx/services/securitypolicy/expand.go
+++ b/pkg/nsx/services/securitypolicy/expand.go
@@ -317,10 +317,7 @@ func (service *SecurityPolicyService) getPodSelectors(obj *v1alpha1.SecurityPoli
 			}
 		}
 	case "OUT":
-		outPeers := rule.To
-		if len(outPeers) == 0 {
-			outPeers = rule.Destinations //nolint:staticcheck
-		}
+		outPeers := getRuleDestinationPeers(rule)
 		if len(outPeers) > 0 {
 			for _, target := range outPeers {
 				var namespaceSelectors []client.ListOptions // ResolveNamespace may return multiple namespaces

--- a/pkg/nsx/services/securitypolicy/expand.go
+++ b/pkg/nsx/services/securitypolicy/expand.go
@@ -317,8 +317,12 @@ func (service *SecurityPolicyService) getPodSelectors(obj *v1alpha1.SecurityPoli
 			}
 		}
 	case "OUT":
-		if len(rule.Destinations) > 0 {
-			for _, target := range rule.Destinations {
+		outPeers := rule.To
+		if len(outPeers) == 0 {
+			outPeers = rule.Destinations //nolint:staticcheck
+		}
+		if len(outPeers) > 0 {
+			for _, target := range outPeers {
 				var namespaceSelectors []client.ListOptions // ResolveNamespace may return multiple namespaces
 				var labelSelector client.ListOptions
 				var namespaceSelector client.ListOptions

--- a/pkg/nsx/services/securitypolicy/expand_test.go
+++ b/pkg/nsx/services/securitypolicy/expand_test.go
@@ -38,7 +38,7 @@ func TestSecurityPolicyService_buildRuleIPGroup(t *testing.T) {
 				{
 					Action:    &allowAction,
 					Direction: &directionIn,
-					Sources: []v1alpha1.SecurityPolicyPeer{
+					From: []v1alpha1.SecurityPolicyPeer{
 						{
 							PodSelector: &v1.LabelSelector{
 								MatchLabels: map[string]string{"pod_selector_1": "pod_value_1"},
@@ -145,7 +145,7 @@ func TestSecurityPolicyService_getPodSelectors(t *testing.T) {
 				PodSelector: podSelector,
 			},
 		},
-		Sources: []v1alpha1.SecurityPolicyPeer{
+		From: []v1alpha1.SecurityPolicyPeer{
 			{
 				PodSelector: &v1.LabelSelector{
 					MatchLabels:      map[string]string{"pod_selector_1": "pod_value_1"},
@@ -163,7 +163,7 @@ func TestSecurityPolicyService_getPodSelectors(t *testing.T) {
 		Direction: &directionIn,
 		Name:      "rule-with-pod-selector-2",
 		AppliedTo: []v1alpha1.SecurityPolicyTarget{},
-		Sources: []v1alpha1.SecurityPolicyPeer{
+		From: []v1alpha1.SecurityPolicyPeer{
 			{
 				PodSelector: &v1.LabelSelector{
 					MatchLabels:      map[string]string{"pod_selector_1": "pod_value_1"},
@@ -246,6 +246,7 @@ func TestSecurityPolicyService_getPodSelectors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			service := &SecurityPolicyService{}
 			got, _ := service.getPodSelectors(tt.args.obj, tt.args.rule)
+			assert.Equal(t, true, len(got) > 0, "getPodSelector(%v, %v) should return 1 selector", tt.args.obj, tt.args.rule)
 			assert.Equalf(t, tt.want, got[0], "getPodSelector(%v, %v)", tt.args.obj, tt.args.rule)
 		})
 	}

--- a/pkg/nsx/services/securitypolicy/firewall.go
+++ b/pkg/nsx/services/securitypolicy/firewall.go
@@ -266,7 +266,7 @@ func (service *SecurityPolicyService) populateRulesForAllowSection(spAllow *v1al
 		rule := &v1alpha1.SecurityPolicyRule{
 			Action:    &actionAllow,
 			Direction: &directionIn,
-			Sources:   []v1alpha1.SecurityPolicyPeer{},
+			From:      []v1alpha1.SecurityPolicyPeer{},
 		}
 		for _, p := range ingress.From {
 			npPeer := p
@@ -274,7 +274,7 @@ func (service *SecurityPolicyService) populateRulesForAllowSection(spAllow *v1al
 			if err != nil {
 				return err
 			}
-			rule.Sources = append(rule.Sources, *spPeer)
+			rule.From = append(rule.From, *spPeer)
 		}
 		for _, p := range ingress.Ports {
 			npPort := p
@@ -289,9 +289,9 @@ func (service *SecurityPolicyService) populateRulesForAllowSection(spAllow *v1al
 
 	for _, egress := range networkPolicy.Spec.Egress {
 		rule := &v1alpha1.SecurityPolicyRule{
-			Action:       &actionAllow,
-			Direction:    &directionOut,
-			Destinations: []v1alpha1.SecurityPolicyPeer{},
+			Action:    &actionAllow,
+			Direction: &directionOut,
+			To:        []v1alpha1.SecurityPolicyPeer{},
 		}
 		for _, p := range egress.To {
 			npPeer := p
@@ -299,7 +299,7 @@ func (service *SecurityPolicyService) populateRulesForAllowSection(spAllow *v1al
 			if err != nil {
 				return err
 			}
-			rule.Destinations = append(rule.Destinations, *spPeer)
+			rule.To = append(rule.To, *spPeer)
 		}
 		for _, p := range egress.Ports {
 			npPort := p
@@ -491,6 +491,9 @@ func (service *SecurityPolicyService) getFinalVPCShareResources(obj *v1alpha1.Se
 func (service *SecurityPolicyService) getFinalSecurityPolicyResource(obj *v1alpha1.SecurityPolicy, createdFor string, vpcInfo *common.VPCResourceInfo, isDefaultProject bool) (*model.SecurityPolicy, []model.Group, []model.Share, []model.Group, bool, error) {
 	securityPolicyStore, ruleStore, groupStore := service.getSecurityPolicyResourceStores()
 
+	// Normalize rule peers so that deprecated Sources/Destinations are migrated into From/To
+	normalizeSecurityPolicyRules(obj)
+
 	nsxSecurityPolicy, nsxGroups, nsxGroupShares, err := service.buildSecurityPolicy(obj, createdFor, vpcInfo, isDefaultProject)
 	if err != nil {
 		log.Error(err, "Failed to build SecurityPolicy from CR", "securityPolicyUID", obj.UID)
@@ -528,6 +531,31 @@ func (service *SecurityPolicyService) getFinalSecurityPolicyResource(obj *v1alph
 		return finalSecurityPolicy, finalGroups, finalShares, finalShareGroups, isChanged, nil
 	} else {
 		return finalSecurityPolicy, finalGroups, nil, nil, isChanged, nil
+	}
+}
+
+// normalizeRulePeers migrates deprecated Sources/Destinations into From/To and then clears
+// the deprecated fields so that rule hashing and downstream logic only use From/To.
+// For upgrade: if only Sources/Destinations are set, they are copied to From/To.
+// For greenfield: only From/To are expected.
+// If both are set, From/To take priority.
+//
+//nolint:staticcheck // SA1019: must touch deprecated Sources/Destinations for upgrade compatibility.
+func normalizeRulePeers(rule *v1alpha1.SecurityPolicyRule) {
+	if len(rule.From) == 0 && len(rule.Sources) > 0 { //nolint:staticcheck
+		rule.From = rule.Sources //nolint:staticcheck
+	}
+	rule.Sources = nil                                   //nolint:staticcheck
+	if len(rule.To) == 0 && len(rule.Destinations) > 0 { //nolint:staticcheck
+		rule.To = rule.Destinations //nolint:staticcheck
+	}
+	rule.Destinations = nil //nolint:staticcheck
+}
+
+// normalizeSecurityPolicyRules applies normalizeRulePeers to all rules in the policy.
+func normalizeSecurityPolicyRules(obj *v1alpha1.SecurityPolicy) {
+	for i := range obj.Spec.Rules {
+		normalizeRulePeers(&obj.Spec.Rules[i])
 	}
 }
 

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -163,7 +163,7 @@ var (
 							},
 						},
 					},
-					Sources: []v1alpha1.SecurityPolicyPeer{
+					From: []v1alpha1.SecurityPolicyPeer{
 						{
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels:      map[string]string{"pod_selector_1": "pod_value_1"},
@@ -186,7 +186,7 @@ var (
 							Port:     intstr.IntOrString{Type: intstr.Int, IntVal: 53},
 						},
 					},
-					Sources: []v1alpha1.SecurityPolicyPeer{
+					From: []v1alpha1.SecurityPolicyPeer{
 						{
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels:      map[string]string{"ns1": "spA"},
@@ -224,7 +224,7 @@ var (
 							},
 						},
 					},
-					Destinations: []v1alpha1.SecurityPolicyPeer{
+					To: []v1alpha1.SecurityPolicyPeer{
 						{
 							VMSelector: &metav1.LabelSelector{
 								MatchLabels:      map[string]string{"VM_selector_1": "VM_value_1"},
@@ -237,7 +237,7 @@ var (
 					Action:    &allowDrop,
 					Direction: &directionOut,
 					Name:      "rule-with-ns-selector",
-					Destinations: []v1alpha1.SecurityPolicyPeer{
+					To: []v1alpha1.SecurityPolicyPeer{
 						{
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{},
@@ -248,7 +248,7 @@ var (
 				{
 					Action:    &allowDrop,
 					Direction: &directionOut,
-					Destinations: []v1alpha1.SecurityPolicyPeer{
+					To: []v1alpha1.SecurityPolicyPeer{
 						{
 							IPBlocks: []v1alpha1.IPBlock{
 								{CIDR: cidr},
@@ -2984,8 +2984,8 @@ func Test_GetFinalSecurityPolicyResourceForVPC(t *testing.T) {
 
 	serviceEntry := getRuleServiceEntries(53, 0, "UDP")
 
-	ruleTags1 := appendRuleIDAndHashTags(vpcBasicTags, "2c822e90", "spA-2c822e90_re0bz")
-	ruleTags2 := appendRuleIDAndHashTags(vpcBasicTags, "2a4595d0", "spA-2a4595d0_re0bz")
+	ruleTags1 := appendRuleIDAndHashTags(vpcBasicTags, "1e510e8a", "spA-1e510e8a_re0bz")
+	ruleTags2 := appendRuleIDAndHashTags(vpcBasicTags, "304ea84a", "spA-304ea84a_re0bz")
 
 	type args struct {
 		spObj      *v1alpha1.SecurityPolicy
@@ -3030,25 +3030,25 @@ func Test_GetFinalSecurityPolicyResourceForVPC(t *testing.T) {
 				Rules: []model.Rule{
 					{
 						DisplayName:       common.String("rule-with-pod-ns-selector_ingress_allow"),
-						Id:                common.String("spA-2c822e90_re0bz_all"),
+						Id:                common.String("spA-1e510e8a_re0bz_all"),
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
-						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA-2c822e90-scope_re0bz"},
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA-1e510e8a-scope_re0bz"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-2c822e90-src_re0bz"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-1e510e8a-src_re0bz"},
 						Action:            &nsxRuleActionAllow,
 						Tags:              ruleTags1,
 					},
 					{
 						DisplayName:       common.String("rule-with-ns-selector_ingress_allow"),
-						Id:                common.String("spA-2a4595d0_re0bz_53"),
+						Id:                common.String("spA-304ea84a_re0bz_53"),
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-2a4595d0-src_re0bz"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-304ea84a-src_re0bz"},
 						Action:            &nsxRuleActionAllow,
 						ServiceEntries:    []*data.StructValue{serviceEntry},
 						Tags:              ruleTags2,
@@ -3137,7 +3137,7 @@ func Test_ConvertNetworkPolicyToInternalSecurityPolicies(t *testing.T) {
 						{
 							Action:    &allowAction,
 							Direction: &directionIn,
-							Sources: []v1alpha1.SecurityPolicyPeer{
+							From: []v1alpha1.SecurityPolicyPeer{
 								{
 									PodSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{"app": "coffee"},
@@ -3162,7 +3162,7 @@ func Test_ConvertNetworkPolicyToInternalSecurityPolicies(t *testing.T) {
 						{
 							Action:    &allowAction,
 							Direction: &directionOut,
-							Destinations: []v1alpha1.SecurityPolicyPeer{
+							To: []v1alpha1.SecurityPolicyPeer{
 								{
 									PodSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{"app": "mysql"},
@@ -3241,8 +3241,8 @@ func Test_GetFinalSecurityPolicyResourceFromNetworkPolicy(t *testing.T) {
 	ingressServiceEntry := getRuleServiceEntries(6001, 0, "TCP")
 	egressServiceEntry := getRuleServiceEntries(3366, 0, "TCP")
 
-	allowRuleTags1 := appendRuleIDAndHashTags(npAllowBasicTags, "6c2a026c", "np-app-access-allow-6c2a026c_aoqj8")
-	allowRuleTags2 := appendRuleIDAndHashTags(npAllowBasicTags, "025d37a6", "np-app-access-allow-025d37a6_aoqj8")
+	allowRuleTags1 := appendRuleIDAndHashTags(npAllowBasicTags, "41134081", "np-app-access-allow-41134081_aoqj8")
+	allowRuleTags2 := appendRuleIDAndHashTags(npAllowBasicTags, "d66432a3", "np-app-access-allow-d66432a3_aoqj8")
 
 	isolationRuleTags1 := appendRuleIDAndHashTags(npIsolationBasicTags, "114fed10", "np-app-access-isolation-114fed10_aoqj8")
 	isolationRuleTags2 := appendRuleIDAndHashTags(npIsolationBasicTags, "8cae63ab", "np-app-access-isolation-8cae63ab_aoqj8")
@@ -3280,21 +3280,21 @@ func Test_GetFinalSecurityPolicyResourceFromNetworkPolicy(t *testing.T) {
 				Rules: []model.Rule{
 					{
 						DisplayName:       common.String("TCP.6001_ingress_allow"),
-						Id:                common.String("np-app-access-allow-6c2a026c_aoqj8_6001"),
+						Id:                common.String("np-app-access-allow-41134081_aoqj8_6001"),
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access-allow-6c2a026c-src_aoqj8"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access-allow-41134081-src_aoqj8"},
 						Action:            &nsxRuleActionAllow,
 						ServiceEntries:    []*data.StructValue{ingressServiceEntry},
 						Tags:              allowRuleTags1,
 					},
 					{
 						DisplayName:       common.String("TCP.3366_egress_allow"),
-						Id:                common.String("np-app-access-allow-025d37a6_aoqj8_3366"),
-						DestinationGroups: []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access-allow-025d37a6-dst_aoqj8"},
+						Id:                common.String("np-app-access-allow-d66432a3_aoqj8_3366"),
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access-allow-d66432a3-dst_aoqj8"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
@@ -3943,6 +3943,81 @@ func Test_applyVPCGroupShareStore(t *testing.T) {
 			assert.Equal(t, tt.wantProjectShareStoreCount, len(fakeService.projectShareStore.ListKeys()))
 			assert.Equal(t, tt.wantInfraGroupStoreCount, len(fakeService.infraGroupStore.ListKeys()))
 			assert.Equal(t, tt.wantInfraShareStoreCount, len(fakeService.infraShareStore.ListKeys()))
+		})
+	}
+}
+
+func Test_normalizeSecurityPolicyRules_FromToAliases(t *testing.T) {
+	inDir := v1alpha1.RuleDirectionIn
+	outDir := v1alpha1.RuleDirectionOut
+
+	fromPeer := v1alpha1.SecurityPolicyPeer{
+		PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"from": "peer"}},
+	}
+	toPeer := v1alpha1.SecurityPolicyPeer{
+		PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"to": "peer"}},
+	}
+	legacySrcPeer := v1alpha1.SecurityPolicyPeer{
+		PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"legacy": "src"}},
+	}
+	legacyDstPeer := v1alpha1.SecurityPolicyPeer{
+		PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"legacy": "dst"}},
+	}
+
+	tests := []struct {
+		name     string
+		rule     v1alpha1.SecurityPolicyRule
+		wantFrom []v1alpha1.SecurityPolicyPeer
+		wantTo   []v1alpha1.SecurityPolicyPeer
+	}{
+		{
+			name: "from/to only — kept as is",
+			rule: v1alpha1.SecurityPolicyRule{
+				Direction: &inDir,
+				From:      []v1alpha1.SecurityPolicyPeer{fromPeer},
+				To:        []v1alpha1.SecurityPolicyPeer{toPeer},
+			},
+			wantFrom: []v1alpha1.SecurityPolicyPeer{fromPeer},
+			wantTo:   []v1alpha1.SecurityPolicyPeer{toPeer},
+		},
+		{
+			name: "sources/destinations only — migrated to from/to (upgrade)",
+			rule: v1alpha1.SecurityPolicyRule{
+				Direction:    &outDir,
+				Sources:      []v1alpha1.SecurityPolicyPeer{legacySrcPeer}, //nolint:staticcheck
+				Destinations: []v1alpha1.SecurityPolicyPeer{legacyDstPeer}, //nolint:staticcheck
+			},
+			wantFrom: []v1alpha1.SecurityPolicyPeer{legacySrcPeer},
+			wantTo:   []v1alpha1.SecurityPolicyPeer{legacyDstPeer},
+		},
+		{
+			name: "both set — from/to takes priority",
+			rule: v1alpha1.SecurityPolicyRule{
+				Direction:    &inDir,
+				Sources:      []v1alpha1.SecurityPolicyPeer{legacySrcPeer}, //nolint:staticcheck
+				Destinations: []v1alpha1.SecurityPolicyPeer{legacyDstPeer}, //nolint:staticcheck
+				From:         []v1alpha1.SecurityPolicyPeer{fromPeer},
+				To:           []v1alpha1.SecurityPolicyPeer{toPeer},
+			},
+			wantFrom: []v1alpha1.SecurityPolicyPeer{fromPeer},
+			wantTo:   []v1alpha1.SecurityPolicyPeer{toPeer},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sp := &v1alpha1.SecurityPolicy{
+				Spec: v1alpha1.SecurityPolicySpec{
+					Rules: []v1alpha1.SecurityPolicyRule{tt.rule},
+				},
+			}
+			normalizeSecurityPolicyRules(sp)
+
+			r := sp.Spec.Rules[0]
+			assert.Equal(t, tt.wantFrom, r.From)
+			assert.Nil(t, r.Sources) //nolint:staticcheck
+			assert.Equal(t, tt.wantTo, r.To)
+			assert.Nil(t, r.Destinations) //nolint:staticcheck
 		})
 	}
 }


### PR DESCRIPTION
Replace the current Sources/Destinations fields with From/To in SecurityPolicy CRD, this aligns with Kubernetes NetworkPolicy naming conventions. 
Introduce from/to peer selectors as the preferred fields in SecurityPolicy rules.
Keep sources/destinations for backward compatibility and normalize aliases so from/to take precedence.
Update CRD schemas, samples, docs, and unit tests accordingly.

TestDone:

- 1.Test SecurityPolicy with 'From/To' fields

Create Namespace in VC

Deploy test Pods (traffic source and destination)

```
apiVersion: v1
kind: Pod
metadata:
  name: fr-srv
  labels:
    vpc-from-test: server
spec:
  restartPolicy: Never
  containers:
    - name: fr-srv
      image: "netfvt-docker-local.packages.vcfd.broadcom.net/humanux/http_https_echo:latest"
---
apiVersion: v1
kind: Pod
metadata:
  name: frclient-allow
  labels:
    vpc-from-test: client-allow
spec:
  restartPolicy: Never
  containers:
    - name: frclient-allow
      image: "netfvt-docker-local.packages.vcfd.broadcom.net/humanux/http_https_echo:latest"
---
apiVersion: v1
kind: Pod
metadata:
  name: frclient-deny
  labels:
    vpc-from-test: client-deny
spec:
  restartPolicy: Never
  containers:
    - name: frclient-deny
      image: "netfvt-docker-local.packages.vcfd.broadcom.net/humanux/http_https_echo:latest"

```

<img width="2110" height="192" alt="e8d1dbdc5ab8b2c72283166d18873bd4" src="https://github.com/user-attachments/assets/2b81b8f9-78ac-494b-9f67-099a7512caa3" />


Baseline connectivity check (before policy)
    
<img width="2032" height="360" alt="01899383a191ad5cf050363cd46c1ed4" src="https://github.com/user-attachments/assets/401dba1d-08d9-4b5c-a321-8514371c3787" />
From Pod frclient-allow, curl to fr-srv:<podPort>; expect success.

```
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# kubectl exec -n wenqi-test frclient-allow -c frclient-allow -- /bin/sh -c 'curl -s -o /dev/null -w "%{http_code}\n" --connect-timeout 2 --max-time 5 "http://10.246.0.37:80"'
200
```
From Pod frclient-deny, curl to fr-srv:<podPort>; expect success.
```
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# kubectl exec -n wenqi-test frclient-deny -c frclient-deny -- /bin/sh -c 'curl -s -o /dev/null -w "%{http_code}\n" --connect-timeout 2 --max-time 5 "http://10.246.0.37:80"'
200
```


Apply the SecurityPolicy (Ingress using from)
    
<img width="1610" height="1536" alt="3127d2e26656836b12780f3052b15652" src="https://github.com/user-attachments/assets/342b1d9c-380f-4436-9c87-794ea110f403" />

```
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# kubectl get securityPolicy -n wenqi-test
NAME                      AGE
vpc-from-field-policy-1   2m49s
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# 
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# 
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# 
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# kubectl get securityPolicy -n wenqi-test -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  kind: SecurityPolicy
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SecurityPolicy","metadata":{"annotations":{},"name":"vpc-from-field-policy-1","namespace":"wenqi-test"},"spec":{"appliedTo":[{"podSelector":{"matchLabels":{"vpc-from-test":"server"}}}],"priority":15,"rules":[{"action":"allow","direction":"in","from":[{"podSelector":{"matchLabels":{"vpc-from-test":"client-allow"}}}],"name":"sp_from_allow","ports":[{"port":80,"protocol":"TCP"}]},{"action":"drop","direction":"in","name":"sp_from_drop"}]}}
    creationTimestamp: "2026-04-01T14:24:23Z"
    generation: 1
    name: vpc-from-field-policy-1
    namespace: wenqi-test
    resourceVersion: "1641887"
    uid: 79659fe0-220b-4475-8b8d-75da517e2594
  spec:
    appliedTo:
    - podSelector:
        matchLabels:
          vpc-from-test: server
    priority: 15
    rules:
    - action: allow
      direction: in
      from:
      - podSelector:
          matchLabels:
            vpc-from-test: client-allow
      name: sp_from_allow
      ports:
      - port: 80
        protocol: TCP
    - action: drop
      direction: in
      name: sp_from_drop
  status:
    conditions:
    - lastTransitionTime: "2026-04-01T14:24:24Z"
      message: NSX Security Policy has been successfully created/updated
      reason: SecurityPolicyReady
      status: "True"
      type: Ready
kind: List
metadata:
  resourceVersion: ""
```


Validate policy enforcement (allow vs. deny)
    
<img width="2030" height="548" alt="a8c90674168adaa3248d594fc4b33f46" src="https://github.com/user-attachments/assets/34b45cdf-81d7-49a5-9141-ac46906b080c" />

From Pod frclient-allow, curl to fr-srv:<podPort>; expect success.
```
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# kubectl exec -n wenqi-test frclient-allow -c frclient-allow -- /bin/sh -c 'curl -s -o /dev/null -w "%{http_code}\n" --connect-timeout 2 --max-time 5 "http://10.246.0.37:80"'
200
```
From Pod frclient-deny, curl to fr-srv:<podPort>; expect blocked / failure.

```
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# kubectl exec -n wenqi-test frclient-deny -c frclient-deny -- /bin/sh -c 'curl -s -o /dev/null -w "%{http_code}\n" --connect-timeout 2 --max-time 5 "http://10.246.0.37:80"'
000
command terminated with exit code 28
```

Delete the SecurityPolicy
```
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# kubectl delete -f sp_from_ingress.yaml -n wenqi-test
securitypolicy.crd.nsx.vmware.com "vpc-from-field-policy-1" deleted
```

Post-delete connectivity check (after policy removal)
    
<img width="2030" height="554" alt="7922f80d7e912a406731e0b2588734fd" src="https://github.com/user-attachments/assets/af9153fd-cb37-4530-898e-2f57a5d6108d" />

From Pod frclient-allow, curl to fr-srv:<podPort>; expect success.
```
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# kubectl exec -n wenqi-test frclient-allow -c frclient-allow -- /bin/sh -c 'curl -s -o /dev/null -w "%{http_code}\n" --connect-timeout 2 --max-time 5 "http://10.246.0.37:80"'
200
```

From Pod frclient-deny, curl to fr-srv:<podPort>; expect success.
```
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# kubectl exec -n wenqi-test frclient-deny -c frclient-deny -- /bin/sh -c 'curl -s -o /dev/null -w "%{http_code}\n" --connect-timeout 2 --max-time 5 "http://10.246.0.37:80"'
200
```


- 2.Use the "destinations/sources" field to test compatibility.

<img width="2032" height="1226" alt="0e04dcf6f0dec6371fe205d450b65d75" src="https://github.com/user-attachments/assets/da78cd37-3ee5-4108-bb16-ec6a58cdabf6" />

```
root@422e284f43dbc8b8d0e7b020987ba0bb [ ~ ]# cat sp_sources_ingress.yaml 
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SecurityPolicy
metadata:
  name: vpc-from-field-policy-1
spec:
  priority: 15
  appliedTo:
    - podSelector:
        matchLabels:
          vpc-from-test: server
  rules:
    - direction: in
      action: allow
      name: sp_from_allow
      sources:
        - podSelector:
            matchLabels:
              vpc-from-test: client-allow
      ports:
        - protocol: TCP
          port: 80
    - direction: in
      action: drop
      name: sp_from_drop
```

3.Upgrade Test

Create test Pods, Test the traffic before apply the SecurityPolicy

<img width="2304" height="568" alt="d506beff6238e1bb7e10ccaa111fefec" src="https://github.com/user-attachments/assets/bc31277c-8ca6-4254-9051-c88cd08a2c8a" />

Apply the SecurityPolicy with 'Sources/Destinations' fields

<img width="1222" height="720" alt="69cc30e0716c01a6afe5ba13451f617d" src="https://github.com/user-attachments/assets/5c99b19d-c000-4167-a2d8-e2bcd69d4422" />

Test the traffic 

<img width="2312" height="288" alt="c0621014240c828e0adc270e838411d9" src="https://github.com/user-attachments/assets/c5745903-e23b-4a2d-9fdb-e2898d43c1bf" />


Start two loops in separate terminals before you upgrade CRD/operator, while upgrading the operator, continuously monitor the traffic between Pods

The `deny` Pod traffic remained stable throughout the entire window.
```
root@4216c7a7745c262bf3c75fcb4d254178 [ ~ ]# while true; do   ts="$(date +%H:%M:%S)";   code="$(kubectl exec -n wenqi-test frclient-deny -c frclient-deny -- /bin/sh -c 'curl -s -o /dev/null -w "%{http_code}\n" --connect-timeout 2 --max-time 5 "http://10.246.0.39:80"' 2>/dev/null || echo ERR)";   echo "$ts allow $code";   sleep 1; done
05:41:08 allow 000
ERR
05:41:12 allow 000
ERR
05:41:15 allow 000
ERR
05:41:18 allow 000
ERR
05:41:22 allow 000
ERR
05:41:25 allow 000
ERR
05:41:28 allow 000
ERR
05:41:31 allow 000
ERR
05:41:35 allow 000
ERR
05:41:38 allow 000
ERR
05:41:41 allow 000
ERR
05:41:45 allow 000
ERR
05:41:48 allow 000
ERR
05:41:51 allow 000
ERR
05:41:55 allow 000
ERR
05:41:58 allow 000
ERR
05:42:01 allow 000
ERR
05:42:04 allow 000
ERR
05:42:08 allow 000
ERR
05:42:11 allow 000
ERR
05:42:14 allow 000
ERR
05:42:18 allow 000
ERR
05:42:21 allow 000
ERR
05:42:24 allow 000
ERR
05:42:28 allow 000
ERR
05:42:31 allow 000
ERR
05:42:34 allow 000
ERR
05:42:38 allow 000
ERR
05:42:41 allow 000
ERR
05:42:44 allow 000
ERR
05:42:48 allow 000
ERR
05:42:51 allow 000
ERR
05:42:55 allow 000
ERR
05:42:58 allow 000
ERR
```

The `allow` Pod traffic remained stable throughout the entire window.

```
root@4216c7a7745c262bf3c75fcb4d254178 [ ~ ]# while true; do   ts="$(date +%H:%M:%S)";   code="$(kubectl exec -n wenqi-test frclient-allow -c frclient-allow -- /bin/sh -c 'curl -s -o /dev/null -w "%{http_code}\n" --connect-timeout 2 --max-time 5 "http://10.246.0.39:80"' 2>/dev/null || echo ERR)";   echo "$ts allow $code";   sleep 1; done
05:41:03 allow 200
05:41:05 allow 200
05:41:06 allow 200
05:41:08 allow 200
05:41:09 allow 200
05:41:10 allow 200
05:41:11 allow 200
05:41:13 allow 200
05:41:14 allow 200
05:41:15 allow 200
05:41:16 allow 200
05:41:18 allow 200
05:41:19 allow 200
05:41:20 allow 200
05:41:21 allow 200
05:41:23 allow 200
05:41:24 allow 200
05:41:25 allow 200
05:41:27 allow 200
05:41:28 allow 200
05:41:29 allow 200
05:41:30 allow 200
05:41:32 allow 200
05:41:33 allow 200
05:41:34 allow 200
05:41:35 allow 200
05:41:37 allow 200
05:41:38 allow 200
05:41:39 allow 200
05:41:40 allow 200
05:41:42 allow 200
05:41:43 allow 200
05:41:44 allow 200
05:41:46 allow 200
05:41:47 allow 200
05:41:48 allow 200
05:41:49 allow 200
05:41:51 allow 200
05:41:52 allow 200
05:41:53 allow 200
05:41:54 allow 200
05:41:56 allow 200
05:41:57 allow 200
05:41:58 allow 200
05:41:59 allow 200
05:42:01 allow 200
05:42:02 allow 200
05:42:03 allow 200
05:42:05 allow 200
05:42:06 allow 200
05:42:08 allow 200
05:42:09 allow 200
05:42:10 allow 200
05:42:11 allow 200
05:42:13 allow 200
05:42:14 allow 200
05:42:15 allow 200
05:42:17 allow 200
05:42:18 allow 200
05:42:19 allow 200
05:42:20 allow 200
05:42:22 allow 200
05:42:23 allow 200
05:42:24 allow 200
05:42:26 allow 200
05:42:27 allow 200
05:42:28 allow 200
05:42:29 allow 200
05:42:31 allow 200
05:42:32 allow 200
05:42:33 allow 200
05:42:34 allow 200
05:42:36 allow 200
05:42:37 allow 200
05:42:38 allow 200
05:42:39 allow 200
05:42:41 allow 200
05:42:42 allow 200
05:42:43 allow 200
05:42:44 allow 200
05:42:46 allow 200
05:42:47 allow 200
05:42:48 allow 200
05:42:50 allow 200
05:42:51 allow 200
05:42:52 allow 200
05:42:54 allow 200
05:42:55 allow 200
05:42:56 allow 200
05:42:58 allow 200
05:42:59 allow 200
05:43:00 allow 200
05:43:02 allow 200
05:43:03 allow 200
05:43:04 allow 200
05:43:06 allow 200
05:43:07 allow 200
05:43:08 allow 200
05:43:10 allow 200
05:43:11 allow 200
05:43:12 allow 200
05:43:14 allow 200
05:43:15 allow 200
05:43:16 allow 200
05:43:17 allow 200
05:43:19 allow 200
05:43:20 allow 200
05:43:21 allow 200
05:43:23 allow 200
05:43:24 allow 200
05:43:25 allow 200
```

<img width="1140" height="694" alt="ebb4901b9910380ac01424d14757f89f" src="https://github.com/user-attachments/assets/72c165c7-6ed1-44f2-87c1-f2e897cdf293" />

After upgrade, the securityPolicy with `From/To` fields can be applied:

<img width="2452" height="1558" alt="61a463a413766f33c410a9016cfdd562" src="https://github.com/user-attachments/assets/5d441aed-bd26-40d7-aa7f-b969ac3d4164" />


Compared with before upgrade:

<img width="2502" height="96" alt="0774fb0f6709ac28fdce39c7d388d212" src="https://github.com/user-attachments/assets/799ea5c4-84fc-4c43-9759-325ca6bb9752" />



