### PR TITLE
Add IPv6 support for SecurityPolicy/NetworkPolicy

### DIFF
--- a/build/yaml/crd/legacy/nsx.vmware.com_securitypolicies.yaml
+++ b/build/yaml/crd/legacy/nsx.vmware.com_securitypolicies.yaml
@@ -270,14 +270,14 @@ spec:
                           ipBlocks:
                             description: IPBlocks is a list of IP CIDRs.
                             items:
-                              description: IPBlock describes a particular CIDR that
-                                is allowed or denied to/from the workloads matched
-                                by an AppliedTo.
+                              description: |-
+                                IPBlock describes a particular CIDR that is allowed or denied to/from the workloads matched by an AppliedTo.
+                                Both IPv4 and IPv6 CIDRs are supported.
                               properties:
                                 cidr:
                                   description: |-
                                     CIDR is a string representing the IP Block.
-                                    A valid example is "192.168.1.1/24".
+                                    Valid examples are "192.168.1.0/24" and "2001:db8::/32".
                                   type: string
                               required:
                               - cidr
@@ -441,14 +441,14 @@ spec:
                           ipBlocks:
                             description: IPBlocks is a list of IP CIDRs.
                             items:
-                              description: IPBlock describes a particular CIDR that
-                                is allowed or denied to/from the workloads matched
-                                by an AppliedTo.
+                              description: |-
+                                IPBlock describes a particular CIDR that is allowed or denied to/from the workloads matched by an AppliedTo.
+                                Both IPv4 and IPv6 CIDRs are supported.
                               properties:
                                 cidr:
                                   description: |-
                                     CIDR is a string representing the IP Block.
-                                    A valid example is "192.168.1.1/24".
+                                    Valid examples are "192.168.1.0/24" and "2001:db8::/32".
                                   type: string
                               required:
                               - cidr
@@ -634,14 +634,14 @@ spec:
                           ipBlocks:
                             description: IPBlocks is a list of IP CIDRs.
                             items:
-                              description: IPBlock describes a particular CIDR that
-                                is allowed or denied to/from the workloads matched
-                                by an AppliedTo.
+                              description: |-
+                                IPBlock describes a particular CIDR that is allowed or denied to/from the workloads matched by an AppliedTo.
+                                Both IPv4 and IPv6 CIDRs are supported.
                               properties:
                                 cidr:
                                   description: |-
                                     CIDR is a string representing the IP Block.
-                                    A valid example is "192.168.1.1/24".
+                                    Valid examples are "192.168.1.0/24" and "2001:db8::/32".
                                   type: string
                               required:
                               - cidr
@@ -801,14 +801,14 @@ spec:
                           ipBlocks:
                             description: IPBlocks is a list of IP CIDRs.
                             items:
-                              description: IPBlock describes a particular CIDR that
-                                is allowed or denied to/from the workloads matched
-                                by an AppliedTo.
+                              description: |-
+                                IPBlock describes a particular CIDR that is allowed or denied to/from the workloads matched by an AppliedTo.
+                                Both IPv4 and IPv6 CIDRs are supported.
                               properties:
                                 cidr:
                                   description: |-
                                     CIDR is a string representing the IP Block.
-                                    A valid example is "192.168.1.1/24".
+                                    Valid examples are "192.168.1.0/24" and "2001:db8::/32".
                                   type: string
                               required:
                               - cidr

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_securitypolicies.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_securitypolicies.yaml
@@ -270,14 +270,14 @@ spec:
                           ipBlocks:
                             description: IPBlocks is a list of IP CIDRs.
                             items:
-                              description: IPBlock describes a particular CIDR that
-                                is allowed or denied to/from the workloads matched
-                                by an AppliedTo.
+                              description: |-
+                                IPBlock describes a particular CIDR that is allowed or denied to/from the workloads matched by an AppliedTo.
+                                Both IPv4 and IPv6 CIDRs are supported.
                               properties:
                                 cidr:
                                   description: |-
                                     CIDR is a string representing the IP Block.
-                                    A valid example is "192.168.1.1/24".
+                                    Valid examples are "192.168.1.0/24" and "2001:db8::/32".
                                   type: string
                               required:
                               - cidr
@@ -441,14 +441,14 @@ spec:
                           ipBlocks:
                             description: IPBlocks is a list of IP CIDRs.
                             items:
-                              description: IPBlock describes a particular CIDR that
-                                is allowed or denied to/from the workloads matched
-                                by an AppliedTo.
+                              description: |-
+                                IPBlock describes a particular CIDR that is allowed or denied to/from the workloads matched by an AppliedTo.
+                                Both IPv4 and IPv6 CIDRs are supported.
                               properties:
                                 cidr:
                                   description: |-
                                     CIDR is a string representing the IP Block.
-                                    A valid example is "192.168.1.1/24".
+                                    Valid examples are "192.168.1.0/24" and "2001:db8::/32".
                                   type: string
                               required:
                               - cidr
@@ -634,14 +634,14 @@ spec:
                           ipBlocks:
                             description: IPBlocks is a list of IP CIDRs.
                             items:
-                              description: IPBlock describes a particular CIDR that
-                                is allowed or denied to/from the workloads matched
-                                by an AppliedTo.
+                              description: |-
+                                IPBlock describes a particular CIDR that is allowed or denied to/from the workloads matched by an AppliedTo.
+                                Both IPv4 and IPv6 CIDRs are supported.
                               properties:
                                 cidr:
                                   description: |-
                                     CIDR is a string representing the IP Block.
