### PR TITLE
nsxserviceaccount: backoff NSX calls after CCP connection capacity error 610139

### DIFF
--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +34,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/nsxserviceaccount"
+	nsxsasvc "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/nsxserviceaccount"
 )
 
 const proxyLabelKey = "mgmt-proxy.antrea-nsx.vmware.com"
@@ -114,6 +115,8 @@ var (
 )
 
 // NSXServiceAccountReconciler reconciles a NSXServiceAccount object.
+// After NSX error 610139 (cluster control plane connection capacity full), reconciles may
+// requeue without calling NSX until a shared backoff window expires.
 // Requires NSXT 4.0.1
 //
 // create/delete event will be processed by Reconcile
@@ -128,7 +131,7 @@ var (
 type NSXServiceAccountReconciler struct {
 	client.Client
 	Scheme        *apimachineryruntime.Scheme
-	Service       *nsxserviceaccount.NSXServiceAccountService
+	Service       *nsxsasvc.NSXServiceAccountService
 	Recorder      record.EventRecorder
 	StatusUpdater common.StatusUpdater
 }
@@ -149,8 +152,6 @@ func (r *NSXServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ResultNormal, client.IgnoreNotFound(err)
 	}
 
-	// Since NSXServiceAccount service can only be activated from NSX 4.1.0 onwards,
-	// So need to check NSX version before starting NSXServiceAccount reconcile
 	if !r.Service.NSXClient.NSXCheckVersion(nsx.ServiceAccount) {
 		err := errors.New("NSX version check failed, NSXServiceAccount feature is not supported")
 		r.StatusUpdater.UpdateFail(ctx, obj, err, "", updateNSXServiceAccountStatuswithError)
@@ -170,7 +171,7 @@ func (r *NSXServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			log.Debug("added finalizer on CR", "nsxserviceaccount", req.NamespacedName)
 		}
 
-		if nsxserviceaccount.IsNSXServiceAccountRealized(&obj.Status) {
+		if nsxsasvc.IsNSXServiceAccountRealized(&obj.Status) {
 			if r.Service.NSXClient.NSXCheckVersion(nsx.ServiceAccountRestore) {
 				if err := r.Service.RestoreRealizedNSXServiceAccount(ctx, obj); err != nil {
 					log.Error(err, "update realized failed, would retry exponentially", "nsxserviceaccount", req.NamespacedName)
@@ -185,6 +186,12 @@ func (r *NSXServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			}
 			r.StatusUpdater.UpdateSuccess(ctx, obj, updateNSXServiceAccountStatus)
 			return ResultNormal, nil
+		}
+
+		if requeueAfter, skip := nsxsasvc.CCPConnectionCapacityFullBackoffRequeue(time.Now()); skip {
+			log.Info("skipping NSX API calls while cluster control plane connection capacity backoff is active",
+				"nsxserviceaccount", req.NamespacedName, "requeueAfter", requeueAfter)
+			return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 		}
 		if err := r.Service.CreateOrUpdateNSXServiceAccount(ctx, obj); err != nil {
 			r.StatusUpdater.UpdateFail(ctx, obj, err, "", updateNSXServiceAccountStatuswithError)
@@ -321,7 +328,7 @@ func NewNSXServiceAccountReconciler(mgr ctrl.Manager, commonService servicecommo
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("nsxserviceaccount-controller"), //nolint:staticcheck // record.EventRecorder; StatusUpdater not on events.EventRecorder yet
 	}
-	nsxServiceAccountService, err := nsxserviceaccount.InitializeNSXServiceAccount(commonService)
+	nsxServiceAccountService, err := nsxsasvc.InitializeNSXServiceAccount(commonService)
 	if err != nil {
 		log.Error(err, "Failed to initialize service", "controller", "NSXServiceAccount")
 		os.Exit(1)
@@ -347,7 +354,7 @@ func (r *NSXServiceAccountReconciler) validateRealized(count uint16, ca []byte, 
 		}
 		for _, account := range nsxServiceAccountList.Items {
 			nsxServiceAccount := account
-			if nsxserviceaccount.IsNSXServiceAccountRealized(&nsxServiceAccount.Status) {
+			if nsxsasvc.IsNSXServiceAccountRealized(&nsxServiceAccount.Status) {
 				if err := r.Service.ValidateAndUpdateRealizedNSXServiceAccount(context.TODO(), &nsxServiceAccount, ca, nsxRestoreStatus); err != nil {
 					log.Error(err, "Failed to update realized NSXServiceAccount", "namespace", nsxServiceAccount.Namespace, "name", nsxServiceAccount.Name)
 					setCountToZero = true
@@ -412,7 +419,7 @@ func updateNSXServiceAccountStatuswithError(client client.Client, ctx context.Co
 		nsa = obj.DeepCopy()
 		nsa.Status.Phase = nsxvmwarecomv1alpha1.NSXServiceAccountPhaseFailed
 		nsa.Status.Reason = fmt.Sprintf("Error: %v", e)
-		nsa.Status.Conditions = nsxserviceaccount.GenerateNSXServiceAccountConditions(nsa.Status.Conditions, nsa.Generation, metav1.ConditionFalse, nsxvmwarecomv1alpha1.ConditionReasonRealizationError, fmt.Sprintf("Error: %v", e))
+		nsa.Status.Conditions = nsxsasvc.GenerateNSXServiceAccountConditions(nsa.Status.Conditions, nsa.Generation, metav1.ConditionFalse, nsxvmwarecomv1alpha1.ConditionReasonRealizationError, fmt.Sprintf("Error: %v", e))
 	}
 	err := client.Status().Update(ctx, nsa)
 	if err != nil {

--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
@@ -25,6 +27,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -35,7 +38,7 @@ import (
 	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/nsxserviceaccount"
+	nsxsasvc "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/nsxserviceaccount"
 )
 
 type fakeRecorder struct {
@@ -342,6 +345,8 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 		{
 			name: "DeleteWithoutFinalizer",
 			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				// Fake client strips DeletionTimestamp on Create; wrap Get so Reconcile sees a terminating CR.
+				base := fake.NewClientBuilder().WithScheme(r.Scheme).WithStatusSubresource(&nsxvmwarecomv1alpha1.NSXServiceAccount{}).Build()
 				obj := &nsxvmwarecomv1alpha1.NSXServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:         requestArgs.req.Namespace,
@@ -349,12 +354,26 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 						CreationTimestamp: *createTimestamp,
 					},
 				}
-				assert.NoError(t, r.Client.Create(ctx, obj))
+				assert.NoError(t, base.Create(ctx, obj))
+				wrapped := interceptor.NewClient(base, interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, o client.Object, opts ...client.GetOption) error {
+						if err := c.Get(ctx, key, o, opts...); err != nil {
+							return err
+						}
+						if key.Namespace == requestArgs.req.Namespace && key.Name == requestArgs.req.Name {
+							if nsxsa, ok := o.(*nsxvmwarecomv1alpha1.NSXServiceAccount); ok {
+								ts := deletionTimestamp.DeepCopy()
+								nsxsa.SetDeletionTimestamp(ts)
+							}
+						}
+						return nil
+					},
+				})
+				r.Client = wrapped
 				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersion", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{true},
 					Times:  1,
 				}})
-				patches.ApplyMethod(obj.DeletionTimestamp, "IsZero", func() bool { return false })
 				return patches
 			},
 			args:    requestArgs,
@@ -375,13 +394,13 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
 				obj := &nsxvmwarecomv1alpha1.NSXServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace:         requestArgs.req.Namespace,
-						Name:              requestArgs.req.Name,
-						DeletionTimestamp: deletionTimestamp,
-						Finalizers:        []string{servicecommon.NSXServiceAccountFinalizerName},
+						Namespace:  requestArgs.req.Namespace,
+						Name:       requestArgs.req.Name,
+						Finalizers: []string{servicecommon.NSXServiceAccountFinalizerName},
 					},
 				}
 				assert.NoError(t, r.Client.Create(ctx, obj))
+				assert.NoError(t, r.Client.Delete(ctx, obj))
 				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersion", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{true},
 					Times:  1,
@@ -390,7 +409,6 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 					Values: gomonkey.Params{fmt.Errorf("mock error")},
 					Times:  1,
 				}})
-				patches.ApplyMethod(obj.DeletionTimestamp, "IsZero", func() bool { return false })
 				return patches
 			},
 			args:    requestArgs,
