### PR TITLE
feat(service): LoadBalancer Service with DNS annotation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -247,7 +247,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			subnetport.NewSubnetPortReconciler(mgr, subnetPortService, subnetService, vpcService, ipAddressAllocationService),
 			pod.NewPodReconciler(mgr, subnetPortService, subnetService, vpcService, nodeService),
 			networkpolicycontroller.NewNetworkPolicyReconciler(mgr, commonService, vpcService),
-			service.NewServiceLbReconciler(mgr, commonService),
+			service.NewServiceLbReconciler(mgr, commonService, dnsRecordService),
 			subnetbindingcontroller.NewReconciler(mgr, subnetService, subnetBindingService),
 			subnetipreservationcontroller.NewReconciler(mgr, subnetIPReservationService, subnetService),
 		)

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	go.uber.org/mock v0.6.0
+	sigs.k8s.io/gateway-api v1.5.1
 )
 
 require (
@@ -113,7 +114,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/onsi/ginkgo/v2 v2.28.1 // indirect
-	github.com/onsi/gomega v1.39.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -420,6 +420,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUo
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
+sigs.k8s.io/gateway-api v1.5.1 h1:RqVRIlkhLhUO8wOHKTLnTJA6o/1un4po4/6M1nRzdd0=
+sigs.k8s.io/gateway-api v1.5.1/go.mod h1:GvCETiaMAlLym5CovLxGjS0NysqFk3+Yuq3/rh6QL2o=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/pkg/controllers/service/service_lb_controller.go
+++ b/pkg/controllers/service/service_lb_controller.go
@@ -5,25 +5,33 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
 	_ "github.com/vmware-tanzu/nsx-operator/pkg/nsx/ratelimiter"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/dns"
 )
 
 var (
@@ -38,6 +46,7 @@ type ServiceLbReconciler struct {
 	Client   client.Client
 	Scheme   *apimachineryruntime.Scheme
 	Service  *servicecommon.Service
+	DNS      dns.DNSRecordProvider
 	Recorder record.EventRecorder
 }
 
@@ -53,6 +62,14 @@ func updateSuccess(r *ServiceLbReconciler, c context.Context, lbService *v1.Serv
 	return err
 }
 
+func (r *ServiceLbReconciler) deleteDNSForService(ctx context.Context, namespace, name string, op string) error {
+	if _, err := r.DNS.DeleteRecordByOwnerNN(ctx, dns.ResourceKindService, namespace, name); err != nil {
+		log.Error(err, "Failed to delete DNS records for Service", "Namespace", namespace, "Name", name, "Operation", op)
+		return fmt.Errorf("deleting DNS records for %s: %w", op, err)
+	}
+	return nil
+}
+
 func (r *ServiceLbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	service := &v1.Service{}
 	startTime := time.Now()
@@ -63,25 +80,44 @@ func (r *ServiceLbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err := r.Client.Get(ctx, req.NamespacedName, service); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("Not found LB service", "req", req.NamespacedName)
-			return ResultNormal, client.IgnoreNotFound(err)
+			if err := r.deleteDNSForService(ctx, req.Namespace, req.Name, "deleted Service"); err != nil {
+				return common.ResultRequeueAfter10sec, nil
+			}
+			return ResultNormal, nil
 		}
 		log.Error(err, "Failed to fetch LB service", "req", req.NamespacedName)
-		return common.ResultRequeueAfter10sec, err
+		return common.ResultRequeueAfter10sec, nil
 	}
 
-	if service.Spec.Type == v1.ServiceTypeLoadBalancer {
-		log.Info("Reconciling LB service", "LBService", req.NamespacedName)
-		log.Debug("Reconciling LB Service", "name", service.Name, "version", service.ResourceVersion, "status", service.Status)
-		metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerSyncTotal, MetricResType)
-
-		if service.ObjectMeta.DeletionTimestamp.IsZero() {
-			metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateTotal, MetricResType)
-			err := updateSuccess(r, ctx, service)
-			if err != nil {
-				log.Error(err, "Failed to update LB service", "Name", service.Name, "Namespace", service.Namespace)
-				return common.ResultRequeueAfter10sec, err
-			}
+	if service.Spec.Type != v1.ServiceTypeLoadBalancer || !service.ObjectMeta.DeletionTimestamp.IsZero() {
+		// Try to delete DNS records for Service when it is not a LoadBalancer or is marked for deletion
+		if err := r.clearDNSAndConditionForService(ctx, req.NamespacedName, "non-LB or terminating Service"); err != nil {
+			return common.ResultRequeueAfter10sec, nil
 		}
+		return ResultNormal, nil
+	}
+
+	log.Info("Reconciling LB service", "LBService", req.NamespacedName)
+	log.Debug("Reconciling LB Service", "name", service.Name, "version", service.ResourceVersion, "status", service.Status)
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerSyncTotal, MetricResType)
+
+	var dnsErr error
+	if err := r.reconcileLoadBalancerServiceDNS(ctx, service); err != nil {
+		log.Error(err, "Failed to reconcile DNS for LoadBalancer Service", "Name", service.Name, "Namespace", service.Namespace)
+		dnsErr = fmt.Errorf("reconciling DNS: %w", err)
+	}
+
+	metrics.CounterInc(r.Service.NSXConfig, metrics.ControllerUpdateTotal, MetricResType)
+	// Even if DNS reconciliation fails, we must proceed to update the Service status.
+	// This ensures that successfully allocated LoadBalancer external IPs are properly
+	// reflected in the Service status, allowing traffic to flow while DNS issues are resolved.
+	if err := updateSuccess(r, ctx, service); err != nil {
+		log.Error(err, "Failed to update LB service", "Name", service.Name, "Namespace", service.Namespace)
+		return common.ResultRequeueAfter10sec, nil
+	}
+
+	if dnsErr != nil {
+		return common.ResultRequeueAfter10sec, nil
 	}
 
 	return ResultNormal, nil
@@ -89,7 +125,6 @@ func (r *ServiceLbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 func (r *ServiceLbReconciler) setServiceLbStatus(ctx context.Context, lbService *v1.Service) error {
 	ipMode := v1.LoadBalancerIPModeProxy
-	statusUpdated := false
 	// If nsx.vmware.com/ingress-ip-mode label with values proxy or vip,
 	// the LoadBalancer service ipMode status would be set to whatever the label is set to,
 	// Otherwise, it's set to Proxy by default when unset or other invalid values.
@@ -98,34 +133,48 @@ func (r *ServiceLbReconciler) setServiceLbStatus(ctx context.Context, lbService 
 			ipMode = v1.LoadBalancerIPModeVIP
 		}
 	}
-	for i, ing := range lbService.Status.LoadBalancer.Ingress {
-		if ing.IP != "" {
-			if ing.IPMode == nil || *(ing.IPMode) != ipMode {
-				lbService.Status.LoadBalancer.Ingress[i].IPMode = &ipMode
-				statusUpdated = true
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		svc := &v1.Service{}
+		if err := r.Client.Get(ctx, types.NamespacedName{Name: lbService.Name, Namespace: lbService.Namespace}, svc); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+
+		statusUpdated := false
+		for i, ing := range svc.Status.LoadBalancer.Ingress {
+			if ing.IP != "" {
+				if ing.IPMode == nil || *(ing.IPMode) != ipMode {
+					svc.Status.LoadBalancer.Ingress[i].IPMode = &ipMode
+					statusUpdated = true
+				}
 			}
 		}
-	}
 
-	if statusUpdated {
-		err := r.Client.Status().Update(ctx, lbService)
-		if err != nil {
-			log.Error(err, "Failed to update LB service status ipMode", "Name", lbService.Name, "Namespace", lbService.Namespace, "ipMode", ipMode)
-			return err
+		if statusUpdated {
+			err := r.Client.Status().Update(ctx, svc)
+			if err != nil {
+				log.Error(err, "Failed to update LB service status ipMode", "Name", svc.Name, "Namespace", svc.Namespace, "ipMode", ipMode)
+				return err
+			}
+			log.Info("Updated LB service status ipMode", "Name", svc.Name, "Namespace", svc.Namespace, "ipMode", ipMode)
 		}
-		log.Info("Updated LB service status ipMode", "Name", lbService.Name, "Namespace", lbService.Namespace, "ipMode", ipMode)
-	}
-	return nil
+		return nil
+	})
 }
 
 func (r *ServiceLbReconciler) setupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&v1.Service{}).
+		Watches(
+			&v1alpha1.NetworkInfo{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueLBServiceRequestsFromNetworkInfo),
+			builder.WithPredicates(predicateNetworkInfoAllowedDNSDomainsChanged()),
+		).
 		WithOptions(
 			controller.Options{
 				MaxConcurrentReconciles: common.NumReconcile(),
-			}).
-		Complete(r)
+			})
+	return b.Complete(r)
 }
 
 // Start setup manager
@@ -172,18 +221,36 @@ func (r *ServiceLbReconciler) StartController(mgr ctrl.Manager, _ webhook.Server
 		log.Error(err, "Failed to create controller", "controller", "ServiceLb")
 		return err
 	}
+	err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		stop := make(chan bool)
+		go func() {
+			<-ctx.Done()
+			close(stop)
+		}()
+		common.GenericGarbageCollector(stop, servicecommon.GCInterval, r.CollectGarbage)
+		return nil
+	}))
+	if err != nil {
+		log.Error(err, "Failed to add LB GC to manager")
+		return err
+	}
 	return nil
 }
 
 func (r *ServiceLbReconciler) CollectGarbage(ctx context.Context) error {
-	return nil
+	return r.collectDNSGarbage(ctx)
 }
 
