### PR TITLE
Add ipaddressallocation restore for tepless mode

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -120,6 +120,11 @@ const (
 	SubnetPortGCInterval = 60 * time.Second
 	DefaultSNATID        = "DEFAULT"
 	AVISubnetLBID        = "_services"
+	// LBServiceIPAllocationID is the fixed NSX resource ID for the VPC-level LB service IP allocation used in tepless mode.
+	// It's only used for backup/restore
+	LBServiceIPAllocationID = "_DEFAULT--VPC_SERVICE_IP"
+	TagScopeVPCService      = "services/vpc_service"
+	TagValueUserSpecifiedIP = "__DEFAULT--VPC_SERVICE_IP__"
 
 	NSXServiceAccountFinalizerName = "nsxserviceaccount.nsx.vmware.com/finalizer"
 	T1SecurityPolicyFinalizerName  = "securitypolicy.nsx.vmware.com/finalizer"

--- a/pkg/nsx/services/vpc/builder.go
+++ b/pkg/nsx/services/vpc/builder.go
@@ -120,6 +120,27 @@ func buildNSXLBS(obj *v1alpha1.NetworkInfo, nsObj *v1.Namespace, cluster, lbsSiz
 	return lbs, nil
 }
 
+// buildNSXLBServiceIPAllocation builds the VpcIpAddressAllocation used to pin the LB service IP in tepless (VLANBackedVPC)
+// restore mode. The allocation uses the fixed well-known ID "_DEFAULT--VPC_SERVICE_IP" and carries the IP that was
+// previously reported in NetworkInfo.VPCs[0].LoadBalancerIPAddresses so that NSX re-uses the same address.
+func buildNSXLBServiceIPAllocation(lbIP string) *model.VpcIpAddressAllocation {
+	visibility := model.VpcIpAddressAllocation_IP_ADDRESS_BLOCK_VISIBILITY_EXTERNAL
+	ipType := model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV4
+	return &model.VpcIpAddressAllocation{
+		Id:                       common.String(common.LBServiceIPAllocationID),
+		DisplayName:              common.String(common.LBServiceIPAllocationID),
+		AllocationIp:             common.String(lbIP),
+		IpAddressBlockVisibility: &visibility,
+		IpAddressType:            &ipType,
+		Tags: []model.Tag{
+			{
+				Scope: common.String(common.TagScopeVPCService),
+				Tag:   common.String(common.TagValueUserSpecifiedIP),
+			},
+		},
+	}
+}
+
 func buildVpcAttachment(obj *v1alpha1.NetworkInfo, nsObj *v1.Namespace, cluster string, vpcconnectiveprofile string, restoreMode bool) (*model.VpcAttachment, error) {
 	attachment := &model.VpcAttachment{}
 	attachment.VpcConnectivityProfile = &vpcconnectiveprofile

--- a/pkg/nsx/services/vpc/builder_test.go
+++ b/pkg/nsx/services/vpc/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -282,6 +283,45 @@ func TestBuildNSXVPC(t *testing.T) {
 			got, err := vpcSvc.buildNSXVPC(netInfoObj, tc.nsObj, nc, clusterStr, tc.existingVPC, tc.useAVILB, tc.lbProviderChanged, tc.serviceClusterReady)
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expVPC, got)
+		})
+	}
+}
+
+func Test_buildNSXLBServiceIPAllocation(t *testing.T) {
+	tests := []struct {
+		name  string
+		lbIP  string
+		check func(t *testing.T, alloc *model.VpcIpAddressAllocation)
+	}{
+		{
+			name: "builds allocation with correct fields",
+			lbIP: "10.0.0.5",
+			check: func(t *testing.T, alloc *model.VpcIpAddressAllocation) {
+				assert.Equal(t, common.LBServiceIPAllocationID, *alloc.Id)
+				assert.Equal(t, common.LBServiceIPAllocationID, *alloc.DisplayName)
+				assert.Equal(t, "10.0.0.5", *alloc.AllocationIp)
+				assert.Equal(t, model.VpcIpAddressAllocation_IP_ADDRESS_BLOCK_VISIBILITY_EXTERNAL, *alloc.IpAddressBlockVisibility)
+				assert.Equal(t, model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV4, *alloc.IpAddressType)
+				require.Len(t, alloc.Tags, 1)
+				assert.Equal(t, common.TagScopeVPCService, *alloc.Tags[0].Scope)
+				assert.Equal(t, common.TagValueUserSpecifiedIP, *alloc.Tags[0].Tag)
+			},
+		},
+		{
+			name: "AllocationIps field is nil (single IP uses AllocationIp)",
+			lbIP: "192.168.1.1",
+			check: func(t *testing.T, alloc *model.VpcIpAddressAllocation) {
+				assert.Nil(t, alloc.AllocationIps)
+				assert.NotNil(t, alloc.AllocationIp)
+				assert.Equal(t, "192.168.1.1", *alloc.AllocationIp)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alloc := buildNSXLBServiceIPAllocation(tt.lbIP)
+			require.NotNil(t, alloc)
+			tt.check(t, alloc)
 		})
 	}
 }

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -565,6 +565,15 @@ func (s *VPCService) CreateOrUpdateVPC(ctx context.Context, obj *v1alpha1.Networ
 		}
 		createdLBS, _ = buildNSXLBS(obj, nsObj, s.NSXConfig.Cluster, lbsSize, vpcPath, relaxScaleValidation)
 	}
