### PR TITLE
feat(networkinfo): Convert allowed DNS zones from VpcNetworkConfiguration to DNS domain names in NetworkInfo

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,6 +58,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/dns"
 	ipaddressallocationservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/ipaddressallocation"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
@@ -192,6 +193,11 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			log.Error(err, "Failed to initialize staticroute commonService", "controller", "StaticRoute")
 			os.Exit(1)
 		}
+		dnsRecordService, err := dns.InitializeDNSRecordService(commonService, vpcService)
+		if err != nil {
+			log.Error(err, "Failed to initialize DNS record service", "controller", "DNS")
+			os.Exit(1)
+		}
 		ipblocksInfoService := ipblocksinfo.InitializeIPBlocksInfoService(commonService, subnetService)
 
 		subnetBindingService, err := subnetbindingservice.InitializeService(commonService)
@@ -230,7 +236,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 		subnetSetReconcile = subnetset.NewSubnetSetReconciler(mgr, subnetService, subnetPortService, vpcService, subnetBindingService)
 		reconcilerList = append(
 			reconcilerList,
-			networkinfocontroller.NewNetworkInfoReconciler(mgr, vpcService, ipblocksInfoService),
+			networkinfocontroller.NewNetworkInfoReconciler(mgr, vpcService, ipblocksInfoService, dnsRecordService),
 			namespacecontroller.NewNamespaceReconciler(mgr, cf, vpcService, subnetService, subnetPortService),
 			subnet.NewSubnetReconciler(mgr, subnetService, subnetPortService, vpcService, subnetBindingService),
 			subnetSetReconcile,

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -6,7 +6,9 @@ package networkinfo
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
+	"slices"
 	"strings"
 	"time"
 
@@ -72,6 +74,7 @@ var (
 	nsMsgVPCAutoSNATDisabled      = newNsUnreadyMessage("SNAT is not enabled in System VPC", NSReasonVPCSnatNotReady)
 	nsMsgVPCDefaultSNATIPGetError = newNsUnreadyMessage("Default SNAT IP is not allocated in VPC: %v", NSReasonVPCSnatNotReady)
 	nsMsgVPCIsReady               = newNsUnreadyMessage("", "")
+	nsMsgVPCDNSZonesSyncError     = newNsUnreadyMessage("Failed to sync permitted DNS zones from NSX: %v", NSReasonVPCNotReady)
 )
 
 type nsUnreadyMessage struct {
@@ -99,12 +102,18 @@ func (m *nsUnreadyMessage) getNSNetworkCondition(options ...interface{}) *corev1
 	return cond
 }
 
+// dnsZoneSyncer is the minimal DNS interface needed by NetworkInfoReconciler for VPC DNS zone lookups.
+type dnsZoneSyncer interface {
+	SyncDNSZonesByVpcNetworkConfig(vpcConfig *v1alpha1.VPCNetworkConfiguration) (map[string]string, error)
+}
+
 // NetworkInfoReconciler NetworkInfoReconcile reconciles a NetworkInfo object
 // Actually it is more like a shell, which is used to manage nsx VPC
 type NetworkInfoReconciler struct {
 	Client              client.Client
 	Scheme              *apimachineryruntime.Scheme
 	Service             *vpc.VPCService
+	DNSRecordService    dnsZoneSyncer
 	IPBlocksInfoService *ipblocksinfo.IPBlocksInfoService
 	Recorder            record.EventRecorder
 	queue               workqueue.TypedRateLimitingInterface[reconcile.Request]
@@ -452,9 +461,25 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		NetworkStack:            networkStack,
 	}
 
+	var allowedDNSDomains []string
+	if r.DNSRecordService != nil && len(nc.Spec.DNSZones) > 0 {
+		zoneMap, zoneSyncErr := r.DNSRecordService.SyncDNSZonesByVpcNetworkConfig(nc)
+		if zoneSyncErr != nil {
+			r.StatusUpdater.UpdateFail(ctx, networkInfoCR, zoneSyncErr, "Failed to sync DNS zones for VPC network configuration", setNetworkInfoVPCStatusWithError, state)
+			setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCDNSZonesSyncError.getNSNetworkCondition(zoneSyncErr))
+			return common.ResultRequeueAfter10sec, zoneSyncErr
+		}
+		for _, domainName := range slices.Sorted(maps.Values(zoneMap)) {
+			if domainName == "" {
+				continue
+			}
+			allowedDNSDomains = append(allowedDNSDomains, domainName)
+		}
+	}
+
 	// AKO needs to know the AVI subnet path created by NSX
 	setVPCNetworkConfigurationStatusWithLBS(ctx, r.Client, ncName, state.Name, aviSubnetPath, nsxLBSPath, *createdVpc.Path)
-	r.StatusUpdater.UpdateSuccess(ctx, networkInfoCR, setNetworkInfoVPCStatus, state)
+	r.StatusUpdater.UpdateSuccess(ctx, networkInfoCR, setNetworkInfoVPCStatus, state, allowedDNSDomains)
 
 	if retryWithSystemVPC {
 		setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, systemNSCondition)
@@ -851,11 +876,12 @@ func (r *NetworkInfoReconciler) StartController(mgr ctrl.Manager, _ webhook.Serv
 	return nil
 }
 