-func NewServiceLbReconciler(mgr ctrl.Manager, commonService servicecommon.Service) *ServiceLbReconciler {
+func NewServiceLbReconciler(mgr ctrl.Manager, commonService servicecommon.Service, dnsRecordService *dns.DNSRecordService) *ServiceLbReconciler {
 	if isServiceLbStatusIpModeSupported(mgr.GetConfig()) {
+		var dnsProv dns.DNSRecordProvider
+		if dnsRecordService != nil {
+			dnsProv = dnsRecordService
+		}
 		serviceLbReconciler := &ServiceLbReconciler{
 			Client:   mgr.GetClient(),
 			Scheme:   mgr.GetScheme(),
+			DNS:      dnsProv,
 			Recorder: mgr.GetEventRecorderFor("serviceLb-controller"), //nolint:staticcheck // record.EventRecorder; StatusUpdater not on events.EventRecorder yet
 		}
 		serviceLbReconciler.Service = &commonService

--- a/pkg/controllers/service/service_lb_controller_test.go
+++ b/pkg/controllers/service/service_lb_controller_test.go
@@ -5,37 +5,72 @@ package service
 
 import (
 	"context"
-	"errors"
-	"os"
-	"reflect"
+	"fmt"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	mockdns "github.com/vmware-tanzu/nsx-operator/pkg/mock/dnsrecordprovider"
 
-	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	ctrlcommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/dns"
 )
 
+func emptyDNSRecordService() *dns.DNSRecordService {
+	return &dns.DNSRecordService{DNSRecordStore: dns.BuildDNSRecordStore()}
+}
+
+// serviceLbFakeClient builds a fake client; scheme must match the reconciler's Scheme (same *runtime.Scheme instance).
+func serviceLbFakeClient(scheme *runtime.Scheme, withStatus bool, objs ...client.Object) client.Client {
+	b := fake.NewClientBuilder().WithScheme(scheme)
+	if withStatus {
+		b = b.WithStatusSubresource(&v1.Service{})
+	}
+	if len(objs) > 0 {
+		b = b.WithObjects(objs...)
+	}
+	return b.Build()
+}
+
+func assignDNSListStubs(m *mockdns.MockDNSRecordProvider) {
+	m.EXPECT().ListReferredGatewayNN().Return(sets.New[types.NamespacedName]()).AnyTimes()
+	m.EXPECT().ListRecordOwnerResource().Return(nil).AnyTimes()
+}
+
 func NewFakeServiceLbReconciler() *ServiceLbReconciler {
+	s := runtime.NewScheme()
+	if err := v1.AddToScheme(s); err != nil {
+		panic(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(s).Build()
 	return &ServiceLbReconciler{
-		Client:   fake.NewClientBuilder().Build(),
-		Scheme:   fake.NewClientBuilder().Build().Scheme(),
+		Client:   c,
+		Scheme:   s,
 		Service:  nil,
+		DNS:      emptyDNSRecordService(),
 		Recorder: fakeRecorder{},
 	}
 }
@@ -74,6 +109,22 @@ func (m *MockManager) GetEventRecorderFor(name string) record.EventRecorder {
 	return nil
 }
 
+func (m *MockManager) GetControllerOptions() ctrlconfig.Controller {
+	return ctrlconfig.Controller{}
+}
+
+func (m *MockManager) GetCache() cache.Cache {
+	return nil
+}
+
+func (m *MockManager) GetRESTMapper() meta.RESTMapper {
+	return nil
+}
+
+func (m *MockManager) GetLogger() logr.Logger {
+	return logr.Discard()
+}
+
 func (m *MockManager) Add(runnable manager.Runnable) error {
 	return nil
 }
@@ -82,211 +133,576 @@ func (m *MockManager) Start(context.Context) error {
 	return nil
 }
 
-func TestServiceLbReconciler_setServiceLbStatus(t *testing.T) {
-	r := NewFakeServiceLbReconciler()
+func TestServiceLbReconciler_setServiceLbStatus_table(t *testing.T) {
+	vipMode := v1.LoadBalancerIPModeVIP
+	proxyMode := v1.LoadBalancerIPModeProxy
+
+	makeSvc := func(ipMode *v1.LoadBalancerIPMode, ip string, labelValue string) *v1.Service {
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-svc", Namespace: "default"},
+			Spec:       v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+		}
+		svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: ip, IPMode: ipMode}}
+		if labelValue != "" {
+			svc.Labels = map[string]string{common.LabelLbIngressIpMode: labelValue}
+		}
+		return svc
+	}
+
+	tests := []struct {
+		name       string
+		svc        *v1.Service
+		wantIPMode *v1.LoadBalancerIPMode
+	}{
+		{
+			name:       "vip_label_keeps_vip_mode",
+			svc:        makeSvc(&vipMode, "192.168.28.1", common.LabelLbIngressIpModeVipValue),
+			wantIPMode: &vipMode,
+		},
+		{
+			name:       "proxy_label_overrides_to_proxy",
+			svc:        makeSvc(&vipMode, "192.168.28.1", common.LabelLbIngressIpModeProxyValue),
+			wantIPMode: &proxyMode,
+		},
+		{
+			name:       "no_label_defaults_to_proxy",
+			svc:        makeSvc(&vipMode, "192.168.28.1", ""),
+			wantIPMode: &proxyMode,
+		},
+		{
+			name:       "nil_ipmode_vip_label_sets_vip",
+			svc:        makeSvc(nil, "192.168.28.1", common.LabelLbIngressIpModeVipValue),
+			wantIPMode: &vipMode,
+		},
+		{
+			name:       "nil_ipmode_proxy_label_sets_proxy",
+			svc:        makeSvc(nil, "192.168.28.1", common.LabelLbIngressIpModeProxyValue),
+			wantIPMode: &proxyMode,
+		},
+		{
+			name:       "nil_ipmode_no_label_sets_proxy",
+			svc:        makeSvc(nil, "192.168.28.1", ""),
+			wantIPMode: &proxyMode,
+		},
+		{
+			name:       "empty_ip_leaves_nil_ipmode",
+			svc:        makeSvc(nil, "", ""),
+			wantIPMode: nil,
+		},
+	}
+
 	ctx := context.TODO()
-	lbService := &v1.Service{}
-	lbService.Spec.Type = v1.ServiceTypeLoadBalancer
-	lbService.Labels = map[string]string{
-		common.LabelLbIngressIpMode: common.LabelLbIngressIpModeVipValue,
-	}
-	vipIpMode := v1.LoadBalancerIPModeVIP
-	lbService.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{
-		{
-			IP:     "192.168.28.1",
-			IPMode: &vipIpMode,
-		},
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewFakeServiceLbReconciler()
+			err := r.Client.Create(ctx, tt.svc)
+			require.NoError(t, err)
 
-	// Case: IPMode is set and ingress-ip-mode label is set as vip.
-	r.setServiceLbStatus(ctx, lbService)
-	assert.Equal(t, v1.LoadBalancerIPModeVIP, *lbService.Status.LoadBalancer.Ingress[0].IPMode)
+			r.setServiceLbStatus(ctx, tt.svc)
 
-	// Case: IPMode is set and ingress-ip-mode label is set as proxy.
-	lbService.Labels = map[string]string{
-		common.LabelLbIngressIpMode: common.LabelLbIngressIpModeProxyValue,
+			updatedSvc := &v1.Service{}
+			err = r.Client.Get(ctx, types.NamespacedName{Name: tt.svc.Name, Namespace: tt.svc.Namespace}, updatedSvc)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantIPMode, updatedSvc.Status.LoadBalancer.Ingress[0].IPMode)
+		})
 	}
-	r.setServiceLbStatus(ctx, lbService)
-	assert.Equal(t, v1.LoadBalancerIPModeProxy, *lbService.Status.LoadBalancer.Ingress[0].IPMode)
-
-	// Case: IPMode is set and ingress-ip-mode label is not set.
-	lbService.Labels = nil
-	lbService.Status.LoadBalancer.Ingress[0].IPMode = &vipIpMode
-	r.setServiceLbStatus(ctx, lbService)
-	assert.Equal(t, v1.LoadBalancerIPModeProxy, *lbService.Status.LoadBalancer.Ingress[0].IPMode)
-
-	// Case IPMode is not set and label is set as VIP.
-	lbService.Labels = map[string]string{
-		common.LabelLbIngressIpMode: common.LabelLbIngressIpModeVipValue,
-	}
-	lbService.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{
-		{
-			IP:     "192.168.28.1",
-			IPMode: nil,
-		},
-	}
-	r.setServiceLbStatus(ctx, lbService)
-	assert.Equal(t, v1.LoadBalancerIPModeVIP, *lbService.Status.LoadBalancer.Ingress[0].IPMode)
-
-	// Case IPMode is not set and label is set as proxy.
-	lbService.Labels = map[string]string{
-		common.LabelLbIngressIpMode: common.LabelLbIngressIpModeProxyValue,
-	}
-	lbService.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{
-		{
-			IP:     "192.168.28.1",
-			IPMode: nil,
-		},
-	}
-	r.setServiceLbStatus(ctx, lbService)
-	assert.Equal(t, v1.LoadBalancerIPModeProxy, *lbService.Status.LoadBalancer.Ingress[0].IPMode)
-
-	// Case IPMode is not set and label is not set
-	lbService.Labels = nil
-	lbService.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{
-		{
-			IP:     "192.168.28.1",
-			IPMode: nil,
-		},
-	}
-	r.setServiceLbStatus(ctx, lbService)
-	assert.Equal(t, v1.LoadBalancerIPModeProxy, *lbService.Status.LoadBalancer.Ingress[0].IPMode)
-
-	// Case Ingress.IP is not set
-	lbService.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{
-		{
-			IP:     "",
-			IPMode: nil,
-		},
-	}
-	r.setServiceLbStatus(ctx, lbService)
-	assert.Equal(t, (*v1.LoadBalancerIPMode)(nil), lbService.Status.LoadBalancer.Ingress[0].IPMode)
 }
 
-func TestServiceLbReconciler_Reconcile(t *testing.T) {
-	mockCtl := gomock.NewController(t)
-	k8sClient := mock_client.NewMockClient(mockCtl)
-	service := &common.Service{
+func serviceLbTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, v1.AddToScheme(s))
+	require.NoError(t, v1alpha1.AddToScheme(s))
+	return s
+}
+
+func testNSXServiceForLb() *common.Service {
+	return &common.Service{
 		NSXClient: &nsx.Client{},
 		NSXConfig: &config.NSXOperatorConfig{
-			CoeConfig: &config.CoeConfig{
-				EnableVPCNetwork: true,
-			},
-			NsxConfig: &config.NsxConfig{
-				EnforcementPoint: "vmc-enforcementpoint",
-			},
+			CoeConfig: &config.CoeConfig{EnableVPCNetwork: true},
+			NsxConfig: &config.NsxConfig{EnforcementPoint: "vmc-enforcementpoint"},
 		},
 	}
-
-	r := &ServiceLbReconciler{
-		Client:   k8sClient,
-		Scheme:   nil,
-		Service:  service,
-		Recorder: fakeRecorder{},
-	}
-	ctx := context.Background()
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "dummy", Name: "dummy"}}
-
-	// lb service not found obj case
-	errNotFound := errors.New("not found")
-	k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errNotFound)
-	_, err := r.Reconcile(ctx, req)
-	assert.Equal(t, err, errNotFound)
-
-	// DeletionTimestamp.IsZero = true and service type is LoadBalancer
-	lbService := &v1.Service{}
-	k8sClient.EXPECT().Get(ctx, gomock.Any(), lbService).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
-		v1lbservice := obj.(*v1.Service)
-		v1lbservice.Spec.Type = v1.ServiceTypeLoadBalancer
-		return nil
-	})
-	_, err = r.Reconcile(ctx, req)
-	assert.Equal(t, err, nil)
-
-	// DeletionTimestamp.IsZero = false and service type is LoadBalancer
-	k8sClient.EXPECT().Get(ctx, gomock.Any(), lbService).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
-		v1lbservice := obj.(*v1.Service)
-		v1lbservice.Spec.Type = v1.ServiceTypeLoadBalancer
-		time := metav1.Now()
-		v1lbservice.ObjectMeta.DeletionTimestamp = &time
-		return nil
-	})
-	_, err = r.Reconcile(ctx, req)
-	assert.Equal(t, err, nil)
-
-	// service type is not LoadBalancer
-	k8sClient.EXPECT().Get(ctx, gomock.Any(), lbService).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
-		v1lbservice := obj.(*v1.Service)
-		v1lbservice.Spec.Type = v1.ServiceTypeClusterIP
-		time := metav1.Now()
-		v1lbservice.ObjectMeta.DeletionTimestamp = &time
-		return nil
-	})
-	_, err = r.Reconcile(ctx, req)
-	assert.Equal(t, err, nil)
 }
 
-func TestServiceLbReconciler_StartController(t *testing.T) {
-	fakeClient := fake.NewClientBuilder().WithObjects().Build()
-	commonService := common.Service{
-		Client: fakeClient,
-	}
-	mockMgr := &MockManager{
-		scheme: runtime.NewScheme(),
-		config: &rest.Config{},
-	}
+func TestUpdateSuccess(t *testing.T) {
+	ctx := context.Background()
+	scheme := serviceLbTestScheme(t)
 
-	testCases := []struct {
-		name         string
-		expectErrStr string
-		patches      func() *gomonkey.Patches
+	t.Run("success", func(t *testing.T) {
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "lb", ResourceVersion: "1"},
+		}
+		c := serviceLbFakeClient(scheme, false, svc)
+		r := &ServiceLbReconciler{Client: c, Service: testNSXServiceForLb(), Recorder: fakeRecorder{}}
+		err := updateSuccess(r, ctx, svc)
+		assert.NoError(t, err)
+	})
+
+	t.Run("error_update", func(t *testing.T) {
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "lb-err", ResourceVersion: "1"},
+			Spec:       v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+			Status: v1.ServiceStatus{
+				LoadBalancer: v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{{IP: "1.1.1.1"}}},
+			},
+		}
+
+		fClient := serviceLbFakeClient(scheme, false, svc)
+		c := &failingClient{Client: fClient}
+
+		r := &ServiceLbReconciler{Client: c, Service: testNSXServiceForLb(), Recorder: fakeRecorder{}}
+		err := updateSuccess(r, ctx, svc)
+		assert.Error(t, err)
+	})
+
+	t.Run("clear_dns_and_condition_error", func(t *testing.T) {
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns", Name: "lb-err-rec", ResourceVersion: "1",
+				DeletionTimestamp: func() *metav1.Time { t := metav1.Now(); return &t }(),
+				Finalizers:        []string{"test.finalizer/nsx-operator"},
+			},
+			Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+			Status: v1.ServiceStatus{
+				LoadBalancer: v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{{IP: "1.1.1.1"}}},
+				Conditions: []metav1.Condition{{
+					Type:   serviceDNSReadyConditionType,
+					Status: metav1.ConditionTrue,
+				}},
+			},
+		}
+
+		fClient := serviceLbFakeClient(scheme, false, svc)
+		fc := failingClient{Client: fClient}
+
+		mockCtl := gomock.NewController(t)
+		t.Cleanup(func() { mockCtl.Finish() })
+		m := mockdns.NewMockDNSRecordProvider(mockCtl)
+		m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns", "lb-err-rec").Return(true, nil).Times(1)
+
+		r := &ServiceLbReconciler{Client: &fc, Service: testNSXServiceForLb(), Recorder: fakeRecorder{}, DNS: m}
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "lb-err-rec"}})
+		assert.NoError(t, err)
+		assert.Equal(t, ctrlcommon.ResultRequeueAfter10sec, res)
+	})
+}
+
+type failingClient struct {
+	client.Client
+}
+
+type failingStatusWriter struct {
+	client.SubResourceWriter
+}
+
+func (w failingStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	return fmt.Errorf("fail")
+}
+func (c *failingClient) Status() client.SubResourceWriter {
+	return failingStatusWriter{}
+}
+
+func TestServiceLbReconciler_Reconcile_table(t *testing.T) {
+	ctx := context.Background()
+	scheme := serviceLbTestScheme(t)
+	nsxSvc := testNSXServiceForLb()
+
+	tests := []struct {
+		name      string
+		objs      []client.Object
+		setupMock func(m *mockdns.MockDNSRecordProvider)
+		req       types.NamespacedName
+		wantRes   *ctrl.Result
+		verify    func(t *testing.T, r *ServiceLbReconciler)
 	}{
-		// expected no error when starting the serviceLb controller
 		{
-			name: "Start serviceLb Controller",
-			patches: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc(os.Exit, func(code int) {
-					assert.FailNow(t, "os.Exit should not be called")
-				})
-				patches.ApplyFunc(isServiceLbStatusIpModeSupported, func(c *rest.Config) bool {
-					return true
-				})
-				patches.ApplyMethod(reflect.TypeOf(&ServiceLbReconciler{}), "Start", func(_ *ServiceLbReconciler, r ctrl.Manager) error {
-					return nil
-				})
-				return patches
+			name: "not_found_deletes_dns",
+			objs: nil,
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "dummy", "missing").Return(false, nil).Times(1)
 			},
+			req:     types.NamespacedName{Namespace: "dummy", Name: "missing"},
+			wantRes: &ResultNormal,
 		},
 		{
-			name:         "Start serviceLb controller return error",
-			expectErrStr: "failed to setupWithManager",
-			patches: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc(os.Exit, func(code int) {
-				})
-				patches.ApplyFunc(isServiceLbStatusIpModeSupported, func(c *rest.Config) bool {
-					return true
-				})
-				patches.ApplyPrivateMethod(reflect.TypeOf(&ServiceLbReconciler{}), "setupWithManager", func(_ *ServiceLbReconciler, mgr ctrl.Manager) error {
-					return errors.New("failed to setupWithManager")
-				})
-				return patches
+			name: "not_found_deletes_dns_error",
+			objs: nil,
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "dummy", "missing").Return(false, fmt.Errorf("mock err")).Times(1)
+			},
+			req:     types.NamespacedName{Namespace: "dummy", Name: "missing"},
+			wantRes: &ctrlcommon.ResultRequeueAfter10sec,
+		},
+		{
+			name: "loadbalancer_active",
+			objs: []client.Object{&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "lb", ResourceVersion: "1"},
+				Spec:       v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{{IP: "192.168.28.1"}}},
+				},
+			}},
+			req: types.NamespacedName{Namespace: "ns", Name: "lb"},
+		},
+		{
+			name: "loadbalancer_with_deletion_timestamp_clears_dns",
+			objs: []client.Object{&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "lb-del", ResourceVersion: "1",
+					DeletionTimestamp: func() *metav1.Time { t := metav1.Now(); return &t }(),
+					Finalizers:        []string{"test.finalizer/nsx-operator"},
+				},
+				Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+			}},
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns", "lb-del").Return(false, nil).Times(1)
+			},
+			req:     types.NamespacedName{Namespace: "ns", Name: "lb-del"},
+			wantRes: &ResultNormal,
+		},
+		{
+			name: "loadbalancer_with_deletion_timestamp_clears_dns_error",
+			objs: []client.Object{&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "lb-del-err", ResourceVersion: "1",
+					DeletionTimestamp: func() *metav1.Time { t := metav1.Now(); return &t }(),
+					Finalizers:        []string{"test.finalizer/nsx-operator"},
+				},
+				Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+			}},
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns", "lb-del-err").Return(false, fmt.Errorf("mock err")).Times(1)
+			},
+			req:     types.NamespacedName{Namespace: "ns", Name: "lb-del-err"},
+			wantRes: &ctrlcommon.ResultRequeueAfter10sec,
+		},
+		{
+			name: "skip_annotation_clears_dns",
+			objs: []client.Object{&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "ns",
+					Name:            "lb-skip",
+					ResourceVersion: "1",
+					Annotations:     map[string]string{common.AnnotationsDNSSkip: "true", common.AnnotationDNSHostnameKey: "a.com"},
+				},
+				Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+			}},
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns", "lb-skip").Return(false, nil).Times(1)
+			},
+			req:     types.NamespacedName{Namespace: "ns", Name: "lb-skip"},
+			wantRes: &ResultNormal,
+		},
+		{
+			name: "reconcile_dns_error_still_updates_status",
+			objs: []client.Object{&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "lb-dns-err", ResourceVersion: "1",
+					Annotations: map[string]string{common.AnnotationDNSHostnameKey: "a.com"},
+				},
+				Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{{IP: "192.168.28.1"}}},
+				},
+			}},
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, fmt.Errorf("mock dns error")).Times(1)
+			},
+			req:     types.NamespacedName{Namespace: "ns", Name: "lb-dns-err"},
+			wantRes: &ctrlcommon.ResultRequeueAfter10sec,
+			verify: func(t *testing.T, r *ServiceLbReconciler) {
+				svc := &v1.Service{}
+				err := r.Client.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "lb-dns-err"}, svc)
+				require.NoError(t, err)
+				require.NotNil(t, svc.Status.LoadBalancer.Ingress[0].IPMode)
+				assert.Equal(t, v1.LoadBalancerIPModeProxy, *svc.Status.LoadBalancer.Ingress[0].IPMode)
 			},
 		},
 	}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			patches := testCase.patches()
-			defer patches.Reset()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtl := gomock.NewController(t)
+			t.Cleanup(func() { mockCtl.Finish() })
+			m := mockdns.NewMockDNSRecordProvider(mockCtl)
+			assignDNSListStubs(m)
+			if tt.setupMock != nil {
+				tt.setupMock(m)
+			}
 