+	// In tepless (VLANBackedVPC) restore mode with NSX LB, pin the LB service IP that was previously allocated
+	// by embedding a VpcIpAddressAllocation child in the HAPI payload before the LBS.
+	var lbServiceIPAlloc *model.VpcIpAddressAllocation
+	if restoreMode {
+		lbServiceIPAlloc, err = s.buildLBServiceIPAllocForRestore(obj, nc, lbProvider)
+		if err != nil {
+			return nil, err
+		}
+	}
 	// build HAPI request
 	createdAttachment, _ := buildVpcAttachment(obj, nsObj, s.NSXConfig.Cluster, nc.Spec.VPCConnectivityProfile, restoreMode)
 
@@ -591,7 +600,7 @@ func (s *VPCService) CreateOrUpdateVPC(ctx context.Context, obj *v1alpha1.Networ
 		return existingVPC[0], nil
 	}
 
-	orgRoot, err := s.WrapHierarchyVPC(org, project, createdVpc, createdLBS, createdAttachment)
+	orgRoot, err := s.WrapHierarchyVPC(org, project, createdVpc, lbServiceIPAlloc, createdLBS, createdAttachment)
 	if err != nil {
 		log.Error(err, "Failed to build HAPI request")
 		return nil, err
@@ -675,6 +684,28 @@ func (s *VPCService) checkVPCRealizationState(createdVpc *model.Vpc, newVpcPath 
 		return err
 	}
 	return nil
+}
+
+// buildLBServiceIPAllocForRestore returns the VpcIpAddressAllocation that should be embedded in the HAPI payload
+// when restoring a tepless (VLANBackedVPC) VPC with NSX LB. It returns nil if the conditions are not met.
+// An error is returned when the network stack is VLANBackedVPC + NSXLB but the previously allocated IP is missing
+// from the NetworkInfo CR, which means the allocation cannot be restored.
+func (s *VPCService) buildLBServiceIPAllocForRestore(obj *v1alpha1.NetworkInfo, nc *v1alpha1.VPCNetworkConfiguration, lbProvider LBProvider) (*model.VpcIpAddressAllocation, error) {
+	if lbProvider != NSXLB {
+		return nil, nil
+	}
+	networkStack, err := s.GetNetworkStackFromNC(nc)
+	if err != nil {
+		return nil, err
+	}
+	if networkStack != v1alpha1.VLANBackedVPC {
+		return nil, nil
+	}
+	if len(obj.VPCs) == 0 || len(obj.VPCs[0].LoadBalancerIPAddresses) == 0 {
+		return nil, fmt.Errorf("cannot restore LB service IP allocation for tepless VPC: LoadBalancerIPAddresses is not set in NetworkInfo %s", obj.Name)
+	}
+	log.Debug("Restoring LB service IP allocation for tepless VPC", "IP", obj.VPCs[0].LoadBalancerIPAddresses, "NetworkInfo", obj.Name)
+	return buildNSXLBServiceIPAllocation(obj.VPCs[0].LoadBalancerIPAddresses), nil
 }
 
 func (s *VPCService) checkLBSRealization(createdLBS *model.LBService, createdVpc *model.Vpc, nc *v1alpha1.VPCNetworkConfiguration, newVpcPath string) error {

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -3175,3 +3175,129 @@ func TestNetworkInfoReconciler_GetVpcConnectivityProfilePathByVpcPath(t *testing
 		})
 	}
 }
