### PR TITLE
Enable restorevif through config flag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -129,6 +129,8 @@ type NsxConfig struct {
 	// VpcWcpEnhance controls StatefulSet pod SubnetPort behavior together with NSX version.
 	// When omitted (nil), treated as false; only an explicit true enables the enhancement path.
 	VpcWcpEnhance *bool `ini:"vpc_wcp_enhance"`
+	// RestoreVif controls whether SubnetPort vif should be restored during restore mode.
+	RestoreVif *bool `ini:"restore_vif"`
 }
 
 type K8sConfig struct {
@@ -410,6 +412,15 @@ func (nsxConfig *NsxConfig) VpcWcpEnhanceEnabled() bool {
 		return false
 	}
 	return *nsxConfig.VpcWcpEnhance
+}
+
+// RestoreVifEnabled reports whether restoring SubnetPort vif is supported by config.
+// Missing or nil key defaults to false; only an explicit true enables.
+func (nsxConfig *NsxConfig) RestoreVifEnabled() bool {
+	if nsxConfig == nil || nsxConfig.RestoreVif == nil {
+		return false
+	}
+	return *nsxConfig.RestoreVif
 }
 
 func (nsxConfig *NsxConfig) validate(enableVPC bool) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -197,6 +197,16 @@ func TestNsxConfig_VpcWcpEnhanceEnabled(t *testing.T) {
 	assert.False(t, (&NsxConfig{VpcWcpEnhance: &f}).VpcWcpEnhanceEnabled())
 }
 
+func TestNsxConfig_RestoreVifEnabled(t *testing.T) {
+	f := false
+	tr := true
+	assert.False(t, (*NsxConfig)(nil).RestoreVifEnabled())
+	assert.False(t, (&NsxConfig{}).RestoreVifEnabled())
+	assert.False(t, (&NsxConfig{RestoreVif: nil}).RestoreVifEnabled())
+	assert.True(t, (&NsxConfig{RestoreVif: &tr}).RestoreVifEnabled())
+	assert.False(t, (&NsxConfig{RestoreVif: &f}).RestoreVifEnabled())
+}
+
 func TestNsxConfig_GetServiceSize(t *testing.T) {
 	type fields struct {
 		ServiceSize string

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -130,7 +130,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			}
 		}
 		r.StatusUpdater.UpdateSuccess(ctx, pod, nil)
-		if r.restoreMode && !r.SubnetPortService.NSXClient.NSXCheckVersion(nsx.RestoreVIF) {
+		if r.restoreMode && !nsx.RestoreVifFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig) {
 			// Update restore status on Pod to notify Spherelet for NSX version < 9.2
 			retry.OnError(util.K8sClientRetry, func(err error) bool {
 				log.Error(err, "Failed to update restore status on Pod", "Namespace", pod.Namespace, "Pod", pod.Name)

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -220,7 +220,7 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			subnetPort.Status.Conditions = nil
 		}
 		r.StatusUpdater.UpdateSuccess(ctx, subnetPort, setReadyStatusTrue, r.SubnetPortService)
-		if r.restoreMode && !r.SubnetPortService.NSXClient.NSXCheckVersion(nsx.RestoreVIF) {
+		if r.restoreMode && !nsx.RestoreVifFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig) {
 			// UpdateSuccess may fail due to k8s connection or update conflicts.
 			// In restore mode, we need to ensure the SubnetPort attachment Id is updated to the new SubnetPort before adding the annotation
 			// Otherwise VM operator will fail to get the new attachment ID.

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -551,10 +551,10 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 				return nil
 			})
 		defer patchesUpdateSubnetStatusOnSubnetPort.Reset()
-		patchesNSXCheckVersion := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetPortService.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+		patchesRestoreVifFeatureEnabled := gomonkey.ApplyFunc(nsx.RestoreVifFeatureEnabled, func(_ *nsx.Client, _ *config.NSXOperatorConfig) bool {
 			return false
 		})
-		defer patchesNSXCheckVersion.Reset()
+		defer patchesRestoreVifFeatureEnabled.Reset()
 
 		k8sClient.EXPECT().Status().Return(fakewriter)
 		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
@@ -665,10 +665,10 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		})
 		defer patchesGetAddressBindingBySubnetPort.Reset()
 
-		patchesNSXCheckVersion := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetPortService.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+		patchesRestoreVifFeatureEnabled := gomonkey.ApplyFunc(nsx.RestoreVifFeatureEnabled, func(_ *nsx.Client, _ *config.NSXOperatorConfig) bool {
 			return false
 		})