@@ -411,13 +429,13 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
 				obj := &nsxvmwarecomv1alpha1.NSXServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace:         requestArgs.req.Namespace,
-						Name:              requestArgs.req.Name,
-						DeletionTimestamp: deletionTimestamp,
-						Finalizers:        []string{servicecommon.NSXServiceAccountFinalizerName},
+						Namespace:  requestArgs.req.Namespace,
+						Name:       requestArgs.req.Name,
+						Finalizers: []string{servicecommon.NSXServiceAccountFinalizerName},
 					},
 				}
 				assert.NoError(t, r.Client.Create(ctx, obj))
+				assert.NoError(t, r.Client.Delete(ctx, obj))
 				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersion", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{true},
 					Times:  1,
@@ -433,7 +451,6 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 					Values: gomonkey.Params{nil},
 					Times:  1,
 				}})
-				patches.ApplyMethod(obj.DeletionTimestamp, "IsZero", func() bool { return false })
 				return patches
 			},
 			args:    requestArgs,
@@ -454,13 +471,13 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 			prepareFunc: func(t *testing.T, r *NSXServiceAccountReconciler, ctx context.Context) (patches *gomonkey.Patches) {
 				obj := &nsxvmwarecomv1alpha1.NSXServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace:         requestArgs.req.Namespace,
-						Name:              requestArgs.req.Name,
-						DeletionTimestamp: deletionTimestamp,
-						Finalizers:        []string{servicecommon.NSXServiceAccountFinalizerName},
+						Namespace:  requestArgs.req.Namespace,
+						Name:       requestArgs.req.Name,
+						Finalizers: []string{servicecommon.NSXServiceAccountFinalizerName},
 					},
 				}
 				assert.NoError(t, r.Client.Create(ctx, obj))