-func NewNetworkInfoReconciler(mgr ctrl.Manager, vpcService *vpc.VPCService, ipblocksInfoService *ipblocksinfo.IPBlocksInfoService) *NetworkInfoReconciler {
+func NewNetworkInfoReconciler(mgr ctrl.Manager, vpcService *vpc.VPCService, ipblocksInfoService *ipblocksinfo.IPBlocksInfoService, dnsRecordService dnsZoneSyncer) *NetworkInfoReconciler {
 	networkInfoReconciler := &NetworkInfoReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("networkinfo-controller"), //nolint:staticcheck // record.EventRecorder; StatusUpdater not on events.EventRecorder yet
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		DNSRecordService: dnsRecordService,
+		Recorder:         mgr.GetEventRecorderFor("networkinfo-controller"), //nolint:staticcheck // record.EventRecorder; StatusUpdater not on events.EventRecorder yet
 	}
 	networkInfoReconciler.Service = vpcService
 	networkInfoReconciler.IPBlocksInfoService = ipblocksInfoService

--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -24,6 +24,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -38,6 +39,7 @@ import (
 	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/dns"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/ipblocksinfo"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
@@ -89,6 +91,13 @@ func (c *fakeVpcAttachmentClient) Delete(orgIdParam string, projectIdParam strin
 
 var fakeAttachmentClient = &fakeVpcAttachmentClient{}
 
+type fakeQueryClient struct{}
+
+func (*fakeQueryClient) List(_ string, _ *string, _ *string, _ *int64, _ *bool, _ *string) (model.SearchResponse, error) {
+	rc := int64(0)
+	return model.SearchResponse{ResultCount: &rc}, nil
+}
+
 type fakeRecorder struct{}
 
 func (recorder fakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
@@ -110,16 +119,33 @@ func createNetworkInfoReconciler(objs []client.Object) *NetworkInfoReconciler {
 		BindingType: model.VpcBindingType(),
 	}}
 
+	lbsStore := &vpc.LBSStore{ResourceStore: servicecommon.ResourceStore{
+		Indexer: cache.NewIndexer(func(obj interface{}) (string, error) {
+			lbs, ok := obj.(*model.LBService)
+			if !ok || lbs.Id == nil {
+				return "", fmt.Errorf("unexpected LBSStore object type %T", obj)
+			}
+			return *lbs.Id, nil
+		}, cache.Indexers{}),
+		BindingType: model.LBServiceBindingType(),
+	}}
+
 	service := &vpc.VPCService{
 		VpcStore: vpcStore,
+		LbsStore: lbsStore,
 		Service: servicecommon.Service{
 			Client: fakeClient,
 			NSXClient: &nsx.Client{
 				VPCConnectivityProfilesClient: &fakeVPCConnectivityProfilesClient{},
 				VpcAttachmentClient:           fakeAttachmentClient,
+				QueryClient:                   &fakeQueryClient{},
+				NsxConfig: &config.NSXOperatorConfig{
+					CoeConfig: &config.CoeConfig{Cluster: "unit-test"},
+				},
 			},
 
 			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{Cluster: "unit-test"},
 				NsxConfig: &config.NsxConfig{
 					EnforcementPoint:   "vmc-enforcementpoint",
 					UseAVILoadBalancer: false,
@@ -129,11 +155,14 @@ func createNetworkInfoReconciler(objs []client.Object) *NetworkInfoReconciler {
 		},
 	}
 
+	dnsSvc := &mockDNSZoneSyncer{}
+
 	r := &NetworkInfoReconciler{
-		Client:   fakeClient,
-		Scheme:   fake.NewClientBuilder().Build().Scheme(),
-		Service:  service,
-		Recorder: &fakeRecorder{},
+		Client:           fakeClient,
+		Scheme:           fake.NewClientBuilder().Build().Scheme(),
+		Service:          service,
+		DNSRecordService: dnsSvc,
+		Recorder:         &fakeRecorder{},
 	}
 	r.StatusUpdater = common.NewStatusUpdater(r.Client, r.Service.NSXConfig, r.Recorder, MetricResType, "VPC", "NetworkInfo")
 	return r
@@ -156,8 +185,8 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 		{
 			name: "Empty",
 			prepareFunc: func(t *testing.T, r *NetworkInfoReconciler, ctx context.Context) (patches *gomonkey.Patches) {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetVPCsByNamespace", func(_ *vpc.VPCService, _ string) []*model.Vpc {
-					return []*model.Vpc{}
+				patches = gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "deleteVPCsByNamespace", func(_ *NetworkInfoReconciler, _ context.Context, _ string) error {
+					return nil
 				})
 				return patches
 			},
@@ -198,7 +227,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 						ServiceClusterReason:   servicecommon.ReasonServiceClusterNotSet,
 					}, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -270,7 +299,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 						ServiceClusterReady:     true,
 					}, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -319,8 +348,12 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					},
 				}))
 				assert.NoError(t, r.Client.Create(ctx, &v1alpha1.VPCNetworkConfiguration{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "system",
+					ObjectMeta: metav1.ObjectMeta{Name: "system"},
+					Status: v1alpha1.VPCNetworkConfigurationStatus{
+						Conditions: []v1alpha1.Condition{{
+							Type:   v1alpha1.GatewayConnectionReady,
+							Status: corev1.ConditionTrue,
+						}},
 					},
 				}))
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetNetworkconfigNameFromNS", func(_ *vpc.VPCService, _ context.Context, _ string) (string, error) {
@@ -335,9 +368,6 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 						},
 					}, true, nil
 				})