+
+func TestVPCService_buildLBServiceIPAllocForRestore(t *testing.T) {
+	tests := []struct {
+		name        string
+		obj         *v1alpha1.NetworkInfo
+		nc          *v1alpha1.VPCNetworkConfiguration
+		lbProvider  LBProvider
+		mockStack   func() *gomonkey.Patches
+		wantNil     bool
+		wantErrLike string
+		wantIP      string
+	}{
+		{
+			name:       "non-NSXLB provider returns nil without calling GetNetworkStackFromNC",
+			lbProvider: AVILB,
+			obj:        &v1alpha1.NetworkInfo{},
+			nc:         &v1alpha1.VPCNetworkConfiguration{},
+			mockStack:  func() *gomonkey.Patches { return nil },
+			wantNil:    true,
+		},
+		{
+			name:       "NSXLB + FullStackVPC returns nil",
+			lbProvider: NSXLB,
+			obj:        &v1alpha1.NetworkInfo{},
+			nc:         &v1alpha1.VPCNetworkConfiguration{},
+			mockStack: func() *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
+					func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
+						return v1alpha1.FullStackVPC, nil
+					})
+			},
+			wantNil: true,
+		},
+		{
+			name:       "NSXLB + VLANBackedVPC + empty VPCs returns error",
+			lbProvider: NSXLB,
+			obj:        &v1alpha1.NetworkInfo{ObjectMeta: metav1.ObjectMeta{Name: "ni-test"}, VPCs: nil},
+			nc:         &v1alpha1.VPCNetworkConfiguration{},
+			mockStack: func() *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
+					func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
+						return v1alpha1.VLANBackedVPC, nil
+					})
+			},
+			wantErrLike: "LoadBalancerIPAddresses is not set in NetworkInfo ni-test",
+		},
+		{
+			name:       "NSXLB + VLANBackedVPC + empty LoadBalancerIPAddresses returns error",
+			lbProvider: NSXLB,
+			obj: &v1alpha1.NetworkInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: "ni-test"},
+				VPCs:       []v1alpha1.VPCState{{LoadBalancerIPAddresses: ""}},
+			},
+			nc: &v1alpha1.VPCNetworkConfiguration{},
+			mockStack: func() *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
+					func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
+						return v1alpha1.VLANBackedVPC, nil
+					})
+			},
+			wantErrLike: "LoadBalancerIPAddresses is not set in NetworkInfo ni-test",
+		},
+		{
+			name:       "NSXLB + VLANBackedVPC + valid IP returns correct allocation",
+			lbProvider: NSXLB,
+			obj: &v1alpha1.NetworkInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: "ni-test"},
+				VPCs:       []v1alpha1.VPCState{{LoadBalancerIPAddresses: "10.1.2.3"}},
+			},
+			nc: &v1alpha1.VPCNetworkConfiguration{},
+			mockStack: func() *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
+					func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
+						return v1alpha1.VLANBackedVPC, nil
+					})
+			},
+			wantNil: false,
+			wantIP:  "10.1.2.3",
+		},
+		{
+			name:       "GetNetworkStackFromNC error is propagated",
+			lbProvider: NSXLB,
+			obj:        &v1alpha1.NetworkInfo{},
+			nc:         &v1alpha1.VPCNetworkConfiguration{},
+			mockStack: func() *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
+					func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
+						return v1alpha1.FullStackVPC, fmt.Errorf("nsx backend failure")
+					})
+			},
+			wantErrLike: "nsx backend failure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := createFakeVPCService(t, []client.Object{})
+			patches := tt.mockStack()
+			if patches != nil {
+				defer patches.Reset()
+			}
+
+			alloc, err := service.buildLBServiceIPAllocForRestore(tt.obj, tt.nc, tt.lbProvider)
+
+			if tt.wantErrLike != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrLike)
+				assert.Nil(t, alloc)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNil {
+				assert.Nil(t, alloc)
+				return
+			}
+			require.NotNil(t, alloc)
+			assert.Equal(t, common.LBServiceIPAllocationID, *alloc.Id)
+			assert.Equal(t, tt.wantIP, *alloc.AllocationIp)
+			assert.Equal(t, model.VpcIpAddressAllocation_IP_ADDRESS_BLOCK_VISIBILITY_EXTERNAL, *alloc.IpAddressBlockVisibility)
+			assert.Equal(t, model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV4, *alloc.IpAddressType)
+			require.Len(t, alloc.Tags, 1)
+			assert.Equal(t, common.TagScopeVPCService, *alloc.Tags[0].Scope)
+			assert.Equal(t, common.TagValueUserSpecifiedIP, *alloc.Tags[0].Tag)
+		})
+	}
+}

