### PR TITLE
CRD changes to support IPv6 part 2

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_ipaddressallocations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_ipaddressallocations.yaml
@@ -23,6 +23,10 @@ spec:
       jsonPath: .status.allocationIPs
       name: AllocationIPs
       type: string
+    - description: IPv6 allocation prefix length of the IPAddressAllocation.
+      jsonPath: .spec.ipv6AllocationPrefixLength
+      name: IPv6AllocationPrefixLength
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -57,7 +61,7 @@ spec:
                   rule: self == oldSelf
               allocationSize:
                 description: |-
-                  AllocationSize specifies the size of allocationIPs to be allocated.
+                  AllocationSize specifies the size of IPv4 allocationIPs to be allocated.
                   It should be a power of 2.
                 minimum: 1
                 type: integer
@@ -66,9 +70,9 @@ spec:
                   rule: self == oldSelf
               ipAddressBlockVisibility:
                 default: Private
-                description: IPAddressBlockVisibility specifies the visibility of
-                  the IPBlocks to allocate IP addresses. Can be External, Private
-                  or PrivateTGW.
+                description: |-
+                  IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.
+                  This field is not applicable if ipAddressType is IPv6.
                 enum:
                 - External
                 - Private
@@ -77,14 +81,45 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
+              ipAddressType:
+                default: IPv4
+                description: IPAddressType specifies the IP address type of the IPAddressAllocation.
+                enum:
+                - IPv4
+                - IPv6
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              ipv6AllocationPrefixLength:
+                description: IPv6AllocationPrefixLength specifies the prefix length
+                  of IPv6 addresses.
+                maximum: 128
+                minimum: 64
+                type: integer
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
             type: object
             x-kubernetes-validations:
             - message: Only one of allocationSize or allocationIPs can be specified
               rule: '!has(self.allocationSize) || !has(self.allocationIPs)'
+            - message: Only one of ipv6AllocationPrefixLength or allocationIPs can
+                be specified
+              rule: '!has(self.ipv6AllocationPrefixLength) || !has(self.allocationIPs)'
             - message: allocationSize is required once set
               rule: '!has(oldSelf.allocationSize) || has(self.allocationSize)'
             - message: allocationIPs is required once set
               rule: '!has(oldSelf.allocationIPs) || has(self.allocationIPs)'
+            - message: ipv6AllocationPrefixLength is required once set
+              rule: '!has(oldSelf.ipv6AllocationPrefixLength) || has(self.ipv6AllocationPrefixLength)'
+            - message: allocationSize can only be set when ipAddressType is IPv4
+              rule: '!has(self.allocationSize) || !has(self.ipAddressType) || self.ipAddressType
+                == ''IPv4'''
+            - message: ipv6AllocationPrefixLength can only be set when ipAddressType
+                is IPv6
+              rule: '!has(self.ipv6AllocationPrefixLength) || self.ipAddressType ==
+                ''IPv6'''
           status:
             description: IPAddressAllocationStatus defines the observed state of IPAddressAllocation.
             properties:

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetipreservations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetipreservations.yaml
@@ -27,6 +27,10 @@ spec:
       jsonPath: .status.ips[:]
       name: IPs
       type: string
+    - description: IP address type of the SubnetIPReservation.
+      jsonPath: .spec.ipAddressType
+      name: IPAddressType
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -53,6 +57,16 @@ spec:
           spec:
             description: SubnetIPReservationSpec defines the desired state of SubnetIPReservation
             properties:
+              ipAddressType:
+                description: IPAddressType defines the IP address type of the SubnetIPReservation.
+                enum:
+                - IPv4
+                - IPv6
+                - IPv4IPv6
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               numberOfIPs:
                 description: NumberOfIPs defines number of IPs requested to be reserved.
                 maximum: 100
@@ -63,9 +77,10 @@ spec:
                   rule: self == oldSelf
               reservedIPs:
                 description: |-
-                  ReservedIPs represents array of Reserved IPs. It can can contain IP addresses,
+                  ReservedIPs represents array of Reserved IPs. It can contain IP addresses,
                   IP Address range and CIDRs.
-                  Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28"]
+                  Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28",
+                  "2001:db8::1", "2001:db8::1-2001:db8::ff", "2001:db8::1/64"]
                 items:
                   type: string
                 minItems: 1