-				patches.ApplyFunc(getGatewayConnectionStatus, func(_ *v1alpha1.VPCNetworkConfiguration) (bool, string) {
-					return true, ""
-				})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "ValidateConnectionStatus", func(_ *vpc.VPCService, _ *v1alpha1.VPCNetworkConfiguration, _ string) (*servicecommon.VPCConnectionStatus, error) {
 					assert.FailNow(t, "should not be called")
 					return &servicecommon.VPCConnectionStatus{
@@ -346,7 +376,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 						ServiceClusterReason:   servicecommon.ReasonServiceClusterNotSet,
 					}, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -420,7 +450,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 						ServiceClusterReason:   servicecommon.ReasonServiceClusterNotSet,
 					}, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					assert.FailNow(t, "should not be called")
 					return &model.Vpc{}, nil
 				})
@@ -473,7 +503,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetNSXLBSNATIP", func(_ *vpc.VPCService, _ model.Vpc, _ string) ([]string, error) {
 					return []string{"100.64.0.3"}, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -565,7 +595,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetNSXLBSNATIP", func(_ *vpc.VPCService, _ model.Vpc, _ string) ([]string, error) {
 					return []string{"100.64.0.3"}, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -647,7 +677,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetNSXLBSNATIP", func(_ *vpc.VPCService, _ model.Vpc, _ string) ([]string, error) {
 					return []string{"100.64.0.3"}, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -701,8 +731,12 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					},
 				}))
 				assert.NoError(t, r.Client.Create(ctx, &v1alpha1.VPCNetworkConfiguration{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "system",
+					ObjectMeta: metav1.ObjectMeta{Name: "system"},
+					Status: v1alpha1.VPCNetworkConfigurationStatus{
+						Conditions: []v1alpha1.Condition{{
+							Type:   v1alpha1.GatewayConnectionReady,
+							Status: corev1.ConditionTrue,
+						}},
 					},
 				}))
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetNetworkconfigNameFromNS", func(_ *vpc.VPCService, ctx context.Context, _ string) (string, error) {
@@ -717,9 +751,6 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 						},
 					}, true, nil
 				})
-				patches.ApplyFunc(getGatewayConnectionStatus, func(_ *v1alpha1.VPCNetworkConfiguration) (bool, string) {
-					return true, ""
-				})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "ValidateConnectionStatus", func(_ *vpc.VPCService, _ *v1alpha1.VPCNetworkConfiguration, _ string) (*servicecommon.VPCConnectionStatus, error) {
 					return &servicecommon.VPCConnectionStatus{
 						GatewayConnectionReady: true,
@@ -733,7 +764,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetNSXLBSNATIP", func(_ *vpc.VPCService, _ model.Vpc, _ string) ([]string, error) {
 					return []string{"100.64.0.3"}, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -791,8 +822,12 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					},
 				}))
 				assert.NoError(t, r.Client.Create(ctx, &v1alpha1.VPCNetworkConfiguration{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "system",
+					ObjectMeta: metav1.ObjectMeta{Name: "system"},
+					Status: v1alpha1.VPCNetworkConfigurationStatus{
+						Conditions: []v1alpha1.Condition{{
+							Type:   v1alpha1.GatewayConnectionReady,
+							Status: corev1.ConditionTrue,
+						}},
 					},
 				}))
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetNetworkconfigNameFromNS", func(_ *vpc.VPCService, ctx context.Context, _ string) (string, error) {
@@ -809,13 +844,10 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 						},
 					}, true, nil
 				})
-				patches.ApplyFunc(getGatewayConnectionStatus, func(_ *v1alpha1.VPCNetworkConfiguration) (bool, string) {
-					return true, ""
-				})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetLBProvider", func(_ *vpc.VPCService) (vpc.LBProvider, error) {
 					return vpc.AVILB, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -855,8 +887,12 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					},
 				}))
 				assert.NoError(t, r.Client.Create(ctx, &v1alpha1.VPCNetworkConfiguration{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "system",
+					ObjectMeta: metav1.ObjectMeta{Name: "system"},
+					Status: v1alpha1.VPCNetworkConfigurationStatus{
+						Conditions: []v1alpha1.Condition{{
+							Type:   v1alpha1.GatewayConnectionReady,
+							Status: corev1.ConditionTrue,
+						}},
 					},
 				}))
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetNetworkconfigNameFromNS", func(_ *vpc.VPCService, ctx context.Context, _ string) (string, error) {
@@ -873,13 +909,10 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 						},
 					}, true, nil
 				})