-                                    A valid example is "192.168.1.1/24".
+                                    Valid examples are "192.168.1.0/24" and "2001:db8::/32".
                                   type: string
                               required:
                               - cidr
@@ -801,14 +801,14 @@ spec:
                           ipBlocks:
                             description: IPBlocks is a list of IP CIDRs.
                             items:
-                              description: IPBlock describes a particular CIDR that
-                                is allowed or denied to/from the workloads matched
-                                by an AppliedTo.
+                              description: |-
+                                IPBlock describes a particular CIDR that is allowed or denied to/from the workloads matched by an AppliedTo.
+                                Both IPv4 and IPv6 CIDRs are supported.
                               properties:
                                 cidr:
                                   description: |-
                                     CIDR is a string representing the IP Block.
-                                    A valid example is "192.168.1.1/24".
+                                    Valid examples are "192.168.1.0/24" and "2001:db8::/32".
                                   type: string
                               required:
                               - cidr

--- a/docs/security-policy.md
+++ b/docs/security-policy.md
@@ -263,7 +263,7 @@ contains a single `from` element allowing connections from VirtualMachines with
 the label `role=client` in namespaces with the label `user=alice`.
 
 **ipBlocks**: This selects particular IP CIDR ranges to allow as ingress sources
-or egress destinations. E.g.
+or egress destinations. Both IPv4 and IPv6 CIDRs are supported. E.g.
 
 ```
 ...
@@ -276,7 +276,7 @@ or egress destinations. E.g.
 ...
 ```
 
-Particularly, it can be used for single IP by suffix `/32`. E.g.
+Particularly, it can be used for single IP by suffix `/32` (IPv4) or `/128` (IPv6). E.g.
 
 ```
 ...
@@ -286,6 +286,40 @@ Particularly, it can be used for single IP by suffix `/32`. E.g.
       from:
         - ipBlocks:
             - cidr: 100.64.232.1/32
+...
+```
+
+IPv6 CIDRs are also supported in `ipBlocks`:
+
+```
+...
+  rules:
+    - direction: ingress
+      action: allow
+      sources:
+        - ipBlocks:
+            - cidr: 2001:db8::/32
+    - direction: out
+      action: allow
+      destinations:
+        - ipBlocks:
+            - cidr: fd00::/64
+...
+```
+
+Dual-stack configurations mixing both IPv4 and IPv6 `ipBlocks` in the same policy
+are supported as well:
+
+```
+...
+  rules:
+    - direction: ingress
+      action: allow
+      sources:
+        - ipBlocks:
+            - cidr: 192.168.0.0/16
+        - ipBlocks:
+            - cidr: 2001:db8::/32
 ...
 ```
 
@@ -363,3 +397,14 @@ Limitations of SecurityPolicy CR:
 7. Max IP elements in one security policy: 4000
 8. Priority range of SecurityPolicy CR is [0, 1000].
 9. Support named port for Pod, but not for VM.
+
+## IPv6 Support
+
+Both SecurityPolicy CRD and standard Kubernetes NetworkPolicy support IPv6 CIDR
+blocks in `ipBlocks`. The `except` field in NetworkPolicy IPBlock also works
+correctly for IPv6 CIDRs. Dual-stack configurations (mixing IPv4 and IPv6 ipBlocks
+in the same policy) are supported.
+
+For NetworkPolicy with IPv6 `except` clauses, the operator computes IP range
+exclusions and translates them to NSX-T `IPAddressExpression` entries using the
+IP range format (e.g., `2001:db8::b-2001:db8::ffff`).

--- a/pkg/apis/legacy/v1alpha1/securitypolicy_types.go
+++ b/pkg/apis/legacy/v1alpha1/securitypolicy_types.go
@@ -98,9 +98,10 @@ type SecurityPolicyPeer struct {
 }
 
 // IPBlock describes a particular CIDR that is allowed or denied to/from the workloads matched by an AppliedTo.
+// Both IPv4 and IPv6 CIDRs are supported.
 type IPBlock struct {
 	// CIDR is a string representing the IP Block.
-	// A valid example is "192.168.1.1/24".
+	// Valid examples are "192.168.1.0/24" and "2001:db8::/32".
 	CIDR string `json:"cidr"`
 }
 

--- a/pkg/apis/vpc/v1alpha1/securitypolicy_types.go
+++ b/pkg/apis/vpc/v1alpha1/securitypolicy_types.go
@@ -98,9 +98,10 @@ type SecurityPolicyPeer struct {
 }
 
 // IPBlock describes a particular CIDR that is allowed or denied to/from the workloads matched by an AppliedTo.
+// Both IPv4 and IPv6 CIDRs are supported.
 type IPBlock struct {
 	// CIDR is a string representing the IP Block.
-	// A valid example is "192.168.1.1/24".
+	// Valid examples are "192.168.1.0/24" and "2001:db8::/32".
 	CIDR string `json:"cidr"`
 }
 

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -4021,3 +4021,86 @@ func Test_normalizeSecurityPolicyRules_FromToAliases(t *testing.T) {
 		})
 	}
 }