@@ -90,6 +105,10 @@ spec:
               rule: '!has(oldSelf.reservedIPs) || has(self.reservedIPs)'
             - message: numberOfIPs cannot be unset once set
               rule: '!has(oldSelf.numberOfIPs) || has(self.numberOfIPs)'
+            - message: ipAddressType cannot be unset once set
+              rule: '!has(oldSelf.ipAddressType) || has(self.ipAddressType)'
+            - message: ipAddressType can only be set when numberOfIPs is specified
+              rule: '!has(self.ipAddressType) || has(self.numberOfIPs)'
           status:
             description: SubnetIPReservationStatus defines the observed state of SubnetIPReservation
             properties:

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
@@ -67,6 +67,29 @@ spec:
                       type: string
                   type: object
                 type: array
+              interfaceIPType:
+                description: |-
+                  InterfaceIPType decides the address families of static IP allocation, when
+                  DHCP or SLAAC is not activated on the Subnet. It will be ignored when
+                  StaticIPAllocationType is set.
+                enum:
+                - IPv4
+                - IPv6
+                - IPv4IPv6
+                type: string
+              staticIPAllocationType:
+                description: |-
+                  StaticIPAllocationType explicitly requests static IP allocation of the
+                  specified the address families. In a mixed-mode Subnet (where both DHCP
+                  and static allocation are enabled), use this to define which families
+                  should be allocated from the static IP pools. This field is only valid
+                  when static allocation is enabled on the Subnet.
+                enum:
+                - IPv4
+                - IPv6
+                - IPv4IPv6
+                - None
+                type: string
               subnet:
                 description: Subnet defines the parent Subnet name of the SubnetPort.
                 type: string

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
@@ -113,13 +113,13 @@ spec:
                     type: object
                 type: object
               ipAddressType:
-                default: IPV4
+                default: IPv4
                 description: IPAddressType defines the IP address type that will be
                   allocated for the Subnet.
                 enum:
-                - IPV4
-                - IPV6
-                - IPV4IPV6
+                - IPv4
+                - IPv6
+                - IPv4IPv6
                 type: string
               ipAddresses:
                 description: Subnet CIDRS.

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
@@ -72,13 +72,12 @@ spec:
                 - message: Value is immutable
                   rule: self == oldSelf
               ipAddressType:
-                default: IPV4
                 description: IPAddressType defines the IP address type that will be
                   allocated for subnets in the SubnetSet.
                 enum:
-                - IPV4
-                - IPV6
-                - IPV4IPV6
+                - IPv4
+                - IPv6
+                - IPv4IPv6
                 type: string
               ipv4SubnetSize:
                 description: Size of IPv4 Subnet based upon estimated workload count.

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -258,9 +258,11 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW. | Private | Enum: [External Private PrivateTGW] <br /> |
-| `allocationSize` _integer_ | AllocationSize specifies the size of allocationIPs to be allocated.<br />It should be a power of 2. |  | Minimum: 1 <br /> |
+| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. | Private | Enum: [External Private PrivateTGW] <br /> |
+| `allocationSize` _integer_ | AllocationSize specifies the size of IPv4 allocationIPs to be allocated.<br />It should be a power of 2. |  | Minimum: 1 <br /> |
 | `allocationIPs` _string_ | AllocationIPs specifies the Allocated IP addresses in CIDR or single IP Address format. |  |  |