-				patches.ApplyFunc(getGatewayConnectionStatus, func(_ *v1alpha1.VPCNetworkConfiguration) (bool, string) {
-					return true, ""
-				})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetLBProvider", func(_ *vpc.VPCService) (vpc.LBProvider, error) {
 					return vpc.NSXLB, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -954,7 +987,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetLBProvider", func(_ *vpc.VPCService) (vpc.LBProvider, error) {
 					return vpc.AVILB, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -1016,7 +1049,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					return vpc.AVILB, nil
 				})
 				// Return VPC with LoadBalancerVpcEndpoint.Enabled = true to trigger AVI LB path retrieval
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -1086,7 +1119,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetLBProvider", func(_ *vpc.VPCService) (vpc.LBProvider, error) {
 					return vpc.NSXLB, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -1158,7 +1191,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetLBProvider", func(_ *vpc.VPCService) (vpc.LBProvider, error) {
 					return vpc.NSXLB, nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider) (*model.Vpc, error) {
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
 					return &model.Vpc{
 						DisplayName: servicecommon.String("vpc-name"),
 						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
@@ -1200,6 +1233,162 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				patches.ApplyFunc(setNSNetworkReadyCondition,
 					func(ctx context.Context, client client.Client, nsName string, condition *corev1.NamespaceCondition) {
 						require.True(t, nsConditionEquals(*condition, *nsMsgVPCNSXLBSNATIPError.getNSNetworkCondition(fmt.Errorf("tier1 uplink port IP not found"))))
+					})
+				return patches
+			},
+			args:    requestArgs,
+			want:    common.ResultRequeueAfter10sec,
+			wantErr: true,
+		},
+		{
+			name: "DNS zones in VpcNetworkConfiguration",
+			prepareFunc: func(t *testing.T, r *NetworkInfoReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &v1alpha1.NetworkInfo{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: requestArgs.req.Namespace,
+						Name:      requestArgs.req.Name,
+					},
+				}))
+				assert.NoError(t, r.Client.Create(ctx, &v1alpha1.VPCNetworkConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "system",
+					},
+				}))
+				patches = gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetNetworkconfigNameFromNS", func(_ *vpc.VPCService, ctx context.Context, _ string) (string, error) {
+					return "pre-vpc-nc", nil
+				})
+				// Return empty connectivity profile path to simulate VPC without attachment
+				patches.ApplyMethod(reflect.TypeOf(r), "GetVpcConnectivityProfilePathByVpcPath", func(_ *NetworkInfoReconciler, _ string) (string, error) {
+					return "", nil
+				})
+				dnsZonePath := "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/project-zone1"
+				invalidDNSZone := "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/inv-zone"
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetVPCNetworkConfig", func(_ *vpc.VPCService, _ string) (*v1alpha1.VPCNetworkConfiguration, bool, error) {
+					return &v1alpha1.VPCNetworkConfiguration{
+						Spec: v1alpha1.VPCNetworkConfigurationSpec{
+							NSXProject: "/orgs/default/projects/project-quality",
+							VPC:        "/orgs/default/projects/nsx_operator_e2e_test/vpcs/pre-vpc",
+							DNSZones: []string{
+								dnsZonePath,
+								invalidDNSZone,
+							},
+						},
+					}, true, nil
+				})
+				r.DNSRecordService = &mockDNSZoneSyncer{
+					dnsZoneConfigurations: map[string]string{
+						dnsZonePath:    "example.com",
+						invalidDNSZone: "",
+					},
+				}
+
+				patches.ApplyFunc(getGatewayConnectionStatus, func(_ *v1alpha1.VPCNetworkConfiguration) (bool, string) {
+					return true, ""
+				})
+				// Use NSXLB provider to verify GetLBSsFromNSXByVPC is NOT called when connectivity profile is empty
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetLBProvider", func(_ *vpc.VPCService) (vpc.LBProvider, error) {
+					return vpc.NSXLB, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
+					return &model.Vpc{
+						DisplayName: servicecommon.String("vpc-name"),
+						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
+						Id:          servicecommon.String("vpc-id"),
+					}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetNetworkStackFromNC", func(_ *vpc.VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
+					return v1alpha1.FullStackVPC, nil
+				})
+				patches.ApplyFunc(setVPCNetworkConfigurationStatusWithLBS,
+					func(ctx context.Context, client client.Client, ncName string, vpcName string, aviSubnetPath string, nsxLBSPath string, vpcPath string) {
+					})
+				patches.ApplyFunc(setNetworkInfoVPCStatus,
+					func(client client.Client, ctx context.Context, obj client.Object, _ metav1.Time, args ...interface{}) {
+						require.NotNil(t, args)
+						require.True(t, len(args) >= 2)
+						require.ElementsMatch(t, []string{"example.com"}, args[1])
+					})
+				patches.ApplyFunc(setNSNetworkReadyCondition,
+					func(ctx context.Context, client client.Client, nsName string, condition *corev1.NamespaceCondition) {
+						require.True(t, nsConditionEquals(*condition, *nsMsgVPCIsReady.getNSNetworkCondition()))
+					})
+				return patches
+			},
+			args:    requestArgs,
+			want:    common.ResultNormal,
+			wantErr: false,
+		},
+		{
+			name: "Failed to sync DNS zones in VpcNetworkConfiguration",
+			prepareFunc: func(t *testing.T, r *NetworkInfoReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &v1alpha1.NetworkInfo{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: requestArgs.req.Namespace,
+						Name:      requestArgs.req.Name,
+					},
+				}))
+				assert.NoError(t, r.Client.Create(ctx, &v1alpha1.VPCNetworkConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "system",
+					},
+				}))
+				patches = gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetNetworkconfigNameFromNS", func(_ *vpc.VPCService, ctx context.Context, _ string) (string, error) {
+					return "pre-vpc-nc", nil
+				})
+				// Return empty connectivity profile path to simulate VPC without attachment
+				patches.ApplyMethod(reflect.TypeOf(r), "GetVpcConnectivityProfilePathByVpcPath", func(_ *NetworkInfoReconciler, _ string) (string, error) {
+					return "", nil
+				})
+				invalidDNSZone := "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/inv-zone"
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetVPCNetworkConfig", func(_ *vpc.VPCService, _ string) (*v1alpha1.VPCNetworkConfiguration, bool, error) {
+					return &v1alpha1.VPCNetworkConfiguration{
+						Spec: v1alpha1.VPCNetworkConfigurationSpec{
+							NSXProject: "/orgs/default/projects/project-quality",
+							VPC:        "/orgs/default/projects/nsx_operator_e2e_test/vpcs/pre-vpc",
+							DNSZones: []string{
+								invalidDNSZone,
+							},
+						},
+					}, true, nil
+				})
+				r.DNSRecordService = &mockDNSZoneSyncer{
+					dnsZoneConfigurations: map[string]string{
+						invalidDNSZone: "",
+					},
+					syncErr: fmt.Errorf("unable to query NSX DNS zone"),
+				}
+
+				patches.ApplyFunc(getGatewayConnectionStatus, func(_ *v1alpha1.VPCNetworkConfiguration) (bool, string) {
+					return true, ""
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetLBProvider", func(_ *vpc.VPCService) (vpc.LBProvider, error) {
+					return vpc.NSXLB, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, ctx context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
+					return &model.Vpc{
+						DisplayName: servicecommon.String("vpc-name"),
+						Path:        servicecommon.String("/orgs/default/projects/project-quality/vpcs/fake-vpc"),
+						Id:          servicecommon.String("vpc-id"),
+					}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetNetworkStackFromNC", func(_ *vpc.VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
+					return v1alpha1.FullStackVPC, nil
+				})
+				patches.ApplyFunc(setNSNetworkReadyCondition,
+					func(ctx context.Context, client client.Client, nsName string, condition *corev1.NamespaceCondition) {
+						require.True(t, nsConditionEquals(*condition, *nsMsgVPCDNSZonesSyncError.getNSNetworkCondition(fmt.Errorf("unable to query NSX DNS zone"))))
+					})
+				patches.ApplyFunc(setNetworkInfoVPCStatus,
+					func(client client.Client, ctx context.Context, obj client.Object, _ metav1.Time, args ...interface{}) {
+						require.NotNil(t, args)
+						// Guard against architectural variances in gomonkey's variadic argument unpacking.
+						// In failure cases, 'args' only contains the state (len=1), so we bypass the domain slice check.
+						if len(args) >= 2 {
+							_, ok := args[1].([]string)
+							require.False(t, ok)
+						} else {
+							require.Equal(t, 1, len(args), "In failure case, only 'state' should be passed")
+						}
 					})
 				return patches
 			},