--- a/pkg/nsx/services/vpc/wrap.go
+++ b/pkg/nsx/services/vpc/wrap.go
@@ -3,10 +3,24 @@ package vpc
 import (
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
-func (s *VPCService) WrapHierarchyVPC(org, nsxtProject string, vpc *model.Vpc, lbs *model.LBService, attachment *model.VpcAttachment) (*model.OrgRoot, error) {
+// WrapHierarchyVPC assembles the HAPI OrgRoot payload for creating/updating a VPC and its children.
+// lbServiceIPAlloc, when non-nil, is added as the first VPC child (before LBS) and is used in tepless
+// restore mode to pin the LB service IP to the previously allocated address.
+func (s *VPCService) WrapHierarchyVPC(org, nsxtProject string, vpc *model.Vpc, lbServiceIPAlloc *model.VpcIpAddressAllocation, lbs *model.LBService, attachment *model.VpcAttachment) (*model.OrgRoot, error) {
 	var vpcChildren []*data.StructValue
+	if lbServiceIPAlloc != nil {
+		log.Debug("Wrapping LB Service IP Allocation", "LB Service IP Allocation", lbServiceIPAlloc.Id, "Allocation IP", lbServiceIPAlloc.AllocationIp)
+		childIPAlloc, err := common.WrapVpcIpAddressAllocation(lbServiceIPAlloc)
+		if err != nil {
+			return nil, err
+		}
+		vpcChildren = append(vpcChildren, childIPAlloc)
+		vpc.Children = vpcChildren
+	}
 	if lbs != nil {
 		childrenLBS, err := s.WrapLBS(lbs)
 		if err != nil {

--- a/pkg/nsx/services/vpc/wrap_test.go
+++ b/pkg/nsx/services/vpc/wrap_test.go
@@ -6,48 +6,102 @@ import (
 
 	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
 func TestVPCService_WrapHierarchyVPC(t *testing.T) {
 	type args struct {
-		org         string
-		nsxtProject string
-		vpc         *model.Vpc
-		lbs         *model.LBService
-		attachment  *model.VpcAttachment
+		org              string
+		nsxtProject      string
+		vpc              *model.Vpc
+		lbServiceIPAlloc *model.VpcIpAddressAllocation
+		lbs              *model.LBService
+		attachment       *model.VpcAttachment
 	}
 	tests := []struct {
-		name         string
-		args         args
-		want         *model.OrgRoot
-		wantChildren int
-		wantErr      assert.ErrorAssertionFunc
+		name            string
+		args            args
+		want            *model.OrgRoot
+		wantOrgChildren int // OrgRoot always has 1 child (the Org wrapper)
+		wantVPCChildren int // VPC.Children count after wrapping
+		wantErr         assert.ErrorAssertionFunc
 	}{
 		{
-			name: "test",
+			name: "without lbServiceIPAlloc",
 			args: args{
-				org:         "testorg",
-				nsxtProject: "testproject",
-				vpc:         &model.Vpc{},
-				lbs:         &model.LBService{},
-				attachment:  &model.VpcAttachment{},
+				org:              "testorg",
+				nsxtProject:      "testproject",
+				vpc:              &model.Vpc{},
+				lbServiceIPAlloc: nil,
+				lbs:              &model.LBService{},
+				attachment:       &model.VpcAttachment{},
 			},
-			want:         &model.OrgRoot{ResourceType: pointy.String("OrgRoot")},
-			wantChildren: 1,
-			wantErr:      assert.NoError,
+			want:            &model.OrgRoot{ResourceType: pointy.String("OrgRoot")},
+			wantOrgChildren: 1,
+			wantVPCChildren: 2, // LBS + Attachment
+			wantErr:         assert.NoError,
+		},
+		{
+			name: "with lbServiceIPAlloc",
+			args: args{
+				org:              "testorg",
+				nsxtProject:      "testproject",
+				vpc:              &model.Vpc{},
+				lbServiceIPAlloc: &model.VpcIpAddressAllocation{Id: common.String(common.LBServiceIPAllocationID)},
+				lbs:              &model.LBService{},
+				attachment:       &model.VpcAttachment{},
+			},
+			want:            &model.OrgRoot{ResourceType: pointy.String("OrgRoot")},
+			wantOrgChildren: 1,
+			wantVPCChildren: 3, // IPAlloc + LBS + Attachment
+			wantErr:         assert.NoError,
+		},
+		{
+			name: "nil lbs and nil attachment",
+			args: args{
+				org:              "testorg",
+				nsxtProject:      "testproject",
+				vpc:              &model.Vpc{},
+				lbServiceIPAlloc: nil,
+				lbs:              nil,
+				attachment:       nil,
+			},
+			want:            &model.OrgRoot{ResourceType: pointy.String("OrgRoot")},
+			wantOrgChildren: 1,
+			wantVPCChildren: 0,
+			wantErr:         assert.NoError,
+		},
+		{
+			name: "only lbServiceIPAlloc, no lbs or attachment",
+			args: args{
+				org:              "testorg",
+				nsxtProject:      "testproject",
+				vpc:              &model.Vpc{},
+				lbServiceIPAlloc: &model.VpcIpAddressAllocation{Id: common.String(common.LBServiceIPAllocationID)},
+				lbs:              nil,
+				attachment:       nil,
+			},
+			want:            &model.OrgRoot{ResourceType: pointy.String("OrgRoot")},
+			wantOrgChildren: 1,
+			wantVPCChildren: 1, // only IPAlloc
+			wantErr:         assert.NoError,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &VPCService{}
-			got, err := s.WrapHierarchyVPC(tt.args.org, tt.args.nsxtProject, tt.args.vpc, tt.args.lbs, tt.args.attachment)
-			if !tt.wantErr(t, err, fmt.Sprintf("WrapHierarchyVPC(%v, %v, %v, %v)", tt.args.org, tt.args.nsxtProject, tt.args.vpc, tt.args.lbs)) {
+			got, err := s.WrapHierarchyVPC(tt.args.org, tt.args.nsxtProject, tt.args.vpc, tt.args.lbServiceIPAlloc, tt.args.lbs, tt.args.attachment)
+			if !tt.wantErr(t, err, fmt.Sprintf("WrapHierarchyVPC(%v, %v, %v, %v, %v)", tt.args.org, tt.args.nsxtProject, tt.args.vpc, tt.args.lbServiceIPAlloc, tt.args.lbs)) {
 				return
 			}
-			assert.Equalf(t, tt.wantChildren, len(got.Children), "WrapHierarchyVPC children count")
+			require.NotNil(t, got)
+			assert.Equalf(t, tt.wantOrgChildren, len(got.Children), "OrgRoot children count")
+			assert.Equalf(t, tt.wantVPCChildren, len(tt.args.vpc.Children), "VPC children count")
 			got.Children = nil
-			assert.Equalf(t, tt.want, got, "WrapHierarchyVPC(%v, %v, %v, %v)", tt.args.org, tt.args.nsxtProject, tt.args.vpc, tt.args.lbs)
+			assert.Equalf(t, tt.want, got, "WrapHierarchyVPC(%v, %v, %v, %v, %v)", tt.args.org, tt.args.nsxtProject, tt.args.vpc, tt.args.lbServiceIPAlloc, tt.args.lbs)
 		})
 	}
 }

--- a/test/e2e/precreated_vpc_test.go
+++ b/test/e2e/precreated_vpc_test.go
@@ -411,7 +411,7 @@ func (data *TestData) createVPC(orgID, projectID, vpcID string, privateIPs []str
 		}
 	}
 	svc := &vpc.VPCService{}
-	orgRoot, err := svc.WrapHierarchyVPC(orgID, projectID, createdVPC, createdLBS, attachment)
+	orgRoot, err := svc.WrapHierarchyVPC(orgID, projectID, createdVPC, nil, createdLBS, attachment)
 	if err != nil {
 		log.Error(err, "Failed to build HAPI request for VPC related resources")
 		return err


### PR DESCRIPTION
To avoid the ipaddressallocation IP used by subnet, need to restore it first

Test Done
Test case 1:
1. delete the vpc qe using nsx API
2. backup from the nsx
3. stop the ncp
4. cleanup the nsx
5. Create ns test from VC side
qe
loadBalancerIPAddresses: 192.168.0.7 
test
loadBalancerIPAddresses: 192.168.0.33
6. restore from the nsx
7. restart the ncp
8. check if the vpc qe/test restored after restore complete, and if the ip is the same
9. Create a new svc under qe, check if the svc has been created and the vip could be accessed