### PR TITLE
Implement Mixed Mode State Detection

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -113,7 +113,7 @@ func init() {
 
 func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 	// Generate webhook certificates and start refreshing webhook certificates periodically
-	if cf.CoeConfig.EnableVPCNetwork {
+	if config.HasVPCNamespaces() {
 		if err := pkgutil.GenerateWebhookCerts(); err != nil {
 			log.Error(err, "Failed to generate webhook certificates")
 			os.Exit(1)
@@ -123,7 +123,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 	}
 
 	// Initialize and start the system health reporter
-	if cf.CoeConfig.EnableVPCNetwork && cf.EnableInventory && cf.CoeConfig.EnableSha {
+	if config.HasVPCNamespaces() && cf.EnableInventory && cf.CoeConfig.EnableSha {
 		health.Start(nsxClient, cf, mgr.GetClient())
 	}
 
@@ -136,7 +136,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 
 	checkLicense(nsxClient, cf.LicenseValidationInterval)
 
-	if cf.K8sConfig.EnableRestore && cf.CoeConfig.EnableVPCNetwork {
+	if cf.K8sConfig.EnableRestore && config.HasVPCNamespaces() {
 		var err error
 		restoreMode, err = pkgutil.CompareNSXRestore(mgr.GetClient(), nsxClient)
 		if err != nil {
@@ -153,7 +153,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 	var hookServer webhook.Server
 	var subnetSetReconcile *subnetset.SubnetSetReconciler
 
-	if cf.CoeConfig.EnableVPCNetwork {
+	if config.HasVPCNamespaces() {
 		// Check NSX version for VPC networking mode
 		if !commonService.NSXClient.NSXCheckVersion(nsx.VPC) {
 			log.Error(nil, "VPC mode cannot be enabled if NSX version is lower than 4.1.1")
@@ -284,6 +284,21 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 		log.Error(err, "Failed to update Pod labels")
 		panic(err)
 	}
+
+	// Watch for mixed-mode state changes (e.g. T1-only → T1+VPC when the migration starts).
+	// If the state changes, exit so the operator restarts with the new configuration
+	// — this is simpler and safer than hot-initializing VPC services after startup.
+	config.SetMixedModeNamespaceRefreshReader(mgr.GetClient())
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			if config.RefreshMixedModeState(context.Background()) {
+				log.Info("Mixed-mode state changed; restarting NSX Operator to pick up new configuration")
+				os.Exit(0)
+			}
+		}
+	}()
 }
 
 func electMaster(mgr manager.Manager, nsxClient *nsx.Client) {
@@ -328,6 +343,12 @@ func main() {
 		log.Error(nil, "Failed to get nsx client")
 		os.Exit(1)
 	}
+
+	if err := config.InitMixedMode(context.Background(), cfg, cf.CoeConfig.EnableVPCNetwork); err != nil {
+		log.Error(err, "Failed to initialize mixed mode state")
+		os.Exit(1)
+	}
+	util.SetHasVPCNamespacesFunc(config.HasVPCNamespaces)
 
 	if cf.HAEnabled() {
 		go electMaster(mgr, nsxClient)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -115,7 +115,7 @@ func init() {
 
 func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 	// Generate webhook certificates and start refreshing webhook certificates periodically
-	if cf.CoeConfig.EnableVPCNetwork {
+	if config.HasVPCNamespaces() {
 		if err := pkgutil.GenerateWebhookCerts(); err != nil {
 			log.Error(err, "Failed to generate webhook certificates")
 			os.Exit(1)
@@ -125,7 +125,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 	}
 
 	// Initialize and start the system health reporter
-	if cf.CoeConfig.EnableVPCNetwork && cf.EnableInventory && cf.CoeConfig.EnableSha {
+	if config.HasVPCNamespaces() && cf.EnableInventory && cf.CoeConfig.EnableSha {
 		health.Start(nsxClient, cf, mgr.GetClient())
 	}
 
@@ -138,7 +138,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 
 	checkLicense(nsxClient, cf.LicenseValidationInterval)
 
-	if cf.K8sConfig.EnableRestore && cf.CoeConfig.EnableVPCNetwork {
+	if cf.K8sConfig.EnableRestore && config.HasVPCNamespaces() {
 		var err error
 		restoreMode, err = pkgutil.CompareNSXRestore(mgr.GetClient(), nsxClient)
 		if err != nil {
@@ -155,7 +155,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 	var hookServer webhook.Server
 	var subnetSetReconcile *subnetset.SubnetSetReconciler
 
-	if cf.CoeConfig.EnableVPCNetwork {
+	if config.HasVPCNamespaces() {
 		// Check NSX version for VPC networking mode
 		if !commonService.NSXClient.NSXCheckVersion(nsx.VPC) {
 			log.Error(nil, "VPC mode cannot be enabled if NSX version is lower than 4.1.1")
@@ -300,6 +300,20 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 		log.Error(err, "Failed to update Pod labels")
 		panic(err)
 	}
+
+	// Watch for mixed-mode state changes (e.g. T1-only → T1+VPC when the migration starts).
+	// If the state changes, exit so the operator restarts with the new configuration
+	config.StartNetworkSettingsInformer(mgr)
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			if config.RefreshMixedModeState(context.Background()) {
+				log.Info("Mixed-mode state changed; restarting NSX Operator to pick up new configuration")
+				os.Exit(0)
+			}
+		}
+	}()
 }
 
 func electMaster(mgr manager.Manager, nsxClient *nsx.Client) {
@@ -344,6 +358,12 @@ func main() {
 		log.Error(nil, "Failed to get nsx client")
 		os.Exit(1)
 	}
+
+	if err := config.InitMixedMode(context.Background(), cfg, cf.CoeConfig.EnableVPCNetwork); err != nil {
+		log.Error(err, "Failed to initialize mixed mode state")
+		os.Exit(1)
+	}
+	util.SetHasVPCNamespacesFunc(config.HasVPCNamespaces)
 
 	if cf.HAEnabled() {
 		go electMaster(mgr, nsxClient)

--- a/pkg/config/mixed_mode.go
+++ b/pkg/config/mixed_mode.go
@@ -1,0 +1,319 @@
+/* Copyright © 2026 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package config
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+)
+
+const (
+	VPCNetworkConfigAnnotation = "nsx.vmware.com/vpc_network_config"
+
+	supervisorCapabilitiesName = "supervisor-capabilities"
+)
+
+var (
+	supervisorCapabilitiesGVR = schema.GroupVersionResource{
+		Group:    "iaas.vmware.com",
+		Version:  "v1alpha1",
+		Resource: "supervisorcapabilities",
+	}
+
+	stateMu                        sync.RWMutex
+	hasT1Namespaces                bool
+	hasVPCNamespaces               bool
+	perNamespaceProvidersSupported *bool
+	stateInitialized               bool
+
+	// retryInitialInterval and retryMaxInterval control the exponential
+	// backoff used when a transient error prevents reading
+	// SupervisorCapabilities or listing namespaces. Overridable in tests.
+	retryInitialInterval = 2 * time.Second
+	retryMaxInterval     = 30 * time.Second
+
+	// storedClientset is kept from InitMixedMode so that RefreshMixedModeState
+	// can re-scan without requiring the caller to pass it each time.
+	storedClientset kubernetes.Interface
+
+	// namespaceRefreshReader, when non-nil, is used by RefreshMixedModeState to list
+	// namespaces from the controller-runtime cache (mgr.GetClient()) instead of
+	// a direct API list on storedClientset — reducing apiserver load on the 30s
+	// refresh ticker. Set via SetMixedModeNamespaceRefreshReader from cmd after
+	// controllers are registered on the manager.
+	namespaceRefreshReader client.Reader
+	refreshReaderMu        sync.RWMutex
+)
+
+var log = logger.Log
+
+// checkPerNamespaceProvidersSupported fetches the SupervisorCapabilities object and
+// returns whether per-namespace network providers are activated. It retries
+// all errors with exponential backoff (starting at retryInitialInterval,
+// doubling each attempt, capped at retryMaxInterval). The SupervisorCapabilities
+// CR is guaranteed to exist; all failures are treated as transient (e.g. API
+// server not yet ready at operator startup). Returns false only when the
+// context is cancelled.
+func checkPerNamespaceProvidersSupported(ctx context.Context, dynClient dynamic.Interface) bool {
+	interval := retryInitialInterval
+	for {
+		obj, err := dynClient.Resource(supervisorCapabilitiesGVR).Get(
+			ctx, supervisorCapabilitiesName, metav1.GetOptions{})
+		if err == nil {
+			return extractCapability(obj)
+		}
+		log.Info("Failed to get SupervisorCapabilities, will retry", "error", err, "retryIn", interval)
+		select {
+		case <-ctx.Done():
+			log.Info("Context cancelled while waiting for SupervisorCapabilities, falling back to legacy config")
+			return false
+		case <-time.After(interval):
+		}
+		interval = min(interval*2, retryMaxInterval)
+	}
+}
+
+func extractCapability(obj *unstructured.Unstructured) bool {
+	status, found, err := unstructured.NestedMap(obj.Object, "status")
+	if err != nil || !found {
+		return false
+	}
+	services, found, err := unstructured.NestedMap(status, "services")
+	if err != nil || !found {
+		return false
+	}
+	for _, svcCaps := range services {
+		capsMap, ok := svcCaps.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		cap, ok := capsMap["supports_per_namespace_network_providers"]
+		if !ok {
+			continue
+		}
+		capMap, ok := cap.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		activated, ok := capMap["activated"]
+		if ok {
+			if b, ok := activated.(bool); ok && b {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func namespaceHasVPCNetworkConfig(ns *v1.Namespace) bool {
+	if ns == nil {
+		return false
+	}
+	v := strings.TrimSpace(ns.Annotations[VPCNetworkConfigAnnotation])
+	return v != ""
+}
+
+func accumulateMixedModeFlagsFromNamespaces(items []v1.Namespace) (hasT1 bool, hasVPC bool) {
+	for i := range items {
+		if namespaceHasVPCNetworkConfig(&items[i]) {
+			hasVPC = true
+		} else {
+			hasT1 = true
+		}
+	}
+	return hasT1, hasVPC
+}
+
+func scanNamespaceProviders(ctx context.Context, clientset kubernetes.Interface) (hasT1 bool, hasVPC bool, err error) {
+	nsList, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, false, err
+	}
+	hasT1, hasVPC = accumulateMixedModeFlagsFromNamespaces(nsList.Items)
+	return hasT1, hasVPC, nil
+}
+
+func scanNamespaceProvidersWithClient(ctx context.Context, reader client.Reader) (hasT1 bool, hasVPC bool, err error) {
+	nsList := &v1.NamespaceList{}
+	if err := reader.List(ctx, nsList); err != nil {
+		return false, false, err
+	}
+	hasT1, hasVPC = accumulateMixedModeFlagsFromNamespaces(nsList.Items)
+	return hasT1, hasVPC, nil
+}
+
+// SetMixedModeNamespaceRefreshReader registers a cache-backed client.Reader
+// (typically mgr.GetClient()) for periodic mixed-mode rescans. When nil,
+// RefreshMixedModeState keeps using the kubernetes.Interface from InitMixedMode.
+// Call once from cmd after controllers are set up on the manager.
+func SetMixedModeNamespaceRefreshReader(r client.Reader) {
+	refreshReaderMu.Lock()
+	defer refreshReaderMu.Unlock()
+	namespaceRefreshReader = r
+}
+
+func currentNamespaceRefreshReader() client.Reader {
+	refreshReaderMu.RLock()
+	defer refreshReaderMu.RUnlock()
+	return namespaceRefreshReader
+}
+
+// waitForNamespaceProviders retries scanNamespaceProviders with exponential
+// backoff on transient errors (e.g. API server not yet ready at operator startup).
+func waitForNamespaceProviders(ctx context.Context, clientset kubernetes.Interface) (bool, bool) {
+	interval := retryInitialInterval
+	for {
+		hasT1, hasVPC, err := scanNamespaceProviders(ctx, clientset)
+		if err == nil {
+			return hasT1, hasVPC
+		}
+		log.Warn("Failed to list namespaces for mixed-mode scan, will retry", "error", err, "retryIn", interval)
+		select {
+		case <-ctx.Done():
+			log.Info("Context cancelled during mixed-mode namespace scan, returning empty state")
+			return false, false
+		case <-time.After(interval):
+		}
+		interval = min(interval*2, retryMaxInterval)
+	}
+}
+
+// InitMixedMode initializes mixed-mode state by checking SupervisorCapabilities
+// and scanning namespaces (non-empty nsx.vmware.com/vpc_network_config to VPC,
+// otherwise T1 for mixed-mode aggregation). If per-namespace providers are not
+// activated, falls back to the legacy EnableVPCNetwork flag.
+//
+// The SupervisorCapabilities lookup is performed outside the state mutex so
+// that transient API errors can be retried without blocking readers for an
+// extended period.
+func InitMixedMode(ctx context.Context, cfg *rest.Config, enableVPCNetwork bool) error {
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	initMixedModeWithClients(ctx, clientset, dynClient, enableVPCNetwork)
+	return nil
+}
+
+func initMixedModeWithClients(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface, enableVPCNetwork bool) {
+	// checkPerNamespaceProvidersSupported retries on transient errors; runs outside
+	// the mutex to avoid holding the lock during potentially many retries.
+	supported := checkPerNamespaceProvidersSupported(ctx, dynClient)
+
+	var t1, vpc bool
+	if supported {
+		log.Info("Per-namespace network providers are supported, scanning namespaces for mixed-mode")
+		t1, vpc = waitForNamespaceProviders(ctx, clientset)
+	} else {
+		log.Info("Per-namespace network providers not supported, using legacy config", "enableVPCNetwork", enableVPCNetwork)
+		if enableVPCNetwork {
+			t1, vpc = false, true
+		} else {
+			t1, vpc = true, false
+		}
+	}
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	storedClientset = clientset
+	perNamespaceProvidersSupported = &supported
+	hasT1Namespaces = t1
+	hasVPCNamespaces = vpc
+	stateInitialized = true
+	log.Info("Mixed-mode state initialized", "hasT1Namespaces", t1, "hasVPCNamespaces", vpc)
+}
+
+// RefreshMixedModeState re-scans namespaces using the clientset stored during
+// InitMixedMode and updates the global state. Returns true if the state
+// changed; the caller should then restart the operator so that VPC services
+// and controllers are initialized for the new mode.
+func RefreshMixedModeState(ctx context.Context) bool {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	if perNamespaceProvidersSupported == nil || !*perNamespaceProvidersSupported {
+		return false
+	}
+	if storedClientset == nil {
+		return false
+	}
+
+	oldT1, oldVPC := hasT1Namespaces, hasVPCNamespaces
+	var newT1, newVPC bool
+	var err error
+	if r := currentNamespaceRefreshReader(); r != nil {
+		newT1, newVPC, err = scanNamespaceProvidersWithClient(ctx, r)
+	} else {
+		newT1, newVPC, err = scanNamespaceProviders(ctx, storedClientset)
+	}
+	if err != nil {
+		log.Warn("Failed to scan namespaces during mixed-mode refresh, keeping current state", "error", err)
+		return false
+	}
+	hasT1Namespaces = newT1
+	hasVPCNamespaces = newVPC
+
+	changed := oldT1 != hasT1Namespaces || oldVPC != hasVPCNamespaces
+	if changed {
+		log.Info("Mixed-mode state changed",
+			"oldHasT1Namespaces", oldT1, "hasT1Namespaces", hasT1Namespaces,
+			"oldHasVPCNamespaces", oldVPC, "hasVPCNamespaces", hasVPCNamespaces)
+	}
+	return changed
+}
+
+// HasT1Namespaces returns true when at least one namespace uses T1 networking.
+func HasT1Namespaces() bool {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return hasT1Namespaces
+}
+
+// HasVPCNamespaces returns true when at least one namespace uses VPC (or VDS in migration).
+func HasVPCNamespaces() bool {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return hasVPCNamespaces
+}
+
+// IsMixedModeStateInitialized returns true after InitMixedMode has been called.
+func IsMixedModeStateInitialized() bool {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return stateInitialized
+}
+
+// SetMixedModeStateForTest sets hasT1Namespaces and hasVPCNamespaces for unit tests.
+// Must only be used from test code so production always goes through InitMixedMode.
+func SetMixedModeStateForTest(hasT1, hasVPC bool) {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	hasT1Namespaces = hasT1
+	hasVPCNamespaces = hasVPC
+	stateInitialized = true
+}
+
+// IsPerNamespaceProvidersSupported returns true when SupervisorCapabilities
+// advertises per-namespace network providers.
+func IsPerNamespaceProvidersSupported() bool {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return perNamespaceProvidersSupported != nil && *perNamespaceProvidersSupported
+}

--- a/pkg/config/mixed_mode.go
+++ b/pkg/config/mixed_mode.go
@@ -1,0 +1,383 @@
+/* Copyright © 2026 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package config
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+)
+
+const (
+	capabilitiesName = "supervisor-capabilities"
+)
+
+var (
+	capabilitiesGVR = schema.GroupVersionResource{
+		Group:    "iaas.vmware.com",
+		Version:  "v1alpha1",
+		Resource: "capabilities",
+	}
+	networkSettingsGVR = schema.GroupVersionResource{
+		Group:    "netoperator.vmware.com",
+		Version:  "v1alpha1",
+		Resource: "networksettings",
+	}
+
+	stateMu                        sync.RWMutex
+	hasT1Namespaces                bool
+	hasVPCNamespaces               bool
+	hasVDSNamespaces               bool
+	perNamespaceProvidersSupported *bool
+	stateInitialized               bool
+
+	// retryInitialInterval and retryMaxInterval control the exponential
+	// backoff used when a transient error prevents reading
+	// Capabilities or listing namespaces. Overridable in tests.
+	retryInitialInterval = 2 * time.Second
+	retryMaxInterval     = 30 * time.Second
+
+	// storedDynClient and storedEnableVPCNetwork are kept from InitMixedMode so that
+	// RefreshMixedModeState can re-scan without requiring the caller to pass them each time.
+	storedDynClient        dynamic.Interface
+	storedEnableVPCNetwork bool
+
+	// namespaceRefreshReader, when non-nil, is used by RefreshMixedModeState to list
+	// namespaces from the controller-runtime cache (mgr.GetClient()) instead of
+	// a direct API list on storedClientset — reducing apiserver load on the 30s
+	// refresh ticker. Set via SetMixedModeNamespaceRefreshReader from cmd after
+	// controllers are registered on the manager.
+	namespaceRefreshReader client.Reader
+	refreshReaderMu        sync.RWMutex
+)
+
+var log = logger.Log
+
+// checkPerNamespaceProvidersSupported fetches the Capabilities object and
+// returns whether per-namespace network providers are activated. It retries
+// all errors with exponential backoff (starting at retryInitialInterval,
+// doubling each attempt, capped at retryMaxInterval). The Capabilities
+// CR is guaranteed to exist; all failures are treated as transient (e.g. API
+// server not yet ready at operator startup). Returns false only when the
+// context is cancelled.
+func checkPerNamespaceProvidersSupported(ctx context.Context, dynClient dynamic.Interface) (bool, error) {
+	interval := retryInitialInterval
+	for {
+		obj, err := dynClient.Resource(capabilitiesGVR).Get(
+			ctx, capabilitiesName, metav1.GetOptions{})
+		if err == nil {
+			return extractCapability(obj), nil
+		}
+		log.Info("Failed to get Capabilities, will retry", "error", err, "retryIn", interval)
+		select {
+		case <-ctx.Done():
+			log.Info("Context cancelled while waiting for Capabilities, falling back to legacy config")
+			return false, ctx.Err()
+		case <-time.After(interval):
+		}
+		interval = min(interval*2, retryMaxInterval)
+	}
+}
+
+func extractCapability(obj *unstructured.Unstructured) bool {
+	status, found, err := unstructured.NestedMap(obj.Object, "status")
+	if err != nil || !found {
+		return false
+	}
+	supervisor, found, err := unstructured.NestedMap(status, "supervisor")
+	if err != nil || !found {
+		return false
+	}
+	cap, ok := supervisor["supports_per_namespace_network_provider"]
+	if !ok {
+		return false
+	}
+	capMap, ok := cap.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	activated, ok := capMap["activated"]
+	if ok {
+		if b, ok := activated.(bool); ok && b {
+			return true
+		}
+	}
+	return false
+}
+
+func parseProvidersFromList(items []unstructured.Unstructured) (hasT1 bool, hasVPC bool, hasVDS bool) {
+	for _, item := range items {
+		provider, _, _ := unstructured.NestedString(item.Object, "provider")
+		switch provider {
+		case "nsx-tier1":
+			hasT1 = true
+		case "vpc":
+			hasVPC = true
+		case "vsphere-distributed":
+			hasVDS = true
+		}
+		if hasT1 && hasVPC && hasVDS {
+			break
+		}
+	}
+	return hasT1, hasVPC, hasVDS
+}
+
+// scanNamespaceProvidersFromAPI uses dynamic.Interface to directly list NetworkSettings
+// from the API Server. Used during initialization before Informer caches are ready.
+func scanNamespaceProvidersFromAPI(ctx context.Context, dynClient dynamic.Interface) (hasT1 bool, hasVPC bool, hasVDS bool, err error) {
+	if dynClient != nil {
+		list, err := dynClient.Resource(networkSettingsGVR).List(ctx, metav1.ListOptions{})
+		if err == nil && len(list.Items) > 0 {
+			t1, vpc, vds := parseProvidersFromList(list.Items)
+			return t1, vpc, vds, nil
+		} else if err != nil {
+			log.V(1).Info("Failed to list NetworkSettings", "error", err)
+			return false, false, false, err
+		}
+	}
+	return false, false, false, nil
+}
+
+// scanNamespaceProvidersFromCache uses controller-runtime client.Reader to list NetworkSettings
+// from the local Informer cache. Used during periodic refresh to avoid API Server load.
+func scanNamespaceProvidersFromCache(ctx context.Context, reader client.Reader) (hasT1 bool, hasVPC bool, hasVDS bool, err error) {
+	nsList := &unstructured.UnstructuredList{}
+	nsList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "netoperator.vmware.com",
+		Version: "v1alpha1",
+		Kind:    "NetworkSettingsList",
+	})
+	if err := reader.List(ctx, nsList); err == nil && len(nsList.Items) > 0 {
+		t1, vpc, vds := parseProvidersFromList(nsList.Items)
+		return t1, vpc, vds, nil
+	} else if err != nil {
+		log.V(1).Info("Failed to list NetworkSettings with reader", "error", err)
+		return false, false, false, err
+	}
+	return false, false, false, nil
+}
+
+// StartNetworkSettingsInformer registers a cache-backed client.Reader
+// (typically mgr.GetClient()) for periodic mixed-mode rescans and ensures
+// the required Informers are started.
+// Call once from cmd after controllers are set up on the manager.
+func StartNetworkSettingsInformer(mgr manager.Manager) {
+	if !IsPerNamespaceProvidersSupported() {
+		return
+	}
+
+	// Ensure NetworkSettings is cached in the controller-runtime manager and the
+	// informer is synced before enabling the cache reader. Until the reader is set,
+	// RefreshMixedModeState falls back to a direct API list, so a not-yet-synced
+	// cache cannot make refresh observe an empty NetworkSettings set and trigger a
+	// spurious mode change/restart.
+	go func() {
+		nsObj := &unstructured.Unstructured{}
+		nsObj.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "netoperator.vmware.com",
+			Version: "v1alpha1",
+			Kind:    "NetworkSettings",
+		})
+		interval := retryInitialInterval
+		for {
+			informer, err := mgr.GetCache().GetInformer(context.TODO(), nsObj)
+			if err != nil {
+				log.Info("Failed to start informer for NetworkSettings, will retry", "error", err, "retryIn", interval)
+				time.Sleep(interval)
+				interval = min(interval*2, retryMaxInterval)
+				continue
+			}
+			if !informer.HasSynced() {
+				time.Sleep(time.Second)
+				continue
+			}
+			refreshReaderMu.Lock()
+			namespaceRefreshReader = mgr.GetClient()
+			refreshReaderMu.Unlock()
+			log.Info("Informer for NetworkSettings synced successfully; enabling cache reader")
+			break
+		}
+	}()
+}
+
+func currentNamespaceRefreshReader() client.Reader {
+	refreshReaderMu.RLock()
+	defer refreshReaderMu.RUnlock()
+	return namespaceRefreshReader
+}
+
+// waitForNamespaceProviders retries scanNamespaceProvidersFromAPI with exponential
+// backoff on transient errors (e.g. API server not yet ready at operator startup).
+func waitForNamespaceProviders(ctx context.Context, dynClient dynamic.Interface) (bool, bool, bool) {
+	interval := retryInitialInterval
+	for {
+		hasT1, hasVPC, hasVDS, err := scanNamespaceProvidersFromAPI(ctx, dynClient)
+		if err == nil {
+			return hasT1, hasVPC, hasVDS
+		}
+		log.Info("Failed to list providers for mixed-mode scan, will retry", "error", err, "retryIn", interval)
+		select {
+		case <-ctx.Done():
+			log.Info("Context cancelled during mixed-mode scan, returning empty state")
+			return false, false, false
+		case <-time.After(interval):
+		}
+		interval = min(interval*2, retryMaxInterval)
+	}
+}
+
+// InitMixedMode initializes mixed-mode state by checking Capabilities
+// and scanning NetworkSettings CRs for T1, VPC, and VDS network providers.
+// If per-namespace providers are not activated, falls back to the legacy EnableVPCNetwork flag.
+//
+// The Capabilities lookup is performed outside the state mutex so
+// that transient API errors can be retried without blocking readers for an
+// extended period.
+func InitMixedMode(ctx context.Context, cfg *rest.Config, enableVPCNetwork bool) error {
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	initMixedModeWithClients(ctx, dynClient, enableVPCNetwork)
+	return nil
+}
+
+func initMixedModeWithClients(ctx context.Context, dynClient dynamic.Interface, enableVPCNetwork bool) {
+	// checkPerNamespaceProvidersSupported retries on transient errors; runs outside
+	// the mutex to avoid holding the lock during potentially many retries.
+	supported, _ := checkPerNamespaceProvidersSupported(ctx, dynClient)
+
+	var t1, vpc, vds bool
+	if supported {
+		log.Info("Per-namespace network providers are supported, scanning namespaces for mixed-mode")
+		t1, vpc, vds = waitForNamespaceProviders(ctx, dynClient)
+		if enableVPCNetwork {
+			vpc = true
+		}
+	} else {
+		log.Info("Per-namespace network providers not supported, using legacy config", "enableVPCNetwork", enableVPCNetwork)
+		if enableVPCNetwork {
+			t1, vpc, vds = false, true, false
+		} else {
+			t1, vpc, vds = true, false, false
+		}
+	}
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	storedDynClient = dynClient
+	storedEnableVPCNetwork = enableVPCNetwork
+	// The capability can be changed in day2. However, we intentionally do NOT poll or watch this capability during runtime to save API Server overhead.
+	// By design, if it changes from deactivated to activated, an external component will restart the nsx-operator pod; changing from activated to deactivated is not a valid scenario.
+	perNamespaceProvidersSupported = &supported
+	hasT1Namespaces = t1
+	hasVPCNamespaces = vpc
+	hasVDSNamespaces = vds
+	stateInitialized = true
+	log.Info("Mixed-mode state initialized", "hasT1Namespaces", t1, "hasVPCNamespaces", vpc, "hasVDSNamespaces", vds)
+}
+
+// RefreshMixedModeState re-scans namespaces using the dynamic client stored during
+// InitMixedMode and updates the global state. Returns true if the state
+// changed; the caller should then restart the operator so that VPC services
+// and controllers are initialized for the new mode.
+func RefreshMixedModeState(ctx context.Context) bool {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	if storedDynClient == nil {
+		log.V(1).Info("Skipping mixed-mode refresh: storedDynClient is nil")
+		return false
+	}
+
+	if perNamespaceProvidersSupported != nil && !*perNamespaceProvidersSupported {
+		log.V(1).Info("Skipping mixed-mode refresh: per-namespace network providers are not supported")
+		return false
+	}
+
+	oldT1, oldVPC, oldVDS := hasT1Namespaces, hasVPCNamespaces, hasVDSNamespaces
+	var newT1, newVPC, newVDS bool
+	var err error
+	if r := currentNamespaceRefreshReader(); r != nil {
+		newT1, newVPC, newVDS, err = scanNamespaceProvidersFromCache(ctx, r)
+	} else {
+		newT1, newVPC, newVDS, err = scanNamespaceProvidersFromAPI(ctx, storedDynClient)
+	}
+	if storedEnableVPCNetwork {
+		newVPC = true
+	}
+	if err != nil {
+		log.Warn("Failed to scan namespaces during mixed-mode refresh, keeping current state", "error", err)
+		return false
+	}
+	hasT1Namespaces = newT1
+	hasVPCNamespaces = newVPC
+	hasVDSNamespaces = newVDS
+
+	changed := oldT1 != hasT1Namespaces || oldVPC != hasVPCNamespaces || oldVDS != hasVDSNamespaces
+	if changed {
+		log.Info("Mixed-mode state changed",
+			"oldT1", oldT1, "newT1", hasT1Namespaces,
+			"oldVPC", oldVPC, "newVPC", hasVPCNamespaces,
+			"oldVDS", oldVDS, "newVDS", hasVDSNamespaces)
+	}
+	return changed
+}
+
+// HasT1Namespaces returns true when at least one NetworkSettings CR uses T1.
+func HasT1Namespaces() bool {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return hasT1Namespaces
+}
+
+// HasVPCNamespaces returns true when enable_vpc_network is true or at least one NetworkSettings CR uses VPC.
+func HasVPCNamespaces() bool {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return hasVPCNamespaces
+}
+
+// HasVDSNamespaces returns true when at least one NetworkSettings CR uses VDS.
+func HasVDSNamespaces() bool {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return hasVDSNamespaces
+}
+
+// IsMixedModeStateInitialized returns true after InitMixedMode has been called.
+func IsMixedModeStateInitialized() bool {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return stateInitialized
+}
+
+// SetMixedModeStateForTest sets hasT1Namespaces and hasVPCNamespaces for unit tests.
+// Must only be used from test code so production always goes through InitMixedMode.
+func SetMixedModeStateForTest(hasT1, hasVPC bool) {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	hasT1Namespaces = hasT1
+	hasVPCNamespaces = hasVPC
+	hasVDSNamespaces = false
+	stateInitialized = true
+}
+
+// IsPerNamespaceProvidersSupported returns true when Capabilities
+// advertises per-namespace network providers.
+func IsPerNamespaceProvidersSupported() bool {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return perNamespaceProvidersSupported != nil && *perNamespaceProvidersSupported
+}

--- a/pkg/config/mixed_mode_test.go
+++ b/pkg/config/mixed_mode_test.go
@@ -1,0 +1,588 @@
+/* Copyright © 2026 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	k8stesting "k8s.io/client-go/testing"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// resetMixedModeState resets all global mixed-mode state for test isolation.
+func resetMixedModeState() {
+	refreshReaderMu.Lock()
+	namespaceRefreshReader = nil
+	refreshReaderMu.Unlock()
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	hasT1Namespaces = false
+	hasVPCNamespaces = false
+	perNamespaceProvidersSupported = nil
+	stateInitialized = false
+	storedClientset = nil
+}
+
+// makeCapabilitiesObj builds an unstructured SupervisorCapabilities object
+// with the given supports_per_namespace_network_providers.activated value.
+func makeCapabilitiesObj(activated bool) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "iaas.vmware.com/v1alpha1",
+			"kind":       "SupervisorCapabilities",
+			"metadata": map[string]interface{}{
+				"name": supervisorCapabilitiesName,
+			},
+			"status": map[string]interface{}{
+				"services": map[string]interface{}{
+					"wcp": map[string]interface{}{
+						"supports_per_namespace_network_providers": map[string]interface{}{
+							"activated": activated,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// makeDynClientWith returns a fake dynamic client pre-seeded with a
+// SupervisorCapabilities object whose activated flag is set as specified.
+func makeDynClientWith(activated bool) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	fc := dynamicfake.NewSimpleDynamicClient(scheme)
+	obj := makeCapabilitiesObj(activated)
+	if err := fc.Tracker().Create(supervisorCapabilitiesGVR, obj, ""); err != nil {
+		panic(fmt.Sprintf("test setup: could not seed capabilities object: %v", err))
+	}
+	return fc
+}
+
+// makeNamespace creates a Namespace. If vpcNetworkConfigValue is non-empty
+// (after trim), the namespace is treated as VPC for mixed-mode discovery;
+// otherwise it counts as T1.
+func makeNamespace(name, vpcNetworkConfigValue string) *v1.Namespace {
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if strings.TrimSpace(vpcNetworkConfigValue) != "" {
+		ns.Annotations = map[string]string{
+			VPCNetworkConfigAnnotation: vpcNetworkConfigValue,
+		}
+	}
+	return ns
+}
+
+// ---------- extractCapability ----------
+
+func TestExtractCapability(t *testing.T) {
+	tests := []struct {
+		name   string
+		obj    *unstructured.Unstructured
+		expect bool
+	}{
+		{
+			name:   "no status field",
+			obj:    &unstructured.Unstructured{Object: map[string]interface{}{}},
+			expect: false,
+		},
+		{
+			name: "status without services",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{},
+			}},
+			expect: false,
+		},
+		{
+			name: "services map is empty",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"services": map[string]interface{}{},
+				},
+			}},
+			expect: false,
+		},
+		{
+			name: "service has no matching capability key",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"services": map[string]interface{}{
+						"wcp": map[string]interface{}{
+							"other_capability": map[string]interface{}{"activated": true},
+						},
+					},
+				},
+			}},
+			expect: false,
+		},
+		{
+			name:   "capability activated=false",
+			obj:    makeCapabilitiesObj(false),
+			expect: false,
+		},
+		{
+			name:   "capability activated=true",
+			obj:    makeCapabilitiesObj(true),
+			expect: true,
+		},
+		{
+			name: "activated is not a bool",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"services": map[string]interface{}{
+						"wcp": map[string]interface{}{
+							"supports_per_namespace_network_providers": map[string]interface{}{
+								"activated": "yes",
+							},
+						},
+					},
+				},
+			}},
+			expect: false,
+		},
+		{
+			name: "capability field is not a map",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"services": map[string]interface{}{
+						"wcp": map[string]interface{}{
+							"supports_per_namespace_network_providers": "true",
+						},
+					},
+				},
+			}},
+			expect: false,
+		},
+		{
+			name: "service entry is not a map",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"services": map[string]interface{}{
+						"wcp": "not-a-map",
+					},
+				},
+			}},
+			expect: false,
+		},
+		{
+			name: "multiple services, second has activated=true",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"services": map[string]interface{}{
+						"svc-a": map[string]interface{}{
+							"supports_per_namespace_network_providers": map[string]interface{}{
+								"activated": false,
+							},
+						},
+						"svc-b": map[string]interface{}{
+							"supports_per_namespace_network_providers": map[string]interface{}{
+								"activated": true,
+							},
+						},
+					},
+				},
+			}},
+			expect: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, extractCapability(tt.obj))
+		})
+	}
+}
+
+// ---------- checkPerNamespaceProvidersSupported ----------
+
+func TestCheckPerNamespaceProvidersSupported(t *testing.T) {
+	ctx := context.Background()
+
+	// Speed up retries so tests complete in milliseconds.
+	origInit, origMax := retryInitialInterval, retryMaxInterval
+	retryInitialInterval = 1 * time.Millisecond
+	retryMaxInterval = 4 * time.Millisecond
+	defer func() { retryInitialInterval, retryMaxInterval = origInit, origMax }()
+
+	t.Run("returns immediately on success (activated=true)", func(t *testing.T) {
+		assert.True(t, checkPerNamespaceProvidersSupported(ctx, makeDynClientWith(true)))
+	})
+
+	t.Run("returns immediately on success (activated=false)", func(t *testing.T) {
+		assert.False(t, checkPerNamespaceProvidersSupported(ctx, makeDynClientWith(false)))
+	})
+
+	t.Run("retries on transient error and eventually succeeds", func(t *testing.T) {
+		scheme := runtime.NewScheme()
+		dynClient := dynamicfake.NewSimpleDynamicClient(scheme)
+		callCount := 0
+		dynClient.PrependReactor("get", "*", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			callCount++
+			if callCount < 3 {
+				return true, nil, fmt.Errorf("transient error %d", callCount)
+			}
+			return true, makeCapabilitiesObj(true), nil
+		})
+		result := checkPerNamespaceProvidersSupported(ctx, dynClient)
+		assert.True(t, result)
+		assert.Equal(t, 3, callCount)
+	})
+
+	t.Run("returns false on context cancellation during retry", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		scheme := runtime.NewScheme()
+		dynClient := dynamicfake.NewSimpleDynamicClient(scheme)
+		dynClient.PrependReactor("get", "*", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			cancel()
+			return true, nil, fmt.Errorf("still failing")
+		})
+		result := checkPerNamespaceProvidersSupported(cancelCtx, dynClient)
+		assert.False(t, result)
+	})
+}
+
+// ---------- waitForNamespaceProviders ----------
+
+func TestWaitForNamespaceProviders(t *testing.T) {
+	ctx := context.Background()
+
+	// Speed up retries so tests complete in milliseconds.
+	origInit, origMax := retryInitialInterval, retryMaxInterval
+	retryInitialInterval = 1 * time.Millisecond
+	retryMaxInterval = 4 * time.Millisecond
+	defer func() { retryInitialInterval, retryMaxInterval = origInit, origMax }()
+
+	t.Run("returns immediately on success", func(t *testing.T) {
+		cs := kubefake.NewClientset(
+			makeNamespace("ns-t1", ""),
+			makeNamespace("ns-vpc", "default"),
+		)
+		hasT1, hasVPC := waitForNamespaceProviders(ctx, cs)
+		assert.True(t, hasT1)
+		assert.True(t, hasVPC)
+	})
+
+	t.Run("retries on transient error and eventually succeeds", func(t *testing.T) {
+		cs := kubefake.NewClientset(makeNamespace("ns-t1", ""))
+		callCount := 0
+		cs.PrependReactor("list", "namespaces", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			callCount++
+			if callCount < 3 {
+				return true, nil, fmt.Errorf("list failed %d", callCount)
+			}
+			return false, nil, nil // fall through to real clientset
+		})
+		hasT1, hasVPC := waitForNamespaceProviders(ctx, cs)
+		assert.True(t, hasT1)
+		assert.False(t, hasVPC)
+		assert.Equal(t, 3, callCount)
+	})
+
+	t.Run("returns false false on context cancellation", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		cs := kubefake.NewClientset()
+		cs.PrependReactor("list", "namespaces", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			cancel()
+			return true, nil, fmt.Errorf("still failing")
+		})
+		hasT1, hasVPC := waitForNamespaceProviders(cancelCtx, cs)
+		assert.False(t, hasT1)
+		assert.False(t, hasVPC)
+	})
+}
+
+// ---------- scanNamespaceProviders ----------
+
+func TestScanNamespaceProviders(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("error listing namespaces returns error", func(t *testing.T) {
+		cs := kubefake.NewClientset()
+		cs.PrependReactor("list", "namespaces", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("apiserver unavailable")
+		})
+		hasT1, hasVPC, err := scanNamespaceProviders(ctx, cs)
+		assert.False(t, hasT1)
+		assert.False(t, hasVPC)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty namespace list returns false false no error", func(t *testing.T) {
+		hasT1, hasVPC, err := scanNamespaceProviders(ctx, kubefake.NewClientset())
+		assert.False(t, hasT1)
+		assert.False(t, hasVPC)
+		assert.NoError(t, err)
+	})
+
+	t.Run("T1-only namespace", func(t *testing.T) {
+		cs := kubefake.NewClientset(makeNamespace("ns-t1", ""))
+		hasT1, hasVPC, err := scanNamespaceProviders(ctx, cs)
+		assert.True(t, hasT1)
+		assert.False(t, hasVPC)
+		assert.NoError(t, err)
+	})
+
+	t.Run("VPC-only namespace", func(t *testing.T) {
+		cs := kubefake.NewClientset(makeNamespace("ns-vpc", "default"))
+		hasT1, hasVPC, err := scanNamespaceProviders(ctx, cs)
+		assert.False(t, hasT1)
+		assert.True(t, hasVPC)
+		assert.NoError(t, err)
+	})
+
+	t.Run("vsphere-style namespace without vpc annotation counts as T1", func(t *testing.T) {
+		cs := kubefake.NewClientset(makeNamespace("ns-vsphere", ""))
+		hasT1, hasVPC, err := scanNamespaceProviders(ctx, cs)
+		assert.True(t, hasT1)
+		assert.False(t, hasVPC)
+		assert.NoError(t, err)
+	})
+
+	t.Run("mixed T1 and VPC namespaces", func(t *testing.T) {
+		cs := kubefake.NewClientset(
+			makeNamespace("ns-t1", ""),
+			makeNamespace("ns-vpc", "default"),
+		)
+		hasT1, hasVPC, err := scanNamespaceProviders(ctx, cs)
+		assert.True(t, hasT1)
+		assert.True(t, hasVPC)
+		assert.NoError(t, err)
+	})
+
+	t.Run("plain namespace without vpc annotation counts as T1", func(t *testing.T) {
+		cs := kubefake.NewClientset(makeNamespace("ns-plain", ""))
+		hasT1, hasVPC, err := scanNamespaceProviders(ctx, cs)
+		assert.True(t, hasT1)
+		assert.False(t, hasVPC)
+		assert.NoError(t, err)
+	})
+}
+
+// ---------- scanNamespaceProvidersWithClient ----------
+
+func TestScanNamespaceProvidersWithClient(t *testing.T) {
+	ctx := context.Background()
+	cl := crfake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).WithObjects(
+		makeNamespace("ns-vpc", "default"),
+	).Build()
+	hasT1, hasVPC, err := scanNamespaceProvidersWithClient(ctx, cl)
+	assert.NoError(t, err)
+	assert.False(t, hasT1)
+	assert.True(t, hasVPC)
+}
+
+// ---------- InitMixedMode ----------
+
+func TestInitMixedModeWithClients(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("capability not activated enableVPCNetwork=true uses legacy config", func(t *testing.T) {
+		resetMixedModeState()
+		initMixedModeWithClients(ctx, kubefake.NewClientset(), makeDynClientWith(false), true)
+		assert.True(t, IsMixedModeStateInitialized())
+		assert.False(t, IsPerNamespaceProvidersSupported())
+		assert.True(t, HasVPCNamespaces())
+		assert.False(t, HasT1Namespaces())
+	})
+
+	t.Run("capability not activated enableVPCNetwork=false uses legacy config", func(t *testing.T) {
+		resetMixedModeState()
+		initMixedModeWithClients(ctx, kubefake.NewClientset(), makeDynClientWith(false), false)
+		assert.True(t, IsMixedModeStateInitialized())
+		assert.False(t, IsPerNamespaceProvidersSupported())
+		assert.False(t, HasVPCNamespaces())
+		assert.True(t, HasT1Namespaces())
+	})
+
+	t.Run("per-namespace supported scans namespaces for mixed-mode", func(t *testing.T) {
+		resetMixedModeState()
+		cs := kubefake.NewClientset(
+			makeNamespace("ns-t1", ""),
+			makeNamespace("ns-vpc", "default"),
+		)
+		initMixedModeWithClients(ctx, cs, makeDynClientWith(true), false)
+		assert.True(t, IsMixedModeStateInitialized())
+		assert.True(t, IsPerNamespaceProvidersSupported())
+		assert.True(t, HasT1Namespaces())
+		assert.True(t, HasVPCNamespaces())
+	})
+
+	t.Run("per-namespace supported but no namespaces", func(t *testing.T) {
+		resetMixedModeState()
+		initMixedModeWithClients(ctx, kubefake.NewClientset(), makeDynClientWith(true), true)
+		assert.True(t, IsMixedModeStateInitialized())
+		assert.True(t, IsPerNamespaceProvidersSupported())
+		assert.False(t, HasT1Namespaces())
+		assert.False(t, HasVPCNamespaces())
+	})
+}
+
+// ---------- RefreshMixedModeState ----------
+
+func TestRefreshMixedModeState(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns false when perNamespaceProvidersSupported is nil", func(t *testing.T) {
+		resetMixedModeState()
+		storedClientset = kubefake.NewClientset()
+		assert.False(t, RefreshMixedModeState(ctx))
+	})
+
+	t.Run("returns false when storedClientset is nil", func(t *testing.T) {
+		resetMixedModeState()
+		supported := true
+		stateMu.Lock()
+		perNamespaceProvidersSupported = &supported
+		stateMu.Unlock()
+		assert.False(t, RefreshMixedModeState(ctx))
+	})
+
+	t.Run("returns false when per-namespace providers not supported", func(t *testing.T) {
+		resetMixedModeState()
+		supported := false
+		stateMu.Lock()
+		perNamespaceProvidersSupported = &supported
+		storedClientset = kubefake.NewClientset()
+		stateMu.Unlock()
+		assert.False(t, RefreshMixedModeState(ctx))
+	})
+
+	t.Run("returns false when state is unchanged", func(t *testing.T) {
+		resetMixedModeState()
+		supported := true
+		stateMu.Lock()
+		perNamespaceProvidersSupported = &supported
+		hasT1Namespaces = true
+		hasVPCNamespaces = false
+		storedClientset = kubefake.NewClientset(makeNamespace("ns-t1", ""))
+		stateMu.Unlock()
+		assert.False(t, RefreshMixedModeState(ctx))
+		assert.True(t, HasT1Namespaces())
+		assert.False(t, HasVPCNamespaces())
+	})
+
+	t.Run("returns true when state changes", func(t *testing.T) {
+		resetMixedModeState()
+		supported := true
+		stateMu.Lock()
+		perNamespaceProvidersSupported = &supported
+		hasT1Namespaces = true
+		hasVPCNamespaces = false
+		storedClientset = kubefake.NewClientset(makeNamespace("ns-vpc", "default"))
+		stateMu.Unlock()
+		assert.True(t, RefreshMixedModeState(ctx))
+		assert.False(t, HasT1Namespaces())
+		assert.True(t, HasVPCNamespaces())
+	})
+
+	t.Run("returns true when new namespace added and state grows", func(t *testing.T) {
+		resetMixedModeState()
+		supported := true
+		stateMu.Lock()
+		perNamespaceProvidersSupported = &supported
+		storedClientset = kubefake.NewClientset(
+			makeNamespace("ns-t1", ""),
+			makeNamespace("ns-vpc", "default"),
+		)
+		stateMu.Unlock()
+		assert.True(t, RefreshMixedModeState(ctx))
+		assert.True(t, HasT1Namespaces())
+		assert.True(t, HasVPCNamespaces())
+	})
+
+	t.Run("namespace list error preserves old state and returns false", func(t *testing.T) {
+		resetMixedModeState()
+		supported := true
+		stateMu.Lock()
+		perNamespaceProvidersSupported = &supported
+		hasT1Namespaces = true
+		hasVPCNamespaces = false
+		cs := kubefake.NewClientset()
+		cs.PrependReactor("list", "namespaces", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("list failed")
+		})
+		storedClientset = cs
+		stateMu.Unlock()
+		assert.False(t, RefreshMixedModeState(ctx))
+		// State must be preserved despite the error.
+		assert.True(t, HasT1Namespaces())
+		assert.False(t, HasVPCNamespaces())
+	})
+
+	t.Run("uses cache-backed reader when set (clientset would miss the namespace)", func(t *testing.T) {
+		resetMixedModeState()
+		supported := true
+		stateMu.Lock()
+		perNamespaceProvidersSupported = &supported
+		hasT1Namespaces = true
+		hasVPCNamespaces = false
+		// Empty clientset: only the cache reader sees the test namespace.
+		storedClientset = kubefake.NewClientset()
+		stateMu.Unlock()
+		cl := crfake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).WithObjects(
+			makeNamespace("ns-vpc", "default"),
+		).Build()
+		SetMixedModeNamespaceRefreshReader(cl)
+		t.Cleanup(func() { SetMixedModeNamespaceRefreshReader(nil) })
+		assert.True(t, RefreshMixedModeState(ctx))
+		assert.False(t, HasT1Namespaces())
+		assert.True(t, HasVPCNamespaces())
+	})
+}
+
+// ---------- Getters and SetMixedModeStateForTest ----------
+
+func TestGettersAndSetMixedModeStateForTest(t *testing.T) {
+	t.Run("SetMixedModeStateForTest sets T1=true VPC=false", func(t *testing.T) {
+		SetMixedModeStateForTest(true, false)
+		assert.True(t, HasT1Namespaces())
+		assert.False(t, HasVPCNamespaces())
+		assert.True(t, IsMixedModeStateInitialized())
+	})
+
+	t.Run("SetMixedModeStateForTest sets T1=false VPC=true", func(t *testing.T) {
+		SetMixedModeStateForTest(false, true)
+		assert.False(t, HasT1Namespaces())
+		assert.True(t, HasVPCNamespaces())
+		assert.True(t, IsMixedModeStateInitialized())
+	})
+
+	t.Run("IsPerNamespaceProvidersSupported false when nil", func(t *testing.T) {
+		resetMixedModeState()
+		assert.False(t, IsPerNamespaceProvidersSupported())
+	})
+
+	t.Run("IsPerNamespaceProvidersSupported false when explicitly false", func(t *testing.T) {
+		resetMixedModeState()
+		supported := false
+		stateMu.Lock()
+		perNamespaceProvidersSupported = &supported
+		stateMu.Unlock()
+		assert.False(t, IsPerNamespaceProvidersSupported())
+	})
+
+	t.Run("IsPerNamespaceProvidersSupported true when set", func(t *testing.T) {
+		resetMixedModeState()
+		supported := true
+		stateMu.Lock()
+		perNamespaceProvidersSupported = &supported
+		stateMu.Unlock()
+		assert.True(t, IsPerNamespaceProvidersSupported())
+	})
+
+	t.Run("IsMixedModeStateInitialized false before init", func(t *testing.T) {
+		resetMixedModeState()
+		assert.False(t, IsMixedModeStateInitialized())
+	})
+}

--- a/pkg/config/mixed_mode_test.go
+++ b/pkg/config/mixed_mode_test.go
@@ -1,0 +1,529 @@
+/* Copyright © 2026 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package config
+
+import (
+	"testing"
+
+	"context"
+	"time"
+
+	"errors"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// makeCapabilitiesObj builds an unstructured Capabilities object
+// with the given supports_per_namespace_network_provider.activated value.
+func makeCapabilitiesObj(activated bool) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "iaas.vmware.com/v1alpha1",
+			"kind":       "Capabilities",
+			"metadata": map[string]interface{}{
+				"name": capabilitiesName,
+			},
+			"status": map[string]interface{}{
+				"supervisor": map[string]interface{}{
+					"supports_per_namespace_network_provider": map[string]interface{}{
+						"activated": activated,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestExtractCapability(t *testing.T) {
+	tests := []struct {
+		name   string
+		obj    *unstructured.Unstructured
+		expect bool
+	}{
+		{
+			name:   "no status field",
+			obj:    &unstructured.Unstructured{Object: map[string]interface{}{}},
+			expect: false,
+		},
+		{
+			name: "status without supervisor",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{},
+			}},
+			expect: false,
+		},
+		{
+			name: "supervisor map is empty",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"supervisor": map[string]interface{}{},
+				},
+			}},
+			expect: false,
+		},
+		{
+			name: "supervisor has no matching capability key",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"supervisor": map[string]interface{}{
+						"other_capability": map[string]interface{}{"activated": true},
+					},
+				},
+			}},
+			expect: false,
+		},
+		{
+			name:   "capability activated=false",
+			obj:    makeCapabilitiesObj(false),
+			expect: false,
+		},
+		{
+			name:   "capability activated=true",
+			obj:    makeCapabilitiesObj(true),
+			expect: true,
+		},
+		{
+			name: "activated is not a bool",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"supervisor": map[string]interface{}{
+						"supports_per_namespace_network_provider": map[string]interface{}{
+							"activated": "yes",
+						},
+					},
+				},
+			}},
+			expect: false,
+		},
+		{
+			name: "capability field is not a map",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"supervisor": map[string]interface{}{
+						"supports_per_namespace_network_provider": "true",
+					},
+				},
+			}},
+			expect: false,
+		},
+		{
+			name: "supervisor entry is not a map",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"supervisor": "not-a-map",
+				},
+			}},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, extractCapability(tt.obj))
+		})
+	}
+}
+
+func makeNetworkSettings(provider string) unstructured.Unstructured {
+	return unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"provider": provider,
+		},
+	}
+}
+
+func TestParseProvidersFromList(t *testing.T) {
+	tests := []struct {
+		name      string
+		items     []unstructured.Unstructured
+		expectT1  bool
+		expectVPC bool
+		expectVDS bool
+	}{
+		{
+			name:      "empty list",
+			items:     []unstructured.Unstructured{},
+			expectT1:  false,
+			expectVPC: false,
+			expectVDS: false,
+		},
+		{
+			name: "only T1",
+			items: []unstructured.Unstructured{
+				makeNetworkSettings("nsx-tier1"),
+			},
+			expectT1:  true,
+			expectVPC: false,
+			expectVDS: false,
+		},
+		{
+			name: "only VPC",
+			items: []unstructured.Unstructured{
+				makeNetworkSettings("vpc"),
+			},
+			expectT1:  false,
+			expectVPC: true,
+			expectVDS: false,
+		},
+		{
+			name: "only VDS",
+			items: []unstructured.Unstructured{
+				makeNetworkSettings("vsphere-distributed"),
+			},
+			expectT1:  false,
+			expectVPC: false,
+			expectVDS: true,
+		},
+		{
+			name: "mixed VPC and VDS",
+			items: []unstructured.Unstructured{
+				makeNetworkSettings("vpc"),
+				makeNetworkSettings("vsphere-distributed"),
+			},
+			expectT1:  false,
+			expectVPC: true,
+			expectVDS: true,
+		},
+		{
+			name: "unknown provider",
+			items: []unstructured.Unstructured{
+				makeNetworkSettings("unknown-provider"),
+			},
+			expectT1:  false,
+			expectVPC: false,
+			expectVDS: false,
+		},
+		{
+			name: "multiple same providers",
+			items: []unstructured.Unstructured{
+				makeNetworkSettings("vpc"),
+				makeNetworkSettings("vpc"),
+			},
+			expectT1:  false,
+			expectVPC: true,
+			expectVDS: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t1, vpc, vds := parseProvidersFromList(tt.items)
+			assert.Equal(t, tt.expectT1, t1)
+			assert.Equal(t, tt.expectVPC, vpc)
+			assert.Equal(t, tt.expectVDS, vds)
+		})
+	}
+}
+
+func TestStateGetters(t *testing.T) {
+	// reset state
+	stateMu.Lock()
+	hasT1Namespaces = false
+	hasVPCNamespaces = false
+	hasVDSNamespaces = false
+	perNamespaceProvidersSupported = nil
+	stateInitialized = false
+	stateMu.Unlock()
+
+	assert.False(t, HasT1Namespaces())
+	assert.False(t, HasVPCNamespaces())
+	assert.False(t, HasVDSNamespaces())
+	assert.False(t, IsMixedModeStateInitialized())
+	assert.False(t, IsPerNamespaceProvidersSupported())
+
+	SetMixedModeStateForTest(true, true)
+	assert.True(t, HasT1Namespaces())
+	assert.True(t, HasVPCNamespaces())
+	assert.False(t, HasVDSNamespaces())
+	assert.True(t, IsMixedModeStateInitialized())
+
+	stateMu.Lock()
+	hasVDSNamespaces = true
+	supported := true
+	perNamespaceProvidersSupported = &supported
+	stateMu.Unlock()
+
+	assert.True(t, HasVDSNamespaces())
+	assert.True(t, IsPerNamespaceProvidersSupported())
+}
+
+func makeNetworkSettingsCR(name, namespace, provider string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "netoperator.vmware.com/v1alpha1",
+			"kind":       "NetworkSettings",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"provider": provider,
+		},
+	}
+}
+
+func setupFakeDynamicClient(t *testing.T, objects ...*unstructured.Unstructured) *fake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		capabilitiesGVR:    "CapabilitiesList",
+		networkSettingsGVR: "NetworkSettingsList",
+	}
+	client := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+
+	ctx := context.TODO()
+	for _, obj := range objects {
+		gvr := capabilitiesGVR
+		if obj.GetKind() == "NetworkSettings" {
+			gvr = networkSettingsGVR
+		}
+
+		ns := obj.GetNamespace()
+		var err error
+		if ns != "" {
+			_, err = client.Resource(gvr).Namespace(ns).Create(ctx, obj, metav1.CreateOptions{})
+		} else {
+			_, err = client.Resource(gvr).Create(ctx, obj, metav1.CreateOptions{})
+		}
+		assert.NoError(t, err)
+	}
+	return client
+}
+
+func TestInitMixedModeWithClients(t *testing.T) {
+	origRetryInitial := retryInitialInterval
+	retryInitialInterval = 1 * time.Millisecond
+	defer func() { retryInitialInterval = origRetryInitial }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Scenario 1: Per-namespace supported = false, EnableVPCNetwork = false
+	capObjFalse := makeCapabilitiesObj(false)
+	dynClientLegacy := setupFakeDynamicClient(t, capObjFalse)
+
+	initMixedModeWithClients(ctx, dynClientLegacy, false)
+	assert.True(t, HasT1Namespaces())
+	assert.False(t, HasVPCNamespaces())
+	assert.False(t, HasVDSNamespaces())
+
+	// Scenario 2: Per-namespace supported = false, EnableVPCNetwork = true
+	initMixedModeWithClients(ctx, dynClientLegacy, true)
+	assert.False(t, HasT1Namespaces())
+	assert.True(t, HasVPCNamespaces())
+	assert.False(t, HasVDSNamespaces())
+
+	// Scenario 3: Per-namespace supported = true, EnableVPCNetwork = false, has VDS and VPC
+	capObjTrue := makeCapabilitiesObj(true)
+	ns1 := makeNetworkSettingsCR("ns1", "ns1", "vpc")
+	ns2 := makeNetworkSettingsCR("ns2", "ns2", "vsphere-distributed")
+	dynClientMixed := setupFakeDynamicClient(t, capObjTrue, ns1, ns2)
+
+	initMixedModeWithClients(ctx, dynClientMixed, false)
+	assert.False(t, HasT1Namespaces())
+	assert.True(t, HasVPCNamespaces())
+	assert.True(t, HasVDSNamespaces())
+
+	// Scenario 4: Per-namespace supported = true, EnableVPCNetwork = true, has T1
+	nsT1 := makeNetworkSettingsCR("ns3", "ns3", "nsx-tier1")
+	dynClientVPC := setupFakeDynamicClient(t, capObjTrue, nsT1)
+	initMixedModeWithClients(ctx, dynClientVPC, true)
+	assert.True(t, HasT1Namespaces())
+	assert.True(t, HasVPCNamespaces())
+	assert.False(t, HasVDSNamespaces())
+}
+
+func TestCheckPerNamespaceProvidersSupported(t *testing.T) {
+	origRetryInitial := retryInitialInterval
+	retryInitialInterval = 1 * time.Millisecond
+	defer func() { retryInitialInterval = origRetryInitial }()
+
+	capObj := makeCapabilitiesObj(true)
+	dynClient := setupFakeDynamicClient(t, capObj)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	supported, err := checkPerNamespaceProvidersSupported(ctx, dynClient)
+
+	assert.NoError(t, err)
+	assert.True(t, supported)
+
+	capObjFalse := makeCapabilitiesObj(false)
+	dynClientFalse := setupFakeDynamicClient(t, capObjFalse)
+	supportedFalse, errFalse := checkPerNamespaceProvidersSupported(ctx, dynClientFalse)
+	assert.NoError(t, errFalse)
+	assert.False(t, supportedFalse)
+
+	ctxCancel, cancelCtx := context.WithCancel(context.Background())
+	cancelCtx()
+
+	dynClientEmpty := setupFakeDynamicClient(t)
+	supportedCancel, errCancel := checkPerNamespaceProvidersSupported(ctxCancel, dynClientEmpty)
+	assert.Error(t, errCancel)
+	assert.False(t, supportedCancel)
+}
+
+// stubReader is a minimal client.Reader for testing cache-backed scans.
+type stubReader struct {
+	items []unstructured.Unstructured
+	err   error
+}
+
+func (s *stubReader) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return nil
+}
+
+func (s *stubReader) List(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	if s.err != nil {
+		return s.err
+	}
+	ul, ok := list.(*unstructured.UnstructuredList)
+	if ok {
+		ul.Items = s.items
+	}
+	return nil
+}
+
+func TestScanNamespaceProvidersFromAPI(t *testing.T) {
+	ctx := context.TODO()
+
+	// nil client returns empty state, no error
+	t1, vpc, vds, err := scanNamespaceProvidersFromAPI(ctx, nil)
+	assert.NoError(t, err)
+	assert.False(t, t1)
+	assert.False(t, vpc)
+	assert.False(t, vds)
+
+	// empty list returns empty state, no error
+	dynClientEmpty := setupFakeDynamicClient(t)
+	t1, vpc, vds, err = scanNamespaceProvidersFromAPI(ctx, dynClientEmpty)
+	assert.NoError(t, err)
+	assert.False(t, t1)
+	assert.False(t, vpc)
+	assert.False(t, vds)
+
+	// list with T1 and VPC providers
+	ns1 := makeNetworkSettingsCR("ns1", "ns1", "nsx-tier1")
+	ns2 := makeNetworkSettingsCR("ns2", "ns2", "vpc")
+	dynClient := setupFakeDynamicClient(t, ns1, ns2)
+	t1, vpc, vds, err = scanNamespaceProvidersFromAPI(ctx, dynClient)
+	assert.NoError(t, err)
+	assert.True(t, t1)
+	assert.True(t, vpc)
+	assert.False(t, vds)
+}
+
+func TestScanNamespaceProvidersFromCache(t *testing.T) {
+	ctx := context.TODO()
+
+	// empty cache returns empty state, no error
+	t1, vpc, vds, err := scanNamespaceProvidersFromCache(ctx, &stubReader{})
+	assert.NoError(t, err)
+	assert.False(t, t1)
+	assert.False(t, vpc)
+	assert.False(t, vds)
+
+	// cache with VPC and T1 providers
+	reader := &stubReader{items: []unstructured.Unstructured{
+		makeNetworkSettings("vpc"),
+		makeNetworkSettings("nsx-tier1"),
+	}}
+	t1, vpc, vds, err = scanNamespaceProvidersFromCache(ctx, reader)
+	assert.NoError(t, err)
+	assert.True(t, t1)
+	assert.True(t, vpc)
+	assert.False(t, vds)
+
+	// list error is propagated
+	errReader := &stubReader{err: errors.New("list failed")}
+	t1, vpc, vds, err = scanNamespaceProvidersFromCache(ctx, errReader)
+	assert.Error(t, err)
+	assert.False(t, t1)
+	assert.False(t, vpc)
+	assert.False(t, vds)
+}
+
+func TestRefreshMixedModeState(t *testing.T) {
+	resetMixedModeGlobals := func() {
+		stateMu.Lock()
+		hasT1Namespaces = false
+		hasVPCNamespaces = false
+		hasVDSNamespaces = false
+		perNamespaceProvidersSupported = nil
+		stateInitialized = false
+		storedDynClient = nil
+		storedEnableVPCNetwork = false
+		stateMu.Unlock()
+		refreshReaderMu.Lock()
+		namespaceRefreshReader = nil
+		refreshReaderMu.Unlock()
+	}
+
+	// storedDynClient is nil -> skip
+	resetMixedModeGlobals()
+	assert.False(t, RefreshMixedModeState(context.TODO()))
+
+	// per-namespace providers not supported -> skip
+	resetMixedModeGlobals()
+	stateMu.Lock()
+	storedDynClient = setupFakeDynamicClient(t)
+	supportedFalse := false
+	perNamespaceProvidersSupported = &supportedFalse
+	stateMu.Unlock()
+	assert.False(t, RefreshMixedModeState(context.TODO()))
+
+	// no change via API path -> false
+	resetMixedModeGlobals()
+	stateMu.Lock()
+	storedDynClient = setupFakeDynamicClient(t)
+	supportedTrue := true
+	perNamespaceProvidersSupported = &supportedTrue
+	hasT1Namespaces = false
+	stateMu.Unlock()
+	assert.False(t, RefreshMixedModeState(context.TODO()))
+
+	// state change via API path -> true
+	resetMixedModeGlobals()
+	ns1 := makeNetworkSettingsCR("ns1", "ns1", "nsx-tier1")
+	stateMu.Lock()
+	storedDynClient = setupFakeDynamicClient(t, ns1)
+	perNamespaceProvidersSupported = &supportedTrue
+	stateMu.Unlock()
+	assert.True(t, RefreshMixedModeState(context.TODO()))
+	assert.True(t, HasT1Namespaces())
+	assert.False(t, HasVPCNamespaces())
+
+	// cache reader takes precedence over API; enableVPCNetwork forces VPC=true
+	resetMixedModeGlobals()
+	stateMu.Lock()
+	storedDynClient = setupFakeDynamicClient(t)
+	perNamespaceProvidersSupported = &supportedTrue
+	storedEnableVPCNetwork = true
+	stateMu.Unlock()
+	refreshReaderMu.Lock()
+	namespaceRefreshReader = &stubReader{items: []unstructured.Unstructured{makeNetworkSettings("nsx-tier1")}}
+	refreshReaderMu.Unlock()
+	assert.True(t, RefreshMixedModeState(context.TODO()))
+	assert.True(t, HasT1Namespaces())
+	assert.True(t, HasVPCNamespaces())
+
+	// scan error keeps current state, returns false
+	resetMixedModeGlobals()
+	stateMu.Lock()
+	storedDynClient = setupFakeDynamicClient(t)
+	perNamespaceProvidersSupported = &supportedTrue
+	hasT1Namespaces = true
+	stateMu.Unlock()
+	refreshReaderMu.Lock()
+	namespaceRefreshReader = &stubReader{err: errors.New("list failed")}
+	refreshReaderMu.Unlock()
+	assert.False(t, RefreshMixedModeState(context.TODO()))
+	assert.True(t, HasT1Namespaces())
+
+	resetMixedModeGlobals()
+}

--- a/pkg/controllers/securitypolicy/securitypolicy_controller_test.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller_test.go
@@ -615,6 +615,7 @@ func TestReconcileSecurityPolicy(t *testing.T) {
 }
 
 func TestSecurityPolicyReconciler_listSecurityPolciyCRIDsForVPC(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	mockCtl := gomock.NewController(t)
 	defer mockCtl.Finish()
 	k8sClient := mock_client.NewMockClient(mockCtl)

--- a/pkg/controllers/securitypolicy/securitypolicy_controller_test.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller_test.go
@@ -618,6 +618,7 @@ func TestReconcileSecurityPolicy(t *testing.T) {
 }
 
 func TestSecurityPolicyReconciler_listSecurityPolciyCRIDsForVPC(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	mockCtl := gomock.NewController(t)
 	defer mockCtl.Finish()
 	k8sClient := mock_client.NewMockClient(mockCtl)

--- a/pkg/mock/realizedentitiesclient/client.go
+++ b/pkg/mock/realizedentitiesclient/client.go
@@ -7,8 +7,8 @@ package mocks
 import (
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
 	model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockRealizedEntitiesClient is a mock of RealizedEntitiesClient interface.

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -398,9 +398,6 @@ func (client *Client) FeatureEnabled(feature int) bool {
 // once license updated, operator will restart
 // if FeatureContainer license is false, operatore will restart
 func (client *Client) ValidateLicense(init bool) error {
-	if init {
-		util.SetEnableVpcNetwork(client.NsxConfig.EnableVPCNetwork)
-	}
 	log.Info("Checking NSX license")
 	oldContainerLicense := util.IsLicensed(util.FeatureContainer)
 	oldDfwLicense := util.GetDFWLicense()
@@ -413,7 +410,7 @@ func (client *Client) ValidateLicense(init bool) error {
 		log.Error(err, "Container license is not supported")
 		return err
 	}
-	if client.NsxConfig.EnableVPCNetwork {
+	if config.HasVPCNamespaces() {
 		if !util.IsLicensed(util.FeatureVPC) {
 			err = errors.New("NSX license check failed")
 			log.Error(err, "VPC license is not supported")

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -432,9 +432,6 @@ func (client *Client) FeatureEnabled(feature int) bool {
 // once license updated, operator will restart
 // if FeatureContainer license is false, operatore will restart
 func (client *Client) ValidateLicense(init bool) error {
-	if init {
-		util.SetEnableVpcNetwork(client.NsxConfig.EnableVPCNetwork)
-	}
 	log.Info("Checking NSX license")
 	oldContainerLicense := util.IsLicensed(util.FeatureContainer)
 	oldDfwLicense := util.GetDFWLicense()
@@ -447,7 +444,7 @@ func (client *Client) ValidateLicense(init bool) error {
 		log.Error(err, "Container license is not supported")
 		return err
 	}
-	if client.NsxConfig.EnableVPCNetwork {
+	if config.HasVPCNamespaces() {
 		if !util.IsLicensed(util.FeatureVPC) {
 			err = errors.New("NSX license check failed")
 			log.Error(err, "VPC license is not supported")

--- a/pkg/nsx/client_test.go
+++ b/pkg/nsx/client_test.go
@@ -340,9 +340,6 @@ func TestValidateLicense(t *testing.T) {
 			})
 			defer patchDfw.Reset()
 
-			patchSetVpc := gomonkey.ApplyFunc(util.SetEnableVpcNetwork, func(enable bool) {})
-			defer patchSetVpc.Reset()
-
 			client := &Client{
 				NsxConfig: &cf,
 				NSXChecker: NSXHealthChecker{

--- a/pkg/nsx/client_test.go
+++ b/pkg/nsx/client_test.go
@@ -351,9 +351,6 @@ func TestValidateLicense(t *testing.T) {
 			})
 			defer patchDfw.Reset()
 
-			patchSetVpc := gomonkey.ApplyFunc(util.SetEnableVpcNetwork, func(enable bool) {})
-			defer patchSetVpc.Reset()
-
 			client := &Client{
 				NsxConfig: &cf,
 				NSXChecker: NSXHealthChecker{

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -185,6 +185,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 	VPCInfo1[0].ProjectID = "default"
 	VPCInfo1[0].VPCID = "vpc1"
 
+	config.SetMixedModeStateForTest(false, true)
 	fakeService := fakeSecurityPolicyService()
 	fakeService.NSXConfig.EnableVPCNetwork = true
 	mockVPCService := mock.MockVPCServiceProvider{}
@@ -436,6 +437,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 }
 
 func Test_BuildPolicyGroupForT1(t *testing.T) {
+	config.SetMixedModeStateForTest(true, false)
 	tests := []struct {
 		name                    string
 		inputPolicy             *v1alpha1.SecurityPolicy
@@ -452,8 +454,16 @@ func Test_BuildPolicyGroupForT1(t *testing.T) {
 		},
 	}
 	s := &SecurityPolicyService{
-		Service: common.Service{},
+		Service: common.Service{
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{
+					Cluster:          "k8scl-one",
+					EnableVPCNetwork: false,
+				},
+			},
+		},
 	}
+	s.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
 	patches := gomonkey.ApplyMethod(reflect.TypeOf(&s.Service), "GetNamespaceUID",
 		func(s *common.Service, ns string) types.UID {
 			return types.UID(tagValueNSUID)
@@ -461,7 +471,7 @@ func Test_BuildPolicyGroupForT1(t *testing.T) {
 	defer patches.Reset()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			observedGroup, observedGroupPath, _ := service.buildPolicyGroup(tt.inputPolicy, common.ResourceTypeSecurityPolicy, nil)
+			observedGroup, observedGroupPath, _ := s.buildPolicyGroup(tt.inputPolicy, common.ResourceTypeSecurityPolicy, nil)
 			assert.Equal(t, tt.expectedPolicyGroupID, observedGroup.Id)
 			assert.Equal(t, tt.expectedPolicyGroupName, observedGroup.DisplayName)
 			assert.Equal(t, tt.expectedPolicyGroupPath, observedGroupPath)
@@ -470,6 +480,7 @@ func Test_BuildPolicyGroupForT1(t *testing.T) {
 }
 
 func Test_BuildPolicyGroupForVPC(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	VPCInfo := make([]common.VPCResourceInfo, 1)
 	VPCInfo[0].OrgID = "default"
 	VPCInfo[0].ProjectID = "project1"
@@ -518,10 +529,19 @@ func Test_BuildPolicyGroupForVPC(t *testing.T) {
 }
 
 func Test_BuildTargetTags(t *testing.T) {
+	config.SetMixedModeStateForTest(true, false)
 	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyCRName
 	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyCRUID
 
-	ruleTagID0 := service.buildRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy)
+	svc := &SecurityPolicyService{
+		Service: common.Service{
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{Cluster: "k8scl-one", EnableVPCNetwork: false},
+			},
+		},
+	}
+	svc.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
+	ruleTagID0 := svc.buildRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy)
 	tests := []struct {
 		name         string
 		inputPolicy  *v1alpha1.SecurityPolicy
@@ -590,24 +610,30 @@ func Test_BuildTargetTags(t *testing.T) {
 			},
 		},
 	}
-	s := &SecurityPolicyService{
-		Service: common.Service{},
-	}
-	patches := gomonkey.ApplyMethod(reflect.TypeOf(&s.Service), "GetNamespaceUID",
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(&svc.Service), "GetNamespaceUID",
 		func(s *common.Service, ns string) types.UID {
 			return types.UID(tagValueNSUID)
 		})
 	defer patches.Reset()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ruleBaseID := service.buildRuleID(tt.inputPolicy, tt.inputIndex, common.ResourceTypeSecurityPolicy)
-			assert.ElementsMatch(t, tt.expectedTags, service.buildTargetTags(tt.inputPolicy, tt.inputTargets, ruleBaseID, common.ResourceTypeSecurityPolicy))
+			ruleBaseID := svc.buildRuleID(tt.inputPolicy, tt.inputIndex, common.ResourceTypeSecurityPolicy)
+			assert.ElementsMatch(t, tt.expectedTags, svc.buildTargetTags(tt.inputPolicy, tt.inputTargets, ruleBaseID, common.ResourceTypeSecurityPolicy))
 		})
 	}
 }
 
 func Test_BuildPeerTags(t *testing.T) {
-	ruleTagID0 := service.buildRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy)
+	config.SetMixedModeStateForTest(true, false)
+	svc := &SecurityPolicyService{
+		Service: common.Service{
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{Cluster: "k8scl-one", EnableVPCNetwork: false},
+			},
+		},
+	}
+	svc.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
+	ruleTagID0 := svc.buildRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy)
 	tests := []struct {
 		name         string
 		inputPolicy  *v1alpha1.SecurityPolicy
@@ -656,17 +682,14 @@ func Test_BuildPeerTags(t *testing.T) {
 			},
 		},
 	}
-	s := &SecurityPolicyService{
-		Service: common.Service{},
-	}
-	patches := gomonkey.ApplyMethod(reflect.TypeOf(&s.Service), "GetNamespaceUID",
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(&svc.Service), "GetNamespaceUID",
 		func(s *common.Service, ns string) types.UID {
 			return types.UID(tagValueNSUID)
 		})
 	defer patches.Reset()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.ElementsMatch(t, tt.expectedTags, service.buildPeerTags(tt.inputPolicy, &tt.inputPolicy.Spec.Rules[0], ruleTagID0, true, VPCScopeGroup, common.ResourceTypeSecurityPolicy))
+			assert.ElementsMatch(t, tt.expectedTags, svc.buildPeerTags(tt.inputPolicy, &tt.inputPolicy.Spec.Rules[0], ruleTagID0, true, VPCScopeGroup, common.ResourceTypeSecurityPolicy))
 		})
 	}
 }
@@ -1357,6 +1380,7 @@ func Test_BuildExpandedRuleID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			config.SetMixedModeStateForTest(!tt.vpcEnabled, tt.vpcEnabled)
 			svc.NSXConfig.EnableVPCNetwork = tt.vpcEnabled
 			ruleBaseID := svc.buildRuleID(tt.inputSecurityPolicy, tt.ruleIdx, common.ResourceTypeSecurityPolicy)
 			observedRuleID := svc.buildExpandedRuleID(tt.inputSecurityPolicy, tt.ruleIdx, ruleBaseID, tt.namedPort)
@@ -1515,6 +1539,7 @@ func Test_BuildSecurityPolicyIDAndName(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			config.SetMixedModeStateForTest(!tc.vpcEnabled, tc.vpcEnabled)
 			svc.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
 			svc.NSXConfig.EnableVPCNetwork = tc.vpcEnabled
 			if tc.existingSecurityPolicy != nil {
@@ -1611,6 +1636,7 @@ func Test_BuildGroupIDAndName(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				config.SetMixedModeStateForTest(!tc.enableVPC, tc.enableVPC)
 				svc.NSXConfig.EnableVPCNetwork = tc.enableVPC
 				dispName := svc.buildRulePeerGroupName(obj, tc.ruleIdx, tc.isSource)
 				assert.Equal(t, tc.expName, dispName)
@@ -1673,6 +1699,7 @@ func Test_BuildGroupIDAndName(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				config.SetMixedModeStateForTest(!tc.enableVPC, tc.enableVPC)
 				svc.NSXConfig.EnableVPCNetwork = tc.enableVPC
 				id, dispName := svc.buildAppliedGroupIDAndName(obj, tc.ruleIdx, tc.ruleBasedID, common.ResourceTypeNetworkPolicy)
 				assert.Equal(t, tc.expId, id)
@@ -1878,6 +1905,7 @@ func Test_dedupBlocks(t *testing.T) {
 }
 
 func Test_getAppliedGroupByRuleID(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
 	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
 
@@ -1971,6 +1999,7 @@ func Test_getAppliedGroupByRuleID(t *testing.T) {
 }
 
 func Test_getPeerGroupByRuleID(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
 	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
 
@@ -2101,6 +2130,7 @@ func Test_getPeerGroupByRuleID(t *testing.T) {
 }
 
 func Test_getRuleIDByUUIDAndRuleHash(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
 	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
 
@@ -2287,6 +2317,7 @@ func Test_buildRuleID(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			config.SetMixedModeStateForTest(!tt.enableVPC, tt.enableVPC)
 			service := fakeSecurityPolicyService()
 			service.NSXConfig.EnableVPCNetwork = tt.enableVPC
 

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -185,6 +185,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 	VPCInfo1[0].ProjectID = "default"
 	VPCInfo1[0].VPCID = "vpc1"
 
+	config.SetMixedModeStateForTest(false, true)
 	fakeService := fakeSecurityPolicyService()
 	fakeService.NSXConfig.EnableVPCNetwork = true
 	mockVPCService := mock.MockVPCServiceProvider{}
@@ -436,6 +437,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 }
 
 func Test_BuildPolicyGroupForT1(t *testing.T) {
+	config.SetMixedModeStateForTest(true, false)
 	tests := []struct {
 		name                    string
 		inputPolicy             *v1alpha1.SecurityPolicy
@@ -452,8 +454,16 @@ func Test_BuildPolicyGroupForT1(t *testing.T) {
 		},
 	}
 	s := &SecurityPolicyService{
-		Service: common.Service{},
+		Service: common.Service{
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{
+					Cluster:          "k8scl-one",
+					EnableVPCNetwork: false,
+				},
+			},
+		},
 	}
+	s.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
 	patches := gomonkey.ApplyMethod(reflect.TypeOf(&s.Service), "GetNamespaceUID",
 		func(s *common.Service, ns string) types.UID {
 			return types.UID(tagValueNSUID)
@@ -461,7 +471,7 @@ func Test_BuildPolicyGroupForT1(t *testing.T) {
 	defer patches.Reset()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			observedGroup, observedGroupPath, _ := service.buildPolicyGroup(tt.inputPolicy, common.ResourceTypeSecurityPolicy, nil)
+			observedGroup, observedGroupPath, _ := s.buildPolicyGroup(tt.inputPolicy, common.ResourceTypeSecurityPolicy, nil)
 			assert.Equal(t, tt.expectedPolicyGroupID, observedGroup.Id)
 			assert.Equal(t, tt.expectedPolicyGroupName, observedGroup.DisplayName)
 			assert.Equal(t, tt.expectedPolicyGroupPath, observedGroupPath)
@@ -470,6 +480,7 @@ func Test_BuildPolicyGroupForT1(t *testing.T) {
 }
 
 func Test_BuildPolicyGroupForVPC(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	VPCInfo := make([]common.VPCResourceInfo, 1)
 	VPCInfo[0].OrgID = "default"
 	VPCInfo[0].ProjectID = "project1"
@@ -518,10 +529,19 @@ func Test_BuildPolicyGroupForVPC(t *testing.T) {
 }
 
 func Test_BuildTargetTags(t *testing.T) {
+	config.SetMixedModeStateForTest(true, false)
 	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyCRName
 	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyCRUID
 
-	ruleTagID0 := service.buildRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy)
+	svc := &SecurityPolicyService{
+		Service: common.Service{
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{Cluster: "k8scl-one", EnableVPCNetwork: false},
+			},
+		},
+	}
+	svc.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
+	ruleTagID0 := svc.buildRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy)
 	tests := []struct {
 		name         string
 		inputPolicy  *v1alpha1.SecurityPolicy
@@ -590,24 +610,30 @@ func Test_BuildTargetTags(t *testing.T) {
 			},
 		},
 	}
-	s := &SecurityPolicyService{
-		Service: common.Service{},
-	}
-	patches := gomonkey.ApplyMethod(reflect.TypeOf(&s.Service), "GetNamespaceUID",
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(&svc.Service), "GetNamespaceUID",
 		func(s *common.Service, ns string) types.UID {
 			return types.UID(tagValueNSUID)
 		})
 	defer patches.Reset()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ruleBaseID := service.buildRuleID(tt.inputPolicy, tt.inputIndex, common.ResourceTypeSecurityPolicy)
-			assert.ElementsMatch(t, tt.expectedTags, service.buildTargetTags(tt.inputPolicy, tt.inputTargets, ruleBaseID, common.ResourceTypeSecurityPolicy))
+			ruleBaseID := svc.buildRuleID(tt.inputPolicy, tt.inputIndex, common.ResourceTypeSecurityPolicy)
+			assert.ElementsMatch(t, tt.expectedTags, svc.buildTargetTags(tt.inputPolicy, tt.inputTargets, ruleBaseID, common.ResourceTypeSecurityPolicy))
 		})
 	}
 }
 
 func Test_BuildPeerTags(t *testing.T) {
-	ruleTagID0 := service.buildRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy)
+	config.SetMixedModeStateForTest(true, false)
+	svc := &SecurityPolicyService{
+		Service: common.Service{
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{Cluster: "k8scl-one", EnableVPCNetwork: false},
+			},
+		},
+	}
+	svc.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
+	ruleTagID0 := svc.buildRuleID(&spWithPodSelector, 0, common.ResourceTypeSecurityPolicy)
 	tests := []struct {
 		name         string
 		inputPolicy  *v1alpha1.SecurityPolicy
@@ -656,17 +682,14 @@ func Test_BuildPeerTags(t *testing.T) {
 			},
 		},
 	}
-	s := &SecurityPolicyService{
-		Service: common.Service{},
-	}
-	patches := gomonkey.ApplyMethod(reflect.TypeOf(&s.Service), "GetNamespaceUID",
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(&svc.Service), "GetNamespaceUID",
 		func(s *common.Service, ns string) types.UID {
 			return types.UID(tagValueNSUID)
 		})
 	defer patches.Reset()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.ElementsMatch(t, tt.expectedTags, service.buildPeerTags(tt.inputPolicy, &tt.inputPolicy.Spec.Rules[0], ruleTagID0, true, VPCScopeGroup, common.ResourceTypeSecurityPolicy))
+			assert.ElementsMatch(t, tt.expectedTags, svc.buildPeerTags(tt.inputPolicy, &tt.inputPolicy.Spec.Rules[0], ruleTagID0, true, VPCScopeGroup, common.ResourceTypeSecurityPolicy))
 		})
 	}
 }
@@ -1357,6 +1380,7 @@ func Test_BuildExpandedRuleID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			config.SetMixedModeStateForTest(!tt.vpcEnabled, tt.vpcEnabled)
 			svc.NSXConfig.EnableVPCNetwork = tt.vpcEnabled
 			ruleBaseID := svc.buildRuleID(tt.inputSecurityPolicy, tt.ruleIdx, common.ResourceTypeSecurityPolicy)
 			observedRuleID := svc.buildExpandedRuleID(tt.inputSecurityPolicy, tt.ruleIdx, ruleBaseID, tt.namedPort)
@@ -1515,6 +1539,7 @@ func Test_BuildSecurityPolicyIDAndName(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			config.SetMixedModeStateForTest(!tc.vpcEnabled, tc.vpcEnabled)
 			svc.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
 			svc.NSXConfig.EnableVPCNetwork = tc.vpcEnabled
 			if tc.existingSecurityPolicy != nil {
@@ -1611,6 +1636,7 @@ func Test_BuildGroupIDAndName(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				config.SetMixedModeStateForTest(!tc.enableVPC, tc.enableVPC)
 				svc.NSXConfig.EnableVPCNetwork = tc.enableVPC
 				dispName := svc.buildRulePeerGroupName(obj, tc.ruleIdx, tc.isSource)
 				assert.Equal(t, tc.expName, dispName)
@@ -1673,6 +1699,7 @@ func Test_BuildGroupIDAndName(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				config.SetMixedModeStateForTest(!tc.enableVPC, tc.enableVPC)
 				svc.NSXConfig.EnableVPCNetwork = tc.enableVPC
 				id, dispName := svc.buildAppliedGroupIDAndName(obj, tc.ruleIdx, tc.ruleBasedID, common.ResourceTypeNetworkPolicy)
 				assert.Equal(t, tc.expId, id)
@@ -1923,6 +1950,7 @@ func Test_dedupBlocks(t *testing.T) {
 }
 
 func Test_getAppliedGroupByRuleID(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
 	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
 
@@ -2016,6 +2044,7 @@ func Test_getAppliedGroupByRuleID(t *testing.T) {
 }
 
 func Test_getPeerGroupByRuleID(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
 	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
 
@@ -2146,6 +2175,7 @@ func Test_getPeerGroupByRuleID(t *testing.T) {
 }
 
 func Test_getRuleIDByUUIDAndRuleHash(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
 	common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
 
@@ -2332,6 +2362,7 @@ func Test_buildRuleID(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			config.SetMixedModeStateForTest(!tt.enableVPC, tt.enableVPC)
 			service := fakeSecurityPolicyService()
 			service.NSXConfig.EnableVPCNetwork = tt.enableVPC
 

--- a/pkg/nsx/services/securitypolicy/expand_test.go
+++ b/pkg/nsx/services/securitypolicy/expand_test.go
@@ -540,6 +540,7 @@ func Test_ExpandRule(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			config.SetMixedModeStateForTest(!tc.vpcEnabled, tc.vpcEnabled)
 			// Initial the security policy related tags. This is executed in `InitializeSecurityPolicy` in
 			// function logic.
 			if tc.vpcEnabled {

--- a/pkg/nsx/services/securitypolicy/expand_test.go
+++ b/pkg/nsx/services/securitypolicy/expand_test.go
@@ -541,6 +541,7 @@ func Test_ExpandRule(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			config.SetMixedModeStateForTest(!tc.vpcEnabled, tc.vpcEnabled)
 			// Initial the security policy related tags. This is executed in `InitializeSecurityPolicy` in
 			// function logic.
 			if tc.vpcEnabled {

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -508,6 +508,7 @@ var (
 )
 
 func Test_GetSecurityService(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	fakeService := fakeSecurityPolicyService()
 	fakeService.NSXConfig.EnableVPCNetwork = true
 	commonService := fakeService.Service
@@ -527,6 +528,7 @@ func Test_GetSecurityService(t *testing.T) {
 }
 
 func Test_InitializeSecurityPolicy(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	fakeService := fakeSecurityPolicyService()
 	fakeService.NSXConfig.EnableVPCNetwork = true
 	commonService := fakeService.Service
@@ -699,6 +701,7 @@ func Test_createOrUpdateGroups(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			config.SetMixedModeStateForTest(false, true)
 			common.TagValueScopeSecurityPolicyName = common.TagScopeSecurityPolicyName
 			common.TagValueScopeSecurityPolicyUID = common.TagScopeSecurityPolicyUID
 
@@ -2389,6 +2392,7 @@ func Test_CreateOrUpdateSecurityPolicyFromNetworkPolicy(t *testing.T) {
 }
 
 func Test_createOrUpdateT1SecurityPolicy(t *testing.T) {
+	config.SetMixedModeStateForTest(true, false)
 	fakeService := fakeSecurityPolicyService()
 	fakeService.NSXConfig.EnableVPCNetwork = false
 
@@ -2533,6 +2537,7 @@ func Test_createOrUpdateT1SecurityPolicy(t *testing.T) {
 }
 
 func Test_createOrUpdateVPCSecurityPolicy(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	VPCInfo := make([]common.VPCResourceInfo, 1)
 	VPCInfo[0].OrgID = "default"
 	VPCInfo[0].ProjectID = "projectQuality"
@@ -2704,6 +2709,7 @@ func Test_createOrUpdateVPCSecurityPolicy(t *testing.T) {
 }
 
 func Test_createOrUpdateVPCSecurityPolicyInDefaultProject(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	VPCInfo := make([]common.VPCResourceInfo, 1)
 	VPCInfo[0].OrgID = "default"
 	VPCInfo[0].ProjectID = "default"
@@ -2884,6 +2890,7 @@ func Test_createOrUpdateVPCSecurityPolicyInDefaultProject(t *testing.T) {
 }
 
 func Test_GetFinalSecurityPolicyResourceForT1(t *testing.T) {
+	config.SetMixedModeStateForTest(true, false)
 	fakeService := fakeSecurityPolicyService()
 
 	type args struct {
@@ -2973,6 +2980,7 @@ func Test_GetFinalSecurityPolicyResourceForT1(t *testing.T) {
 }
 
 func Test_GetFinalSecurityPolicyResourceForVPC(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	VPCInfo := make([]common.VPCResourceInfo, 1)
 	VPCInfo[0].OrgID = "default"
 	VPCInfo[0].ProjectID = "projectQuality"
@@ -3228,6 +3236,7 @@ func Test_ConvertNetworkPolicyToInternalSecurityPolicies(t *testing.T) {
 }
 
 func Test_GetFinalSecurityPolicyResourceFromNetworkPolicy(t *testing.T) {
+	config.SetMixedModeStateForTest(false, true)
 	VPCInfo := make([]common.VPCResourceInfo, 1)
 	VPCInfo[0].OrgID = "default"
 	VPCInfo[0].ProjectID = "projectQuality"

--- a/pkg/nsx/services/securitypolicy/parse.go
+++ b/pkg/nsx/services/securitypolicy/parse.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/legacy/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
@@ -62,8 +63,10 @@ func getDefaultProjectDomain() string {
 	return "default"
 }
 
+// IsVPCEnabled returns whether VPC namespaces exist. Callers must ensure mixed-mode
+// state has been initialized (InitMixedMode in main; SetMixedModeStateForTest in tests).
 func IsVPCEnabled(service *SecurityPolicyService) bool {
-	return service.NSXConfig.EnableVPCNetwork
+	return config.HasVPCNamespaces()
 }
 
 func getScopeCluserTag(service *SecurityPolicyService) string {

--- a/pkg/nsx/util/license.go
+++ b/pkg/nsx/util/license.go
@@ -17,10 +17,11 @@ const (
 )
 
 var (
-	licenseMutex      sync.Mutex
-	licenseMap        = map[string]bool{}
-	FeaturesToCheck   = []string{}
-	FeatureLicenseMap = map[string][]string{
+	licenseMutex         sync.Mutex
+	licenseMap           = map[string]bool{}
+	hasVPCNamespacesFunc func() bool // set from cmd/main after mixed-mode init to avoid import cycle
+	FeaturesToCheck      = []string{}
+	FeatureLicenseMap    = map[string][]string{
 		FeatureContainer: {
 			LicenseContainerNetwork,
 			LicenseContainer,
@@ -29,7 +30,6 @@ var (
 		FeatureVPCSecurity: {LicenseVPCSecurity},
 		FeatureVPC:         {LicenseVPCNetworking},
 	}
-	enableVpcNetwork bool
 )
 
 func init() {
@@ -47,16 +47,28 @@ type NsxLicense struct {
 	ResultCount int `json:"result_count"`
 }
 
-func GetDFWLicense() bool {
-	if enableVpcNetwork {
-		return IsLicensed(LicenseVPCSecurity)
-	} else {
-		return IsLicensed(LicenseDFW)
+// SetHasVPCNamespacesFunc sets the callback used by GetDFWLicense/UpdateDFWLicense.
+// Must be called from cmd/main after mixed-mode init to avoid config->util import cycle.
+func SetHasVPCNamespacesFunc(f func() bool) {
+	hasVPCNamespacesFunc = f
+}
+
+func hasVPCNamespaces() bool {
+	if hasVPCNamespacesFunc != nil {
+		return hasVPCNamespacesFunc()
 	}
+	return false
+}
+
+func GetDFWLicense() bool {
+	if hasVPCNamespaces() {
+		return IsLicensed(LicenseVPCSecurity)
+	}
+	return IsLicensed(LicenseDFW)
 }
 
 func UpdateDFWLicense(isLicensed bool) {
-	if enableVpcNetwork {
+	if hasVPCNamespaces() {
 		UpdateLicense(LicenseVPCSecurity, isLicensed)
 	} else {
 		UpdateLicense(LicenseDFW, isLicensed)
@@ -67,10 +79,6 @@ func IsLicensed(feature string) bool {
 	licenseMutex.Lock()
 	defer licenseMutex.Unlock()
 	return licenseMap[feature]
-}
-
-func SetEnableVpcNetwork(vpcNetwork bool) {
-	enableVpcNetwork = vpcNetwork
 }
 
 func UpdateLicense(feature string, isLicensed bool) {

--- a/pkg/nsx/util/license_test.go
+++ b/pkg/nsx/util/license_test.go
@@ -93,6 +93,8 @@ func TestSearchLicense(t *testing.T) {
 }
 
 func TestUpdateFeatureLicense(t *testing.T) {
+	t.Cleanup(func() { SetHasVPCNamespacesFunc(nil) })
+	SetHasVPCNamespacesFunc(nil)
 
 	// Normal case
 	licenses := &NsxLicense{
@@ -131,7 +133,8 @@ func TestUpdateFeatureLicense(t *testing.T) {
 	assert.False(t, IsLicensed(FeatureContainer))
 
 	assert.False(t, IsLicensed(FeatureVPC))
-	SetEnableVpcNetwork(true)
+	// Equivalent to legacy SetEnableVpcNetwork(true): cluster has VPC namespaces.
+	SetHasVPCNamespacesFunc(func() bool { return true })
 	licenses = &NsxLicense{
 		Results: []struct {
 			FeatureName string `json:"feature_name"`
@@ -148,8 +151,8 @@ func TestUpdateFeatureLicense(t *testing.T) {
 	assert.False(t, IsLicensed(FeatureContainer))
 	assert.True(t, IsLicensed(FeatureVPC))
 
-	// enable vpc network: true; LicenseVPCSecurity: true, GetDFWLicense: true
-	SetEnableVpcNetwork(true)
+	// Has VPC namespaces; LicenseVPCSecurity: true, GetDFWLicense: true (mirrors main SetEnableVpcNetwork(true))
+	SetHasVPCNamespacesFunc(func() bool { return true })
 	licenses = &NsxLicense{
 		Results: []struct {
 			FeatureName string `json:"feature_name"`
@@ -167,8 +170,8 @@ func TestUpdateFeatureLicense(t *testing.T) {
 	assert.False(t, IsLicensed(FeatureContainer))
 	assert.True(t, IsLicensed(FeatureVPC))
 
-	// enable vpc network: false; LicenseDFW: false, GetDFWLicense: false
-	SetEnableVpcNetwork(false)
+	// Equivalent to legacy SetEnableVpcNetwork(false): no VPC namespaces, use DFW license for GetDFWLicense.
+	SetHasVPCNamespacesFunc(nil)
 	licenses = &NsxLicense{
 		Results: []struct {
 			FeatureName string `json:"feature_name"`
@@ -187,60 +190,48 @@ func TestUpdateFeatureLicense(t *testing.T) {
 	assert.True(t, IsLicensed(FeatureVPC))
 }
 
-func TestSetEnableVpcNetwork(t *testing.T) {
-	// Test enabling VPC network
-	SetEnableVpcNetwork(true)
-	assert.Equal(t, []string{LicenseVPCSecurity}, FeatureLicenseMap[FeatureVPCSecurity])
-
-	// Test disabling VPC network
-	SetEnableVpcNetwork(false)
-	assert.Equal(t, []string{LicenseDFW}, FeatureLicenseMap[FeatureDFW])
-
-	// Test toggling back to enabled
-	SetEnableVpcNetwork(true)
-	assert.Equal(t, []string{LicenseVPCSecurity}, FeatureLicenseMap[FeatureVPCSecurity])
-}
 func TestGetSecurityPolicyLicense(t *testing.T) {
-	// Test with VPC network disabled, DFW licensed
-	SetEnableVpcNetwork(false)
+	// Test with VPC namespaces disabled (callback nil or returns false), DFW licensed
+	SetHasVPCNamespacesFunc(nil)
 	UpdateLicense(LicenseDFW, true)
 	assert.True(t, GetDFWLicense())
 
-	// Test with VPC network disabled, DFW not licensed
+	// Test with VPC namespaces disabled, DFW not licensed
 	UpdateLicense(LicenseDFW, false)
 	assert.False(t, GetDFWLicense())
 
-	// Test with VPC network enabled, VPC security licensed
-	SetEnableVpcNetwork(true)
+	// Test with VPC namespaces enabled (callback returns true), VPC security licensed
+	SetHasVPCNamespacesFunc(func() bool { return true })
 	UpdateLicense(LicenseVPCSecurity, true)
 	assert.True(t, GetDFWLicense())
 
-	// Test with VPC network enabled, VPC security not licensed
+	// Test with VPC namespaces enabled, VPC security not licensed
 	UpdateLicense(LicenseVPCSecurity, false)
 	assert.False(t, GetDFWLicense())
 
 	// Clean up
-	SetEnableVpcNetwork(false)
+	SetHasVPCNamespacesFunc(nil)
 }
+
 func TestUpdateDFWLicense(t *testing.T) {
-	// Test with VPC network disabled, updating to licensed
-	SetEnableVpcNetwork(false)
+	// Test with VPC namespaces disabled, updating to licensed
+	SetHasVPCNamespacesFunc(nil)
 	UpdateDFWLicense(true)
 	assert.True(t, licenseMap[LicenseDFW])
 
-	// Test with VPC network disabled, updating to not licensed
+	// Test with VPC namespaces disabled, updating to not licensed
 	UpdateDFWLicense(false)
 	assert.False(t, licenseMap[LicenseDFW])
 
-	// Test with VPC network enabled, updating to licensed
-	SetEnableVpcNetwork(true)
+	// Test with VPC namespaces enabled, updating to licensed
+	SetHasVPCNamespacesFunc(func() bool { return true })
 	UpdateDFWLicense(true)
 	assert.True(t, licenseMap[LicenseVPCSecurity])
 
-	// Test with VPC network enabled, updating to not licensed
+	// Test with VPC namespaces enabled, updating to not licensed
 	UpdateDFWLicense(false)
 	assert.False(t, licenseMap[LicenseVPCSecurity])
 
 	// Clean up
-	SetEnableVpcNetwork(false)
+	SetHasVPCNamespacesFunc(nil)
 }


### PR DESCRIPTION
This patch introduces the Mixed Mode state detection logic for NSX Operator
to determine the network scope (T1, VPC, or VDS) it operates within. This
is critical for deciding which controllers should be activated.

Key features:
- Introduced an informer for the NetworkSettings CR in the Controller
  Runtime cache to efficiently determine the global network state.
- Added detection logic for VDS alongside T1 and VPC based on the
  NetworkSettings `provider` field.
- Implemented capability checking by reading the
  `supports_per_namespace_network_provider` key from the `status.supervisor`
  path in the SupervisorCapabilities CR.
- Incorporated the `EnableVPCNetwork` configuration override to act as an
  early trigger. This solves the "chicken-and-egg" problem by allowing
  VPC-specific controllers to start before the NetworkSettings CRs are
  updated to `provider: vpc`.
- Re-enabled the enable_vpc_network config override check in mixed mode
  initialization and state refresh, which acts as an early trigger for
  VPC-specific controllers.

After this change, the NSX-Operator will start VPC controllers as long as
enable_vpc_network is true. And the T1 controllers will be started when:
  (supports_per_namespace_network_provider is activated) AND (at least one NetworkingSettings CR has provider=="nsx-tier1")
OR
  (supports_per_namespace_network_provider is deactivated) AND (enable_vpc_network is false)

Testing done:
1. T1 pipeline with ID 5771
2. VPC pipeline with ID 19252