-		defer patchesNSXCheckVersion.Reset()
+		defer patchesRestoreVifFeatureEnabled.Reset()
 
 		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
 			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
@@ -752,10 +752,10 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			})
 		defer patchesUpdateSubnetStatusOnSubnetPort.Reset()
 
-		patchesNSXCheckVersion := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetPortService.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+		patchesRestoreVifFeatureEnabled := gomonkey.ApplyFunc(nsx.RestoreVifFeatureEnabled, func(_ *nsx.Client, _ *config.NSXOperatorConfig) bool {
 			return false
 		})
-		defer patchesNSXCheckVersion.Reset()
+		defer patchesRestoreVifFeatureEnabled.Reset()
 
 		k8sClient.EXPECT().Status().Return(fakewriter)
 		_, ret := r.Reconcile(ctx, req)

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -377,10 +377,6 @@ func (client *Client) resetNSXVersionFeatureCache() {
 }
 
 func (client *Client) NSXCheckVersion(feature int) bool {
-	// TODO: Remove this once NSX implementation for SubnetPort VIF restore is merged
-	if feature == RestoreVIF {
-		return false
-	}
 	if client.NSXVerChecker.featureSupported[feature] {
 		return true
 	}

--- a/pkg/nsx/feature.go
+++ b/pkg/nsx/feature.go
@@ -18,3 +18,15 @@ func StatefulSetPodSubnetPortFeatureEnabled(client *Client, operatorConfig *conf
 	}
 	return operatorConfig.NsxConfig.VpcWcpEnhanceEnabled()
 }
+
+// RestoreVifFeatureEnabled is true when NSX supports restoring SubnetPort vif and
+// operator config set restore_vif to true.
+func RestoreVifFeatureEnabled(client *Client, operatorConfig *config.NSXOperatorConfig) bool {
+	if client == nil || !client.NSXCheckVersion(RestoreVIF) {
+		return false
+	}
+	if operatorConfig == nil || operatorConfig.NsxConfig == nil {
+		return false
+	}
+	return operatorConfig.NsxConfig.RestoreVifEnabled()
+}

--- a/pkg/nsx/feature_test.go
+++ b/pkg/nsx/feature_test.go
@@ -42,3 +42,33 @@ func TestStatefulSetPodSubnetPortFeatureEnabled(t *testing.T) {
 		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}))
 	})
 }
+
+func TestRestoreVifFeatureEnabled(t *testing.T) {
+	f := false
+	tr := true
+	nsxClient := &Client{}
+
+	t.Run("nil client", func(t *testing.T) {
+		assert.False(t, RestoreVifFeatureEnabled(nil, &config.NSXOperatorConfig{}))
+	})
+
+	t.Run("version supports and restore_vif opt-in", func(t *testing.T) {
+		p := gomonkey.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *Client, feature int) bool {
+			return feature == RestoreVIF
+		})
+		defer p.Reset()
+		assert.False(t, RestoreVifFeatureEnabled(nsxClient, nil))
+		assert.False(t, RestoreVifFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: nil}))
+		assert.False(t, RestoreVifFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}))
+		assert.True(t, RestoreVifFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{RestoreVif: &tr}}))
+		assert.False(t, RestoreVifFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{RestoreVif: &f}}))
+	})
+
+	t.Run("version does not support", func(t *testing.T) {
+		p := gomonkey.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *Client, feature int) bool {
+			return false
+		})
+		defer p.Reset()
+		assert.False(t, RestoreVifFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}))
+	})
+}

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -161,7 +161,7 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 		isChanged = servicecommon.CompareResource(SubnetPortToComparable(existingSubnetPort), SubnetPortToComparable(nsxSubnetPort))
 	}
 	// In restore mode, restore attachment id in k8s CR when NSX >= 9.2
-	if restoreMode && service.NSXClient.NSXCheckVersion(nsx.RestoreVIF) && attachmentID != "" {
+	if restoreMode && nsx.RestoreVifFeatureEnabled(service.NSXClient, service.NSXConfig) && attachmentID != "" {
 		nsxSubnetPort.Attachment.Id = &attachmentID
 	}
 	subnetInfo, err := servicecommon.ParseVPCResourcePath(*nsxSubnet.Path)


### PR DESCRIPTION
This PR refers to a field `restore_vif` in configmap to determine
if restore the SubnetPort with unchanged vif.

Testing done:
Set restore_vif to true, observed the SubnetPort is restored with unchanged vif.
Set restore_vif to false, observed the SubnetPort is restored with changed vif.