### PR TITLE
Add Proxy field in NSXServiceAccount CRD

### DIFF
--- a/build/yaml/crd/legacy/nsx.vmware.com_nsxserviceaccounts.yaml
+++ b/build/yaml/crd/legacy/nsx.vmware.com_nsxserviceaccounts.yaml
@@ -43,6 +43,15 @@ spec:
                 description: EnableCertRotation enables cert rotation feature in this
                   cluster when NSXT >=4.1.3
                 type: boolean
+              proxy:
+                default: SupervisorManagementProxy
+                description: |-
+                  Proxy specifies the proxy type for NSX connectivity
+                  Defaults to SupervisorManagementProxy if not specified
+                enum:
+                - VMCIProxy
+                - SupervisorManagementProxy
+                type: string
               vpcName:
                 type: string
             type: object

--- a/docs/ref/apis/legacy.md
+++ b/docs/ref/apis/legacy.md
@@ -206,6 +206,24 @@ _Appears in:_
 | `failed` |  |
 
 
+#### NSXServiceAccountProxyType
+
+_Underlying type:_ _string_
+
+NSXServiceAccountProxyType defines the proxy type used for NSX connectivity
+
+_Validation:_
+- Enum: [VMCIProxy SupervisorManagementProxy]
+
+_Appears in:_
+- [NSXServiceAccountSpec](#nsxserviceaccountspec)
+
+| Field | Description |
+| --- | --- |
+| `VMCIProxy` |  |
+| `SupervisorManagementProxy` |  |
+
+
 #### NSXServiceAccountSpec
 
 
@@ -221,6 +239,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `vpcName` _string_ |  |  |  |
 | `enableCertRotation` _boolean_ | EnableCertRotation enables cert rotation feature in this cluster when NSXT >=4.1.3 |  |  |
+| `proxy` _[NSXServiceAccountProxyType](#nsxserviceaccountproxytype)_ | Proxy specifies the proxy type for NSX connectivity<br />Defaults to SupervisorManagementProxy if not specified | SupervisorManagementProxy | Enum: [VMCIProxy SupervisorManagementProxy] <br /> |
 
 
 #### NSXServiceAccountStatus

--- a/pkg/apis/legacy/v1alpha1/nsxserviceaccount_types.go
+++ b/pkg/apis/legacy/v1alpha1/nsxserviceaccount_types.go
@@ -7,11 +7,24 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// NSXServiceAccountProxyType defines the proxy type used for NSX connectivity
+// +kubebuilder:validation:Enum=VMCIProxy;SupervisorManagementProxy
+type NSXServiceAccountProxyType string
+
+const (
+	VMCIProxy                 NSXServiceAccountProxyType = "VMCIProxy"
+	SupervisorManagementProxy NSXServiceAccountProxyType = "SupervisorManagementProxy"
+)
+
 // NSXServiceAccountSpec defines the desired state of NSXServiceAccount
 type NSXServiceAccountSpec struct {
 	VPCName string `json:"vpcName,omitempty"`
 	// EnableCertRotation enables cert rotation feature in this cluster when NSXT >=4.1.3
 	EnableCertRotation bool `json:"enableCertRotation,omitempty"`
+	// Proxy specifies the proxy type for NSX connectivity
+	// Defaults to SupervisorManagementProxy if not specified
+	// +kubebuilder:default=SupervisorManagementProxy
+	Proxy NSXServiceAccountProxyType `json:"proxy,omitempty"`
 }
 
 type NSXProxyEndpointAddress struct {

--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
@@ -255,6 +255,12 @@ func (r *NSXServiceAccountReconciler) serviceMapFunc(ctx context.Context, _ clie
 	}
 
 	for _, nsxserviceaccount := range nsxServiceAccountList.Items {
+		// Only enqueue NSXServiceAccounts that use SupervisorManagementProxy
+		// Skip VMCIProxy since it uses hardcoded addresses (127.0.0.1) and is not affected by Service IP changes
+		if nsxserviceaccount.Spec.Proxy == nsxvmwarecomv1alpha1.VMCIProxy {
+			continue
+		}
+
 		requests = append(requests, reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: nsxserviceaccount.GetNamespace(),

--- a/pkg/nsx/services/nsxserviceaccount/cluster.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster.go
@@ -112,7 +112,7 @@ func (s *NSXServiceAccountService) CreateOrUpdateNSXServiceAccount(ctx context.C
 	vpcPath := fmt.Sprintf("/orgs/default/projects/%s/vpcs/%s", util.NormalizeId(project), vpcName)
 
 	// get proxy
-	proxyEndpoints, err := s.getProxyEndpoints(ctx)
+	proxyEndpoints, err := s.getProxyEndpoints(ctx, obj)
 	if err != nil {
 		return err
 	}
@@ -306,11 +306,30 @@ func (s *NSXServiceAccountService) createPIAndCCP(normalizedClusterName string, 
 	return clusterId, nil
 }
 
-func (s *NSXServiceAccountService) getProxyEndpoints(ctx context.Context) (v1alpha1.NSXProxyEndpoint, error) {
+func (s *NSXServiceAccountService) getProxyType(obj *v1alpha1.NSXServiceAccount) v1alpha1.NSXServiceAccountProxyType {
+	if obj.Spec.Proxy != "" {
+		return obj.Spec.Proxy
+	}
+	return v1alpha1.SupervisorManagementProxy
+}
+
+func (s *NSXServiceAccountService) getProxyEndpoints(ctx context.Context, obj *v1alpha1.NSXServiceAccount) (v1alpha1.NSXProxyEndpoint, error) {
+	proxyType := s.getProxyType(obj)
+
+	if proxyType == v1alpha1.VMCIProxy {
+		return v1alpha1.NSXProxyEndpoint{
+			Addresses: []v1alpha1.NSXProxyEndpointAddress{{IP: "127.0.0.1"}},
+			Ports: []v1alpha1.NSXProxyEndpointPort{
+				{Name: PortRestAPI, Port: 10091, Protocol: v1alpha1.NSXProxyProtocolTCP},
+				{Name: PortNSXRPCFwdProxy, Port: 10092, Protocol: v1alpha1.NSXProxyProtocolTCP},
+			},
+		}, nil
+	}
+
 	proxyEndpoints := v1alpha1.NSXProxyEndpoint{}
 	proxies := &v1.ServiceList{}
 	if err := s.Client.List(ctx, proxies, client.MatchingLabels(proxyLabels)); err != nil {
-		return v1alpha1.NSXProxyEndpoint{}, err
+		return proxyEndpoints, err
 	}
 	for _, proxy := range proxies.Items {
 		if proxy.Spec.Type == v1.ServiceTypeLoadBalancer {
@@ -650,7 +669,7 @@ func (s *NSXServiceAccountService) GetNSXRestoreStatus() (*v1alpha1.NSXRestoreSt
 }
 
 func (s *NSXServiceAccountService) UpdateProxyEndpointsIfNeeded(ctx context.Context, obj *v1alpha1.NSXServiceAccount) error {
-	proxyEndpoints, err := s.getProxyEndpoints(ctx)
+	proxyEndpoints, err := s.getProxyEndpoints(ctx, obj)
 	if err != nil {
 		return err
 	}

--- a/pkg/nsx/services/nsxserviceaccount/cluster.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster.go
@@ -33,10 +33,12 @@ import (
 )
 
 const (
-	siteId             = "default"
-	enforcementpointId = "default"
-	PortRestAPI        = "rest-api"
-	PortNSXRPCFwdProxy = "nsx-rpc-fwd-proxy"
+	siteId                = "default"
+	enforcementpointId    = "default"
+	PortRestAPI           = "rest-api"
+	PortNumRestAPI        = 10091
+	PortNSXRPCFwdProxy    = "nsx-rpc-fwd-proxy"
+	PortNumNSXRPCFwdProxy = 10092
 	// #nosec G101: false positive triggered by variable name which includes "secret"
 	SecretSuffix   = "-nsx-cert"
 	SecretCAName   = "ca.crt"
@@ -320,8 +322,8 @@ func (s *NSXServiceAccountService) getProxyEndpoints(ctx context.Context, obj *v
 		return v1alpha1.NSXProxyEndpoint{
 			Addresses: []v1alpha1.NSXProxyEndpointAddress{{IP: "127.0.0.1"}},
 			Ports: []v1alpha1.NSXProxyEndpointPort{
-				{Name: PortRestAPI, Port: 10091, Protocol: v1alpha1.NSXProxyProtocolTCP},
-				{Name: PortNSXRPCFwdProxy, Port: 10092, Protocol: v1alpha1.NSXProxyProtocolTCP},
+				{Name: PortRestAPI, Port: PortNumRestAPI, Protocol: v1alpha1.NSXProxyProtocolTCP},
+				{Name: PortNSXRPCFwdProxy, Port: PortNumNSXRPCFwdProxy, Protocol: v1alpha1.NSXProxyProtocolTCP},
 			},
 		}, nil
 	}

--- a/pkg/nsx/services/nsxserviceaccount/cluster_test.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster_test.go
@@ -549,6 +549,143 @@ func TestNSXServiceAccountService_CreateOrUpdateNSXServiceAccount(t *testing.T) 
 			},
 		},
 		{
+			name: "Success with VMCIProxy",
+			prepareFunc: func(t *testing.T, s *NSXServiceAccountService, ctx context.Context, obj *v1alpha1.NSXServiceAccount) *gomonkey.Patches {
+				assert.NoError(t, s.Client.Create(ctx, obj))
+				normalizedClusterName := "k8scl-one_test-ns1-name1"
+				vpcPath := "/orgs/default/projects/k8scl-one:test/vpcs/vpc1"
+				piId := "Id1"
+				uid := "00000000-0000-0000-0000-000000000001"
+				patches := gomonkey.ApplyMethodSeq(s.NSXClient.WithCertificateClient, "Create", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{mpmodel.PrincipalIdentity{
+						IsProtected: &isProtectedTrue,
+						Name:        &normalizedClusterName,
+						NodeId:      &normalizedClusterName,
+						Role:        nil,
+						RolesForPaths: []mpmodel.RolesForPath{{
+							Path: &readerPath,
+							Roles: []mpmodel.Role{{
+								Role: &readerRole,
+							}},
+						}, {
+							Path: &vpcPath,
+							Roles: []mpmodel.Role{{
+								Role: &vpcRole,
+							}},
+						}},
+						Id: &piId,
+						Tags: []mpmodel.Tag{{
+							Scope: &tagScopeCluster,
+							Tag:   &s.NSXConfig.CoeConfig.Cluster,
+						}, {
+							Scope: &tagScopeNamespace,
+							Tag:   &obj.Namespace,
+						}, {
+							Scope: &tagScopeNSXServiceAccountCRName,
+							Tag:   &obj.Name,
+						}, {
+							Scope: &tagScopeNSXServiceAccountCRUID,
+							Tag:   &uid,
+						}},
+					}, nil},
+					Times: 1,
+				}})
+				nodeId := "clusterId1"
+				patches.ApplyMethodSeq(s.NSXClient.ClusterControlPlanesClient, "Update", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.ClusterControlPlane{
+						Id:           &normalizedClusterName,
+						NodeId:       &nodeId,
+						Revision:     &revision1,
+						ResourceType: &antreaClusterResourceType,
+						Certificate:  nil,
+						VhcPath:      &vpcPath,
+						Tags: []model.Tag{{
+							Scope: &tagScopeCluster,
+							Tag:   &s.NSXConfig.CoeConfig.Cluster,
+						}, {
+							Scope: &tagScopeNamespace,
+							Tag:   &obj.Namespace,
+						}, {
+							Scope: &tagScopeNSXServiceAccountCRName,
+							Tag:   &obj.Name,
+						}, {
+							Scope: &tagScopeNSXServiceAccountCRUID,
+							Tag:   &uid,
+						}},
+					}, nil},
+					Times: 1,
+				}})
+				patches.ApplyMethodSeq(s.NSXClient, "NSXCheckVersion", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{true},
+					Times:  1,
+				}})
+				return patches
+			},
+			args: args{
+				obj: &v1alpha1.NSXServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name1",
+						Namespace: "ns1",
+						UID:       "00000000-0000-0000-0000-000000000001",
+					},
+					Spec: v1alpha1.NSXServiceAccountSpec{
+						VPCName: "vpc1",
+						Proxy:   v1alpha1.VMCIProxy,
+					},
+				},
+			},
+			wantErr:    false,
+			wantSecret: true,
+			expectedCR: &v1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "name1",
+					Namespace:       "ns1",
+					UID:             "00000000-0000-0000-0000-000000000001",
+					ResourceVersion: "2",
+				},
+				Spec: v1alpha1.NSXServiceAccountSpec{
+					VPCName: "vpc1",
+					Proxy:   v1alpha1.VMCIProxy,
+				},
+				Status: v1alpha1.NSXServiceAccountStatus{
+					Phase:  "realized",
+					Reason: "Success",
+					Conditions: []metav1.Condition{
+						{
+							Type:    v1alpha1.ConditionTypeRealized,
+							Status:  metav1.ConditionTrue,
+							Reason:  v1alpha1.ConditionReasonRealizationSuccess,
+							Message: "Success.",
+						},
+					},
+					VPCPath:     "/orgs/default/projects/k8scl-one_test/vpcs/ns1-default-vpc",
+					NSXManagers: []string{"mgr1:443", "mgr2:443"},
+					ProxyEndpoints: v1alpha1.NSXProxyEndpoint{
+						Addresses: []v1alpha1.NSXProxyEndpointAddress{
+							{
+								IP: "127.0.0.1",
+							},
+						},
+						Ports: []v1alpha1.NSXProxyEndpointPort{
+							{
+								Name:     PortRestAPI,
+								Port:     10091,
+								Protocol: v1alpha1.NSXProxyProtocolTCP,
+							},
+							{
+								Name:     PortNSXRPCFwdProxy,
+								Port:     10092,
+								Protocol: v1alpha1.NSXProxyProtocolTCP,
+							},
+						},
+					},
+					ClusterID:   "clusterId1",
+					ClusterName: "k8scl-one_test-ns1-name1",
+					Secrets:     []v1alpha1.NSXSecret{{Name: "name1-nsx-cert", Namespace: "ns1"}},
+				},
+			},
+		},
+		{
 			name: "LongNameSuccess",
 			prepareFunc: func(t *testing.T, s *NSXServiceAccountService, ctx context.Context, obj *v1alpha1.NSXServiceAccount) *gomonkey.Patches {
 				assert.NoError(t, s.Client.Create(ctx, obj))
@@ -2138,12 +2275,16 @@ func TestNSXServiceAccountService_GetNSXServiceAccountNameByUID(t *testing.T) {
 func TestNSXServiceAccountService_getProxyEndpoints(t *testing.T) {
 	tests := []struct {
 		name        string
+		obj         *v1alpha1.NSXServiceAccount
 		prepareFunc func(*testing.T, *NSXServiceAccountService, context.Context)
 		want        v1alpha1.NSXProxyEndpoint
 		wantErr     assert.ErrorAssertionFunc
 	}{
 		{
 			name: "NoProxy",
+			obj: &v1alpha1.NSXServiceAccount{
+				Spec: v1alpha1.NSXServiceAccountSpec{},
+			},
 			prepareFunc: func(t *testing.T, s *NSXServiceAccountService, c context.Context) {
 				svc := &v1.Service{
 					TypeMeta: metav1.TypeMeta{},
@@ -2167,7 +2308,12 @@ func TestNSXServiceAccountService_getProxyEndpoints(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "Proxy",
+			name: "SupervisorManagementProxy",
+			obj: &v1alpha1.NSXServiceAccount{
+				Spec: v1alpha1.NSXServiceAccountSpec{
+					Proxy: v1alpha1.SupervisorManagementProxy,
+				},
+			},
 			prepareFunc: func(t *testing.T, s *NSXServiceAccountService, c context.Context) {
 				svc := &v1.Service{
 					TypeMeta: metav1.TypeMeta{},
@@ -2179,23 +2325,23 @@ func TestNSXServiceAccountService_getProxyEndpoints(t *testing.T) {
 					Spec: v1.ServiceSpec{
 						Ports: []v1.ServicePort{
 							{
-								Name:     "rest-api",
+								Name:     PortRestAPI,
 								Protocol: "",
 								Port:     10000,
 							},
 							{
-								Name:     "nsx-rpc-fwd-proxy",
-								Protocol: "TCP",
+								Name:     PortNSXRPCFwdProxy,
+								Protocol: v1.ProtocolTCP,
 								Port:     10001,
 							},
 							{
-								Name:     "rest-api",
-								Protocol: "UDP",
+								Name:     PortRestAPI,
+								Protocol: v1.ProtocolUDP,
 								Port:     10002,
 							},
 							{
 								Name:     "wrong-rest-api",
-								Protocol: "TCP",
+								Protocol: v1.ProtocolTCP,
 								Port:     10003,
 							},
 						},
@@ -2213,14 +2359,91 @@ func TestNSXServiceAccountService_getProxyEndpoints(t *testing.T) {
 				Addresses: []v1alpha1.NSXProxyEndpointAddress{{IP: "1.2.3.4"}, {IP: "1.2.3.5"}},
 				Ports: []v1alpha1.NSXProxyEndpointPort{
 					{
-						Name:     "rest-api",
+						Name:     PortRestAPI,
 						Port:     10000,
-						Protocol: "TCP",
+						Protocol: v1alpha1.NSXProxyProtocolTCP,
 					},
 					{
-						Name:     "nsx-rpc-fwd-proxy",
+						Name:     PortNSXRPCFwdProxy,
 						Port:     10001,
-						Protocol: "TCP",
+						Protocol: v1alpha1.NSXProxyProtocolTCP,
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "VMCIProxy",
+			obj: &v1alpha1.NSXServiceAccount{
+				Spec: v1alpha1.NSXServiceAccountSpec{
+					Proxy: v1alpha1.VMCIProxy,
+				},
+			},
+			want: v1alpha1.NSXProxyEndpoint{
+				Addresses: []v1alpha1.NSXProxyEndpointAddress{{IP: "127.0.0.1"}},
+				Ports: []v1alpha1.NSXProxyEndpointPort{
+					{
+						Name:     PortRestAPI,
+						Port:     10091,
+						Protocol: v1alpha1.NSXProxyProtocolTCP,
+					},
+					{
+						Name:     PortNSXRPCFwdProxy,
+						Port:     10092,
+						Protocol: v1alpha1.NSXProxyProtocolTCP,
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "DefaultToSupervisorManagementProxy",
+			obj: &v1alpha1.NSXServiceAccount{
+				Spec: v1alpha1.NSXServiceAccountSpec{},
+			},
+			prepareFunc: func(t *testing.T, s *NSXServiceAccountService, c context.Context) {
+				svc := &v1.Service{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "with-label",
+						Namespace: "any",
+						Labels:    map[string]string{"mgmt-proxy.antrea-nsx.vmware.com": "", "dummy": "dummy"},
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{
+							{
+								Name:     PortRestAPI,
+								Protocol: v1.ProtocolTCP,
+								Port:     10000,
+							},
+							{
+								Name:     PortNSXRPCFwdProxy,
+								Protocol: v1.ProtocolTCP,
+								Port:     10001,
+							},
+						},
+						Type: v1.ServiceTypeLoadBalancer,
+					},
+					Status: v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						},
+					},
+				}
+				assert.NoError(t, s.Client.Create(c, svc))
+			},
+			want: v1alpha1.NSXProxyEndpoint{
+				Addresses: []v1alpha1.NSXProxyEndpointAddress{{IP: "1.2.3.4"}},
+				Ports: []v1alpha1.NSXProxyEndpointPort{
+					{
+						Name:     PortRestAPI,
+						Port:     10000,
+						Protocol: v1alpha1.NSXProxyProtocolTCP,
+					},
+					{
+						Name:     PortNSXRPCFwdProxy,
+						Port:     10001,
+						Protocol: v1alpha1.NSXProxyProtocolTCP,
 					},
 				},
 			},
@@ -2233,9 +2456,11 @@ func TestNSXServiceAccountService_getProxyEndpoints(t *testing.T) {
 			commonService := newFakeCommonService()
 			s := &NSXServiceAccountService{Service: commonService}
 			s.SetUpStore()
-			tt.prepareFunc(t, s, ctx)
+			if tt.prepareFunc != nil {
+				tt.prepareFunc(t, s, ctx)
+			}
 
-			got, err := s.getProxyEndpoints(ctx)
+			got, err := s.getProxyEndpoints(ctx, tt.obj)
 			if !tt.wantErr(t, err, "getProxyEndpoints()") {
 				return
 			}
@@ -2379,6 +2604,9 @@ func TestUpdateProxyEndpointsIfNeeded(t *testing.T) {
 					Name:      "nsxsa1",
 					Namespace: "ns1",
 				},
+				Spec: v1alpha1.NSXServiceAccountSpec{
+					Proxy: v1alpha1.SupervisorManagementProxy,
+				},
 				Status: v1alpha1.NSXServiceAccountStatus{
 					Phase: v1alpha1.NSXServiceAccountPhaseRealized,
 					ProxyEndpoints: v1alpha1.NSXProxyEndpoint{
@@ -2389,13 +2617,13 @@ func TestUpdateProxyEndpointsIfNeeded(t *testing.T) {
 						},
 						Ports: []v1alpha1.NSXProxyEndpointPort{
 							{
-								Name:     "rest-api",
+								Name:     PortRestAPI,
 								Port:     10081,
-								Protocol: "TCP",
+								Protocol: v1alpha1.NSXProxyProtocolTCP,
 							},
 							{
-								Name:     "nsx-rpc-fwd-proxy",
-								Protocol: "TCP",
+								Name:     PortNSXRPCFwdProxy,
+								Protocol: v1alpha1.NSXProxyProtocolTCP,
 								Port:     10082,
 							},
 						},
@@ -2412,13 +2640,13 @@ func TestUpdateProxyEndpointsIfNeeded(t *testing.T) {
 					Spec: v1.ServiceSpec{
 						Ports: []v1.ServicePort{
 							{
-								Name:     "rest-api",
-								Protocol: "TCP",
+								Name:     PortRestAPI,
+								Protocol: v1.ProtocolTCP,
 								Port:     10081,
 							},
 							{
-								Name:     "nsx-rpc-fwd-proxy",
-								Protocol: "TCP",
+								Name:     PortNSXRPCFwdProxy,
+								Protocol: v1.ProtocolTCP,
 								Port:     10082,
 							},
 						},
@@ -2440,14 +2668,67 @@ func TestUpdateProxyEndpointsIfNeeded(t *testing.T) {
 				},
 				Ports: []v1alpha1.NSXProxyEndpointPort{
 					{
-						Name:     "rest-api",
+						Name:     PortRestAPI,
 						Port:     10081,
-						Protocol: "TCP",
+						Protocol: v1alpha1.NSXProxyProtocolTCP,
 					},
 					{
-						Name:     "nsx-rpc-fwd-proxy",
-						Protocol: "TCP",
+						Name:     PortNSXRPCFwdProxy,
+						Protocol: v1alpha1.NSXProxyProtocolTCP,
 						Port:     10082,
+					},
+				},
+			},
+		},
+		{
+			name: "update nsx service account with VMCIProxy endpoints",
+			nsxServiceAccount: &v1alpha1.NSXServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nsxsa1",
+					Namespace: "ns1",
+				},
+				Spec: v1alpha1.NSXServiceAccountSpec{
+					Proxy: v1alpha1.VMCIProxy,
+				},
+				Status: v1alpha1.NSXServiceAccountStatus{
+					Phase: v1alpha1.NSXServiceAccountPhaseRealized,
+					ProxyEndpoints: v1alpha1.NSXProxyEndpoint{
+						Addresses: []v1alpha1.NSXProxyEndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+						Ports: []v1alpha1.NSXProxyEndpointPort{
+							{
+								Name:     PortRestAPI,
+								Port:     10081,
+								Protocol: v1alpha1.NSXProxyProtocolTCP,
+							},
+							{
+								Name:     PortNSXRPCFwdProxy,
+								Protocol: v1alpha1.NSXProxyProtocolTCP,
+								Port:     10082,
+							},
+						},
+					},
+				},
+			},
+			expectedProxyEndpoints: v1alpha1.NSXProxyEndpoint{
+				Addresses: []v1alpha1.NSXProxyEndpointAddress{
+					{
+						IP: "127.0.0.1",
+					},
+				},
+				Ports: []v1alpha1.NSXProxyEndpointPort{
+					{
+						Name:     PortRestAPI,
+						Port:     10091,
+						Protocol: v1alpha1.NSXProxyProtocolTCP,
+					},
+					{
+						Name:     PortNSXRPCFwdProxy,
+						Protocol: v1alpha1.NSXProxyProtocolTCP,
+						Port:     10092,
 					},
 				},
 			},
@@ -2459,7 +2740,9 @@ func TestUpdateProxyEndpointsIfNeeded(t *testing.T) {
 			commonService := newFakeCommonService()
 			s := &NSXServiceAccountService{Service: commonService}
 			assert.NoError(t, s.Client.Create(ctx, tt.nsxServiceAccount))
-			tt.prepareFunc(t, s, ctx)
+			if tt.prepareFunc != nil {
+				tt.prepareFunc(t, s, ctx)
+			}
 
 			err := s.UpdateProxyEndpointsIfNeeded(ctx, tt.nsxServiceAccount)
 			require.NoError(t, err)

--- a/pkg/nsx/services/nsxserviceaccount/cluster_test.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster_test.go
@@ -669,12 +669,12 @@ func TestNSXServiceAccountService_CreateOrUpdateNSXServiceAccount(t *testing.T) 
 						Ports: []v1alpha1.NSXProxyEndpointPort{
 							{
 								Name:     PortRestAPI,
-								Port:     10091,
+								Port:     PortNumRestAPI,
 								Protocol: v1alpha1.NSXProxyProtocolTCP,
 							},
 							{
 								Name:     PortNSXRPCFwdProxy,
-								Port:     10092,
+								Port:     PortNumNSXRPCFwdProxy,
 								Protocol: v1alpha1.NSXProxyProtocolTCP,
 							},
 						},
@@ -2327,12 +2327,12 @@ func TestNSXServiceAccountService_getProxyEndpoints(t *testing.T) {
 							{
 								Name:     PortRestAPI,
 								Protocol: "",
-								Port:     10000,
+								Port:     PortNumRestAPI,
 							},
 							{
 								Name:     PortNSXRPCFwdProxy,
 								Protocol: v1.ProtocolTCP,
-								Port:     10001,
+								Port:     PortNumNSXRPCFwdProxy,
 							},
 							{
 								Name:     PortRestAPI,
@@ -2360,12 +2360,12 @@ func TestNSXServiceAccountService_getProxyEndpoints(t *testing.T) {
 				Ports: []v1alpha1.NSXProxyEndpointPort{
 					{
 						Name:     PortRestAPI,
-						Port:     10000,
+						Port:     PortNumRestAPI,
 						Protocol: v1alpha1.NSXProxyProtocolTCP,
 					},
 					{
 						Name:     PortNSXRPCFwdProxy,
-						Port:     10001,
+						Port:     PortNumNSXRPCFwdProxy,
 						Protocol: v1alpha1.NSXProxyProtocolTCP,
 					},
 				},
@@ -2384,12 +2384,12 @@ func TestNSXServiceAccountService_getProxyEndpoints(t *testing.T) {
 				Ports: []v1alpha1.NSXProxyEndpointPort{
 					{
 						Name:     PortRestAPI,
-						Port:     10091,
+						Port:     PortNumRestAPI,
 						Protocol: v1alpha1.NSXProxyProtocolTCP,
 					},
 					{
 						Name:     PortNSXRPCFwdProxy,
-						Port:     10092,
+						Port:     PortNumNSXRPCFwdProxy,
 						Protocol: v1alpha1.NSXProxyProtocolTCP,
 					},
 				},
@@ -2414,12 +2414,12 @@ func TestNSXServiceAccountService_getProxyEndpoints(t *testing.T) {
 							{
 								Name:     PortRestAPI,
 								Protocol: v1.ProtocolTCP,
-								Port:     10000,
+								Port:     PortNumRestAPI,
 							},
 							{
 								Name:     PortNSXRPCFwdProxy,
 								Protocol: v1.ProtocolTCP,
-								Port:     10001,
+								Port:     PortNumNSXRPCFwdProxy,
 							},
 						},
 						Type: v1.ServiceTypeLoadBalancer,
@@ -2437,12 +2437,12 @@ func TestNSXServiceAccountService_getProxyEndpoints(t *testing.T) {
 				Ports: []v1alpha1.NSXProxyEndpointPort{
 					{
 						Name:     PortRestAPI,
-						Port:     10000,
+						Port:     PortNumRestAPI,
 						Protocol: v1alpha1.NSXProxyProtocolTCP,
 					},
 					{
 						Name:     PortNSXRPCFwdProxy,
-						Port:     10001,
+						Port:     PortNumNSXRPCFwdProxy,
 						Protocol: v1alpha1.NSXProxyProtocolTCP,
 					},
 				},
@@ -2618,13 +2618,13 @@ func TestUpdateProxyEndpointsIfNeeded(t *testing.T) {
 						Ports: []v1alpha1.NSXProxyEndpointPort{
 							{
 								Name:     PortRestAPI,
-								Port:     10081,
+								Port:     PortNumRestAPI,
 								Protocol: v1alpha1.NSXProxyProtocolTCP,
 							},
 							{
 								Name:     PortNSXRPCFwdProxy,
 								Protocol: v1alpha1.NSXProxyProtocolTCP,
-								Port:     10082,
+								Port:     PortNumNSXRPCFwdProxy,
 							},
 						},
 					},
@@ -2642,12 +2642,12 @@ func TestUpdateProxyEndpointsIfNeeded(t *testing.T) {
 							{
 								Name:     PortRestAPI,
 								Protocol: v1.ProtocolTCP,
-								Port:     10081,
+								Port:     PortNumRestAPI,
 							},
 							{
 								Name:     PortNSXRPCFwdProxy,
 								Protocol: v1.ProtocolTCP,
-								Port:     10082,
+								Port:     PortNumNSXRPCFwdProxy,
 							},
 						},
 						Type: v1.ServiceTypeLoadBalancer,
@@ -2669,13 +2669,13 @@ func TestUpdateProxyEndpointsIfNeeded(t *testing.T) {
 				Ports: []v1alpha1.NSXProxyEndpointPort{
 					{
 						Name:     PortRestAPI,
-						Port:     10081,
+						Port:     PortNumRestAPI,
 						Protocol: v1alpha1.NSXProxyProtocolTCP,
 					},
 					{
 						Name:     PortNSXRPCFwdProxy,
 						Protocol: v1alpha1.NSXProxyProtocolTCP,
-						Port:     10082,
+						Port:     PortNumNSXRPCFwdProxy,
 					},
 				},
 			},
@@ -2701,13 +2701,13 @@ func TestUpdateProxyEndpointsIfNeeded(t *testing.T) {
 						Ports: []v1alpha1.NSXProxyEndpointPort{
 							{
 								Name:     PortRestAPI,
-								Port:     10081,
+								Port:     PortNumRestAPI,
 								Protocol: v1alpha1.NSXProxyProtocolTCP,
 							},
 							{
 								Name:     PortNSXRPCFwdProxy,
 								Protocol: v1alpha1.NSXProxyProtocolTCP,
-								Port:     10082,
+								Port:     PortNumNSXRPCFwdProxy,
 							},
 						},
 					},
@@ -2722,13 +2722,13 @@ func TestUpdateProxyEndpointsIfNeeded(t *testing.T) {
 				Ports: []v1alpha1.NSXProxyEndpointPort{
 					{
 						Name:     PortRestAPI,
-						Port:     10091,
+						Port:     PortNumRestAPI,
 						Protocol: v1alpha1.NSXProxyProtocolTCP,
 					},
 					{
 						Name:     PortNSXRPCFwdProxy,
 						Protocol: v1alpha1.NSXProxyProtocolTCP,
-						Port:     10092,
+						Port:     PortNumNSXRPCFwdProxy,
 					},
 				},
 			},


### PR DESCRIPTION
Test Summary

1. Existing NSXServiceAccount before applying the patch
```
apiVersion: nsx.vmware.com/v1alpha1
kind: NSXServiceAccount
metadata:
  creationTimestamp: "2026-04-13T06:06:00Z"
  finalizers:
  - nsxserviceaccount.nsx.vmware.com/finalizer
  generation: 1
  name: cluster-default-antrea
  namespace: antrea-test
  ownerReferences:
  - apiVersion: cluster.x-k8s.io/v1beta2
    kind: Cluster
    name: cluster-default
    uid: 0dfc2d6a-e03c-40e1-8870-c3ca066ef5e9
  resourceVersion: "2190994"
  uid: cbbf67cb-3d5d-427b-8101-afcf53188f96
spec: {}
status:
  clusterID: b353932d-0066-4f5d-ad3d-4f0f132ff11b
  clusterName: 86ab913f-fa9b-46d2-988a-8c7d96ca6457-antrea-test-cluster-default-antrea
  conditions:
  - lastTransitionTime: "2026-04-13T06:06:01Z"
    message: Success.
    observedGeneration: 1
    reason: RealizationSuccess
    status: "True"
    type: Realized
  nsxManagers:
  - xx.xx.xxx.xxx:xxx
  phase: realized
  proxyEndpoints: {}
  reason: Success
  secrets:
  - name: cluster-default-antrea-nsx-cert
    namespace: antrea-test
  vpcPath: /orgs/default/projects/86ab913f-fa9b-46d2-988a-8c7d96ca6457/vpcs/antrea-test-default-vpc
```
2. Apply the new NSXServiceAccount CRD and replace nsx-operator image with image built using this patch.
3. Existing NSXServiceAccount gets updated with default value `spec.proxy: SupervisorManagementProxy`
```
apiVersion: nsx.vmware.com/v1alpha1
kind: NSXServiceAccount
metadata:
  creationTimestamp: "2026-04-13T06:06:00Z"
  finalizers:
  - nsxserviceaccount.nsx.vmware.com/finalizer
  generation: 1
  name: cluster-default-antrea
  namespace: antrea-test
  ownerReferences:
  - apiVersion: cluster.x-k8s.io/v1beta2
    kind: Cluster
    name: cluster-default
    uid: 0dfc2d6a-e03c-40e1-8870-c3ca066ef5e9
  resourceVersion: "8378491"
  uid: cbbf67cb-3d5d-427b-8101-afcf53188f96
spec:
  proxy: SupervisorManagementProxy
status:
  clusterID: b353932d-0066-4f5d-ad3d-4f0f132ff11b
  clusterName: 86ab913f-fa9b-46d2-988a-8c7d96ca6457-antrea-test-cluster-default-antrea
  conditions:
  - lastTransitionTime: "2026-04-13T06:06:01Z"
    message: Success.
    observedGeneration: 1
    reason: RealizationSuccess
    status: "True"
    type: Realized
  nsxManagers:
  - xx.xx.xxx.xxx:xxx
  phase: realized
  proxyEndpoints: {}
  reason: Success
  secrets:
  - name: cluster-default-antrea-nsx-cert
    namespace: antrea-test
  vpcPath: /orgs/default/projects/86ab913f-fa9b-46d2-988a-8c7d96ca6457/vpcs/antrea-test-default-vpc
```
4. Register and Install Supervisor Management Proxy Supervisor Service, `status.proxyEndpoints` gets updated.
```
apiVersion: nsx.vmware.com/v1alpha1
kind: NSXServiceAccount
metadata:
  creationTimestamp: "2026-04-13T06:06:00Z"
  finalizers:
  - nsxserviceaccount.nsx.vmware.com/finalizer
  generation: 1
  name: cluster-default-antrea
  namespace: antrea-test
  ownerReferences:
  - apiVersion: cluster.x-k8s.io/v1beta2
    kind: Cluster
    name: cluster-default
    uid: 0dfc2d6a-e03c-40e1-8870-c3ca066ef5e9
  resourceVersion: "8385548"
  uid: cbbf67cb-3d5d-427b-8101-afcf53188f96
spec:
  proxy: SupervisorManagementProxy
status:
  clusterID: b353932d-0066-4f5d-ad3d-4f0f132ff11b
  clusterName: 86ab913f-fa9b-46d2-988a-8c7d96ca6457-antrea-test-cluster-default-antrea
  conditions:
  - lastTransitionTime: "2026-04-13T06:06:01Z"
    message: Success.
    observedGeneration: 1
    reason: RealizationSuccess
    status: "True"
    type: Realized
  nsxManagers:
  - xx.xx.xxx.xxx:xxx
  phase: realized
  proxyEndpoints:
    addresses:
    - ip: 192.168.0.8
    ports:
    - name: rest-api
      port: 10091
      protocol: TCP
    - name: nsx-rpc-fwd-proxy
      port: 10092
      protocol: TCP
  reason: Success
  secrets:
  - name: cluster-default-antrea-nsx-cert
    namespace: antrea-test
  vpcPath: /orgs/default/projects/86ab913f-fa9b-46d2-988a-8c7d96ca6457/vpcs/antrea-test-default-vpc
```
5. Edit NSXServiceAccount to set `spec.proxy: VMCIProxy`, `status.proxyEndpoints` gets updated.
```
apiVersion: nsx.vmware.com/v1alpha1
kind: NSXServiceAccount
metadata:
  creationTimestamp: "2026-04-13T06:06:00Z"
  finalizers:
  - nsxserviceaccount.nsx.vmware.com/finalizer
  generation: 2
  name: cluster-default-antrea
  namespace: antrea-test
  ownerReferences:
  - apiVersion: cluster.x-k8s.io/v1beta2
    kind: Cluster
    name: cluster-default
    uid: 0dfc2d6a-e03c-40e1-8870-c3ca066ef5e9
  resourceVersion: "8387801"
  uid: cbbf67cb-3d5d-427b-8101-afcf53188f96
spec:
  proxy: VMCIProxy
status:
  clusterID: b353932d-0066-4f5d-ad3d-4f0f132ff11b
  clusterName: 86ab913f-fa9b-46d2-988a-8c7d96ca6457-antrea-test-cluster-default-antrea
  conditions:
  - lastTransitionTime: "2026-04-13T06:06:01Z"
    message: Success.
    observedGeneration: 1
    reason: RealizationSuccess
    status: "True"
    type: Realized
  nsxManagers:
  - xx.xx.xxx.xxx:xxx
  phase: realized
  proxyEndpoints:
    addresses:
    - ip: 127.0.0.1
    ports:
    - name: rest-api
      port: 10091
      protocol: TCP
    - name: nsx-rpc-fwd-proxy
      port: 10092
      protocol: TCP
  reason: Success
  secrets:
  - name: cluster-default-antrea-nsx-cert
    namespace: antrea-test
  vpcPath: /orgs/default/projects/86ab913f-fa9b-46d2-988a-8c7d96ca6457/vpcs/antrea-test-default-vpc
```