@@ -1902,6 +2091,15 @@ func TestNetworkInfoReconciler_StartController(t *testing.T) {
 	vpcService := &vpc.VPCService{
 		Service: servicecommon.Service{
 			Client: fakeClient,
+			NSXClient: &nsx.Client{
+				QueryClient: &fakeQueryClient{},
+				NsxConfig: &config.NSXOperatorConfig{
+					CoeConfig: &config.CoeConfig{Cluster: "unit-test"},
+				},
+			},
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{Cluster: "unit-test"},
+			},
 		},
 	}
 	ipblocksInfoService := &ipblocksinfo.IPBlocksInfoService{
@@ -1918,8 +2116,10 @@ func TestNetworkInfoReconciler_StartController(t *testing.T) {
 	patches.ApplyFunc(common.GenericGarbageCollector, func(cancel chan bool, timeout time.Duration, f func(ctx context.Context) error) {
 	})
 	defer patches.Reset()
-	r := NewNetworkInfoReconciler(mockMgr, vpcService, ipblocksInfoService)
-	err := r.StartController(mockMgr, nil)
+	dnsSvc, err := dns.InitializeDNSRecordService(vpcService.Service, vpcService)
+	require.NoError(t, err)
+	r := NewNetworkInfoReconciler(mockMgr, vpcService, ipblocksInfoService, dnsSvc)
+	err = r.StartController(mockMgr, nil)
 	assert.Nil(t, err)
 	// Sleep to make sure the patches are reset after the goroutine in StartController get executed
 	time.Sleep(time.Second)
@@ -2407,4 +2607,13 @@ func TestPrimaryLBIP(t *testing.T) {
 			assert.Equal(t, tt.want, primaryLBIP(tt.ips))
 		})
 	}
+}
+
+type mockDNSZoneSyncer struct {
+	dnsZoneConfigurations map[string]string
+	syncErr               error
+}
+
+func (s *mockDNSZoneSyncer) SyncDNSZonesByVpcNetworkConfig(_ *v1alpha1.VPCNetworkConfiguration) (map[string]string, error) {
+	return s.dnsZoneConfigurations, s.syncErr
 }