+| `ipv6AllocationPrefixLength` _integer_ | IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses. |  | Maximum: 128 <br />Minimum: 64 <br /> |
+| `ipAddressType` _[IPAllocationAddressType](#ipallocationaddresstype)_ | IPAddressType specifies the IP address type of the IPAddressAllocation. | IPv4 | Enum: [IPv4 IPv6] <br /> |
 
 
 #### IPAddressAllocationStatus
@@ -289,17 +291,32 @@ _Underlying type:_ _string_
 
 
 _Appears in:_
+- [SubnetIPReservationSpec](#subnetipreservationspec)
+- [SubnetPortSpec](#subnetportspec)
 - [SubnetSetSpec](#subnetsetspec)
 - [SubnetSpec](#subnetspec)
 
 | Field | Description |
 | --- | --- |
-| `IPV4` |  |
-| `IPV6` |  |
-| `IPV4IPV6` |  |
+| `IPv4` |  |
+| `IPv6` |  |
+| `IPv4IPv6` |  |
 
 
 #### IPAddressVisibility
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [IPAddressAllocationSpec](#ipaddressallocationspec)
+
+
+
+#### IPAllocationAddressType
 
 _Underlying type:_ _string_
 
@@ -692,6 +709,25 @@ _Appears in:_
 | `enabled` _boolean_ | Activate or deactivate static IP allocation for VPC Subnet Ports.<br />If the DHCP mode is DHCPDeactivated or not set, its default value is true.<br />If the DHCP mode is DHCPServer or DHCPRelay, its default value is false.<br />The value cannot be set to true when the DHCP mode is DHCPServer or DHCPRelay. |  |  |
 
 
+#### StaticIPAllocationType
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [SubnetPortSpec](#subnetportspec)
+
+| Field | Description |
+| --- | --- |
+| `IPv4` |  |
+| `IPv6` |  |
+| `IPv4IPv6` |  |
+| `None` |  |
+
+
 #### StaticRoute
 
 
@@ -928,7 +964,8 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `subnet` _string_ | Subnet specifies the Subnet to reserve IPs from.<br />The Subnet needs to have static IP allocation activated. |  | Required: \{\} <br /> |
 | `numberOfIPs` _integer_ | NumberOfIPs defines number of IPs requested to be reserved. |  | Maximum: 100 <br />Minimum: 1 <br /> |
-| `reservedIPs` _string array_ | ReservedIPs represents array of Reserved IPs. It can can contain IP addresses,<br />IP Address range and CIDRs.<br />Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28"] |  | MinItems: 1 <br /> |
+| `reservedIPs` _string array_ | ReservedIPs represents array of Reserved IPs. It can contain IP addresses,<br />IP Address range and CIDRs.<br />Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28",<br />"2001:db8::1", "2001:db8::1-2001:db8::ff", "2001:db8::1/64"] |  | MinItems: 1 <br /> |
+| `ipAddressType` _[IPAddressType](#ipaddresstype)_ | IPAddressType defines the IP address type of the SubnetIPReservation. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
 
 
 #### SubnetIPReservationStatus
@@ -1001,6 +1038,8 @@ _Appears in:_
 | `subnet` _string_ | Subnet defines the parent Subnet name of the SubnetPort. |  |  |
 | `subnetSet` _string_ | SubnetSet defines the parent SubnetSet name of the SubnetPort. |  |  |
 | `addressBindings` _[PortAddressBinding](#portaddressbinding) array_ | AddressBindings defines static address bindings used for the SubnetPort. |  |  |
+| `interfaceIPType` _[IPAddressType](#ipaddresstype)_ | InterfaceIPType decides the address families of static IP allocation, when<br />DHCP or SLAAC is not activated on the Subnet. It will be ignored when<br />StaticIPAllocationType is set. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
+| `staticIPAllocationType` _[StaticIPAllocationType](#staticipallocationtype)_ | StaticIPAllocationType explicitly requests static IP allocation of the<br />specified the address families. In a mixed-mode Subnet (where both DHCP<br />and static allocation are enabled), use this to define which families<br />should be allocated from the static IP pools. This field is only valid<br />when static allocation is enabled on the Subnet. |  | Enum: [IPv4 IPv6 IPv4IPv6 None] <br /> |
 
 
 #### SubnetPortStatus
@@ -1053,7 +1092,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `ipAddressType` _[IPAddressType](#ipaddresstype)_ | IPAddressType defines the IP address type that will be allocated for subnets in the SubnetSet. | IPV4 | Enum: [IPV4 IPV6 IPV4IPV6] <br /> |
+| `ipAddressType` _[IPAddressType](#ipaddresstype)_ | IPAddressType defines the IP address type that will be allocated for subnets in the SubnetSet. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
 | `ipv4SubnetSize` _integer_ | Size of IPv4 Subnet based upon estimated workload count. |  | Maximum: 65536 <br /> |
 | `ipv6PrefixLength` _integer_ | IPv6 prefix length for subnets in the SubnetSet (e.g. 64 means /64). |  | Maximum: 127 <br />Minimum: 2 <br /> |
 | `accessMode` _[AccessMode](#accessmode)_ | Access mode of IPv4 Subnet, accessible only from within VPC or from outside VPC. |  | Enum: [Private Public PrivateTGW] <br /> |
@@ -1093,7 +1132,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `vpcName` _string_ | VPC name of the Subnet. |  |  |
-| `ipAddressType` _[IPAddressType](#ipaddresstype)_ | IPAddressType defines the IP address type that will be allocated for the Subnet. | IPV4 | Enum: [IPV4 IPV6 IPV4IPV6] <br /> |
+| `ipAddressType` _[IPAddressType](#ipaddresstype)_ | IPAddressType defines the IP address type that will be allocated for the Subnet. | IPv4 | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
 | `ipv4SubnetSize` _integer_ | Size of IPv4 Subnet based upon estimated workload count. |  | Maximum: 65536 <br /> |
 | `ipv6PrefixLength` _integer_ | IPv6 prefix length for the Subnet (e.g. 64 means /64). |  | Maximum: 127 <br />Minimum: 2 <br /> |
 | `accessMode` _[AccessMode](#accessmode)_ | Access mode of IPv4 Subnet, accessible only from within VPC or from outside VPC. |  | Enum: [Private Public PrivateTGW L2Only] <br /> |

--- a/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
+++ b/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
@@ -6,11 +6,14 @@ package v1alpha1
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 type IPAddressVisibility string
+type IPAllocationAddressType string
 
 var (
-	IPAddressVisibilityExternal   IPAddressVisibility = "External"
-	IPAddressVisibilityPrivate    IPAddressVisibility = "Private"
-	IPAddressVisibilityPrivateTGW IPAddressVisibility = "PrivateTGW"
+	IPAddressVisibilityExternal   IPAddressVisibility     = "External"
+	IPAddressVisibilityPrivate    IPAddressVisibility     = "Private"
+	IPAddressVisibilityPrivateTGW IPAddressVisibility     = "PrivateTGW"
+	IPAllocationIPAddressTypeIPv4 IPAllocationAddressType = "IPv4"
+	IPAllocationIPAddressTypeIPv6 IPAllocationAddressType = "IPv6"
 )
 
 // +genclient
@@ -21,6 +24,7 @@ var (
 // IPAddressAllocation is the Schema for the IP allocation API.
 // +kubebuilder:printcolumn:name="IPAddressBlockVisibility",type=string,JSONPath=`.spec.ipAddressBlockVisibility`,description="IPAddressBlockVisibility of IPAddressAllocation"
 // +kubebuilder:printcolumn:name="AllocationIPs",type=string,JSONPath=`.status.allocationIPs`, description="AllocationIPs for the IPAddressAllocation"
+// +kubebuilder:printcolumn:name="IPv6AllocationPrefixLength",type=string,JSONPath=`.spec.ipv6AllocationPrefixLength`,description="IPv6 allocation prefix length of the IPAddressAllocation."
 type IPAddressAllocation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -40,16 +44,21 @@ type IPAddressAllocationList struct {
 
 // IPAddressAllocationSpec defines the desired state of IPAddressAllocation.
 // +kubebuilder:validation:XValidation:rule="!has(self.allocationSize) || !has(self.allocationIPs)", message="Only one of allocationSize or allocationIPs can be specified"
+// +kubebuilder:validation:XValidation:rule="!has(self.ipv6AllocationPrefixLength) || !has(self.allocationIPs)", message="Only one of ipv6AllocationPrefixLength or allocationIPs can be specified"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.allocationSize) || has(self.allocationSize)", message="allocationSize is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.allocationIPs) || has(self.allocationIPs)", message="allocationIPs is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.ipv6AllocationPrefixLength) || has(self.ipv6AllocationPrefixLength)", message="ipv6AllocationPrefixLength is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(self.allocationSize) || !has(self.ipAddressType) || self.ipAddressType == 'IPv4'", message="allocationSize can only be set when ipAddressType is IPv4"
+// +kubebuilder:validation:XValidation:rule="!has(self.ipv6AllocationPrefixLength) || self.ipAddressType == 'IPv6'", message="ipv6AllocationPrefixLength can only be set when ipAddressType is IPv6"
 type IPAddressAllocationSpec struct {
 	// IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.
+	// This field is not applicable if ipAddressType is IPv6.
 	// +kubebuilder:validation:Enum=External;Private;PrivateTGW
 	// +kubebuilder:default=Private
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	IPAddressBlockVisibility IPAddressVisibility `json:"ipAddressBlockVisibility,omitempty"`
-	// AllocationSize specifies the size of allocationIPs to be allocated.
+	// AllocationSize specifies the size of IPv4 allocationIPs to be allocated.
 	// It should be a power of 2.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	// +kubebuilder:validation:Minimum:=1
@@ -57,6 +66,16 @@ type IPAddressAllocationSpec struct {
 	// AllocationIPs specifies the Allocated IP addresses in CIDR or single IP Address format.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	AllocationIPs string `json:"allocationIPs,omitempty"`
+	// IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses.
+	// +kubebuilder:validation:Minimum:=64
+	// +kubebuilder:validation:Maximum:=128
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	IPv6AllocationPrefixLength int `json:"ipv6AllocationPrefixLength,omitempty"`
+	// IPAddressType specifies the IP address type of the IPAddressAllocation.
+	// +kubebuilder:validation:Enum=IPv4;IPv6
+	// +kubebuilder:default=IPv4
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	IPAddressType IPAllocationAddressType `json:"ipAddressType,omitempty"`
 }
 
 // IPAddressAllocationStatus defines the observed state of IPAddressAllocation.

--- a/pkg/apis/vpc/v1alpha1/subnet_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnet_types.go
@@ -26,9 +26,9 @@ const (
 	DHCPv6ConfigModeRelay         DHCPv6ConfigMode  = "DHCPRelay"
 	ConnectivityStateConnected    ConnectivityState = "Connected"
 	ConnectivityStateDisconnected ConnectivityState = "Disconnected"
-	IPAddressTypeIPv4             IPAddressType     = "IPV4"
-	IPAddressTypeIPv6             IPAddressType     = "IPV6"
-	IPAddressTypeIPv4IPv6         IPAddressType     = "IPV4IPV6"
+	IPAddressTypeIPv4             IPAddressType     = "IPv4"
+	IPAddressTypeIPv6             IPAddressType     = "IPv6"
+	IPAddressTypeIPv4IPv6         IPAddressType     = "IPv4IPv6"
 )
 
 // SubnetSpec defines the desired state of Subnet.
@@ -47,8 +47,8 @@ type SubnetSpec struct {
 	// VPC name of the Subnet.
 	VPCName string `json:"vpcName,omitempty"`
 	// IPAddressType defines the IP address type that will be allocated for the Subnet.
-	// +kubebuilder:validation:Enum=IPV4;IPV6;IPV4IPV6
-	// +kubebuilder:default=IPV4
+	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
+	// +kubebuilder:default=IPv4
 	IPAddressType IPAddressType `json:"ipAddressType,omitempty"`
 	// Size of IPv4 Subnet based upon estimated workload count.
 	// +kubebuilder:validation:Maximum:=65536

--- a/pkg/apis/vpc/v1alpha1/subnetipreservation_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetipreservation_types.go
@@ -12,6 +12,8 @@ import (
 // +kubebuilder:validation:XValidation:rule="has(self.numberOfIPs) || has(self.reservedIPs)",message="One of numberOfIPs or reservedIPs must be specified"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.reservedIPs) || has(self.reservedIPs)",message="reservedIPs cannot be unset once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.numberOfIPs) || has(self.numberOfIPs)",message="numberOfIPs cannot be unset once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.ipAddressType) || has(self.ipAddressType)",message="ipAddressType cannot be unset once set"
+// +kubebuilder:validation:XValidation:rule="!has(self.ipAddressType) || has(self.numberOfIPs)",message="ipAddressType can only be set when numberOfIPs is specified"
 type SubnetIPReservationSpec struct {
 	// Subnet specifies the Subnet to reserve IPs from.
 	// The Subnet needs to have static IP allocation activated.
@@ -25,11 +27,17 @@ type SubnetIPReservationSpec struct {
 	// +kubebuilder:validation:Minimum:=1
 	NumberOfIPs int `json:"numberOfIPs,omitempty"`
 
-	// ReservedIPs represents array of Reserved IPs. It can can contain IP addresses,
+	// ReservedIPs represents array of Reserved IPs. It can contain IP addresses,
 	// IP Address range and CIDRs.
-	// Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28"]
+	// Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28",
+	// "2001:db8::1", "2001:db8::1-2001:db8::ff", "2001:db8::1/64"]
 	// +kubebuilder:validation:MinItems=1
 	ReservedIPs []string `json:"reservedIPs,omitempty"`
+
+	// IPAddressType defines the IP address type of the SubnetIPReservation.
+	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	IPAddressType IPAddressType `json:"ipAddressType,omitempty"`
 }
 
 // SubnetIPReservationStatus defines the observed state of SubnetIPReservation
@@ -52,6 +60,7 @@ type SubnetIPReservationStatus struct {
 // +kubebuilder:printcolumn:name="Subnet",type=string,JSONPath=`.spec.subnet`,description="The parent Subnet name of the SubnetIPReservation."
 // +kubebuilder:printcolumn:name="NumberOfIPs",type=string,JSONPath=`.spec.numberOfIPs`,description="Number of IPs requested to be reserved."
 // +kubebuilder:printcolumn:name="IPs",type=string,JSONPath=`.status.ips[:]`,description="List of reserved IPs."
+// +kubebuilder:printcolumn:name="IPAddressType",type=string,JSONPath=`.spec.ipAddressType`,description="IP address type of the SubnetIPReservation."
 type SubnetIPReservation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/vpc/v1alpha1/subnetport_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetport_types.go
@@ -7,6 +7,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type StaticIPAllocationType string
+
+const (
+	StaticIPAllocationTypeIPv4     StaticIPAllocationType = "IPv4"
+	StaticIPAllocationTypeIPv6     StaticIPAllocationType = "IPv6"
+	StaticIPAllocationTypeIPv4IPv6 StaticIPAllocationType = "IPv4IPv6"
+	StaticIPAllocationTypeNone     StaticIPAllocationType = "None"
+)
+
 // +kubebuilder:validation:XValidation:rule="!has(self.subnetSet) || !has(self.subnet)",message="Only one of subnet or subnetSet can be specified or both set to empty in which case default SubnetSet for VM will be used"
 // SubnetPortSpec defines the desired state of SubnetPort.
 type SubnetPortSpec struct {
@@ -16,6 +25,18 @@ type SubnetPortSpec struct {
 	SubnetSet string `json:"subnetSet,omitempty"`
 	// AddressBindings defines static address bindings used for the SubnetPort.
 	AddressBindings []PortAddressBinding `json:"addressBindings,omitempty"`
+	// InterfaceIPType decides the address families of static IP allocation, when
+	// DHCP or SLAAC is not activated on the Subnet. It will be ignored when
+	// StaticIPAllocationType is set.
+	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
+	InterfaceIPType IPAddressType `json:"interfaceIPType,omitempty"`
+	// StaticIPAllocationType explicitly requests static IP allocation of the
+	// specified the address families. In a mixed-mode Subnet (where both DHCP
+	// and static allocation are enabled), use this to define which families
+	// should be allocated from the static IP pools. This field is only valid
+	// when static allocation is enabled on the Subnet.
+	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6;None
+	StaticIPAllocationType StaticIPAllocationType `json:"staticIPAllocationType,omitempty"`
 }
 
 // PortAddressBinding defines static addresses for the Port.

--- a/pkg/apis/vpc/v1alpha1/subnetset_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetset_types.go
@@ -17,8 +17,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(self.subnetDHCPv6Config) || !has(self.subnetDHCPv6Config.mode) || self.subnetDHCPv6Config.mode!='DHCPRelay'", message="DHCPRelay is not supported in SubnetSet"
 type SubnetSetSpec struct {
 	// IPAddressType defines the IP address type that will be allocated for subnets in the SubnetSet.
-	// +kubebuilder:validation:Enum=IPV4;IPV6;IPV4IPV6
-	// +kubebuilder:default=IPV4
+	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
 	IPAddressType IPAddressType `json:"ipAddressType,omitempty"`
 	// Size of IPv4 Subnet based upon estimated workload count.
 	// +kubebuilder:validation:Maximum:=65536


### PR DESCRIPTION
The PR includes the CRD changes to support IPv6 for
SubnetPort, IPAddressAllocation and SubnetIPReservation.