+
+func Test_convertNetworkPolicyPeerToSecurityPolicyPeer_IPv6(t *testing.T) {
+	fakeService := fakeSecurityPolicyService()
+
+	tests := []struct {
+		name     string
+		npPeer   *networkingv1.NetworkPolicyPeer
+		expected *v1alpha1.SecurityPolicyPeer
+		wantErr  bool
+	}{
+		{
+			name: "IPv6 IPBlock without except",
+			npPeer: &networkingv1.NetworkPolicyPeer{
+				IPBlock: &networkingv1.IPBlock{
+					CIDR: "2001:db8::/32",
+				},
+			},
+			expected: &v1alpha1.SecurityPolicyPeer{
+				IPBlocks: []v1alpha1.IPBlock{
+					{CIDR: "2001:db8::/32"},
+				},
+			},
+		},
+		{
+			name: "IPv6 IPBlock with except",
+			npPeer: &networkingv1.NetworkPolicyPeer{
+				IPBlock: &networkingv1.IPBlock{
+					CIDR:   "fd00::/112",
+					Except: []string{"fd00::a/128"},
+				},
+			},
+			expected: &v1alpha1.SecurityPolicyPeer{
+				IPBlocks: []v1alpha1.IPBlock{
+					{CIDR: "fd00::-fd00::9"},
+					{CIDR: "fd00::b-fd00::ffff"},
+				},
+			},
+		},
+		{
+			name: "IPv6 IPBlock with multiple excepts",
+			npPeer: &networkingv1.NetworkPolicyPeer{
+				IPBlock: &networkingv1.IPBlock{
+					CIDR:   "fd00::/112",
+					Except: []string{"fd00::a/128", "fd00::14/128"},
+				},
+			},
+			expected: &v1alpha1.SecurityPolicyPeer{
+				IPBlocks: []v1alpha1.IPBlock{
+					{CIDR: "fd00::-fd00::9"},
+					{CIDR: "fd00::b-fd00::13"},
+					{CIDR: "fd00::15-fd00::ffff"},
+				},
+			},
+		},
+		{
+			name: "IPv4 IPBlock with except still works",
+			npPeer: &networkingv1.NetworkPolicyPeer{
+				IPBlock: &networkingv1.IPBlock{
+					CIDR:   "172.17.0.0/16",
+					Except: []string{"172.17.1.0/24"},
+				},
+			},
+			expected: &v1alpha1.SecurityPolicyPeer{
+				IPBlocks: []v1alpha1.IPBlock{
+					{CIDR: "172.17.0.0-172.17.0.255"},
+					{CIDR: "172.17.2.0-172.17.255.255"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fakeService.convertNetworkPolicyPeerToSecurityPolicyPeer(tt.npPeer)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/pkg/util/ip.go
+++ b/pkg/util/ip.go
@@ -63,6 +63,10 @@ func IsIPv6(addr string) bool {
 	return ip.To4() == nil
 }
 
+// CalculateIPFromCIDRs returns the sum of host address counts for the given CIDRs.
+// IPv6 subnets can have counts far larger than int can represent; this helper is
+// intended for callers that only need IPv4-scale totals (not used on the security
+// policy path). Revisit if NSX IPv6 subnet features need accurate IPv6 totals.
 func CalculateIPFromCIDRs(IPAddresses []string) (int, error) {
 	total := 0
 	for _, addr := range IPAddresses {

--- a/pkg/util/ip.go
+++ b/pkg/util/ip.go
@@ -4,9 +4,9 @@
 package util
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"strconv"
 	"strings"
@@ -34,41 +34,53 @@ func GetIPPrefix(ipAddress string) (int, error) {
 	return num, err
 }
 
-// GetSubnetMask get the mask for a given prefix length, e.g.
-// 24 -> "255.255.255.0"
+// GetSubnetMask returns the IPv4 dotted-decimal mask for a given prefix length, e.g.
+// 24 -> "255.255.255.0". Only valid for IPv4 prefix lengths (0-32).
 func GetSubnetMask(subnetLength int) (string, error) {
 	if subnetLength < 0 || subnetLength > 32 {
 		return "", errors.New("invalid subnet mask length")
 	}
-	// Create a 32-bit subnet mask with leading 1's and trailing 0's
 	subnetBinary := uint32(0xffffffff) << (32 - subnetLength)
-	// Convert the binary representation to dotted-decimal format
 	subnetMask := net.IPv4(byte(subnetBinary>>24), byte(subnetBinary>>16), byte(subnetBinary>>8), byte(subnetBinary))
 	return subnetMask.String(), nil
+}
+
+// IsIPv6CIDR returns true if the given CIDR string is an IPv6 CIDR.
+func IsIPv6CIDR(cidrStr string) bool {
+	ip, _, err := net.ParseCIDR(cidrStr)
+	if err != nil {
+		return false
+	}
+	return ip.To4() == nil
+}
+
+// IsIPv6 returns true if the given IP address string is IPv6.
+func IsIPv6(addr string) bool {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return false
+	}
+	return ip.To4() == nil
 }
 
 func CalculateIPFromCIDRs(IPAddresses []string) (int, error) {
 	total := 0
 	for _, addr := range IPAddresses {
-		mask, err := strconv.Atoi(strings.Split(addr, "/")[1])
+		_, ipNet, err := net.ParseCIDR(addr)
 		if err != nil {
 			return -1, err
 		}
-		total += int(cidr.AddressCount(&net.IPNet{
-			IP:   net.ParseIP(strings.Split(addr, "/")[0]),
-			Mask: net.CIDRMask(mask, 32),
-		}))
+		total += int(cidr.AddressCount(ipNet))
 	}
 	return total, nil
 }
 
 func parseCIDRRange(cidr string) (startIP, endIP net.IP, err error) {
-	// TODO: confirm whether the error message is enough
 	_, ipnet, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return nil, nil, err
 	}
-	startIP = ipnet.IP
+	startIP = normalizeIP(ipnet.IP)
 	endIP = make(net.IP, len(startIP))
 	copy(endIP, startIP)
 	for i := len(startIP) - 1; i >= 0; i-- {
@@ -77,29 +89,45 @@ func parseCIDRRange(cidr string) (startIP, endIP net.IP, err error) {
 	return startIP, endIP, nil
 }
 
-func calculateOffsetIP(ip net.IP, offset int) (net.IP, error) {
-	ipInt := ipToUint32(ip)
-	ipInt += uint32(offset)
-	return uint32ToIP(ipInt), nil
+// normalizeIP returns the canonical form of an IP address:
+// 4 bytes for IPv4, 16 bytes for IPv6.
+func normalizeIP(ip net.IP) net.IP {
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+	return ip.To16()
 }
 
-func ipToUint32(ip net.IP) uint32 {
-	ip = ip.To4()
-	return binary.BigEndian.Uint32(ip)
+func ipToBigInt(ip net.IP) *big.Int {
+	return new(big.Int).SetBytes(normalizeIP(ip))
 }
 
-func uint32ToIP(ipInt uint32) net.IP {
-	ip := make(net.IP, net.IPv4len)
-	binary.BigEndian.PutUint32(ip, ipInt)
+func bigIntToIP(n *big.Int, ipLen int) net.IP {
+	ip := make(net.IP, ipLen)
+	if n.Sign() <= 0 {
+		return ip
+	}
+	b := n.Bytes()
+	if len(b) > ipLen {
+		b = b[len(b)-ipLen:]
+	}
+	copy(ip[ipLen-len(b):], b)
 	return ip
 }
 
+func calculateOffsetIP(ip net.IP, offset int) (net.IP, error) {
+	ip = normalizeIP(ip)
+	n := ipToBigInt(ip)
+	n.Add(n, big.NewInt(int64(offset)))
+	return bigIntToIP(n, len(ip)), nil
+}
+
 func compareIP(ip1, ip2 net.IP) bool {
-	return ipToUint32(ip1) < ipToUint32(ip2)
+	return ipToBigInt(ip1).Cmp(ipToBigInt(ip2)) < 0
 }
 
 func equalIP(ip1, ip2 net.IP) bool {
-	return ipToUint32(ip1) == ipToUint32(ip2)
+	return normalizeIP(ip1).Equal(normalizeIP(ip2))
 }
 
 func rangeAppend(ranges [][]net.IP, appendRange []net.IP) [][]net.IP {
@@ -114,8 +142,8 @@ func rangesAbstractRange(ranges [][]net.IP, except []net.IP) [][]net.IP {
 	// except: [172.0.100.1 172.0.100.255]
 	// return: [[172.0.0.1 172.0.100.0] [172.0.101.0 172.0.255.255] [172.2.0.1 172.2.255.255]]
 	results := [][]net.IP{}
-	except[0] = except[0].To4()
-	except[1] = except[1].To4()
+	except[0] = normalizeIP(except[0])
+	except[1] = normalizeIP(except[1])
 	const (
 		// Location identifiers for the except range point in relation to the given range
 		LocationBeforeStart = iota // 0: before rng[0]
@@ -144,8 +172,8 @@ func rangesAbstractRange(ranges [][]net.IP, except []net.IP) [][]net.IP {
 			}
 			return position
 		}
-		rng[0] = rng[0].To4()
-		rng[1] = rng[1].To4()
+		rng[0] = normalizeIP(rng[0])
+		rng[1] = normalizeIP(rng[1])
 		exceptPrev, _ := calculateOffsetIP(except[0], -1)
 		exceptNext, _ := calculateOffsetIP(except[1], 1)
 		if getIPPositionInRange(except[0]) == LocationBeforeStart {

--- a/pkg/util/ip.go
+++ b/pkg/util/ip.go
@@ -119,11 +119,11 @@ func bigIntToIP(n *big.Int, ipLen int) net.IP {
 	return ip
 }
 
-func calculateOffsetIP(ip net.IP, offset int) (net.IP, error) {
+func calculateOffsetIP(ip net.IP, offset int) net.IP {
 	ip = normalizeIP(ip)
 	n := ipToBigInt(ip)
 	n.Add(n, big.NewInt(int64(offset)))
-	return bigIntToIP(n, len(ip)), nil
+	return bigIntToIP(n, len(ip))
 }
 
 func compareIP(ip1, ip2 net.IP) bool {
@@ -178,8 +178,8 @@ func rangesAbstractRange(ranges [][]net.IP, except []net.IP) [][]net.IP {
 		}
 		rng[0] = normalizeIP(rng[0])
 		rng[1] = normalizeIP(rng[1])
-		exceptPrev, _ := calculateOffsetIP(except[0], -1)
-		exceptNext, _ := calculateOffsetIP(except[1], 1)
+		exceptPrev := calculateOffsetIP(except[0], -1)
+		exceptNext := calculateOffsetIP(except[1], 1)
 		if getIPPositionInRange(except[0]) == LocationBeforeStart {
 			if getIPPositionInRange(except[1]) == LocationBeforeStart {
 				results = rangeAppend(results, []net.IP{rng[0], rng[1]})

--- a/pkg/util/ip_test.go
+++ b/pkg/util/ip_test.go
@@ -255,10 +255,7 @@ func Test_calculateOffsetIP(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := calculateOffsetIP(tt.args.ip, tt.args.offset)
-			if err != nil {
-				t.Errorf("%s failed: %s", tt.name, err)
-			}
+			got := calculateOffsetIP(tt.args.ip, tt.args.offset)
 			want := normalizeIP(tt.want)
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("%s failed: calculateOffsetIP got %v, want %v", tt.name, got, want)

--- a/pkg/util/ip_test.go
+++ b/pkg/util/ip_test.go
@@ -248,15 +248,259 @@ func Test_calculateOffsetIP(t *testing.T) {
 		name string
 		args args
 		want net.IP
-	}{{"1", args{ip, offset1}, want1}}
+	}{
+		{"IPv4 offset +1", args{ip, offset1}, want1},
+		{"IPv6 offset +1", args{net.ParseIP("2001:db8::1"), 1}, net.ParseIP("2001:db8::2")},
+		{"IPv6 offset -1", args{net.ParseIP("2001:db8::ff"), -1}, net.ParseIP("2001:db8::fe")},
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := calculateOffsetIP(tt.args.ip, tt.args.offset)
 			if err != nil {
 				t.Errorf("%s failed: %s", tt.name, err)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("%s failed: calculateOffsetIP got %v, want %v", tt.name, got, tt.want)
+			want := normalizeIP(tt.want)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("%s failed: calculateOffsetIP got %v, want %v", tt.name, got, want)
+			}
+		})
+	}
+}
+
+func Test_rangesAbstractRange_IPv6(t *testing.T) {
+	empty := [][]net.IP{}
+	type args struct {
+		ranges [][]net.IP
+		except []net.IP
+	}
+	tests := []struct {
+		name string
+		args args
+		want [][]net.IP
+	}{
+		{
+			name: "IPv6: except range is completely included in the range",
+			args: args{
+				ranges: [][]net.IP{
+					{
+						net.ParseIP("2001:db8::1"),
+						net.ParseIP("2001:db8::ffff"),
+					},
+				},
+				except: []net.IP{
+					net.ParseIP("2001:db8::100"),
+					net.ParseIP("2001:db8::1ff"),
+				},
+			},
+			want: [][]net.IP{
+				{
+					net.ParseIP("2001:db8::1"),
+					net.ParseIP("2001:db8::ff"),
+				},
+				{
+					net.ParseIP("2001:db8::200"),
+					net.ParseIP("2001:db8::ffff"),
+				},
+			},
+		},
+		{
+			name: "IPv6: except is exactly the same as the range",
+			args: args{
+				ranges: [][]net.IP{
+					{
+						net.ParseIP("2001:db8::1"),
+						net.ParseIP("2001:db8::10"),
+					},
+				},
+				except: []net.IP{
+					net.ParseIP("2001:db8::1"),
+					net.ParseIP("2001:db8::10"),
+				},
+			},
+			want: empty,
+		},
+		{
+			name: "IPv6: except is completely outside the range",
+			args: args{
+				ranges: [][]net.IP{
+					{
+						net.ParseIP("2001:db8:1::1"),
+						net.ParseIP("2001:db8:1::ffff"),
+					},
+				},
+				except: []net.IP{
+					net.ParseIP("2001:db8:2::1"),
+					net.ParseIP("2001:db8:2::ff"),
+				},
+			},
+			want: [][]net.IP{
+				{
+					net.ParseIP("2001:db8:1::1"),
+					net.ParseIP("2001:db8:1::ffff"),
+				},
+			},
+		},
+		{
+			name: "IPv6: except is a single IP inside the range",
+			args: args{
+				ranges: [][]net.IP{
+					{
+						net.ParseIP("fd00::1"),
+						net.ParseIP("fd00::a"),
+					},
+				},
+				except: []net.IP{
+					net.ParseIP("fd00::5"),
+					net.ParseIP("fd00::5"),
+				},
+			},
+			want: [][]net.IP{
+				{
+					net.ParseIP("fd00::1"),
+					net.ParseIP("fd00::4"),
+				},
+				{
+					net.ParseIP("fd00::6"),
+					net.ParseIP("fd00::a"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rangesAbstractRange(tt.args.ranges, tt.args.except)
+			normalizeRanges := func(ranges [][]net.IP) [][]net.IP {
+				for i := range ranges {
+					for j := range ranges[i] {
+						ranges[i][j] = normalizeIP(ranges[i][j])
+					}
+				}
+				return ranges
+			}
+			if !reflect.DeepEqual(got, normalizeRanges(tt.want)) {
+				t.Errorf("%s failed: rangesAbstractRange got %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCIDRRangesWithExcept_IPv6(t *testing.T) {
+	type args struct {
+		cidr    string
+		excepts []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "IPv6 single except",
+			args: args{
+				cidr:    "2001:db8::/32",
+				excepts: []string{"2001:db8:1::/48"},
+			},
+			want: []string{"2001:db8::-2001:db8:0:ffff:ffff:ffff:ffff:ffff", "2001:db8:2::-2001:db8:ffff:ffff:ffff:ffff:ffff:ffff"},
+		},
+		{
+			name: "IPv6 multiple excepts",
+			args: args{
+				cidr:    "fd00::/112",
+				excepts: []string{"fd00::a/128", "fd00::14/128"},
+			},
+			want: []string{"fd00::-fd00::9", "fd00::b-fd00::13", "fd00::15-fd00::ffff"},
+		},
+	}
+	for _, tt := range tests {
+		got, err := GetCIDRRangesWithExcept(tt.args.cidr, tt.args.excepts)
+		if err != nil {
+			t.Errorf("%s failed: %s", tt.name, err)
+		}
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("%s failed: GetCIDRRangesWithExcept got %s, want %s", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestIsIPv6CIDR(t *testing.T) {
+	tests := []struct {
+		cidr string
+		want bool
+	}{
+		{"192.168.0.0/24", false},
+		{"10.0.0.0/8", false},
+		{"2001:db8::/32", true},
+		{"fd00::/64", true},
+		{"::1/128", true},
+		{"invalid", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cidr, func(t *testing.T) {
+			if got := IsIPv6CIDR(tt.cidr); got != tt.want {
+				t.Errorf("IsIPv6CIDR(%q) = %v, want %v", tt.cidr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsIPv6(t *testing.T) {
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		{"192.168.0.1", false},
+		{"10.0.0.1", false},
+		{"2001:db8::1", true},
+		{"::1", true},
+		{"fe80::1", true},
+		{"invalid", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			if got := IsIPv6(tt.addr); got != tt.want {
+				t.Errorf("IsIPv6(%q) = %v, want %v", tt.addr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalculateIPFromCIDRs_IPv6(t *testing.T) {
+	tests := []struct {
+		name    string
+		cidrs   []string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:  "IPv6 /128",
+			cidrs: []string{"2001:db8::1/128"},
+			want:  1,
+		},
+		{
+			name:  "IPv6 /126",
+			cidrs: []string{"2001:db8::/126"},
+			want:  4,
+		},
+		{
+			name:  "IPv4 /24",
+			cidrs: []string{"192.168.1.0/24"},
+			want:  256,
+		},
+		{
+			name:  "mixed IPv4 and IPv6",
+			cidrs: []string{"192.168.1.0/24", "2001:db8::/126"},
+			want:  260,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CalculateIPFromCIDRs(tt.cidrs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CalculateIPFromCIDRs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("CalculateIPFromCIDRs() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/test/e2e/e2e_namespaces.go
+++ b/test/e2e/e2e_namespaces.go
@@ -17,6 +17,9 @@ var (
 	NsSecurityPolicyNamedPortClient = "e2e-sp-np-client-" + getRandomString()
 	NsSecurityPolicyNamedPortWeb    = "e2e-sp-np-web-" + getRandomString()
 
+	// NsIPv6PolicyVC IPv6 policy test namespace (VC-based, isolated from other security policy tests).
+	NsIPv6PolicyVC = "e2e-ipv6-policy-vc-" + getRandomString()
+
 	// NsInventorySync Inventory sync test namespaces - need VC namespace for pod creation
 	NsInventorySync = "e2e-inventory-" + getRandomString()
 
@@ -41,6 +44,7 @@ var allVCNamespaces = []string{
 	NsSecurityPolicy,
 	NsSecurityPolicyNamedPortClient,
 	NsSecurityPolicyNamedPortWeb,
+	NsIPv6PolicyVC,
 	NsInventorySync,
 	NsLoadBalancerLB,
 	NsLoadBalancerPod,
@@ -112,7 +116,9 @@ func CleanupVCNamespaces(namespaces ...string) {
 // This is a safety net cleanup - most namespaces should be deleted by individual tests
 func CleanupAllNamespaces() {
 	cleanupOnce.Do(func() {
-		log.Info("Running safety net cleanup for VC namespaces", "count", len(allVCNamespaces))
+		// Safety net cleanup: most namespaces should be deleted by individual tests,
+		// but we still try to clean up shared namespace here.
+		log.Info("Running safety net cleanup for namespaces", "vcCount", len(allVCNamespaces))
 		CleanupVCNamespaces(allVCNamespaces...)
 		log.Info("Safety net cleanup completed")
 	})

--- a/test/e2e/manifest/testNetworkPolicy/np_dualstack_ipblock.yaml
+++ b/test/e2e/manifest/testNetworkPolicy/np_dualstack_ipblock.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: np-dualstack-ipblock
+spec:
+  podSelector:
+    matchLabels:
+      role: db
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 192.168.0.0/16
+        except:
+        - 192.168.1.0/24
+    - ipBlock:
+        cidr: 2001:db8::/32
+        except:
+        - 2001:db8:1::/48
+    ports:
+    - protocol: TCP
+      port: 3306
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 10.0.0.0/8
+    - ipBlock:
+        cidr: fd00::/64
+    ports:
+    - protocol: TCP
+      port: 443

--- a/test/e2e/manifest/testNetworkPolicy/np_ipv6_ipblock.yaml
+++ b/test/e2e/manifest/testNetworkPolicy/np_ipv6_ipblock.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: np-ipv6-ipblock
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 2001:db8::/32
+        except:
+        - 2001:db8:1::/48
+    ports:
+    - protocol: TCP
+      port: 80
+  egress:
+  - to:
+    - ipBlock:
+        cidr: fd00::/64
+    ports:
+    - protocol: TCP
+      port: 443

--- a/test/e2e/manifest/testSecurityPolicy/ipv6-ipblock-policy.yaml
+++ b/test/e2e/manifest/testSecurityPolicy/ipv6-ipblock-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: crd.nsx.vmware.com/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: ipv6-ipblock-policy
+spec:
+  priority: 10
+  appliedTo:
+    - podSelector:
+        matchLabels:
+          role: db
+  rules:
+    - direction: in
+      action: allow
+      sources:
+        - ipBlocks:
+            - cidr: 2001:db8::/32
+    - direction: out
+      action: allow
+      destinations:
+        - ipBlocks:
+            - cidr: fd00::/64
+    - direction: in
+      action: drop
+    - direction: out
+      action: drop

--- a/test/e2e/nsx_ipv6_policy_test.go
+++ b/test/e2e/nsx_ipv6_policy_test.go
@@ -21,9 +21,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
-const (
-	NsIPv6Policy = "e2e-ipv6-policy"
-)
+var NsIPv6Policy = "e2e-ipv6-policy-" + getRandomString()
 
 func TestIPv6SecurityPolicy(t *testing.T) {
 	TrackTest(t)

--- a/test/e2e/nsx_ipv6_policy_test.go
+++ b/test/e2e/nsx_ipv6_policy_test.go
@@ -1,0 +1,120 @@
+// This file contains end-to-end tests for IPv6 support in SecurityPolicy and NetworkPolicy.
+// It verifies that IPv6 CIDR blocks (including ipBlock.except) are correctly translated to
+// NSX-T resources. These tests validate the resource creation path; traffic verification
+// requires a dual-stack cluster and is left to targeted integration tests.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+const (
+	NsIPv6Policy = "e2e-ipv6-policy"
+)
+
+func TestIPv6SecurityPolicy(t *testing.T) {
+	TrackTest(t)
+	deadlineCtx, deadlineCancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer deadlineCancel()
+
+	ns := NsIPv6Policy
+	setupNamespace(t, ns)
+	defer teardownNamespace(t, ns)
+
+	securityPolicyName := "ipv6-ipblock-policy"
+
+	// Create security policy with IPv6 ipBlocks
+	yamlPath, _ := filepath.Abs("./manifest/testSecurityPolicy/ipv6-ipblock-policy.yaml")
+	require.NoError(t, applyYAML(yamlPath, ns))
+	defer deleteYAML(yamlPath, ns)
+
+	assureSecurityPolicyReady(t, ns, securityPolicyName)
+
+	// Verify NSX-T SecurityPolicy resource was created
+	assert.NoError(t, testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, securityPolicyName, true))
+	log.Info("Verified IPv6 SecurityPolicy NSX resource exists", "name", securityPolicyName)
+
+	// Cleanup
+	_ = deleteYAML(yamlPath, ns)
+	err := wait.PollUntilContextTimeout(deadlineCtx, 1*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
+		_, err = testData.crdClientset.CrdV1alpha1().SecurityPolicies(ns).Get(ctx, securityPolicyName, v1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, fmt.Errorf("error waiting for SecurityPolicy %s deletion", securityPolicyName)
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	assert.NoError(t, testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, securityPolicyName, false))
+	log.Info("Verified IPv6 SecurityPolicy NSX resource cleaned up", "name", securityPolicyName)
+}
+
+func TestIPv6NetworkPolicy(t *testing.T) {
+	TrackTest(t)
+
+	ns := NsIPv6Policy
+	setupNamespace(t, ns)
+	defer teardownNamespace(t, ns)
+
+	npName := "np-ipv6-ipblock"
+
+	// Create NetworkPolicy with IPv6 ipBlock and except
+	yamlPath, _ := filepath.Abs("./manifest/testNetworkPolicy/np_ipv6_ipblock.yaml")
+	require.NoError(t, applyYAML(yamlPath, ns))
+	defer deleteYAML(yamlPath, ns)
+
+	// The nsx-operator converts NetworkPolicy to SecurityPolicy internally.
+	// Verify that the corresponding NSX SecurityPolicy is created.
+	assert.NoError(t, testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, npName, true))
+	log.Info("Verified IPv6 NetworkPolicy -> NSX SecurityPolicy exists", "name", npName)
+}
+
+func TestDualStackNetworkPolicy(t *testing.T) {
+	TrackTest(t)
+
+	ns := NsIPv6Policy
+	setupNamespace(t, ns)
+	defer teardownNamespace(t, ns)
+
+	npName := "np-dualstack-ipblock"
+
+	// Create NetworkPolicy with both IPv4 and IPv6 ipBlocks
+	yamlPath, _ := filepath.Abs("./manifest/testNetworkPolicy/np_dualstack_ipblock.yaml")
+	require.NoError(t, applyYAML(yamlPath, ns))
+	defer deleteYAML(yamlPath, ns)
+
+	assert.NoError(t, testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, npName, true))
+	log.Info("Verified dual-stack NetworkPolicy -> NSX SecurityPolicy exists", "name", npName)
+}
+
+func setupNamespace(t *testing.T, ns string) {
+	t.Helper()
+	err := testData.createNamespace(ns)
+	if err != nil {
+		t.Logf("Namespace %s may already exist: %v", ns, err)
+	}
+}
+
+func teardownNamespace(t *testing.T, ns string) {
+	t.Helper()
+	err := testData.deleteNamespace(ns, defaultTimeout)
+	if err != nil {
+		t.Logf("Error deleting namespace %s: %v", ns, err)
+	}
+}

--- a/test/e2e/nsx_ipv6_policy_test.go
+++ b/test/e2e/nsx_ipv6_policy_test.go
@@ -21,16 +21,11 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
-var NsIPv6Policy = "e2e-ipv6-policy-" + getRandomString()
-
-func TestIPv6SecurityPolicy(t *testing.T) {
-	TrackTest(t)
+func testIPv6SecurityPolicy(t *testing.T) {
 	deadlineCtx, deadlineCancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer deadlineCancel()
 
-	ns := NsIPv6Policy
-	setupNamespace(t, ns)
-	defer teardownNamespace(t, ns)
+	ns := NsIPv6PolicyVC
 
 	securityPolicyName := "ipv6-ipblock-policy"
 
@@ -63,12 +58,8 @@ func TestIPv6SecurityPolicy(t *testing.T) {
 	log.Info("Verified IPv6 SecurityPolicy NSX resource cleaned up", "name", securityPolicyName)
 }
 
-func TestIPv6NetworkPolicy(t *testing.T) {
-	TrackTest(t)
-
-	ns := NsIPv6Policy
-	setupNamespace(t, ns)
-	defer teardownNamespace(t, ns)
+func testIPv6NetworkPolicy(t *testing.T) {
+	ns := NsIPv6PolicyVC
 
 	npName := "np-ipv6-ipblock"
 
@@ -83,12 +74,8 @@ func TestIPv6NetworkPolicy(t *testing.T) {
 	log.Info("Verified IPv6 NetworkPolicy -> NSX SecurityPolicy exists", "name", npName)
 }
 
-func TestDualStackNetworkPolicy(t *testing.T) {
-	TrackTest(t)
-
-	ns := NsIPv6Policy
-	setupNamespace(t, ns)
-	defer teardownNamespace(t, ns)
+func testDualStackNetworkPolicy(t *testing.T) {
+	ns := NsIPv6PolicyVC
 
 	npName := "np-dualstack-ipblock"
 
@@ -99,20 +86,4 @@ func TestDualStackNetworkPolicy(t *testing.T) {
 
 	assert.NoError(t, testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, npName, true))
 	log.Info("Verified dual-stack NetworkPolicy -> NSX SecurityPolicy exists", "name", npName)
-}
-
-func setupNamespace(t *testing.T, ns string) {
-	t.Helper()
-	err := testData.createNamespace(ns)
-	if err != nil {
-		t.Logf("Namespace %s may already exist: %v", ns, err)
-	}
-}
-
-func teardownNamespace(t *testing.T, ns string) {
-	t.Helper()
-	err := testData.deleteNamespace(ns, defaultTimeout)
-	if err != nil {
-		t.Logf("Error deleting namespace %s: %v", ns, err)
-	}
 }

--- a/test/e2e/nsx_security_policy_test.go
+++ b/test/e2e/nsx_security_policy_test.go
@@ -59,9 +59,9 @@ func TestSecurityPolicy(t *testing.T) {
 		}
 		// Allow this suite to run concurrently with other security policy subtests.
 		t.Parallel()
-		RunSubtest(t, "testIPv6SecurityPolicy", func(t *testing.T) {testIPv6SecurityPolicy(t)})
-		RunSubtest(t, "testIPv6NetworkPolicy", func(t *testing.T) {testIPv6NetworkPolicy(t)})
-		RunSubtest(t, "testDualStackNetworkPolicy", func(t *testing.T) {testDualStackNetworkPolicy(t)})
+		RunSubtest(t, "testIPv6SecurityPolicy", func(t *testing.T) { testIPv6SecurityPolicy(t) })
+		RunSubtest(t, "testIPv6NetworkPolicy", func(t *testing.T) { testIPv6NetworkPolicy(t) })
+		RunSubtest(t, "testDualStackNetworkPolicy", func(t *testing.T) { testDualStackNetworkPolicy(t) })
 	})
 }
 

--- a/test/e2e/nsx_security_policy_test.go
+++ b/test/e2e/nsx_security_policy_test.go
@@ -37,7 +37,7 @@ func TestSecurityPolicy(t *testing.T) {
 
 	// Clean up shared namespaces when all subtests complete
 	t.Cleanup(func() {
-		CleanupVCNamespaces(NsSecurityPolicy, NsSecurityPolicyNamedPortClient, NsSecurityPolicyNamedPortWeb)
+		CleanupVCNamespaces(NsSecurityPolicy, NsSecurityPolicyNamedPortClient, NsSecurityPolicyNamedPortWeb, NsIPv6PolicyVC)
 	})
 	StartParallel(t)
 
@@ -49,6 +49,19 @@ func TestSecurityPolicy(t *testing.T) {
 		RunSubtest(t, "testSecurityPolicyMatchExpression", func(t *testing.T) { testSecurityPolicyMatchExpression(t) })
 		RunSubtest(t, "testSecurityPolicyNamedPortWithoutPod", func(t *testing.T) { testSecurityPolicyNamedPortWithoutPod(t) })
 		RunSubtest(t, "testSecurityPolicyNamedPorWithPod", func(t *testing.T) { testSecurityPolicyNamedPorWithPod(t) })
+	})
+
+	// IPv6-only tests: run only when cluster has IPv6 Pod CIDR configured.
+	// They use an isolated VC namespace and can run in parallel with other security policy subtests.
+	RunSubtest(t, "IPv6SecurityPolicyTests", func(t *testing.T) {
+		if clusterInfo.podV6NetworkCIDR == "" {
+			t.Skip("cluster does not support IPv6 Pod CIDR")
+		}
+		// Allow this suite to run concurrently with other security policy subtests.
+		t.Parallel()
+		RunSubtest(t, "testIPv6SecurityPolicy", func(t *testing.T) {testIPv6SecurityPolicy(t)})
+		RunSubtest(t, "testIPv6NetworkPolicy", func(t *testing.T) {testIPv6NetworkPolicy(t)})
+		RunSubtest(t, "testDualStackNetworkPolicy", func(t *testing.T) {testDualStackNetworkPolicy(t)})
 	})
 }
 


### PR DESCRIPTION
Add IPv6 support for SecurityPolicy and NetworkPolicy ipBlocks

Refactor IP arithmetic utilities in pkg/util/ip.go to use math/big
instead of uint32, enabling dual-stack (IPv4/IPv6) support for CIDR
range calculations including the except/exclusion logic. The previous
implementation was hardcoded to 32-bit IPv4 addresses, causing failures
when processing IPv6 CIDRs.