--- a/pkg/controllers/networkinfo/networkinfo_utils.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils.go
@@ -21,19 +21,27 @@ func setNetworkInfoVPCStatusWithError(client client.Client, ctx context.Context,
 }
 
 func setNetworkInfoVPCStatus(client client.Client, ctx context.Context, obj client.Object, _ metav1.Time, args ...interface{}) {
-	if len(args) != 1 {
+	if len(args) < 1 {
 		log.Error(nil, "VPC State is needed when updating NetworkInfo status")
 		return
 	}
 	networkInfo := obj.(*v1alpha1.NetworkInfo)
-	var createdVPC *v1alpha1.VPCState
 	if args[0] == nil {
 		// Not clear the existing VPC in NetworkInfo as
 		// currently one Namespace only maps to one VPC
 		return
-	} else {
-		createdVPC = args[0].(*v1alpha1.VPCState)
 	}
+	createdVPC := args[0].(*v1alpha1.VPCState)
+
+	var allowedDNSDomains []string
+	updateAllowedDomains := false
+	if len(args) >= 2 {
+		if d, ok := args[1].([]string); ok {
+			allowedDNSDomains = append([]string(nil), d...)
+			updateAllowedDomains = true
+		}
+	}
+
 	existingVPC := &v1alpha1.VPCState{}
 	if len(networkInfo.VPCs) > 0 {
 		existingVPC = &networkInfo.VPCs[0]
@@ -42,11 +50,25 @@ func setNetworkInfoVPCStatus(client client.Client, ctx context.Context, obj clie
 	slices.Sort(createdVPC.PrivateIPs)
 	slices.Sort(existingVPC.LoadBalancerBackendIPs)
 	slices.Sort(createdVPC.LoadBalancerBackendIPs)
-	if reflect.DeepEqual(*existingVPC, *createdVPC) {
+
+	domainsEqual := true
+	if updateAllowedDomains {
+		currentDomains := append([]string(nil), networkInfo.AllowedDNSDomains...)
+		slices.Sort(currentDomains)
+		slices.Sort(allowedDNSDomains)
+		domainsEqual = slices.Equal(currentDomains, allowedDNSDomains)
+	}
+
+	if reflect.DeepEqual(*existingVPC, *createdVPC) && domainsEqual {
 		return
 	}
 	networkInfo.VPCs = []v1alpha1.VPCState{*createdVPC}
-	client.Update(ctx, networkInfo)
+	if updateAllowedDomains {
+		networkInfo.AllowedDNSDomains = allowedDNSDomains
+	}
+	if err := client.Update(ctx, networkInfo); err != nil {
+		log.Error(err, "Failed to update NetworkInfo VPC status", "NetworkInfo", networkInfo.Name)
+	}
 }
 
 func setVPCNetworkConfigurationStatusWithLBS(ctx context.Context, client client.Client, ncName, vpcName, aviSubnetPath, nsxLBSPath, vpcPath string) {

--- a/pkg/controllers/networkinfo/networkinfo_utils_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils_test.go
@@ -487,3 +487,30 @@ func TestHasPodOrVMDefaultSubnets(t *testing.T) {
 	assert.False(t, hasPodDefaultSubnets(subnets))
 	assert.False(t, hasVMDefaultSubnets(subnets))
 }
+
+func TestSetNetworkInfoVPCStatus_AllowedDNSDomains(t *testing.T) {
+	ctx := context.TODO()
+	scheme := clientgoscheme.Scheme
+	v1alpha1.AddToScheme(scheme)
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&v1alpha1.NetworkInfo{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "ni1"},
+	}).Build()
+
+	networkInfoCR := &v1alpha1.NetworkInfo{}
+	require.NoError(t, kubeClient.Get(ctx, apitypes.NamespacedName{Namespace: "ns1", Name: "ni1"}, networkInfoCR))
+
+	state := &v1alpha1.VPCState{Name: "vpc-a"}
+	domains := []string{"zone1.example.com", "zone2.example.com"}
+	setNetworkInfoVPCStatus(kubeClient, ctx, networkInfoCR, metav1.Now(), state, domains)
+
+	require.NoError(t, kubeClient.Get(ctx, apitypes.NamespacedName{Namespace: "ns1", Name: "ni1"}, networkInfoCR))
+	require.Len(t, networkInfoCR.VPCs, 1)
+	assert.Equal(t, "vpc-a", networkInfoCR.VPCs[0].Name)
+	assert.Equal(t, domains, networkInfoCR.AllowedDNSDomains)
+
+	// Clearing domains while keeping VPC state requires explicit second arg (nil slice).
+	state2 := &v1alpha1.VPCState{Name: "vpc-a"}
+	setNetworkInfoVPCStatus(kubeClient, ctx, networkInfoCR, metav1.Now(), state2, []string(nil))
+	require.NoError(t, kubeClient.Get(ctx, apitypes.NamespacedName{Namespace: "ns1", Name: "ni1"}, networkInfoCR))
+	assert.Nil(t, networkInfoCR.AllowedDNSDomains)
+}


### PR DESCRIPTION
Wire NetworkInfo reconciler to DNSRecordService for per-namespace allowed DNS domains derived from VPC DNS zone configuration. Register DNS recordservice initialization in cmd when VPC networking is enabled.


Test Done:
0. Prepare the NSX DNS zone as the following,
```
- path: /orgs/default/projects/project-quality/dns-services/default-dns-service/zones/project-zone1 
   dns_domain_name: "example.com"
   id: "project-zone1"
- path: /orgs/default/projects/project-quality/dns-services/default-dns-service/zones/project-zone2
   dns_domain_name: "cook.com"
   id: "project-zone2"
```

1. Create vSphere Namespace with DNS zone,
```
dcli> com vmware vcenter namespaces instances createv2 --namespace test1 --supervisor 175cb1b9-3d3f-4bb5-8547-689382c58a32 --network-spec-network-provider NSX_VPC --network-spec-vpc-network-dns-zones "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/project-zone1"
```
2. Check VpcNetworkConfiguration has configured the allowed DNS zones
```
root@422f5cfecf62541aada3656d5173e654 [ ~ ]# kubectl get ns test1 -oyaml
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    nsx.vmware.com/vpc_network_config: test1-326a6e97-8854-4cca-88f3-1c7918196579
  creationTimestamp: "2026-06-01T07:34:34Z"
  labels:
    kubernetes.io/metadata.name: test1
    vSphereClusterID: 175cb1b9-3d3f-4bb5-8547-689382c58a32
  name: test1
  resourceVersion: "4662043"
  uid: 6d6b0529-eb10-434b-b7b5-548ab8ca4250
spec:
  finalizers:
  - kubernetes
status:
  conditions:
  - lastTransitionTime: "2026-06-01T07:34:39Z"
    status: "True"
    type: NamespaceNetworkReady
  phase: Active
root@422f5cfecf62541aada3656d5173e654 [ ~ ]# kubectl get vpcnetworkconfiguration test1-326a6e97-8854-4cca-88f3-1c7918196579 -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: VPCNetworkConfiguration
metadata:
  creationTimestamp: "2026-06-01T07:34:34Z"
  generation: 1
  name: test1-326a6e97-8854-4cca-88f3-1c7918196579
  resourceVersion: "4662040"
  uid: 068d2711-9a5b-45e8-9e7d-6c1acdd25a61
spec:
  defaultIPv6PrefixLength: 64
  defaultSubnetSize: 32
  dnsZones:
  - /orgs/default/projects/project-quality/dns-services/default-dns-service/zones/project-zone1
  nsxProject: /orgs/default/projects/project-quality
  privateIPs:
  - 172.26.0.0/16
  vpcConnectivityProfile: /orgs/default/projects/project-quality/vpc-connectivity-profiles/default--c5160cb4-753a-48b4-9c12-aa694068f6af
status:
  vpcs:
  - name: test1_hsgrw
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/test1_hsgrw/vpc-lbs/default
    vpcPath: /orgs/default/projects/project-quality/vpcs/test1_hsgrw
```

4. Check NetworkInfo has configured with the allowed DNS domain name
```
root@422f5cfecf62541aada3656d5173e654 [ ~ ]# kubectl get networkinfo -n test1 test1 -oyaml
allowedDNSDomains:
- example.com
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: NetworkInfo
metadata:
  creationTimestamp: "2026-06-01T07:34:34Z"
  generation: 2
  name: test1
  namespace: test1
  resourceVersion: "4662042"
  uid: 5119b4e5-c732-43c7-b989-fbfb25ce7522
vpcs:
- defaultSNATIP: 192.168.0.7
  loadBalancerBackendIPs:
  - 100.64.0.5
  loadBalancerIPAddresses: 100.64.0.5
  name: test1_hsgrw
  networkStack: FullStackVPC
  privateIPs:
  - 172.26.0.0/16
```
6. Update an existing vSphere Namespace with DNS zones to project-zone2
```
dcli> com vmware vcenter namespaces instances update --namespace test1  --network-spec-network-provider NSX_VPC --network-spec-vpc-config-dns-zones "/orgs/default/projects/project-quality
/dns-services/default-dns-service/zones/project-zone2"
```
7 Check VPCNetworkConfiguration resource in the supervisor cluster, the DNS zone project-zone2 path is updated.
```
root@422f5cfecf62541aada3656d5173e654 [ ~ ]# kubectl get vpcnetworkconfiguration test1-326a6e97-8854-4cca-88f3-1c7918196579 -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: VPCNetworkConfiguration
metadata:
  creationTimestamp: "2026-06-01T07:34:34Z"
  generation: 2
  name: test1-326a6e97-8854-4cca-88f3-1c7918196579
  resourceVersion: "4668451"
  uid: 068d2711-9a5b-45e8-9e7d-6c1acdd25a61
spec:
  defaultIPv6PrefixLength: 64
  defaultSubnetSize: 32
  dnsZones:
  - /orgs/default/projects/project-quality/dns-services/default-dns-service/zones/project-zone2
  nsxProject: /orgs/default/projects/project-quality
  privateIPs:
  - 172.26.0.0/16
  vpcConnectivityProfile: /orgs/default/projects/project-quality/vpc-connectivity-profiles/default--c5160cb4-753a-48b4-9c12-aa694068f6af
status:
  vpcs:
  - name: test1_hsgrw
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/test1_hsgrw/vpc-lbs/default
    vpcPath: /orgs/default/projects/project-quality/vpcs/test1_hsgrw
```

8. Check NetworkInfo status, it is updated to project-zone2 domain name
```
root@422f5cfecf62541aada3656d5173e654 [ ~ ]# kubectl get networkinfo -n test1 test1 -oyaml
allowedDNSDomains:
- cook.com
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: NetworkInfo
metadata:
  creationTimestamp: "2026-06-01T07:34:34Z"
  generation: 3
  name: test1
  namespace: test1
  resourceVersion: "4668454"
  uid: 5119b4e5-c732-43c7-b989-fbfb25ce7522
vpcs:
- defaultSNATIP: 192.168.0.7
  loadBalancerBackendIPs:
  - 100.64.0.5
  loadBalancerIPAddresses: 100.64.0.5
  name: test1_hsgrw
  networkStack: FullStackVPC
  privateIPs:
  - 172.26.0.0/16
```
9.  Update vSphere Namespace with DNS zones by appending project-zone1 with REST API
```
# curl --location --request PATCH 'https://<vcenter-ip-or-fqdn>/api/vcenter/namespaces/instances/<your-namespace-name>' \
--header 'vmware-api-session-id: <your-session-id>' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--data-raw '{
  "network_spec": {
    "vpc_config": {
      "dns_zones": [
        "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/project-zone2",
        "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/project-zone1"
      ]
    },
    "network_provider": "NSX_VPC"
  }
}'
```

10. Check VPCNetworkConfiguration resource in the supervisor cluster, two DNS zones are updated into the resource.
```
root@422f5cfecf62541aada3656d5173e654 [ ~ ]# kubectl get vpcnetworkconfiguration test1-326a6e97-8854-4cca-88f3-1c7918196579 -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: VPCNetworkConfiguration
metadata:
  creationTimestamp: "2026-06-01T07:34:34Z"
  generation: 9
  name: test1-326a6e97-8854-4cca-88f3-1c7918196579
  resourceVersion: "4693463"
  uid: 068d2711-9a5b-45e8-9e7d-6c1acdd25a61
spec:
  defaultIPv6PrefixLength: 64
  defaultSubnetSize: 32
  dnsZones:
  - /orgs/default/projects/project-quality/dns-services/default-dns-service/zones/project-zone2
  - /orgs/default/projects/project-quality/dns-services/default-dns-service/zones/project-zone1
  nsxProject: /orgs/default/projects/project-quality
  privateIPs:
  - 172.26.0.0/16
  vpcConnectivityProfile: /orgs/default/projects/project-quality/vpc-connectivity-profiles/default--c5160cb4-753a-48b4-9c12-aa694068f6af
status:
  vpcs:
  - name: test1_hsgrw
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/test1_hsgrw/vpc-lbs/default
    vpcPath: /orgs/default/projects/project-quality/vpcs/test1_hsgrw
```
11. Check NetworkInfo status, both two DNS zones' domain names are updated.
```
root@422f5cfecf62541aada3656d5173e654 [ ~ ]# kubectl get networkinfo -n test1 test1 -oyaml
allowedDNSDomains:
- cook.com
- example.com
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: NetworkInfo
metadata:
  creationTimestamp: "2026-06-01T07:34:34Z"
  generation: 6
  name: test1
  namespace: test1
  resourceVersion: "4693466"
  uid: 5119b4e5-c732-43c7-b989-fbfb25ce7522
vpcs:
- defaultSNATIP: 192.168.0.7
  loadBalancerBackendIPs:
  - 100.64.0.5
  loadBalancerIPAddresses: 100.64.0.5
  name: test1_hsgrw
  networkStack: FullStackVPC
  privateIPs:
  - 172.26.0.0/16
```
12. Update vSphere Namespace by clearing all DNS zones using REST API
```
# curl --location --request PATCH 'https://<vcenter-ip-or-fqdn>/api/vcenter/namespaces/instances/<your-namespace-name>' \
--header 'vmware-api-session-id: <your-session-id>' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--data-raw '{
  "network_spec": {
    "vpc_config": {
      "dns_zones": []
    },
    "network_provider": "NSX_VPC"
  }
}'
```

13. Check VPCNetworkConfiguration resource in the supervisor cluster, all DNS zones are cleared.
```
root@422f5cfecf62541aada3656d5173e654 [ ~ ]# kubectl get vpcnetworkconfiguration test1-326a6e97-8854-4cca-88f3-1c7918196579 -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: VPCNetworkConfiguration
metadata:
  creationTimestamp: "2026-06-01T07:34:34Z"
  generation: 10
  name: test1-326a6e97-8854-4cca-88f3-1c7918196579
  resourceVersion: "4698445"
  uid: 068d2711-9a5b-45e8-9e7d-6c1acdd25a61
spec:
  defaultIPv6PrefixLength: 64
  defaultSubnetSize: 32
  nsxProject: /orgs/default/projects/project-quality
  privateIPs:
  - 172.26.0.0/16
  vpcConnectivityProfile: /orgs/default/projects/project-quality/vpc-connectivity-profiles/default--c5160cb4-753a-48b4-9c12-aa694068f6af
status:
  vpcs:
  - name: test1_hsgrw
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/test1_hsgrw/vpc-lbs/default
    vpcPath: /orgs/default/projects/project-quality/vpcs/test1_hsgrw
```

14. Check NetworkInfo status, all DNS zones' domain names are cleared.
```
root@422f5cfecf62541aada3656d5173e654 [ ~ ]# kubectl get networkinfo -n test1 test1 -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: NetworkInfo
metadata:
  creationTimestamp: "2026-06-01T07:34:34Z"
  generation: 7
  name: test1
  namespace: test1
  resourceVersion: "4698447"
  uid: 5119b4e5-c732-43c7-b989-fbfb25ce7522
vpcs:
- defaultSNATIP: 192.168.0.7
  loadBalancerBackendIPs:
  - 100.64.0.5
  loadBalancerIPAddresses: 100.64.0.5
  name: test1_hsgrw
  networkStack: FullStackVPC
  privateIPs:
  - 172.26.0.0/16
```