-			r := NewServiceLbReconciler(mockMgr, commonService)
-			err := r.StartController(mockMgr, nil)
-
-			if testCase.expectErrStr != "" {
-				assert.Contains(t, err.Error(), testCase.expectErrStr)
-			} else {
-				assert.Nil(t, err)
+			var dnsProvider dns.DNSRecordProvider = m
+			// For cases without mock expectations, use the empty in-memory service.
+			if tt.setupMock == nil {
+				dnsProvider = emptyDNSRecordService()
+			}
+			r := &ServiceLbReconciler{
+				Client:   serviceLbFakeClient(scheme, true, tt.objs...),
+				Scheme:   scheme,
+				Service:  nsxSvc,
+				DNS:      dnsProvider,
+				Recorder: fakeRecorder{},
+			}
+			res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: tt.req})
+			require.NoError(t, err)
+			if tt.wantRes != nil {
+				require.Equal(t, *tt.wantRes, res)
+			}
+			if tt.verify != nil {
+				tt.verify(t, r)
 			}
 		})
 	}
+}
+
+func TestServiceLbReconciler_CollectGarbage_table(t *testing.T) {
+	ctx := context.Background()
+	scheme := serviceLbTestScheme(t)
+
+	tests := []struct {
+		name      string
+		dns       dns.DNSRecordProvider
+		objs      []client.Object
+		setupMock func(m *mockdns.MockDNSRecordProvider)
+		wantErr   bool
+	}{
+		{
+			name: "nil_dns_is_noop",
+			dns:  nil,
+		},
+		{
+			name: "empty_store_is_noop",
+			dns:  emptyDNSRecordService(),
+		},
+		{
+			name: "prunes_stale_service_owners",
+			objs: []client.Object{&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "keep",
+					Annotations: map[string]string{common.AnnotationDNSHostnameKey: "app.example.com"},
+				},
+				Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+			}},
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				keepNN := types.NamespacedName{Namespace: "ns", Name: "keep"}
+				staleNN := types.NamespacedName{Namespace: "ns", Name: "stale"}
+				m.EXPECT().ListReferredGatewayNN().Return(sets.New[types.NamespacedName]()).AnyTimes()
+				m.EXPECT().ListRecordOwnerResource().Return(map[string]sets.Set[types.NamespacedName]{
+					dns.ResourceKindService: sets.New(keepNN, staleNN),
+				}).Times(1)
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, staleNN.Namespace, staleNN.Name).Return(true, nil).Times(1)
+			},
+		},
+		{
+			name: "prunes_stale_service_owners_error",
+			objs: []client.Object{&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "keep",
+					Annotations: map[string]string{common.AnnotationDNSHostnameKey: "app.example.com"},
+				},
+				Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+			}},
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				keepNN := types.NamespacedName{Namespace: "ns", Name: "keep"}
+				staleNN := types.NamespacedName{Namespace: "ns", Name: "stale"}
+				m.EXPECT().ListReferredGatewayNN().Return(sets.New[types.NamespacedName]()).AnyTimes()
+				m.EXPECT().ListRecordOwnerResource().Return(map[string]sets.Set[types.NamespacedName]{
+					dns.ResourceKindService: sets.New(keepNN, staleNN),
+				}).Times(1)
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, staleNN.Namespace, staleNN.Name).Return(false, fmt.Errorf("mock error")).Times(1)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dnsProvider := tt.dns
+			if tt.setupMock != nil {
+				mockCtl := gomock.NewController(t)
+				t.Cleanup(func() { mockCtl.Finish() })
+				m := mockdns.NewMockDNSRecordProvider(mockCtl)
+				tt.setupMock(m)
+				dnsProvider = m
+			}
+			r := &ServiceLbReconciler{
+				Client: serviceLbFakeClient(scheme, true, tt.objs...),
+				Scheme: scheme,
+				DNS:    dnsProvider,
+			}
+			err := r.CollectGarbage(ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPredicateNetworkInfoAllowedDNSDomainsChanged(t *testing.T) {
+	p := predicateNetworkInfoAllowedDNSDomainsChanged()
+
+	assert.False(t, p.Create(event.CreateEvent{}))
+	assert.False(t, p.Delete(event.DeleteEvent{}))
+	assert.False(t, p.Generic(event.GenericEvent{}))
+
+	// Test Update
+	tests := []struct {
+		name string
+		old  client.Object
+		new  client.Object
+		want bool
+	}{
+		{
+			name: "different types",
+			old:  &v1.Service{},
+			new:  &v1.Service{},
+			want: false,
+		},
+		{
+			name: "domains same",
+			old:  &v1alpha1.NetworkInfo{AllowedDNSDomains: []string{"a"}},
+			new:  &v1alpha1.NetworkInfo{AllowedDNSDomains: []string{"a"}},
+			want: false,
+		},
+		{
+			name: "domains changed",
+			old:  &v1alpha1.NetworkInfo{AllowedDNSDomains: []string{"a"}},
+			new:  &v1alpha1.NetworkInfo{AllowedDNSDomains: []string{"b"}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.Update(event.UpdateEvent{ObjectOld: tt.old, ObjectNew: tt.new})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestServiceLbReconciler_RestoreReconcile(t *testing.T) {
+	r := &ServiceLbReconciler{}
+	err := r.RestoreReconcile()
+	assert.NoError(t, err)
+}
+
+func TestServiceLbReconciler_StartController(t *testing.T) {
+	mockMgr := &MockManager{scheme: runtime.NewScheme(), config: &rest.Config{}}
+	r := &ServiceLbReconciler{}
+	// will return error from Start because dependencies for complete are missing
+	err := r.StartController(mockMgr, nil)
+	assert.Error(t, err)
+}
+
+func TestServiceLbReconciler_setupWithManager(t *testing.T) {
+	mockMgr := &MockManager{scheme: runtime.NewScheme(), config: &rest.Config{}}
+	r := &ServiceLbReconciler{}
+	err := r.Start(mockMgr)
+	assert.Error(t, err)
+}
+
+func TestNewServiceLbReconciler_whenIpModeSupported(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects().Build()
+	commonService := common.Service{Client: fakeClient}
+	mockMgr := &MockManager{scheme: runtime.NewScheme(), config: &rest.Config{}}
+
+	patches := gomonkey.ApplyFunc(isServiceLbStatusIpModeSupported, func(c *rest.Config) bool { return true })
+	defer patches.Reset()
+
+	r := NewServiceLbReconciler(mockMgr, commonService, nil)
+	require.NotNil(t, r)
+}
+
+func TestGetLoadBalancerServicesWithDNS(t *testing.T) {
+	ctx := context.Background()
+	scheme := serviceLbTestScheme(t)
+
+	nonLBSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "non-lb", Annotations: map[string]string{
+			common.AnnotationDNSHostnameKey: "no-lb.example.com",
+		}},
+		Spec: v1.ServiceSpec{Type: v1.ServiceTypeClusterIP},
+	}
+
+	makeLbSvc := func(name string, annotations map[string]string) *v1.Service {
+		return &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: name, Annotations: annotations},
+			Spec:       v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+		}
+	}
+
+	objs := []client.Object{
+		nonLBSvc,
+		makeLbSvc("eligible", map[string]string{common.AnnotationDNSHostnameKey: "a.example.com"}),
+		makeLbSvc("multi-hostnames", map[string]string{common.AnnotationDNSHostnameKey: "a.example.com,b.example.com"}),
+		makeLbSvc("opted-out", map[string]string{
+			common.AnnotationDNSHostnameKey: "c.example.com",
+			common.AnnotationsDNSSkip:       "",
+		}),
+		makeLbSvc("no-annotation", map[string]string{}),
+	}
+	wantNNs := []types.NamespacedName{{Namespace: "ns", Name: "eligible"}, {Namespace: "ns", Name: "multi-hostnames"}}
+	wantMiss := []types.NamespacedName{{Namespace: "ns", Name: "non-lb"}, {Namespace: "ns", Name: "no-annotation"},
+		{Namespace: "ns", Name: "opted-out"}}
+
+	c := serviceLbFakeClient(scheme, false, objs...)
+	gotSvcs, err := getLoadBalancerServicesWithDNS(ctx, c)
+	require.NoError(t, err)
+	got := sets.New[types.NamespacedName]()
+	for _, svc := range gotSvcs {
+		got.Insert(types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name})
+	}
+	for _, nn := range wantNNs {
+		require.True(t, got.Has(nn), "expected %v to be in set", nn)
+	}
+	for _, nn := range wantMiss {
+		require.False(t, got.Has(nn), "expected %v NOT to be in set", nn)
+	}
+}
+
+func TestEnqueueLBServiceRequestsFromNetworkInfo_skipAnnotation(t *testing.T) {
+	ctx := context.Background()
+	scheme := serviceLbTestScheme(t)
+	ni := &v1alpha1.NetworkInfo{}
+
+	makeLbSvc := func(name string, annotations map[string]string) client.Object {
+		return &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: name, Annotations: annotations},
+			Spec:       v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+		}
+	}
+
+	// "eligible" has a hostname annotation and no skip → should be enqueued.
+	// "skipped" has both annotations → should NOT be enqueued.
+	c := serviceLbFakeClient(scheme, false,
+		makeLbSvc("eligible", map[string]string{common.AnnotationDNSHostnameKey: "app.example.com"}),
+		makeLbSvc("skipped", map[string]string{
+			common.AnnotationDNSHostnameKey: "app.example.com",
+			common.AnnotationsDNSSkip:       "",
+		}),
+	)
+	r := &ServiceLbReconciler{Client: c, DNS: emptyDNSRecordService()}
+	reqs := r.enqueueLBServiceRequestsFromNetworkInfo(ctx, ni)
+	require.Len(t, reqs, 1)
+	require.Equal(t, types.NamespacedName{Namespace: "ns", Name: "eligible"}, reqs[0].NamespacedName)
+
+	t.Run("invalid_object", func(t *testing.T) {
+		reqs := r.enqueueLBServiceRequestsFromNetworkInfo(ctx, &v1.Pod{})
+		assert.Nil(t, reqs)
+	})
+
+	t.Run("list_error", func(t *testing.T) {
+		fc := &failingClient{Client: c}
+		rErr := &ServiceLbReconciler{Client: fc, DNS: emptyDNSRecordService()}
+		reqs := rErr.enqueueLBServiceRequestsFromNetworkInfo(ctx, ni)
+		assert.Nil(t, reqs)
+	})
+}
+
+// failingClient needs to override List to return an error for this test
+func (c *failingClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return fmt.Errorf("list error")
 }