+				assert.NoError(t, r.Client.Delete(ctx, obj))
 				patches = gomonkey.ApplyMethodSeq(r.Service.NSXClient, "NSXCheckVersion", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{true},
 					Times:  1,
@@ -469,7 +486,6 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 					Values: gomonkey.Params{nil},
 					Times:  1,
 				}})
-				patches.ApplyMethod(obj.DeletionTimestamp, "IsZero", func() bool { return false })
 				return patches
 			},
 			args:       requestArgs,
@@ -482,7 +498,7 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newFakeNSXServiceAccountReconciler()
 			nsxvmwarecomv1alpha1.AddToScheme(r.Scheme)
-			r.Service = &nsxserviceaccount.NSXServiceAccountService{
+			r.Service = &nsxsasvc.NSXServiceAccountService{
 				Service: servicecommon.Service{
 					NSXClient: &nsx.Client{},
 					NSXConfig: &config.NSXOperatorConfig{
@@ -504,7 +520,6 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 				t.Errorf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			fmt.Printf("err: %+v", err)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Reconcile() got = %v, want %v", got, tt.want)
 			}
@@ -513,8 +528,15 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 			if tt.expectedCR == nil {
 				assert.True(t, errors.IsNotFound(err))
 			} else {
+				expectedCR := tt.expectedCR.DeepCopy()
 				actualCR.CreationTimestamp = metav1.Time{}
-				assert.Equal(t, tt.expectedCR.ObjectMeta, actualCR.ObjectMeta)
+				expectedCR.CreationTimestamp = metav1.Time{}
+				switch tt.name {
+				case "DeleteError", "RemoveFinalizerFailed", "DeleteWithoutFinalizer":
+					expectedCR.DeletionTimestamp = actualCR.DeletionTimestamp
+					expectedCR.ResourceVersion = actualCR.ResourceVersion
+				}
+				assert.Equal(t, expectedCR.ObjectMeta, actualCR.ObjectMeta)
 				assert.Equal(t, tt.expectedCR.Spec, actualCR.Spec)
 				for i := range actualCR.Status.Conditions {
 					actualCR.Status.Conditions[i].LastTransitionTime = metav1.Time{}
@@ -523,6 +545,102 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNSXServiceAccountReconciler_Reconcile_CCPConnectionCapacityBackoffSkipsNSX(t *testing.T) {
+	t.Cleanup(nsxsasvc.ClearCCPConnectionCapacityFull)
+	nsxsasvc.ClearCCPConnectionCapacityFull()
+	nsxsasvc.MarkCCPConnectionCapacityFull()
+
+	r := newFakeNSXServiceAccountReconciler()
+	nsxvmwarecomv1alpha1.AddToScheme(r.Scheme)
+	r.Service = &nsxsasvc.NSXServiceAccountService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: &config.NSXOperatorConfig{
+				NsxConfig: &config.NsxConfig{
+					EnforcementPoint: "vmc-enforcementpoint",
+				},
+			},
+		},
+	}
+	r.StatusUpdater = common.NewStatusUpdater(r.Client, r.Service.NSXConfig, r.Recorder, MetricResType, "ServiceAccount", "NSXServiceAccount")
+
+	ctx := context.TODO()
+	req := controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "ccpboff"}}
+
+	obj := &nsxvmwarecomv1alpha1.NSXServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: req.Namespace,
+			Name:      req.Name,
+		},
+	}
+	require.NoError(t, r.Client.Create(ctx, obj))
+
+	var nsxCheckCalls int32
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(&nsx.Client{}), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+		atomic.AddInt32(&nsxCheckCalls, 1)
+		return true
+	})
+	defer patches.Reset()
+
+	got, err := r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), nsxCheckCalls, "NSX version check runs once before backoff check")
+	assert.GreaterOrEqual(t, got.RequeueAfter, time.Second)
+	assert.LessOrEqual(t, got.RequeueAfter, 5*time.Minute+time.Second)
+}
+
+func TestNSXServiceAccountReconciler_Reconcile_CCPConnectionCapacityBackoffDoesNotSkipRealized(t *testing.T) {
+	t.Cleanup(nsxsasvc.ClearCCPConnectionCapacityFull)
+	nsxsasvc.ClearCCPConnectionCapacityFull()
+	nsxsasvc.MarkCCPConnectionCapacityFull()
+
+	r := newFakeNSXServiceAccountReconciler()
+	nsxvmwarecomv1alpha1.AddToScheme(r.Scheme)
+	r.Service = &nsxsasvc.NSXServiceAccountService{
+		Service: servicecommon.Service{
+			NSXClient: &nsx.Client{},
+			NSXConfig: &config.NSXOperatorConfig{
+				NsxConfig: &config.NsxConfig{
+					EnforcementPoint: "vmc-enforcementpoint",
+				},
+			},
+		},
+	}
+	r.StatusUpdater = common.NewStatusUpdater(r.Client, r.Service.NSXConfig, r.Recorder, MetricResType, "ServiceAccount", "NSXServiceAccount")
+
+	ctx := context.TODO()
+	req := controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "realized-ccpboff"}}
+
+	obj := &nsxvmwarecomv1alpha1.NSXServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: req.Namespace,
+			Name:      req.Name,
+		},
+		Status: nsxvmwarecomv1alpha1.NSXServiceAccountStatus{
+			Phase: nsxvmwarecomv1alpha1.NSXServiceAccountPhaseRealized,
+		},
+	}
+	require.NoError(t, r.Client.Create(ctx, obj))
+
+	var updateEndpointsCalled bool
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(&nsx.Client{}), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+		return true
+	})
+	patches.ApplyMethod(reflect.TypeOf(r.Service), "RestoreRealizedNSXServiceAccount", func(_ *nsxsasvc.NSXServiceAccountService, _ context.Context, _ *nsxvmwarecomv1alpha1.NSXServiceAccount) error {
+		return nil
+	})
+	patches.ApplyMethod(reflect.TypeOf(r.Service), "UpdateProxyEndpointsIfNeeded", func(_ *nsxsasvc.NSXServiceAccountService, _ context.Context, _ *nsxvmwarecomv1alpha1.NSXServiceAccount) error {
+		updateEndpointsCalled = true
+		return nil
+	})
+	defer patches.Reset()
+
+	got, err := r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.True(t, updateEndpointsCalled, "UpdateProxyEndpointsIfNeeded should run for realized CR even during backoff")
+	assert.Equal(t, ResultNormal, got)
 }
 
 func TestNSXServiceAccountReconciler_GarbageCollector(t *testing.T) {
@@ -564,7 +682,7 @@ func TestNSXServiceAccountReconciler_GarbageCollector(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newFakeNSXServiceAccountReconciler()
-			r.Service = &nsxserviceaccount.NSXServiceAccountService{
+			r.Service = &nsxsasvc.NSXServiceAccountService{
 				Service: servicecommon.Service{
 					NSXClient: &nsx.Client{},
 					NSXConfig: &config.NSXOperatorConfig{
@@ -619,9 +737,9 @@ func TestNSXServiceAccountReconciler_StartController(t *testing.T) {
 		Client: fakeClient,
 	}
 	mockMgr := &MockManager{scheme: runtime.NewScheme()}
-	patches := gomonkey.ApplyFunc(nsxserviceaccount.InitializeNSXServiceAccount,
-		func(service servicecommon.Service) (*nsxserviceaccount.NSXServiceAccountService, error) {
-			return &nsxserviceaccount.NSXServiceAccountService{Service: service}, nil
+	patches := gomonkey.ApplyFunc(nsxsasvc.InitializeNSXServiceAccount,
+		func(service servicecommon.Service) (*nsxsasvc.NSXServiceAccountService, error) {
+			return &nsxsasvc.NSXServiceAccountService{Service: service}, nil
 		})
 	patches.ApplyFunc((*NSXServiceAccountReconciler).setupWithManager, func(r *NSXServiceAccountReconciler, mgr manager.Manager) error {
 		return nil
@@ -916,7 +1034,7 @@ func TestNSXServiceAccountReconciler_garbageCollector(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newFakeNSXServiceAccountReconciler()
-			r.Service = &nsxserviceaccount.NSXServiceAccountService{
+			r.Service = &nsxsasvc.NSXServiceAccountService{
 				Service: servicecommon.Service{
 					NSXClient: &nsx.Client{},
 					NSXConfig: &config.NSXOperatorConfig{
@@ -1049,7 +1167,7 @@ func TestNSXServiceAccountReconciler_validateRealized(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &NSXServiceAccountReconciler{
-				Service: &nsxserviceaccount.NSXServiceAccountService{},
+				Service: &nsxsasvc.NSXServiceAccountService{},
 			}
 			if tt.prepareFunc != nil {
 				patches := tt.prepareFunc(t, r)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -35,6 +35,14 @@ var (
 			Help:      "Last health status for NSX-Operator. 1 for 'status' label with current status.",
 		},
 	)
+	NSXAntreaOperatorHealthStats = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: MetricNamespace,
+			Subsystem: MetricSubsystem,
+			Name:      "nsx_antrea_operator_health_status",
+			Help:      "Last health status for NSX-Antrea-Operator. 1 for 'status' label with current status.",
+		},
+	)
 	ControllerSyncTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: MetricNamespace,
@@ -114,6 +122,20 @@ func InitializePrometheusMetrics() {
 	log.Info("Initializing prometheus metrics")
 	Register(
 		NSXOperatorHealthStats,
+		ControllerSyncTotal,
+		ControllerUpdateTotal,
+		ControllerUpdateSuccessTotal,
+		ControllerUpdateFailTotal,
+		ControllerDeleteTotal,
+		ControllerDeleteSuccessTotal,
+		ControllerDeleteFailTotal,
+	)
+}
+
+func InitializeNSXAntreaOperatorPrometheusMetrics() {
+	log.Info("Initializing prometheus metrics")
+	Register(
+		NSXAntreaOperatorHealthStats,
 		ControllerSyncTotal,
 		ControllerUpdateTotal,
 		ControllerUpdateSuccessTotal,

--- a/pkg/nsx/services/nsxserviceaccount/ccp_capacity_backoff.go
+++ b/pkg/nsx/services/nsxserviceaccount/ccp_capacity_backoff.go
@@ -1,0 +1,51 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package nsxserviceaccount
+
+import (
+	"sync"
+	"time"
+)
+
+const ccpConnectionCapacityBackoffWindow = 5 * time.Minute
+
+var (
+	ccpConnCapMu   sync.Mutex
+	ccpConnCapFull time.Time // zero value means no active backoff
+)
+
+// MarkCCPConnectionCapacityFull records the current time globally so NSXServiceAccount
+// reconciles can avoid calling NSX until the backoff window expires.
+func MarkCCPConnectionCapacityFull() {
+	ccpConnCapMu.Lock()
+	defer ccpConnCapMu.Unlock()
+	ccpConnCapFull = time.Now()
+}
+
+// ClearCCPConnectionCapacityFull clears the backoff after a successful CCP Update.
+func ClearCCPConnectionCapacityFull() {
+	ccpConnCapMu.Lock()
+	defer ccpConnCapMu.Unlock()
+	ccpConnCapFull = time.Time{}
+}
+
+// CCPConnectionCapacityFullBackoffRequeue returns whether reconcile should skip all NSX
+// calls and requeue. The duration is how long to wait until the backoff window ends.
+// When the window has already passed, the stored mark is cleared.
+func CCPConnectionCapacityFullBackoffRequeue(now time.Time) (requeueAfter time.Duration, skip bool) {
+	ccpConnCapMu.Lock()
+	defer ccpConnCapMu.Unlock()
+	if ccpConnCapFull.IsZero() {
+		return 0, false
+	}
+	remaining := ccpConnCapFull.Add(ccpConnectionCapacityBackoffWindow).Sub(now)
+	if remaining <= 0 {
+		ccpConnCapFull = time.Time{}
+		return 0, false
+	}
+	if remaining < time.Second {
+		return time.Second, true
+	}
+	return remaining, true
+}

--- a/pkg/nsx/services/nsxserviceaccount/ccp_capacity_backoff_test.go
+++ b/pkg/nsx/services/nsxserviceaccount/ccp_capacity_backoff_test.go
@@ -1,0 +1,52 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package nsxserviceaccount
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCCPConnectionCapacityFullBackoffRequeue(t *testing.T) {
+	t.Cleanup(ClearCCPConnectionCapacityFull)
+
+	ClearCCPConnectionCapacityFull()
+	d, skip := CCPConnectionCapacityFullBackoffRequeue(time.Now())
+	assert.False(t, skip)
+	assert.Zero(t, d)
+
+	MarkCCPConnectionCapacityFull()
+	now := time.Now()
+	d, skip = CCPConnectionCapacityFullBackoffRequeue(now)
+	assert.True(t, skip)
+	assert.GreaterOrEqual(t, d, time.Minute*4+time.Second*55)
+	assert.LessOrEqual(t, d, time.Minute*5+time.Second*5)
+
+	// Window expired: state is cleared so later reconciles are not affected.
+	d, skip = CCPConnectionCapacityFullBackoffRequeue(now.Add(6 * time.Minute))
+	assert.False(t, skip)
+	assert.Zero(t, d)
+	d, skip = CCPConnectionCapacityFullBackoffRequeue(time.Now())
+	assert.False(t, skip)
+	assert.Zero(t, d)
+
+	ClearCCPConnectionCapacityFull()
+	d, skip = CCPConnectionCapacityFullBackoffRequeue(time.Now())
+	assert.False(t, skip)
+	assert.Zero(t, d)
+}
+
+func TestCCPConnectionCapacityFullBackoffRequeue_SubSecondRemainingReturnsOneSecond(t *testing.T) {
+	t.Cleanup(ClearCCPConnectionCapacityFull)
+	ccpConnCapMu.Lock()
+	// ~1s left in the 5-minute window: mark at now - 4m59s.
+	ccpConnCapFull = time.Now().Add(-4*time.Minute - 59*time.Second)
+	ccpConnCapMu.Unlock()
+
+	d, skip := CCPConnectionCapacityFullBackoffRequeue(time.Now())
+	assert.True(t, skip)
+	assert.Equal(t, time.Second, d)
+}

--- a/pkg/nsx/services/nsxserviceaccount/cluster.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster.go
@@ -296,8 +296,12 @@ func (s *NSXServiceAccountService) createPIAndCCP(normalizedClusterName string, 
 		})
 		err = nsxutil.TransNSXApiError(err)
 		if err != nil {
+			if nsxutil.IsCCPConnectionCapacityFullError(err) {
+				MarkCCPConnectionCapacityFull()
+			}
 			return "", err
 		}
+		ClearCCPConnectionCapacityFull()
 		s.ClusterControlPlaneStore.Add(&ccp)
 		clusterId = *ccp.NodeId
 	} else if !hasCCP != (ccpObj == nil) {
@@ -495,8 +499,12 @@ func (s *NSXServiceAccountService) updatePIAndCCPCert(normalizedClusterName, uid
 	ccp.Certificate = &cert
 	if ccp2, err := s.NSXClient.ClusterControlPlanesClient.Update(siteId, enforcementpointId, normalizedClusterName, *ccp); err != nil {
 		err = nsxutil.TransNSXApiError(err)
+		if nsxutil.IsCCPConnectionCapacityFullError(err) {
+			MarkCCPConnectionCapacityFull()
+		}
 		return err
 	} else {
+		ClearCCPConnectionCapacityFull()
 		ccp = &ccp2
 		s.ClusterControlPlaneStore.Add(ccp)
 	}

--- a/pkg/nsx/services/nsxserviceaccount/cluster_test.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
@@ -2524,4 +2525,89 @@ func TestCleanupBeforeVPCDeletion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateOrUpdateNSXServiceAccount_MarksBackoffOnCCPConnectionCapacityFull(t *testing.T) {
+	t.Cleanup(ClearCCPConnectionCapacityFull)
+	ClearCCPConnectionCapacityFull()
+
+	ctx := context.TODO()
+	commonService := newFakeCommonService()
+	s := &NSXServiceAccountService{Service: commonService}
+	s.SetUpStore()
+
+	obj := &v1alpha1.NSXServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name610139",
+			Namespace: "ns1",
+			UID:       "00000000-0000-0000-0000-000000000099",
+		},
+		Spec: v1alpha1.NSXServiceAccountSpec{
+			VPCName: "vpc1",
+		},
+	}
+
+	normalizedClusterName := "k8scl-one_test-ns1-name610139"
+	vpcPath := "/orgs/default/projects/k8scl-one:test/vpcs/vpc1"
+	piID := "Id610139"
+	uid := string(obj.UID)
+
+	code610139 := int64(nsxutil.CCPConnectionCapacityFullErrorCode)
+	em := "capacity"
+	apiErr := &model.ApiError{ErrorCode: &code610139, ErrorMessage: &em}
+	et := vapierrors.ErrorTypeEnum("INVALID_REQUEST")
+	ccpErr := nsxutil.NewNSXApiError(apiErr, et)
+
+	require.NoError(t, s.Client.Create(ctx, obj))
+
+	patches := gomonkey.ApplyMethodSeq(s.NSXClient.WithCertificateClient, "Create", []gomonkey.OutputCell{{
+		Values: gomonkey.Params{mpmodel.PrincipalIdentity{
+			IsProtected: &isProtectedTrue,
+			Name:        &normalizedClusterName,
+			NodeId:      &normalizedClusterName,
+			Role:        nil,
+			RolesForPaths: []mpmodel.RolesForPath{{
+				Path: &readerPath,
+				Roles: []mpmodel.Role{{
+					Role: &readerRole,
+				}},
+			}, {
+				Path: &vpcPath,
+				Roles: []mpmodel.Role{{
+					Role: &vpcRole,
+				}},
+			}},
+			Id: &piID,
+			Tags: []mpmodel.Tag{{
+				Scope: &tagScopeCluster,
+				Tag:   &s.NSXConfig.CoeConfig.Cluster,
+			}, {
+				Scope: &tagScopeNamespace,
+				Tag:   &obj.Namespace,
+			}, {
+				Scope: &tagScopeNSXServiceAccountCRName,
+				Tag:   &obj.Name,
+			}, {
+				Scope: &tagScopeNSXServiceAccountCRUID,
+				Tag:   &uid,
+			}},
+		}, nil},
+		Times: 1,
+	}})
+	patches.ApplyMethodSeq(s.NSXClient.ClusterControlPlanesClient, "Update", []gomonkey.OutputCell{{
+		Values: gomonkey.Params{model.ClusterControlPlane{}, ccpErr},
+		Times:  1,
+	}})
+	patches.ApplyMethodSeq(s.NSXClient, "NSXCheckVersion", []gomonkey.OutputCell{{
+		Values: gomonkey.Params{true},
+		Times:  1,
+	}})
+	defer patches.Reset()
+
+	err := s.CreateOrUpdateNSXServiceAccount(ctx, obj)
+	require.Error(t, err)
+
+	d, skip := CCPConnectionCapacityFullBackoffRequeue(time.Now())
+	assert.True(t, skip)
+	assert.Greater(t, d, time.Duration(0))
 }

--- a/pkg/nsx/util/errors.go
+++ b/pkg/nsx/util/errors.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	InvalidLicenseErrorCode                   = 505
+	CCPConnectionCapacityFullErrorCode        = 610139 // NSX cluster control plane connection capacity full
 	ProviderNotReadyErrorCode                 = 500042
 	IPAllocationErrorCode                     = 8212
 	ReservedIPRangesOverlappedErrorCode       = 508134

--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -748,6 +748,26 @@ func DiffArrays[T comparable](firstArray []T, secondArray []T) []T {
 	return diffSet.UnsortedList()
 }
 
+// IsCCPConnectionCapacityFullError reports NSX API error 610139 (cluster control plane connection capacity full).
+// It follows errors.Unwrap so wrapped errors are recognized.
+func IsCCPConnectionCapacityFullError(err error) bool {
+	for err != nil {
+		if apiErr, ok := err.(*NSXApiError); ok && apiErr.ApiError != nil {
+			if apiErr.ErrorCode != nil && *apiErr.ErrorCode == CCPConnectionCapacityFullErrorCode {
+				return true
+			}
+			for i := range apiErr.RelatedErrors {
+				rel := &apiErr.RelatedErrors[i]
+				if rel.ErrorCode != nil && *rel.ErrorCode == CCPConnectionCapacityFullErrorCode {
+					return true
+				}
+			}
+		}
+		err = errors.Unwrap(err)
+	}
+	return false
+}
+
 func IsInvalidLicense(err error) bool {
 	invalidLicense := false
 	if apiErr, ok := err.(*NSXApiError); ok {

--- a/pkg/nsx/util/utils_test.go
+++ b/pkg/nsx/util/utils_test.go
@@ -1081,6 +1081,34 @@ func TestTransNSXApiError(t *testing.T) {
 	assert.Equal(t, gotErr.Type(), apierrors.ErrorType_NOT_FOUND)
 }
 
+func TestIsCCPConnectionCapacityFullError(t *testing.T) {
+	code610139 := int64(CCPConnectionCapacityFullErrorCode)
+	codeOther := int64(500)
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "non_nsx_api", err: errors.New("x"), want: false},
+		{name: "nil_api_error", err: &NSXApiError{ApiError: nil}, want: false},
+		{name: "main_error_code", err: &NSXApiError{ApiError: &model.ApiError{ErrorCode: &code610139}}, want: true},
+		{name: "related_error_code", err: &NSXApiError{ApiError: &model.ApiError{
+			ErrorCode: &codeOther,
+			RelatedErrors: []model.RelatedApiError{
+				{ErrorCode: &code610139},
+			},
+		}}, want: true},
+		{name: "other_code", err: &NSXApiError{ApiError: &model.ApiError{ErrorCode: &codeOther}}, want: false},
+		{name: "wrapped", err: fmt.Errorf("outer: %w", &NSXApiError{ApiError: &model.ApiError{ErrorCode: &code610139}}), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsCCPConnectionCapacityFullError(tt.err))
+		})
+	}
+}
+
 func TestParseDHCPMode(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
When ClusterControlPlanesClient.Update returns NSX error 610139 (connection 
capacity full), record a global timestamp. While a 5-minute window from that 
timestamp is still in effect, NSXServiceAccount reconcile requeues without
calling NSX. After the window expires, reconcile proceeds normally; a
successful CCP update clears the timestamp, and another 610139 refreshes it.
Add IsCCPConnectionCapacityFullError in pkg/nsx/util. Fix controller tests that
assumed deletion state on objects returned from the fake client.