--- a/pkg/controllers/service/service_lb_dns.go
+++ b/pkg/controllers/service/service_lb_dns.go
@@ -1,0 +1,306 @@
+/* Copyright © 2026 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/dns"
+	extannotations "github.com/vmware-tanzu/nsx-operator/pkg/third_party/externaldns/annotations"
+	extdns "github.com/vmware-tanzu/nsx-operator/pkg/third_party/externaldns/endpoint"
+)
+
+const (
+	// serviceDNSReadyConditionType is the Service status condition type for LoadBalancer DNS publish state (mirrors Gateway DNSConfig semantics, name per product request).
+	serviceDNSReadyConditionType     = "Ready"
+	reasonServiceDNSRecordConfigured = "DNSRecordConfigured"
+	reasonServiceDNSRecordFailed     = "DNSRecordFailed"
+)
+
+// parseDNSHostnamesFromAnnotation returns trimmed unique FQDNs from nsx.vmware.com/hostname using the same
+// gateway-hostname-source + hostname annotation path as Gateway direct DNS (comma-separated tokens are supported).
+func parseDNSHostnamesFromAnnotation(annotations map[string]string) []string {
+	if len(annotations) == 0 {
+		return nil
+	}
+
+	if _, ok := annotations[servicecommon.AnnotationsDNSSkip]; ok {
+		return nil
+	}
+	return extannotations.HostnamesFromAnnotations(annotations, servicecommon.AnnotationDNSHostnameKey)
+}
+
+// targetsFromLoadBalancerIngress collects IP and Hostname values from Service.Status.LoadBalancer.Ingress.
+func targetsFromLoadBalancerIngress(ingress []v1.LoadBalancerIngress) extdns.Targets {
+	vals := make([]string, 0, len(ingress)*2)
+	for i := range ingress {
+		ing := ingress[i]
+		if ip := strings.TrimSpace(ing.IP); ip != "" {
+			vals = append(vals, ip)
+		}
+		if hn := strings.TrimSpace(ing.Hostname); hn != "" {
+			vals = append(vals, hn)
+		}
+	}
+	return extdns.NewTargets(vals...)
+}
+
+// buildLoadBalancerServiceDNSBatch builds owner-scoped DNS rows for a LoadBalancer Service: annotation hostnames,
+// targets from LB ingress, then ValidateEndpointsByZone for namespace VPC policy.
+func buildLoadBalancerServiceDNSBatch(svc *v1.Service, w dns.DNSRecordProvider) (*dns.AggregatedDNSEndpoints, error) {
+	hostnames := parseDNSHostnamesFromAnnotation(svc.GetAnnotations())
+	if len(hostnames) == 0 {
+		return nil, nil
+	}
+	targets := targetsFromLoadBalancerIngress(svc.Status.LoadBalancer.Ingress)
+	if len(targets) == 0 {
+		log.Debug("LB service has hostname annotation but no ingress targets yet", "namespace", svc.Namespace, "name", svc.Name)
+		return nil, nil
+	}
+	log.Debug("Building DNS batch for LB service", "namespace", svc.Namespace, "name", svc.Name,
+		"hostnames", len(hostnames), "targets", len(targets))
+	ttl := extdns.TTL(0)
+	var eps []*extdns.Endpoint
+	for _, h := range hostnames {
+		for _, ep := range extdns.EndpointsForHostname(h, targets, ttl) {
+			if ep == nil {
+				log.Info("Skipping invalid DNS hostname", "hostname", h, "namespace", svc.Namespace, "name", svc.Name)
+				continue
+			}
+			eps = append(eps, ep)
+		}
+	}
+	if len(eps) == 0 {
+		return nil, nil
+	}
+	owner := &dns.ResourceRef{Kind: dns.ResourceKindService, Object: svc.GetObjectMeta()}
+	rows, _, err := w.ValidateEndpointsByZone(svc.Namespace, owner, eps)
+
+	if len(rows) == 0 {
+		return nil, err
+	}
+	log.Info("DNS batch built for LB service", "namespace", svc.Namespace, "name", svc.Name, "rows", len(rows))
+	return dns.NewOwnerScopedAggregatedRouteDNS(owner, rows), err
+}
+
+func buildServiceDNSReadyCondition(err error) metav1.Condition {
+	cond := metav1.Condition{
+		Type:               serviceDNSReadyConditionType,
+		LastTransitionTime: metav1.Now(),
+	}
+	if err != nil {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = reasonServiceDNSRecordFailed
+		cond.Message = err.Error()
+	} else {
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = reasonServiceDNSRecordConfigured
+	}
+	return cond
+}
+
+// updateServiceDNSReadyCondition sets Service status condition type Ready from DNS reconcile outcome (True when err is nil).
+func (r *ServiceLbReconciler) updateServiceDNSReadyCondition(ctx context.Context, ownerKey types.NamespacedName, err error) error {
+	cond := buildServiceDNSReadyCondition(err)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		svc := &v1.Service{}
+		if getErr := r.Client.Get(ctx, ownerKey, svc); getErr != nil {
+			return client.IgnoreNotFound(getErr)
+		}
+		c := cond
+		c.ObservedGeneration = svc.GetGeneration()
+		if !meta.SetStatusCondition(&svc.Status.Conditions, c) {
+			return nil
+		}
+		return r.Client.Status().Update(ctx, svc)
+	})
+}
+
+// removeServiceDNSReadyCondition removes the Ready DNS status condition; ignores NotFound.
+func (r *ServiceLbReconciler) removeServiceDNSReadyCondition(ctx context.Context, key types.NamespacedName) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		svc := &v1.Service{}
+		if err := r.Client.Get(ctx, key, svc); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+		if !meta.RemoveStatusCondition(&svc.Status.Conditions, serviceDNSReadyConditionType) {
+			return nil
+		}
+		return r.Client.Status().Update(ctx, svc)
+	})
+}
+
+// reconcileLoadBalancerServiceDNS applies DNS rows for the Service.
+func (r *ServiceLbReconciler) reconcileLoadBalancerServiceDNS(ctx context.Context, svc *v1.Service) error {
+	svcNN := types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
+	log.Info("Reconciling DNS for LB service", "Service", svcNN)
+	batch, err := buildLoadBalancerServiceDNSBatch(svc, r.DNS)
+	if err != nil {
+		var zoneValErr *dns.DNSZoneValidationError
+		if errors.As(err, &zoneValErr) {
+			log.Error(err, "Failed to validate DNS records for Service with the allowed DNS zones", "Service", svcNN)
+			if uerr := r.updateServiceDNSReadyCondition(ctx, svcNN, err); uerr != nil {
+				log.Error(uerr, "Failed to update DNS conditions", "Service", svcNN)
+				return uerr
+			}
+			// If there are valid rows, we should still apply them
+			if batch != nil && len(batch.Rows) > 0 {
+				_, uErr := r.DNS.CreateOrUpdateRecords(ctx, batch)
+				if uErr != nil {
+					log.Error(uErr, "Failed to reconcile valid DNS records despite validation errors", "Service", svcNN)
+					return uErr
+				}
+			} else {
+				if _, dErr := r.DNS.DeleteRecordByOwnerNN(ctx, dns.ResourceKindService, svc.Namespace, svc.Name); dErr != nil {
+					log.Error(dErr, "Failed to delete stale DNS records", "Service", svcNN)
+					return dErr
+				}
+			}
+			// For validation errors, we do not automatically requeue. We wait for the user to update the service.
+			return nil
+		}
+		log.Error(err, "Failed to build DNS endpoints for Service", "Service", svcNN)
+		if uerr := r.updateServiceDNSReadyCondition(ctx, svcNN, err); uerr != nil {
+			log.Error(uerr, "Failed to update DNS conditions", "Service", svcNN)
+			return uerr
+		}
+		return err
+	}
+
+	if batch == nil || len(batch.Rows) == 0 {
+		return r.clearDNSAndConditionForService(ctx, svcNN, "stale DNS records")
+	}
+
+	_, uErr := r.DNS.CreateOrUpdateRecords(ctx, batch)
+	if uErr != nil {
+		log.Error(uErr, "Failed to reconcile DNS records", "Service", svcNN)
+	}
+	if condErr := r.updateServiceDNSReadyCondition(ctx, svcNN, uErr); condErr != nil {
+		log.Error(condErr, "Failed to update DNS ready condition", "Service", svcNN)
+		if uErr != nil {
+			return fmt.Errorf("updating condition: %v, reconciling DNS: %w", condErr, uErr)
+		}
+		return fmt.Errorf("updating condition: %w", condErr)
+	}
+	return uErr
+}
+
+// getLoadBalancerServicesWithDNS returns LoadBalancer Services that should have DNS records.
+func getLoadBalancerServicesWithDNS(ctx context.Context, c client.Client, listOpts ...client.ListOption) ([]v1.Service, error) {
+	svcList := &v1.ServiceList{}
+	if err := c.List(ctx, svcList, listOpts...); err != nil {
+		return nil, err
+	}
+	var filtered []v1.Service
+	for i := range svcList.Items {
+		svc := svcList.Items[i]
+		if svc.Spec.Type != v1.ServiceTypeLoadBalancer || !svc.ObjectMeta.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if len(parseDNSHostnamesFromAnnotation(svc.GetAnnotations())) == 0 {
+			continue
+		}
+		filtered = append(filtered, svc)
+	}
+	return filtered, nil
+}
+
+// enqueueLBServiceRequestsFromNetworkInfo requeues LoadBalancer Services that publish DNS when namespace AllowedDNSDomains change.
+func (r *ServiceLbReconciler) enqueueLBServiceRequestsFromNetworkInfo(ctx context.Context, obj client.Object) []reconcile.Request {
+	ni, ok := obj.(*v1alpha1.NetworkInfo)
+	if !ok || ni == nil {
+		return nil
+	}
+	svcs, err := getLoadBalancerServicesWithDNS(ctx, r.Client, client.InNamespace(ni.Namespace))
+	if err != nil {
+		log.Error(err, "Failed to list Services for NetworkInfo DNS domain change", "Namespace", ni.Namespace)
+		return nil
+	}
+	var reqs []reconcile.Request
+	for _, svc := range svcs {
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}})
+	}
+	return reqs
+}
+
+func predicateNetworkInfoAllowedDNSDomainsChanged() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNI, ok1 := e.ObjectOld.(*v1alpha1.NetworkInfo)
+			newNI, ok2 := e.ObjectNew.(*v1alpha1.NetworkInfo)
+			if !ok1 || !ok2 {
+				return false
+			}
+			return !slices.Equal(oldNI.AllowedDNSDomains, newNI.AllowedDNSDomains)
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// collectDNSGarbage performs DNS record garbage collection for LoadBalancer Services.
+func (r *ServiceLbReconciler) collectDNSGarbage(ctx context.Context) error {
+	if r.DNS == nil {
+		return nil
+	}
+	apiSet := sets.New[types.NamespacedName]()
+	svcs, err := getLoadBalancerServicesWithDNS(ctx, r.Client)
+	if err != nil {
+		log.Error(err, "Service LB GC: failed to list Services")
+		return err
+	}
+	for _, svc := range svcs {
+		apiSet.Insert(types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name})
+	}
+	ownersByKind := r.DNS.ListRecordOwnerResource()
+	cachedServices := ownersByKind[dns.ResourceKindService]
+	var errs []error
+	for nn := range cachedServices {
+		if apiSet.Has(nn) {
+			continue
+		}
+		if err := r.clearDNSAndConditionForService(ctx, nn, "GC: missing or ineligible Service owner"); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("service LB garbage collection encountered %d error(s): %w", len(errs), errors.Join(errs...))
+	}
+	return nil
+}
+
+func (r *ServiceLbReconciler) clearDNSAndConditionForService(ctx context.Context, reqNN types.NamespacedName, op string) error {
+	if delErr := r.deleteDNSForService(ctx, reqNN.Namespace, reqNN.Name, op); delErr != nil {
+		return delErr
+	}
+	if uerr := r.removeServiceDNSReadyCondition(ctx, reqNN); uerr != nil {
+		log.Error(uerr, "Failed to clear Service DNS Ready condition", "Service", reqNN.String(), "Operation", op)
+		return fmt.Errorf("clearing DNS condition for %s: %w", op, uerr)
+	}
+	return nil
+}

--- a/pkg/controllers/service/service_lb_dns_test.go
+++ b/pkg/controllers/service/service_lb_dns_test.go
@@ -1,0 +1,419 @@
+/* Copyright © 2026 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	mockdns "github.com/vmware-tanzu/nsx-operator/pkg/mock/dnsrecordprovider"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/dns"
+	extdns "github.com/vmware-tanzu/nsx-operator/pkg/third_party/externaldns/endpoint"
+)
+
+// stubValidatedRows mimics ValidateEndpointsByZone for *.example.com under /zones/t.
+func stubValidatedRows(eps []*extdns.Endpoint) ([]dns.EndpointRow, map[string]string, error) {
+	const zpath = "/orgs/org1/projects/proj1/dns-services/dns1/zones/t"
+	var rows []dns.EndpointRow
+	for _, ep := range eps {
+		if ep == nil {
+			continue
+		}
+		dn := strings.ToLower(strings.TrimSpace(ep.DNSName))
+		if !strings.HasSuffix(dn, ".example.com") {
+			return nil, nil, fmt.Errorf("hostname %q does not match stub allowed domain", ep.DNSName)
+		}
+		rel := strings.TrimSuffix(dn, ".example.com")
+		rel = strings.TrimPrefix(rel, ".")
+		rows = append(rows, *dns.NewEndpointRow(ep, zpath, rel))
+	}
+	return rows, map[string]string{zpath: "example.com"}, nil
+}
+
+func TestTargetsFromLoadBalancerIngress_table(t *testing.T) {
+	tests := []struct {
+		name    string
+		ingress []v1.LoadBalancerIngress
+		want    []string
+	}{
+		{
+			name: "ip_and_hostname",
+			ingress: []v1.LoadBalancerIngress{
+				{IP: "10.0.0.1"},
+				{Hostname: "lb.vendor.example"},
+			},
+			want: []string{"10.0.0.1", "lb.vendor.example"},
+		},
+		{
+			name:    "empty",
+			ingress: nil,
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := targetsFromLoadBalancerIngress(tt.ingress)
+			if tt.want == nil {
+				require.Empty(t, got)
+				return
+			}
+			assert.ElementsMatch(t, tt.want, []string(got))
+		})
+	}
+}
+
+func TestReconcileLoadBalancerServiceDNS(t *testing.T) {
+	ctx := context.Background()
+	scheme := serviceLbTestScheme(t)
+
+	makeLbSvc := func(ns, name, uid, hostname, ip string) *v1.Service {
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, UID: types.UID(uid)},
+			Spec:       v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+		}
+		if hostname != "" {
+			svc.Annotations = map[string]string{servicecommon.AnnotationDNSHostnameKey: hostname}
+		}
+		if ip != "" {
+			svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: ip}}
+		}
+		return svc
+	}
+
+	tests := []struct {
+		name      string
+		svc       *v1.Service
+		setupMock func(m *mockdns.MockDNSRecordProvider)
+		wantErr   bool
+	}{
+		{
+			name: "hostname_with_ip_publishes",
+			svc:  makeLbSvc("ns1", "lb", "u1", "app.example.com", "203.0.113.5"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ string, _ *dns.ResourceRef, eps []*extdns.Endpoint) ([]dns.EndpointRow, map[string]string, error) {
+						rows, allowed, err := stubValidatedRows(eps)
+						return rows, allowed, err
+					}).Times(1)
+				m.EXPECT().CreateOrUpdateRecords(gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+			},
+		},
+		{
+			name: "dnsZoneValidationError_deletesOutsideAllowed",
+			svc:  makeLbSvc("ns1", "lb", "u4", "app.example.com", "203.0.113.6"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				allowed := map[string]string{"/zones/t": "example.com"}
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, allowed, &dns.DNSZoneValidationError{Msg: "zone mismatch"}).Times(1)
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb").Return(false, nil).Times(1)
+			},
+		},
+		{
+			name: "empty_targets",
+			svc:  makeLbSvc("ns1", "lb-empty-targets", "u9", "app.example.com", ""),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				// No interactions expected, just returns nil, nil, nil internally
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb-empty-targets").Return(true, nil).Times(1)
+			},
+		},
+		{
+			name: "dnsZoneValidationError_deletesOutsideAllowed_error",
+			svc:  makeLbSvc("ns1", "lb-err2", "u5", "app.example.com", "203.0.113.6"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				allowed := map[string]string{"/zones/t": "example.com"}
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, allowed, &dns.DNSZoneValidationError{Msg: "zone mismatch"}).Times(1)
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb-err2").Return(false, fmt.Errorf("mock delete error")).Times(1)
+			},
+			wantErr: true,
+		},
+		{
+			name: "dnsZoneValidationError_updateCondition_error",
+			svc:  makeLbSvc("ns1", "lb-err-cond", "u5-cond", "app.example.com", "203.0.113.6"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				allowed := map[string]string{"/zones/t": "example.com"}
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, allowed, &dns.DNSZoneValidationError{Msg: "zone mismatch"}).Times(1)
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb-err-cond").Return(false, fmt.Errorf("mock delete error")).Times(1)
+			},
+			wantErr: true,
+		},
+		{
+			name: "validateEndpoints_error_updateCondition_error",
+			svc:  makeLbSvc("ns1", "lb-val-cond-err", "u11", "app.example.com", "203.0.113.6"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, fmt.Errorf("mock val error")).Times(1)
+			},
+			wantErr: true,
+		},
+		{
+			name: "stale_dns_records_deletes",
+			svc:  makeLbSvc("ns1", "lb-stale", "u6", "app.example.com", "203.0.113.6"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil).Times(1)
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb-stale").Return(true, nil).Times(1)
+			},
+		},
+		{
+			name: "stale_dns_records_deletes_error",
+			svc:  makeLbSvc("ns1", "lb-stale-err", "u7", "app.example.com", "203.0.113.6"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil).Times(1)
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb-stale-err").Return(false, fmt.Errorf("mock error")).Times(1)
+			},
+			wantErr: true,
+		},
+		{
+			name: "create_or_update_dns_records_error",
+			svc:  makeLbSvc("ns1", "lb-create-err", "u8", "app.example.com", "203.0.113.6"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ string, _ *dns.ResourceRef, eps []*extdns.Endpoint) ([]dns.EndpointRow, map[string]string, error) {
+						rows, allowed, err := stubValidatedRows(eps)
+						return rows, allowed, err
+					}).Times(1)
+				m.EXPECT().CreateOrUpdateRecords(gomock.Any(), gomock.Any()).Return(false, fmt.Errorf("mock create error")).Times(1)
+			},
+			wantErr: true,
+		},
+		{
+			name: "validate_endpoints_error",
+			svc:  makeLbSvc("ns1", "lb-val-err", "u10", "app.example.com", "203.0.113.6"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, fmt.Errorf("mock val error")).Times(1)
+			},
+			wantErr: true,
+		},
+		{
+			name: "targetsFromLoadBalancerIngress_empty_skip_batch",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "lb-no-target", UID: "u11",
+					Annotations: map[string]string{servicecommon.AnnotationDNSHostnameKey: "a.com"},
+				},
+				Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{}}, // empty targets
+				},
+			},
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb-no-target").Return(true, nil).Times(1)
+			},
+		},
+		{
+			name: "no_ip_targets_deletes",
+			svc:  makeLbSvc("ns1", "lb", "u2", "app.example.com", ""),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb").Return(true, nil).Times(1)
+			},
+		},
+		{
+			name: "no_annotation_skips",
+			svc:  makeLbSvc("ns1", "lb", "u3", "", "203.0.113.5"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb").Return(false, nil).Times(1)
+			},
+		},
+		{
+			name: "invalid_annotation_extra_commas_and_spaces",
+			svc:  makeLbSvc("ns1", "lb", "u4", "  app.example.com  , ,  ", "203.0.113.5"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				allowed := map[string]string{"/zones/t": "example.com"}
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(namespace string, owner *dns.ResourceRef, eps []*extdns.Endpoint) ([]dns.EndpointRow, []*extdns.Endpoint, map[string]string, error) {
+						require.Len(t, eps, 3)
+						require.Equal(t, "app.example.com", eps[0].DNSName)
+						require.Equal(t, "", eps[1].DNSName)
+						require.Equal(t, "", eps[2].DNSName)
+						return []dns.EndpointRow{*dns.NewEndpointRow(&extdns.Endpoint{DNSName: "app.example.com", Targets: []string{"203.0.113.5"}, RecordType: "A"}, "/zones/t", "app")}, nil, allowed, nil
+					}).Times(1)
+				m.EXPECT().CreateOrUpdateRecords(gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+			},
+		},
+		{
+			name: "invalid_annotation_wildcard",
+			svc:  makeLbSvc("ns1", "lb", "u5", "*.example.com", "203.0.113.5"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				allowed := map[string]string{"/zones/t": "example.com"}
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(namespace string, owner *dns.ResourceRef, eps []*extdns.Endpoint) ([]dns.EndpointRow, map[string]string, error) {
+						require.Len(t, eps, 1)
+						require.Equal(t, "*.example.com", eps[0].DNSName)
+						return nil, allowed, nil
+					}).Times(1)
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb").Return(false, nil).Times(1)
+			},
+		},
+		{
+			name: "invalid_annotation_empty_hostname",
+			svc:  makeLbSvc("ns1", "lb", "u6", " , ", "203.0.113.5"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				allowed := map[string]string{"/zones/t": "example.com"}
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, allowed, &dns.DNSZoneValidationError{Msg: "empty hostname"}).Times(1)
+
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb").Return(false, nil).Times(1)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtl := gomock.NewController(t)
+			t.Cleanup(func() { mockCtl.Finish() })
+			m := mockdns.NewMockDNSRecordProvider(mockCtl)
+			assignDNSListStubs(m)
+			tt.setupMock(m)
+			r := &ServiceLbReconciler{
+				Client: serviceLbFakeClient(scheme, false, tt.svc),
+				DNS:    m,
+			}
+			err := r.reconcileLoadBalancerServiceDNS(ctx, tt.svc)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestServiceLbReconciler_Reconcile_dnsOnDelete(t *testing.T) {
+	ctx := context.Background()
+	scheme := serviceLbTestScheme(t)
+	mockCtl := gomock.NewController(t)
+	t.Cleanup(func() { mockCtl.Finish() })
+	m := mockdns.NewMockDNSRecordProvider(mockCtl)
+	assignDNSListStubs(m)
+	m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "gone").Return(false, nil).Times(1)
+	r := &ServiceLbReconciler{
+		Client:   serviceLbFakeClient(scheme, false),
+		DNS:      m,
+		Recorder: fakeRecorder{},
+	}
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns1", Name: "gone"}})
+	require.NoError(t, err)
+}
+
+// TestReconcileLoadBalancerServiceDNS_nonZoneValidationErrUpdatesCondition verifies that when
+// buildLoadBalancerServiceDNSBatch returns a plain (non-DNSZoneValidationError) error, the
+// reconciler still sets the Ready condition to False/DNSRecordFailed and returns the error.
+func TestReconcileLoadBalancerServiceDNS_nonZoneValidationErrUpdatesCondition(t *testing.T) {
+	ctx := context.Background()
+	scheme := serviceLbTestScheme(t)
+	mockCtl := gomock.NewController(t)
+	t.Cleanup(func() { mockCtl.Finish() })
+	m := mockdns.NewMockDNSRecordProvider(mockCtl)
+	assignDNSListStubs(m)
+
+	infraErr := fmt.Errorf("vpc service unavailable")
+	m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, infraErr).Times(1)
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "ns1",
+			Name:        "lb",
+			UID:         "u-infra",
+			Annotations: map[string]string{servicecommon.AnnotationDNSHostnameKey: "app.example.com"},
+			Generation:  2,
+		},
+		Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{{IP: "203.0.113.5"}}},
+		},
+	}
+	r := &ServiceLbReconciler{
+		Client: serviceLbFakeClient(scheme, true, svc),
+		DNS:    m,
+	}
+	err := r.reconcileLoadBalancerServiceDNS(ctx, svc)
+	require.ErrorIs(t, err, infraErr)
+
+	got := &v1.Service{}
+	require.NoError(t, r.Client.Get(ctx, types.NamespacedName{Namespace: "ns1", Name: "lb"}, got))
+	c := meta.FindStatusCondition(got.Status.Conditions, serviceDNSReadyConditionType)
+	require.NotNil(t, c, "Ready condition must be set even for non-DNSZoneValidationError")
+	assert.Equal(t, metav1.ConditionFalse, c.Status)
+	assert.Equal(t, reasonServiceDNSRecordFailed, c.Reason)
+	assert.Contains(t, c.Message, "vpc service unavailable")
+}
+
+func TestServiceLbReconciler_updateServiceDNSReadyCondition_table(t *testing.T) {
+	ctx := context.Background()
+	scheme := serviceLbTestScheme(t)
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus metav1.ConditionStatus
+		wantReason string
+		msgSub     string
+	}{
+		{
+			name:       "success_sets_true",
+			err:        nil,
+			wantStatus: metav1.ConditionTrue,
+			wantReason: reasonServiceDNSRecordConfigured,
+		},
+		{
+			name:       "error_sets_false",
+			err:        fmt.Errorf("zone validation failed"),
+			wantStatus: metav1.ConditionFalse,
+			wantReason: reasonServiceDNSRecordFailed,
+			msgSub:     "zone validation failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "lb", Generation: 3},
+				Spec:       v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+			}
+			r := &ServiceLbReconciler{Client: serviceLbFakeClient(scheme, true, svc)}
+			nn := types.NamespacedName{Namespace: "ns1", Name: "lb"}
+			require.NoError(t, r.updateServiceDNSReadyCondition(ctx, nn, tt.err))
+			got := &v1.Service{}
+			require.NoError(t, r.Client.Get(ctx, nn, got))
+			c := meta.FindStatusCondition(got.Status.Conditions, serviceDNSReadyConditionType)
+			require.NotNil(t, c)
+			assert.Equal(t, tt.wantStatus, c.Status)
+			assert.Equal(t, tt.wantReason, c.Reason)
+			if tt.msgSub != "" {
+				assert.Contains(t, c.Message, tt.msgSub)
+			}
+			assert.Equal(t, int64(3), c.ObservedGeneration)
+		})
+	}
+}
+
+func TestServiceLbReconciler_removeServiceDNSReadyCondition(t *testing.T) {
+	ctx := context.Background()
+	scheme := serviceLbTestScheme(t)
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "lb"},
+		Spec:       v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+		Status: v1.ServiceStatus{
+			Conditions: []metav1.Condition{{
+				Type: serviceDNSReadyConditionType, Status: metav1.ConditionTrue, Reason: reasonServiceDNSRecordConfigured,
+			}},
+		},
+	}
+	r := &ServiceLbReconciler{Client: serviceLbFakeClient(scheme, true, svc)}
+	nn := types.NamespacedName{Namespace: "ns1", Name: "lb"}
+	require.NoError(t, r.removeServiceDNSReadyCondition(ctx, nn))
+	got := &v1.Service{}
+	require.NoError(t, r.Client.Get(ctx, nn, got))
+	assert.Nil(t, meta.FindStatusCondition(got.Status.Conditions, serviceDNSReadyConditionType))
+}

--- a/pkg/mock/dnsrecordprovider/client.go
+++ b/pkg/mock/dnsrecordprovider/client.go
@@ -83,21 +83,6 @@ func (mr *MockDNSRecordProviderMockRecorder) ValidateEndpointsByZone(namespace, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateEndpointsByZone", reflect.TypeOf((*MockDNSRecordProvider)(nil).ValidateEndpointsByZone), namespace, owner, eps)
 }
 
-// DeleteRecordsForOwnerOutsideAllowedZones mocks base method.
-func (m *MockDNSRecordProvider) DeleteRecordsForOwnerOutsideAllowedZones(ctx context.Context, kind, namespace, name string, allowedZonePaths sets.Set[string]) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRecordsForOwnerOutsideAllowedZones", ctx, kind, namespace, name, allowedZonePaths)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteRecordsForOwnerOutsideAllowedZones indicates an expected call of DeleteRecordsForOwnerOutsideAllowedZones.
-func (mr *MockDNSRecordProviderMockRecorder) DeleteRecordsForOwnerOutsideAllowedZones(ctx, kind, namespace, name, allowedZonePaths interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRecordsForOwnerOutsideAllowedZones", reflect.TypeOf((*MockDNSRecordProvider)(nil).DeleteRecordsForOwnerOutsideAllowedZones), ctx, kind, namespace, name, allowedZonePaths)
-}
-
 // ListReferredGatewayNN mocks base method.
 func (m *MockDNSRecordProvider) ListReferredGatewayNN() sets.Set[types.NamespacedName] {
 	m.ctrl.T.Helper()

--- a/pkg/mock/realizedentitiesclient/client.go
+++ b/pkg/mock/realizedentitiesclient/client.go
@@ -7,8 +7,8 @@ package mocks
 import (
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
 	model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockRealizedEntitiesClient is a mock of RealizedEntitiesClient interface.

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -118,6 +118,9 @@ const (
 	TagValueDNSRecordForGRPCRoute       string = "grpcroute"
 	TagValueDNSRecordForTLSRoute        string = "tlsroute"
 	TagValueDNSRecordForService         string = "service"
+	AnnotationDNSHostnameKey            string = "nsx.vmware.com/hostname"
+	AnnotationDNSHostnameSourceKey      string = "nsx.vmware.com/gateway-hostname-source"
+	AnnotationsDNSSkip                  string = "nsx.vmware.com/skip"
 
 	// TagScopePodIndex is the NSX tag scope for Pod label apps.kubernetes.io/pod-index when synced onto the port (not set in BuildBasicTags).
 	TagScopePodIndex   string = "apps.kubernetes.io/pod-index"

--- a/pkg/nsx/services/dns/recordservice.go
+++ b/pkg/nsx/services/dns/recordservice.go
@@ -152,8 +152,8 @@ func (s *DNSRecordService) validateEndpointRowConflict(zonePath string, ep *extd
 	}
 	fqdn := strings.ToLower(ep.DNSName)
 	recTypeForIdx := strings.ToLower(strings.TrimSpace(ep.RecordType))
-	idxKey := dnsRecordZonePathFQDNIndexKey(zonePath, fqdn, recTypeForIdx)
-	recs := s.DNSRecordStore.GetByIndex(indexKeyDNSRecordZonePathFQDN, idxKey)
+	idxKey := dnsRecordZonePathRecordNameIndexKey(zonePath, recordName, recTypeForIdx)
+	recs := s.DNSRecordStore.GetByIndex(indexKeyDNSRecordZonePathRecordName, idxKey)
 	log.Debug("Checking DNS record conflict", "fqdn", fqdn, "zone", zonePath, "type", recTypeForIdx, "existingCount", len(recs))
 	currentNNKey := ownerNNIndexKeyForResourceRef(owner)
 	for _, rec := range recs {
@@ -374,41 +374,6 @@ func (s *DNSRecordService) ListReferredGatewayNN() sets.Set[types.NamespacedName
 		gatewaySet.Insert(types.NamespacedName{Namespace: gwNamespace, Name: gwName})
 	}
 	return gatewaySet
-}
-
-// DeleteRecordsForOwnerOutsideAllowedZones deletes primary-owner DNS records whose zone_path is not in allowedZonePaths.
-func (s *DNSRecordService) DeleteRecordsForOwnerOutsideAllowedZones(ctx context.Context, kind, namespace, name string, allowedZonePaths sets.Set[string]) (bool, error) {
-	if allowedZonePaths == nil {
-		allowedZonePaths = sets.New[string]()
-	}
-	// Only delete the ProjectDnsRecord which is owned by the kind/namespace/name; the contributed records are
-	// deleted in the reconciliation by the record owner.
-	owned := s.DNSRecordStore.GetByOwnerResourceNamespacedName(kind, namespace, name)
-	var toDelete []*model.ProjectDnsRecord
-	for _, rec := range owned {
-		// rec.ZonePath is not nil which is guarded when creating the ProjectDnsRecord.
-		zp := strings.TrimSpace(*rec.ZonePath)
-		if allowedZonePaths.Has(zp) {
-			continue
-		}
-		cp := *rec
-		cp.MarkedForDelete = common.Bool(true)
-		toDelete = append(toDelete, &cp)
-	}
-	if len(toDelete) == 0 {
-		log.Debug("No out-of-zone DNS records to delete", "kind", kind, "namespace", namespace, "name", name)
-		return false, nil
-	}
-	log.Info("Deleting DNS records outside allowed zones", "kind", kind, "namespace", namespace, "name", name,
-		"toDelete", len(toDelete), "allowedZones", allowedZonePaths.Len())
-
-	toApply, syncErr := s.syncProjectDnsRecordsInNSX(ctx, nil, toDelete)
-	if len(toApply) > 0 {
-		if applyErr := s.DNSRecordStore.Apply(toApply); applyErr != nil {
-			return false, applyErr
-		}
-	}
-	return len(toApply) > 0, syncErr
 }
 
 func getCluster(s *DNSRecordService) string {

--- a/pkg/nsx/services/dns/recordservice_test.go
+++ b/pkg/nsx/services/dns/recordservice_test.go
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
+
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -629,34 +629,6 @@ func Test_CreateOrUpdateRecords_Service_DeleteByOwnerNN(t *testing.T) {
 	assert.Empty(t, env.DNSRecordStore.GetByOwnerResourceNamespacedName(ResourceKindService, "ns1", "lbsvc"))
 }
 
-func TestDeleteRecordsForOwnerOutsideAllowedZones(t *testing.T) {
-	ctx := context.Background()
-	env := newTestDNSRecordService(t, BuildDNSRecordStore())
-	owner := &ResourceRef{Kind: ResourceKindGateway, Object: &metav1.ObjectMeta{Namespace: "ns", Name: "gw", UID: types.UID("u1")}}
-	zOld := testDNSZonePathOld
-	zKeep := testDNSZonePathKeep
-	ep1 := extdns.NewEndpoint("a.example.com", extdns.RecordTypeA, "10.0.0.1")
-	ep1.WithLabel(EndpointLabelParentGateway, "ns/gw")
-	rowOut := EndpointRow{Endpoint: ep1, zonePath: zOld, nsxRecordName: "a"}
-	requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(owner, []EndpointRow{rowOut}))
-
-	allowed := sets.New(zKeep)
-	mut, err := env.DeleteRecordsForOwnerOutsideAllowedZones(ctx, ResourceKindGateway, "ns", "gw", allowed)
-	require.NoError(t, err)
-	require.True(t, mut)
-	assert.Empty(t, env.DNSRecordStore.GetByOwnerResourceNamespacedName(ResourceKindGateway, "ns", "gw"))
-
-	// Add a row in the allowed zone; deleting with a disjoint allow-list should not remove it.
-	ep2 := extdns.NewEndpoint("b.example.com", extdns.RecordTypeA, "10.0.0.2")
-	ep2.WithLabel(EndpointLabelParentGateway, "ns/gw")
-	rowKeep := EndpointRow{Endpoint: ep2, zonePath: zKeep, nsxRecordName: "b"}
-	requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(owner, []EndpointRow{rowKeep}))
-	mut2, err2 := env.DeleteRecordsForOwnerOutsideAllowedZones(ctx, ResourceKindGateway, "ns", "gw", sets.New(testDNSZonePathOther))
-	require.NoError(t, err2)
-	require.True(t, mut2)
-	require.Len(t, env.DNSRecordStore.GetByOwnerResourceNamespacedName(ResourceKindGateway, "ns", "gw"), 0)
-}
-
 func TestParseProjectDNSRecordPolicyPath_table(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1135,6 +1107,7 @@ func TestValidateEndpointRowConflict_table(t *testing.T) {
 			Path:         servicecommon.String(path),
 			ZonePath:     servicecommon.String(zonePath),
 			RecordType:   servicecommon.String(model.ProjectDnsRecord_RECORD_TYPE_A),
+			RecordName:   servicecommon.String("svc"),
 			Fqdn:         servicecommon.String(fqdn),
 			RecordValues: values,
 			Tags: []model.Tag{
@@ -1181,6 +1154,7 @@ func TestValidateEndpointRowConflict_table(t *testing.T) {
 				Path:         servicecommon.String("/orgs/org1/projects/proj1/dns-records/r-noowner"),
 				ZonePath:     servicecommon.String(zonePath),
 				RecordType:   servicecommon.String(model.ProjectDnsRecord_RECORD_TYPE_A),
+				RecordName:   servicecommon.String("svc"),
 				Fqdn:         servicecommon.String(fqdn),
 				RecordValues: []string{"10.0.0.1"},
 				Tags:         []model.Tag{},
@@ -1246,30 +1220,6 @@ func TestDeleteRecordByOwnerNN_noRecords_noOp(t *testing.T) {
 	ctx := context.Background()
 	env := newTestDNSRecordService(t, BuildDNSRecordStore())
 	mut, err := env.DeleteRecordByOwnerNN(ctx, ResourceKindService, "ns", "svc")
-	require.NoError(t, err)
-	require.False(t, mut)
-}
-
-func TestDeleteRecordsForOwnerOutsideAllowedZones_nilAllowedZones(t *testing.T) {
-	ctx := context.Background()
-	env := newTestDNSRecordService(t, BuildDNSRecordStore())
-	owner := &ResourceRef{Kind: ResourceKindGateway, Object: &metav1.ObjectMeta{Namespace: "ns", Name: "gw", UID: types.UID("u1")}}
-	ep := extdns.NewEndpoint("a.example.com", extdns.RecordTypeA, "10.0.0.1")
-	ep.WithLabel(EndpointLabelParentGateway, "ns/gw")
-	row := EndpointRow{Endpoint: ep, zonePath: testDNSZonePathOld, nsxRecordName: "a"}
-	requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(owner, []EndpointRow{row}))
-
-	// nil allowedZones treated as empty set → all owned records are outside and deleted.
-	mut, err := env.DeleteRecordsForOwnerOutsideAllowedZones(ctx, ResourceKindGateway, "ns", "gw", nil)
-	require.NoError(t, err)
-	require.True(t, mut)
-	require.Empty(t, env.DNSRecordStore.GetByOwnerResourceNamespacedName(ResourceKindGateway, "ns", "gw"))
-}
-
-func TestDeleteRecordsForOwnerOutsideAllowedZones_noOwnedRecords(t *testing.T) {
-	ctx := context.Background()
-	env := newTestDNSRecordService(t, BuildDNSRecordStore())
-	mut, err := env.DeleteRecordsForOwnerOutsideAllowedZones(ctx, ResourceKindGateway, "ns", "gw", nil)
 	require.NoError(t, err)
 	require.False(t, mut)
 }

--- a/pkg/nsx/services/dns/store.go
+++ b/pkg/nsx/services/dns/store.go
@@ -139,21 +139,21 @@ func parseGateways(raw string) []string {
 	return sets.List(seen)
 }
 
-func dnsRecordZonePathFQDNIndexKey(zonePath, fqdnLower, recordType string) string {
+func dnsRecordZonePathRecordNameIndexKey(zonePath, recordNameLower, recordType string) string {
 	zp := strings.TrimSpace(zonePath)
-	fq := strings.TrimSpace(strings.ToLower(fqdnLower))
+	rn := strings.TrimSpace(strings.ToLower(recordNameLower))
 	rt := strings.ToLower(strings.TrimSpace(recordType))
-	return zp + "|" + fq + "|" + rt
+	return zp + "|" + rn + "|" + rt
 }
 
-func dnsRecordFQDNLower(rec *model.ProjectDnsRecord) string {
-	if rec == nil || rec.Fqdn == nil {
+func dnsRecordRecordNameLower(rec *model.ProjectDnsRecord) string {
+	if rec == nil || rec.RecordName == nil {
 		return ""
 	}
-	return strings.TrimSpace(strings.ToLower(*rec.Fqdn))
+	return strings.TrimSpace(strings.ToLower(*rec.RecordName))
 }
 
-func indexDNSRecordByZonePathFQDN(obj interface{}) ([]string, error) {
+func indexDNSRecordByZonePathRecordName(obj interface{}) ([]string, error) {
 	switch v := obj.(type) {
 	case *model.ProjectDnsRecord:
 		dnsZone := v.ZonePath
@@ -164,14 +164,14 @@ func indexDNSRecordByZonePathFQDN(obj interface{}) ([]string, error) {
 		if v.RecordType == nil {
 			return []string{}, nil
 		}
-		fq := dnsRecordFQDNLower(v)
+		rn := dnsRecordRecordNameLower(v)
 		rt := strings.TrimSpace(*v.RecordType)
-		if fq == "" || rt == "" { // This is for security purpose, should not happen in the runtime
+		if rn == "" || rt == "" { // This is for security purpose, should not happen in the runtime
 			return []string{}, nil
 		}
-		return []string{dnsRecordZonePathFQDNIndexKey(zp, fq, rt)}, nil
+		return []string{dnsRecordZonePathRecordNameIndexKey(zp, rn, rt)}, nil
 	default:
-		return nil, errors.New("indexDNSRecordByZonePathFQDN doesn't support unknown type")
+		return nil, errors.New("indexDNSRecordByZonePathRecordName doesn't support unknown type")
 	}
 }
 
@@ -209,11 +209,11 @@ func dnsRecordOwnerNamespacedNameKey(namespace, name string) string {
 }
 
 const (
-	indexKeyDNSRecordOwnerTypeNN       = "ownerNamespacedName"
-	indexKeyDNSRecordGatewayNN         = "gatewayNamespacedName"
-	indexKeyDNSRecordZonePathFQDN      = "dnsZonePathFqdn"
-	indexKeyDNSRecordZonePath          = "dnsZonePath"
-	indexKeyDNSRecordContributingOwner = "contributingOwner"
+	indexKeyDNSRecordOwnerTypeNN        = "ownerNamespacedName"
+	indexKeyDNSRecordGatewayNN          = "gatewayNamespacedName"
+	indexKeyDNSRecordZonePathRecordName = "dnsZonePathRecordName"
+	indexKeyDNSRecordZonePath           = "dnsZonePath"
+	indexKeyDNSRecordContributingOwner  = "contributingOwner"
 )
 
 func (s *RecordStore) Apply(i interface{}) error {
@@ -370,11 +370,11 @@ func BuildDNSRecordStore() *RecordStore {
 	return &RecordStore{
 		ResourceStore: common.ResourceStore{
 			Indexer: cache.NewIndexer(dnsRecordKeyFunc, cache.Indexers{
-				indexKeyDNSRecordOwnerTypeNN:       indexDNSRecordByOwnerTypeNN,
-				indexKeyDNSRecordGatewayNN:         indexDNSRecordByGatewayNamespacedName,
-				indexKeyDNSRecordZonePathFQDN:      indexDNSRecordByZonePathFQDN,
-				indexKeyDNSRecordZonePath:          indexDNSRecordByZonePath,
-				indexKeyDNSRecordContributingOwner: indexDNSRecordByContributingOwner,
+				indexKeyDNSRecordOwnerTypeNN:        indexDNSRecordByOwnerTypeNN,
+				indexKeyDNSRecordGatewayNN:          indexDNSRecordByGatewayNamespacedName,
+				indexKeyDNSRecordZonePathRecordName: indexDNSRecordByZonePathRecordName,
+				indexKeyDNSRecordZonePath:           indexDNSRecordByZonePath,
+				indexKeyDNSRecordContributingOwner:  indexDNSRecordByContributingOwner,
 			}),
 			BindingType: model.ProjectDnsRecordBindingType(),
 		},

--- a/pkg/nsx/services/dns/store_test.go
+++ b/pkg/nsx/services/dns/store_test.go
@@ -78,11 +78,11 @@ func TestDNSRecordFQDNLower_table(t *testing.T) {
 	}{
 		{"nil record", nil, ""},
 		{"nil fqdn field", &model.ProjectDnsRecord{}, ""},
-		{"valid fqdn lowercased", &model.ProjectDnsRecord{Fqdn: &fqdn}, "a.example.com"},
+		{"valid fqdn lowercased", &model.ProjectDnsRecord{RecordName: &fqdn}, "a.example.com"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, dnsRecordFQDNLower(tc.rec))
+			require.Equal(t, tc.want, dnsRecordRecordNameLower(tc.rec))
 		})
 	}
 }
@@ -128,7 +128,7 @@ func TestIndexFunctions_unsupported_type(t *testing.T) {
 	}{
 		{"indexDNSRecordByOwnerTypeNN", indexDNSRecordByOwnerTypeNN},
 		{"indexDNSRecordByGatewayNamespacedName", indexDNSRecordByGatewayNamespacedName},
-		{"indexDNSRecordByZonePathFQDN", indexDNSRecordByZonePathFQDN},
+		{"indexDNSRecordByZonePathRecordName", indexDNSRecordByZonePathRecordName},
 		{"indexDNSRecordByZonePath", indexDNSRecordByZonePath},
 		{"indexDNSRecordByContributingOwner", indexDNSRecordByContributingOwner},
 	}
@@ -151,12 +151,12 @@ func TestIndexDNSRecordByZonePathFQDN_earlyReturn_table(t *testing.T) {
 	}{
 		{
 			name:    "nil ZonePath returns empty",
-			rec:     &model.ProjectDnsRecord{RecordType: &rt, Fqdn: &fqdn},
+			rec:     &model.ProjectDnsRecord{RecordType: &rt, RecordName: &fqdn},
 			wantLen: 0,
 		},
 		{
 			name:    "nil RecordType returns empty",
-			rec:     &model.ProjectDnsRecord{ZonePath: &zp, Fqdn: &fqdn},
+			rec:     &model.ProjectDnsRecord{ZonePath: &zp, RecordName: &fqdn},
 			wantLen: 0,
 		},
 		{
@@ -166,13 +166,13 @@ func TestIndexDNSRecordByZonePathFQDN_earlyReturn_table(t *testing.T) {
 		},
 		{
 			name:    "valid record returns one index key",
-			rec:     &model.ProjectDnsRecord{ZonePath: &zp, RecordType: &rt, Fqdn: &fqdn},
+			rec:     &model.ProjectDnsRecord{ZonePath: &zp, RecordType: &rt, RecordName: &fqdn},
 			wantLen: 1,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			keys, err := indexDNSRecordByZonePathFQDN(tc.rec)
+			keys, err := indexDNSRecordByZonePathRecordName(tc.rec)
 			require.NoError(t, err)
 			require.Len(t, keys, tc.wantLen)
 		})

--- a/pkg/nsx/services/dns/types.go
+++ b/pkg/nsx/services/dns/types.go
@@ -73,8 +73,6 @@ type DNSRecordProvider interface {
 	CreateOrUpdateRecords(ctx context.Context, batch *AggregatedDNSEndpoints) (bool, error)
 	DeleteRecordByOwnerNN(ctx context.Context, kind, namespace, name string) (bool, error)
 	ValidateEndpointsByZone(namespace string, owner *ResourceRef, eps []*extdns.Endpoint) ([]EndpointRow, map[string]string, error)
-	// DeleteRecordsForOwnerOutsideAllowedZones deletes the DNS records whose zone_path is not in allowedZonePaths (NSX + store).
-	DeleteRecordsForOwnerOutsideAllowedZones(ctx context.Context, kind, namespace, name string, allowedZonePaths sets.Set[string]) (bool, error)
 	ListReferredGatewayNN() sets.Set[types.NamespacedName]
 	ListRecordOwnerResource() map[string]sets.Set[types.NamespacedName]
 }

--- a/pkg/nsx/services/dns/zones.go
+++ b/pkg/nsx/services/dns/zones.go
@@ -74,7 +74,7 @@ func (s *DNSRecordService) getZonePathForHostname(z extprovider.ZoneIDName, host
 	return recordName, zonePath, nil
 }
 
-// ValidateEndpointsByZone maps each endpoint to a zone and row; returns validated rows, path→domain map for permitted zones (from sync), and err. owner must be non-nil.
+// ValidateEndpointsByZone maps each endpoint to a zone and row; returns validated rows, invalid rows, path→domain map for permitted zones (from sync), and err. owner must be non-nil.
 func (s *DNSRecordService) ValidateEndpointsByZone(namespace string, owner *ResourceRef, eps []*extdns.Endpoint) ([]EndpointRow, map[string]string, error) {
 	log.Info("Validating DNS endpoints by zone", "namespace", namespace,
 		"owner", owner.GetName(), "endpoints", len(eps))
@@ -92,7 +92,9 @@ func (s *DNSRecordService) ValidateEndpointsByZone(namespace string, owner *Reso
 	}
 	z := generateZoneIdFromMap(allowedZones)
 
-	var rows []EndpointRow
+	var validRows []EndpointRow
+	var validationErr error
+
 	for i := range eps {
 		ep := eps[i]
 		if endpointDNSNameIsWildcard(ep.DNSName) {
@@ -101,16 +103,22 @@ func (s *DNSRecordService) ValidateEndpointsByZone(namespace string, owner *Reso
 		}
 		recName, zonePath, parseErr := s.getZonePathForHostname(z, ep.DNSName)
 		if parseErr != nil {
-			return nil, allowedZones, &DNSZoneValidationError{Msg: parseErr.Error()}
+			if validationErr == nil {
+				validationErr = &DNSZoneValidationError{Msg: parseErr.Error()}
+			}
+			continue
 		}
 		log.Debug("Mapped DNS endpoint to zone", "dnsName", ep.DNSName, "zonePath", zonePath, "recordName", recName)
 		row, validErr := s.validateEndpointRowConflict(zonePath, ep, recName, owner)
 		if validErr != nil {
-			return nil, allowedZones, &DNSZoneValidationError{Msg: "DNS endpoint validation failed for DNS zone policy", Cause: validErr}
+			if validationErr == nil {
+				validationErr = &DNSZoneValidationError{Msg: "DNS endpoint validation failed for DNS zone policy", Cause: validErr}
+			}
+			continue
 		}
-		rows = append(rows, *row)
+		validRows = append(validRows, *row)
 	}
-	return rows, allowedZones, nil
+	return validRows, allowedZones, validationErr
 }
 
 // SyncDNSZonesByVpcNetworkConfig ensures DNSZoneMap entries for vpcConfig.Spec.DNSZones; returns path→domain map or err.

--- a/pkg/third_party/externaldns/annotations/doc.go
+++ b/pkg/third_party/externaldns/annotations/doc.go
@@ -1,0 +1,20 @@
+// Package annotations provides a small subset of ExternalDNS source annotation helpers.
+// Upstream: sigs.k8s.io/external-dns/source/annotations (notably processors.go for hostname splitting/list parsing;
+// upstream also defines fixed annotation key constants used by the full Gateway/Ingress sources).
+//
+// # Direct copy from external-dns (same logic; same exported names where applicable)
+//
+//	SplitHostnameAnnotation — same comma-separated hostname tokenization as upstream processors.
+//	HostnamesFromAnnotations(input, hostnameKey) — same parsing as upstream after resolving the key; upstream
+//	overload reads a package-level hostname key constant.
+//
+// # Modified from external-dns
+//
+//	HostnamesFromAnnotations — returns nil if hostnameKey is "" or input is nil (defensive); upstream resolves
+//	from a fixed key and may not short-circuit the same way.
+//
+// # nsx-operator / subset
+//
+//	This package does **not** vendor upstream annotation **key** constants. Callers (e.g. gateway controller +
+//	source.RouteHostnames) pass key strings—typically from pkg/nsx/services/common—or any compatible key for tests.
+package annotations

--- a/pkg/third_party/externaldns/annotations/hostnames.go
+++ b/pkg/third_party/externaldns/annotations/hostnames.go
@@ -1,0 +1,34 @@
+// Copyright 2025 The Kubernetes Authors.
+// Copyright 2026 Broadcom, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Derived from sigs.k8s.io/external-dns/source/annotations/processors.go (hostname helpers).
+// Attribution: see package doc.go.
+
+package annotations
+
+import (
+	"strings"
+)
+
+// SplitHostnameAnnotation splits a comma-separated hostname annotation string into a slice of hostnames.
+func SplitHostnameAnnotation(input string) []string {
+	return strings.Split(strings.TrimSpace(strings.ReplaceAll(input, " ", "")), ",")
+}
+
+// HostnamesFromAnnotations extracts hostnames from the annotation identified by hostnameKey
+// (e.g. nsx.vmware.com/hostname or external-dns.alpha.kubernetes.io/hostname).
+func HostnamesFromAnnotations(input map[string]string, hostnameKey string) []string {
+	if hostnameKey == "" {
+		return nil
+	}
+	if input == nil {
+		return nil
+	}
+	annotation, ok := input[hostnameKey]
+	if !ok {
+		return nil
+	}
+	return SplitHostnameAnnotation(annotation)
+}

--- a/pkg/third_party/externaldns/annotations/hostnames_test.go
+++ b/pkg/third_party/externaldns/annotations/hostnames_test.go
@@ -1,0 +1,24 @@
+package annotations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostnamesFromAnnotations(t *testing.T) {
+	annotations := map[string]string{
+		"hostname": "a.com, b.com",
+	}
+	hosts := HostnamesFromAnnotations(annotations, "hostname")
+	assert.Equal(t, []string{"a.com", "b.com"}, hosts)
+
+	hosts = HostnamesFromAnnotations(nil, "hostname")
+	assert.Nil(t, hosts)
+
+	hosts = HostnamesFromAnnotations(annotations, "")
+	assert.Nil(t, hosts)
+
+	hosts = HostnamesFromAnnotations(annotations, "missing")
+	assert.Nil(t, hosts)
+}

--- a/pkg/third_party/externaldns/doc.go
+++ b/pkg/third_party/externaldns/doc.go
@@ -18,8 +18,6 @@
 //     (nsx-operator uses pkg/nsx/services/common constants at the gateway controller), not fixed upstream key constants.
 //   - [github.com/vmware-tanzu/nsx-operator/pkg/third_party/externaldns/endpoint]: subset of external-dns/endpoint
 //     (see endpoint/doc.go for omissions vs upstream).
-//   - [github.com/vmware-tanzu/nsx-operator/pkg/third_party/externaldns/source]: stateless helpers and types
-//     factored from external-dns/source/gateway.go (see source/doc.go); no informers or template engine.
 //     gateway_host_matching.go holds GwMatchingHost / GatewayCanonicalHost (from upstream gateway.go) plus
 //     nsx-operator-only ClaimGwMatchingDNSName for ordered Gateway direct-DNS batch dedupe.
 //   - [github.com/vmware-tanzu/nsx-operator/pkg/third_party/externaldns/provider]: ZoneIDName / FindZone from

--- a/pkg/third_party/externaldns/endpoint/endpoint_test.go
+++ b/pkg/third_party/externaldns/endpoint/endpoint_test.go
@@ -284,3 +284,8 @@ func TestNewEndpointWithTTL_table(t *testing.T) {
 		})
 	}
 }
+
+func TestTTLIsConfigured(t *testing.T) {
+	assert.False(t, TTL(0).IsConfigured())
+	assert.True(t, TTL(1).IsConfigured())
+}

--- a/pkg/third_party/externaldns/endpoint/utils_test.go
+++ b/pkg/third_party/externaldns/endpoint/utils_test.go
@@ -4,6 +4,7 @@
 package endpoint
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,4 +75,14 @@ func TestEndpointsForHostname_table(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEndpointsForHostname(t *testing.T) {
+	targets := Targets{"1.2.3.4", "2001:db8::1", "cname.com"}
+	eps := EndpointsForHostname("foo.com", targets, TTL(300))
+	assert.Len(t, eps, 3)
+
+	longLabel := strings.Repeat("a", 64)
+	eps = EndpointsForHostname(longLabel+".com", targets, TTL(300))
+	assert.Len(t, eps, 0)
 }


### PR DESCRIPTION
This PR introduces the core capability to automatically manage DNS records for Kubernetes LoadBalancer Services. By annotating a Service with desired hostnames, the NSX operator will automatically provision and lifecycle the corresponding DNS records in NSX using the allocated External IPs, while strictly enforcing VPC-level DNS zone policies. 

The following functions are delivered,
1. Automated Service DNS Provisioning The operator now watches LoadBalancer Services and automatically creates DNS records in NSX. It reads the nsx.vmware.com/hostname annotation (which supports comma-separated multiple hostnames) and maps them to the dynamically allocated External IPs from the Service's LoadBalancerIngress status.
2. DNS Zone Policy Enforcement All requested hostnames are strictly validated against the allowed DNS zones configured for the namespace's VPC (via NetworkInfo). The operator ensures that records are only created in permitted zones and automatically rejects unsupported formats like wildcard domains.
3. Partial Success and Error Isolation When multiple hostnames are requested on a single Service, the system evaluates them independently. Valid hostnames are successfully provisioned even if others fail validation (e.g., domains outside allowed zones). This ensures that a single invalid hostname annotation does not block the entire DNS provisioning process.
4. Automated Garbage Collection The reconciliation loop features robust, implicit garbage collection. It automatically detects and prunes stale, removed, or disallowed DNS records by comparing the newly validated batch of endpoints against all existing records owned by the Service. This ensures the NSX state perfectly matches the valid desired state.
5. Decoupled IP and DNS Status Updates Core LoadBalancer functionality is prioritized over DNS. Even if DNS reconciliation encounters errors, the operator ensures the Service's status is still updated with the successfully allocated External IPs. This allows IP-based traffic to continue uninterrupted while users troubleshoot their DNS configurations.
6. Observability via Conditions The status of DNS provisioning is surfaced directly on the Service object via a DNSReady condition. This provides users with clear, immediate feedback on validation failures or provisioning errors without needing to check operator logs.

AI-Tool-Used: Cursor
AI-Tool-Use-Level: Category 2 (Medium)
AI-Code-Category: Category 1 (Production)

Test Done:
1. Prepare two DNS zones as below,
```
{
  "results": [
    {
      "dns_domain_name": "example.com",
      "ttl": 300,
      "resource_type": "ProjectDnsZone",
      "path": "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
      ...
    },
    {
      "dns_domain_name": "cook.com",
      "ttl": 300,
      "resource_type": "ProjectDnsZone",
      "path": "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone2",
      ....
    }
  ],
  "result_count": 2,
  "sort_by": "display_name",
  "sort_ascending": true
}
```  
2. Create a vSphere Namespace which is configured with DNS zone "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1", and then nsx-operator has sync the DNS domain names of the zone to NetworkInfo CR
```
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get vpcnetworkconfigurations test1-9e070406-930e-4ac0-a779-a4b8c6718b41 -ojsonpath='{.spec.dnsZones}'
["/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1"]
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get networkinfo test1 -n test1 -o jsonpath='{.allowedDNSDomains}'
["example.com"]
```
3. Prepare a LB Service in the namespace
```
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~/wenying ]# kubectl -n test1 get svc httpbin --show-labels
NAME      TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE     LABELS
httpbin   LoadBalancer   172.24.61.217   192.168.0.8   80:30389/TCP   2m55s   app=httpbin,service.route.lbapi.run.tanzu.vmware.com/gateway-name=httpbin,service.route.lbapi.run.tanzu.vmware.com/gateway-namespace=test1,service.route.lbapi.run.tanzu.vmware.com/type=direct,service=httpbin
```
4. Annotate the LB Service with the desired hostname, check a Ready=True condition is added
```
root@421833fb973aade676c9a60ec986fda1 [ ~ ]#  kubectl -n test1 annotate svc httpbin nsx.vmware.com/hostname="my-svc.example.com"
service/httpbin annotated

root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.status.conditions}'
[{"lastTransitionTime":"2026-06-12T02:22:30Z","message":"","reason":"DNSRecordConfigured","status":"True","type":"Ready"}]

root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# curl -k -u $cred https://10.162.215.111/policy/api/v1/orgs/default/projects/project-quality/dns-records
/my-svc_zone1_a
{
  "zone_path" : "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
  "record_name" : "my-svc",
  "record_type" : "A",
  "record_values" : [ "192.168.0.8" ],
  "ttl" : 300,
  "resource_type" : "ProjectDnsRecord",
  "id" : "my-svc_zone1_a",
  "display_name" : "my-svc",
  "tags" : [ {
    "scope" : "nsx-op/cluster",
    "tag" : "8bb2d1d0-c954-437b-872e-a6d50909e141"
  }, {
    "scope" : "nsx-op/version",
    "tag" : "1.0.0"
  }, {
    "scope" : "nsx-op/namespace_uid",
    "tag" : "76ea4b65-7147-4632-a196-cd0aadc51142"
  }, {
    "scope" : "nsx-op/dns_for",
    "tag" : "service"
  }, {
    "scope" : "nsx-op/dns_owner_namespace",
    "tag" : "test1"
  }, {
    "scope" : "nsx-op/dns_owner_name",
    "tag" : "httpbin"
  } ],
  "path" : "/orgs/default/projects/project-quality/dns-records/my-svc_zone1_a",
  "relative_path" : "my-svc_zone1_a",
  "parent_path" : "/orgs/default/projects/project-quality",
  "remote_path" : "",
  "unique_id" : "54e10272-5211-4d32-923e-9d56d06bf52a",
  "realization_id" : "54e10272-5211-4d32-923e-9d56d06bf52a",
  "owner_id" : "ed2f2d7a-f308-4bd3-a1b3-c37d9f7e7935",
  "marked_for_delete" : false,
  "overridden" : false,
  "_system_owned" : false,
  "_protection" : "REQUIRE_OVERRIDE",
  "_create_time" : 1781230950337,
  "_create_user" : "wcp-cluster-user-8bb2d1d0-c954-437b-872e-a6d50909e141-93ff32d9-9ac8-41f8-8d80-06a338a15454",
  "_last_modified_time" : 1781230950337,
  "_last_modified_user" : "wcp-cluster-user-8bb2d1d0-c954-437b-872e-a6d50909e141-93ff32d9-9ac8-41f8-8d80-06a338a15454",
  "_revision" : 0
}
```
5. Check Annotate an invalid the hostname in the Service which is not matched by the DNS zone, check a Ready=False condition is added
```
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl -n test1 annotate svc httpbin nsx.vmware.com/hostname="my-svc.example1.com" --overwrite
service/httpbin annotated
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.status.conditions}'
[{"lastTransitionTime":"2026-06-12T02:37:50Z","message":"hostname \"my-svc.example1.com\" does not match any allowed DNS domain in the namespace","reason":"DNSRecordFailed","status":"False","type":"Ready"}]

// Check NSX stale records (before update) is deleted,
root@wd008124-vdnet-nsxmanager-ob-25445005-1-dev-nsxvpc-18854:~# curl -k -u $cred https://10.162.215.111/policy/api/v1/orgs/default/projects/project-quality/dns-records
{
  "results" : [ ],
  "result_count" : 0,
  "sort_by" : "display_name",
  "sort_ascending" : true
}
```
6. Update the annotation with a valid hostname back, the Ready condition is updated as true, and the NSX record is created again,
```
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl -n test1 annotate svc httpbin nsx.vmware.com/hostname="my-svc.example.com" --overwrite
service/httpbin annotated
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.status.conditions}'
[{"lastTransitionTime":"2026-06-12T03:59:07Z","message":"","reason":"DNSRecordConfigured","status":"True","type":"Ready"}]
root@wd008124-vdnet-nsxmanager-ob-25445005-1-dev-nsxvpc-18854:~#curl -k -u $cred https://10.162.215.111/policy/api/v1/orgs/default/projects/project-quality/dns-records
{
  "results" : [ {
    "zone_path" : "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
    "record_name" : "my-svc",
    "record_type" : "A",
    "record_values" : [ "192.168.0.8" ],
    "ttl" : 300,
    "resource_type" : "ProjectDnsRecord",
    "id" : "my-svc_zone1_a",
    "display_name" : "my-svc",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "8bb2d1d0-c954-437b-872e-a6d50909e141"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "76ea4b65-7147-4632-a196-cd0aadc51142"
    }, {
      "scope" : "nsx-op/dns_for",
      "tag" : "service"
    }, {
      "scope" : "nsx-op/dns_owner_namespace",
      "tag" : "test1"
    }, {
      "scope" : "nsx-op/dns_owner_name",
      "tag" : "httpbin"
    } ],
    "path" : "/orgs/default/projects/project-quality/dns-records/my-svc_zone1_a",
    "relative_path" : "my-svc_zone1_a",
    "parent_path" : "/orgs/default/projects/project-quality",
    "remote_path" : "",
    "unique_id" : "33ddfe90-b4e0-4362-9fc2-e4d0c47158fc",
    "realization_id" : "33ddfe90-b4e0-4362-9fc2-e4d0c47158fc",
    "owner_id" : "ed2f2d7a-f308-4bd3-a1b3-c37d9f7e7935",
    "marked_for_delete" : false,
    "overridden" : false,
    "_system_owned" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_create_time" : 1781236747118,
    "_create_user" : "wcp-cluster-user-8bb2d1d0-c954-437b-872e-a6d50909e141-93ff32d9-9ac8-41f8-8d80-06a338a15454",
    "_last_modified_time" : 1781236747118,
    "_last_modified_user" : "wcp-cluster-user-8bb2d1d0-c954-437b-872e-a6d50909e141-93ff32d9-9ac8-41f8-8d80-06a338a15454",
    "_revision" : 0
  } ],
  "result_count" : 1,
  "sort_by" : "display_name",
  "sort_ascending" : true
}
``` 

7. Remove the annotation, the Ready condition is deleted; NSX DNS record is removed,
```
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl -n test1 annotate svc httpbin nsx.vmware.com/hostname-
service/httpbin annotated
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.status.conditions}'
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# 

root@wd008124-vdnet-nsxmanager-ob-25445005-1-dev-nsxvpc-18854:~# curl -k -u $cred https://10.162.215.111/policy/api/v1/orgs/default/projects/project-quality/dns-records
{
  "results" : [ ],
  "result_count" : 0,
  "sort_by" : "display_name",
  "sort_ascending" : true
}
```

8. Update the annotation with two valid FQDNs, using "," split, two NSX records are created
```
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl -n test1 annotate svc httpbin nsx.vmware.com/hostname="my-svc.example.com,svc2.example.com" --overwrite
service/httpbin annotated
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.status.conditions}'
[{"lastTransitionTime":"2026-06-12T04:02:39Z","message":"","reason":"DNSRecordConfigured","status":"True","type":"Ready"}]

root@wd008124-vdnet-nsxmanager-ob-25445005-1-dev-nsxvpc-18854:~# curl -k -u $cred https://10.162.215.111/policy/api/v1/orgs/default/projects/project-quality/dns-records
{
  "results" : [ {
    "zone_path" : "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
    "record_name" : "my-svc",
    "record_type" : "A",
    "record_values" : [ "192.168.0.8" ],
    "ttl" : 300,
    "resource_type" : "ProjectDnsRecord",
    "id" : "my-svc_zone1_a",
    "display_name" : "my-svc",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "8bb2d1d0-c954-437b-872e-a6d50909e141"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "76ea4b65-7147-4632-a196-cd0aadc51142"
    }, {
      "scope" : "nsx-op/dns_for",
      "tag" : "service"
    }, {
      "scope" : "nsx-op/dns_owner_namespace",
      "tag" : "test1"
    }, {
      "scope" : "nsx-op/dns_owner_name",
      "tag" : "httpbin"
    } ],
    "path" : "/orgs/default/projects/project-quality/dns-records/my-svc_zone1_a",
    ...
  }, {
    "zone_path" : "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
    "record_name" : "svc2",
    "record_type" : "A",
    "record_values" : [ "192.168.0.8" ],
    "ttl" : 300,
    "resource_type" : "ProjectDnsRecord",
    "id" : "svc2_zone1_a",
    "display_name" : "svc2",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "8bb2d1d0-c954-437b-872e-a6d50909e141"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "76ea4b65-7147-4632-a196-cd0aadc51142"
    }, {
      "scope" : "nsx-op/dns_for",
      "tag" : "service"
    }, {
      "scope" : "nsx-op/dns_owner_namespace",
      "tag" : "test1"
    }, {
      "scope" : "nsx-op/dns_owner_name",
      "tag" : "httpbin"
    } ],
    "path" : "/orgs/default/projects/project-quality/dns-records/svc2_zone1_a",
    "relative_path" : "svc2_zone1_a",
    "parent_path" : "/orgs/default/projects/project-quality",
    ...
  } ],
  "result_count" : 2,
  "sort_by" : "display_name",
  "sort_ascending" : true
}
```

9. Update the annotation with two valid FQDNs, adding a white space after the splitter,
```
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl -n test1 annotate svc httpbin nsx.vmware.com/hostname="my-svc.example.com, svc2.example.com" --overwrite
service/httpbin annotated
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.metadata.annotations}'
{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"httpbin\",\"service\":\"httpbin\"},\"name\":\"httpbin\",\"namespace\":\"test1\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"targetPort\":80}],\"selector\":{\"app\":\"httpbin\"},\"type\":\"LoadBalancer\"}}\n","nsx.vmware.com/hostname":"my-svc.example.com, svc2.example.com"}

root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.status.conditions}'
[{"lastTransitionTime":"2026-06-12T04:02:39Z","message":"","reason":"DNSRecordConfigured","status":"True","type":"Ready"}]

root@wd008124-vdnet-nsxmanager-ob-25445005-1-dev-nsxvpc-18854:~# curl -k -u $cred https://10.162.215.111/policy/api/v1/orgs/default/projects/project-quality/dns-records
{
  "results" : [ {
    "zone_path" : "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
    "record_name" : "my-svc",
    "record_type" : "A",
    "record_values" : [ "192.168.0.8" ],
    "ttl" : 300,
    "resource_type" : "ProjectDnsRecord",
    "id" : "my-svc_zone1_a",
    "display_name" : "my-svc",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "8bb2d1d0-c954-437b-872e-a6d50909e141"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "76ea4b65-7147-4632-a196-cd0aadc51142"
    }, {
      "scope" : "nsx-op/dns_for",
      "tag" : "service"
    }, {
      "scope" : "nsx-op/dns_owner_namespace",
      "tag" : "test1"
    }, {
      "scope" : "nsx-op/dns_owner_name",
      "tag" : "httpbin"
    } ],
    "path" : "/orgs/default/projects/project-quality/dns-records/my-svc_zone1_a",
    "relative_path" : "my-svc_zone1_a",
    "parent_path" : "/orgs/default/projects/project-quality",
    ....
    "_revision" : 0
  }, {
    "zone_path" : "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
    "record_name" : "svc2",
    "record_type" : "A",
    "record_values" : [ "192.168.0.8" ],
    "ttl" : 300,
    "resource_type" : "ProjectDnsRecord",
    "id" : "svc2_zone1_a",
    "display_name" : "svc2",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "8bb2d1d0-c954-437b-872e-a6d50909e141"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "76ea4b65-7147-4632-a196-cd0aadc51142"
    }, {
      "scope" : "nsx-op/dns_for",
      "tag" : "service"
    }, {
      "scope" : "nsx-op/dns_owner_namespace",
      "tag" : "test1"
    }, {
      "scope" : "nsx-op/dns_owner_name",
      "tag" : "httpbin"
    } ],
    "path" : "/orgs/default/projects/project-quality/dns-records/svc2_zone1_a",
    "relative_path" : "svc2_zone1_a",
    "parent_path" : "/orgs/default/projects/project-quality",
    ...
    "_revision" : 0
  } ],
  "result_count" : 2,
  "sort_by" : "display_name",
  "sort_ascending" : true
}
```

10. Update the annotation with one valid hostname and one invalid hostname, Ready=False condition is configured, only the valid DNS record is left
```
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl -n test1 annotate svc httpbin nsx.vmware.com/hostname="my-svc.example.com, svc2.example1.com" --overwrite
service/httpbin annotated
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# 
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.metadata.annotations}'
{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"httpbin\",\"service\":\"httpbin\"},\"name\":\"httpbin\",\"namespace\":\"test1\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"targetPort\":80}],\"selector\":{\"app\":\"httpbin\"},\"type\":\"LoadBalancer\"}}\n","nsx.vmware.com/hostname":"my-svc.example.com, svc2.example1.com"}
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# 
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.status.conditions}'
[{"lastTransitionTime":"2026-06-12T04:08:29Z","message":"hostname \"svc2.example1.com\" does not match any allowed DNS domain in the namespace","reason":"DNSRecordFailed","status":"False","type":"Ready"}]

root@wd008124-vdnet-nsxmanager-ob-25445005-1-dev-nsxvpc-18854:~# curl -k -u $cred https://10.162.215.111/policy/api/v1/orgs/default/projects/project-quality/dns-records
{
  "results" : [ {
    "zone_path" : "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
    "record_name" : "my-svc",
    "record_type" : "A",
    "record_values" : [ "192.168.0.8" ],
    "ttl" : 300,
    "resource_type" : "ProjectDnsRecord",
    "id" : "my-svc_zone1_a",
    "display_name" : "my-svc",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "8bb2d1d0-c954-437b-872e-a6d50909e141"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "76ea4b65-7147-4632-a196-cd0aadc51142"
    }, {
      "scope" : "nsx-op/dns_for",
      "tag" : "service"
    }, {
      "scope" : "nsx-op/dns_owner_namespace",
      "tag" : "test1"
    }, {
      "scope" : "nsx-op/dns_owner_name",
      "tag" : "httpbin"
    } ],
    "path" : "/orgs/default/projects/project-quality/dns-records/my-svc_zone1_a",
    "relative_path" : "my-svc_zone1_a",
    "parent_path" : "/orgs/default/projects/project-quality",
    ...
    "_last_modified_user" : "wcp-cluster-user-8bb2d1d0-c954-437b-872e-a6d50909e141-93ff32d9-9ac8-41f8-8d80-06a338a15454",
    "_revision" : 0
  } ],
  "result_count" : 1,
  "sort_by" : "display_name",
  "sort_ascending" : true
}
```

11. Check the valid hostname can not be requested by other services
```
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc -n test1 -owide
NAME       TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE     SELECTOR
httpbin    LoadBalancer   172.24.61.217   192.168.0.8   80:30389/TCP   5h59m   app=httpbin
httpbin2   LoadBalancer   172.24.20.41    192.168.0.9   80:31683/TCP   89m     app=httpbin2
// Revert Service httpbin with a valid hostname first
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl -n test1 annotate svc httpbin nsx.vmware.com/hostname="my-svc.example.com" --overwrite
service/httpbin annotated
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.status.conditions}'
[{"lastTransitionTime":"2026-06-12T07:55:54Z","message":"","reason":"DNSRecordConfigured","status":"True","type":"Ready"}]
// Use the same hostname in Service httpbin2 annotation, the expectation is rejected.
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl -n test1 annotate svc httpbin2 nsx.vmware.com/hostname="my-svc.example.com" --overwrite
service/httpbin2 annotated
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin2 -n test1 -ojsonpath='{.status.conditions}'
[{"lastTransitionTime":"2026-06-12T07:56:29Z","message":"DNS endpoint validation failed for DNS zone policy: FQDN my-svc.example.com is configured with different values in DNS zone /orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1","reason":"DNSRecordFailed","status":"False","type":"Ready"}]

// NSX Record is created for the first Service
root@wd008124-vdnet-nsxmanager-ob-25445005-1-dev-nsxvpc-18854:~# curl -k -u $cred https://10.162.215.111/policy/api/v1/orgs/default/projects/project-quality/dns-records
{
  "results" : [ {
    "zone_path" : "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
    "record_name" : "my-svc",
    "record_type" : "A",
    "record_values" : [ "192.168.0.8" ],
    "ttl" : 300,
    "resource_type" : "ProjectDnsRecord",
    "id" : "my-svc_zone1_a",
    "display_name" : "my-svc",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "8bb2d1d0-c954-437b-872e-a6d50909e141"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "76ea4b65-7147-4632-a196-cd0aadc51142"
    }, {
      "scope" : "nsx-op/dns_for",
      "tag" : "service"
    }, {
      "scope" : "nsx-op/dns_owner_namespace",
      "tag" : "test1"
    }, {
      "scope" : "nsx-op/dns_owner_name",
      "tag" : "httpbin"
    } ],
    "path" : "/orgs/default/projects/project-quality/dns-records/my-svc_zone1_a",
    "relative_path" : "my-svc_zone1_a",
    "parent_path" : "/orgs/default/projects/project-quality",
    "remote_path" : "",
    "unique_id" : "f5556985-dd9e-4357-84e9-606c566b556a",
    "realization_id" : "f5556985-dd9e-4357-84e9-606c566b556a",
    "owner_id" : "ed2f2d7a-f308-4bd3-a1b3-c37d9f7e7935",
    "marked_for_delete" : false,
    "overridden" : false,
    "_system_owned" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_create_time" : 1781250723182,
    "_create_user" : "wcp-cluster-user-8bb2d1d0-c954-437b-872e-a6d50909e141-93ff32d9-9ac8-41f8-8d80-06a338a15454",
    "_last_modified_time" : 1781250723182,
    "_last_modified_user" : "wcp-cluster-user-8bb2d1d0-c954-437b-872e-a6d50909e141-93ff32d9-9ac8-41f8-8d80-06a338a15454",
    "_revision" : 0
  } ],
  "result_count" : 1,
  "sort_by" : "display_name",
  "sort_ascending" : true
}
```
12. Annotate Service with "wildcard" FQDN, the request is ignored, and records are cleared
```
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl -n test1 annotate svc httpbin nsx.vmware.com/hostname="*.my-svc.example.com" --overwrite
service/httpbin annotated
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]#
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.metadata.annotations}'
{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"httpbin\",\"service\":\"httpbin\"},\"name\":\"httpbin\",\"namespace\":\"test1\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"targetPort\":80}],\"selector\":{\"app\":\"httpbin\"},\"type\":\"LoadBalancer\"}}\n","nsx.vmware.com/hostname":"*.my-svc.example.com"}
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]#
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.status.conditions}'
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# 
root@wd008124-vdnet-nsxmanager-ob-25445005-1-dev-nsxvpc-18854:~# curl -k -u $cred https://10.162.215.111/policy/api/v1/orgs/default/projects/project-quality/dns-records
{
  "results" : [ ],
  "result_count" : 0,
  "sort_by" : "display_name",
  "sort_ascending" : true
}
```
13. Update the permitted DNS zones in vSphere Namespace, clear the invalid DNS records automatically
```
// Revert the Service httpbin to annotate with a valid hostname
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl -n test1 annotate svc httpbin nsx.vmware.com/hostname="my-svc.example.com" --overwrite
service/httpbin annotated
root@wd008124-vdnet-nsxmanager-ob-25445005-1-dev-nsxvpc-18854:~# curl -k -u $cred https://10.162.215.111/policy/api/v1/orgs/default/projects/project-quality/dns-records
{
  "results" : [ {
    "zone_path" : "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
    "record_name" : "my-svc",
    "record_type" : "A",
    "record_values" : [ "192.168.0.8" ],
    "ttl" : 300,
    "resource_type" : "ProjectDnsRecord",
    "id" : "my-svc_zone1_a",
    "display_name" : "my-svc",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "8bb2d1d0-c954-437b-872e-a6d50909e141"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "76ea4b65-7147-4632-a196-cd0aadc51142"
    }, {
      "scope" : "nsx-op/dns_for",
      "tag" : "service"
    }, {
      "scope" : "nsx-op/dns_owner_namespace",
      "tag" : "test1"
    }, {
      "scope" : "nsx-op/dns_owner_name",
      "tag" : "httpbin"
    } ],
    "path" : "/orgs/default/projects/project-quality/dns-records/my-svc_zone1_a",
    "relative_path" : "my-svc_zone1_a",
    "parent_path" : "/orgs/default/projects/project-quality",
    "remote_path" : "",
    "unique_id" : "ffa331c4-bd5c-4a94-8096-947f65dc9305",
    "realization_id" : "ffa331c4-bd5c-4a94-8096-947f65dc9305",
    "owner_id" : "ed2f2d7a-f308-4bd3-a1b3-c37d9f7e7935",
    "marked_for_delete" : false,
    "overridden" : false,
    "_system_owned" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_create_time" : 1781251401834,
    "_create_user" : "wcp-cluster-user-8bb2d1d0-c954-437b-872e-a6d50909e141-93ff32d9-9ac8-41f8-8d80-06a338a15454",
    "_last_modified_time" : 1781251401834,
    "_last_modified_user" : "wcp-cluster-user-8bb2d1d0-c954-437b-872e-a6d50909e141-93ff32d9-9ac8-41f8-8d80-06a338a15454",
    "_revision" : 0
  } ],
  "result_count" : 1,
  "sort_by" : "display_name",
  "sort_ascending" : true
}

// Update vSphere Namespace DNS zones and check VpcNetworkConfiguration/NetowrkInfo CRs
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get vpcnetworkconfigurations test1-9e070406-930e-4ac0-a779-a4b8c6718b41 -ojsonpath='{.spec.dnsZones}'
["/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone2"]
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get networkinfo test1 -n test1 -o jsonpath='{.allowedDNSDomains}'
["cook.com"]

// Check Service annotation and conditions
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.metadata.annotations}'
{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"httpbin\",\"service\":\"httpbin\"},\"name\":\"httpbin\",\"namespace\":\"test1\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"targetPort\":80}],\"selector\":{\"app\":\"httpbin\"},\"type\":\"LoadBalancer\"}}\n","nsx.vmware.com/hostname":"my-svc.example.com"}
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]#
root@423e84c75814f2d2942ea47e4a72a7b3 [ ~ ]# kubectl get svc httpbin -n test1 -ojsonpath='{.status.conditions}'
[{"lastTransitionTime":"2026-06-12T08:05:08Z","message":"hostname \"my-svc.example.com\" does not match any allowed DNS domain in the namespace","reason":"DNSRecordFailed","status":"False","type":"Ready"}]

// DNS record was cleared
root@wd008124-vdnet-nsxmanager-ob-25445005-1-dev-nsxvpc-18854:~# curl -k -u $cred https://10.162.215.111/policy/api/v1/orgs/default/projects/project-quality/dns-records
{
  "results" : [ ],
  "result_count" : 0,
  "sort_by" : "display_name",
  "sort_ascending" : true
}
```
