### PR TITLE
Add IPv6 and dual-stack support for SubnetIPReservation

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetipreservations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetipreservations.yaml
@@ -145,8 +145,9 @@ spec:
                 type: array
               ips:
                 description: |-
-                  List of reserved IPs.
-                  Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28"]
+                  List of reserved IPs for both IPv4 and IPv6.
+                  Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28",
+                  "2001:db8::1", "2001:db8::1-2001:db8::ff", "2001:db8::/64"]
                 items:
                   type: string
                 type: array

--- a/build/yaml/samples/nsx_v1alpha1_subnetipreservation.yaml
+++ b/build/yaml/samples/nsx_v1alpha1_subnetipreservation.yaml
@@ -1,7 +1,53 @@
+---
+# Example 1: Dynamic IPv4 reservation (numberOfIPs mode, default)
 apiVersion: crd.nsx.vmware.com/v1alpha1
 kind: SubnetIPReservation
 metadata:
-  name: subnet-ipa-1
+  name: subnet-ipr-ipv4
 spec:
   subnet: subnet-1
   numberOfIPs: 10
+---
+# Example 2: Dynamic IPv6 reservation (numberOfIPs mode)
+apiVersion: crd.nsx.vmware.com/v1alpha1
+kind: SubnetIPReservation
+metadata:
+  name: subnet-ipr-ipv6
+spec:
+  subnet: subnet-1-ipv6
+  numberOfIPs: 10
+  ipAddressType: IPV6
+---
+# Example 3: Dynamic dual-stack reservation — reserves 5 IPv4 IPs and 5 IPv6 IPs
+apiVersion: crd.nsx.vmware.com/v1alpha1
+kind: SubnetIPReservation
+metadata:
+  name: subnet-ipr-dualstack
+spec:
+  subnet: subnet-1-dualstack
+  numberOfIPs: 5
+  ipAddressType: IPV4IPV6
+---
+# Example 4: Static IPv4 reservation (reservedIPs mode)
+apiVersion: crd.nsx.vmware.com/v1alpha1
+kind: SubnetIPReservation
+metadata:
+  name: subnet-sipr-ipv4
+spec:
+  subnet: subnet-1
+  reservedIPs:
+    - "192.168.1.1"
+    - "192.168.1.3-192.168.1.100"
+    - "192.168.2.0/28"
+---
+# Example 5: Static IPv6 reservation (reservedIPs mode)
+apiVersion: crd.nsx.vmware.com/v1alpha1
+kind: SubnetIPReservation
+metadata:
+  name: subnet-sipr-ipv6
+spec:
+  subnet: subnet-1-ipv6
+  reservedIPs:
+    - "2001:db8::1"
+    - "2001:db8::10-2001:db8::ff"
+    - "2001:db8:1::/64"

--- a/docs/ref/apis/legacy.md
+++ b/docs/ref/apis/legacy.md
@@ -29,7 +29,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -117,7 +117,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 
@@ -260,7 +260,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br /> |
+| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br />Optional: \{\} <br /> |
 | `allocationSize` _integer_ | AllocationSize specifies the size of IPv4 allocationIPs to be allocated.<br />It should be a power of 2. |  | Minimum: 1 <br /> |
 | `allocationIPs` _string_ | AllocationIPs specifies the Allocated IP addresses in CIDR or single IP Address format. |  |  |
 | `ipv6AllocationPrefixLength` _integer_ | IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses.<br />Defaults to 64 when ipAddressType is IPv6 and this field is not specified. |  | Maximum: 128 <br />Minimum: 64 <br /> |
@@ -766,7 +766,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 
@@ -987,7 +987,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `conditions` _[Condition](#condition) array_ | Conditions described if the SubnetIPReservation is configured on NSX or not.<br />Condition type "" |  |  |
-| `ips` _string array_ | List of reserved IPs.<br />Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28"] |  |  |
+| `ips` _string array_ | List of reserved IPs for both IPv4 and IPv6.<br />Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28",<br />"2001:db8::1", "2001:db8::1-2001:db8::ff", "2001:db8::/64"] |  |  |
 
 
 #### SubnetInfo
@@ -1241,8 +1241,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  |  |
-| `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  |  |
+| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  | Optional: \{\} <br /> |
+| `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  | Optional: \{\} <br /> |
 | `nsxProject` _string_ | NSX Project the Namespace is associated with. |  |  |
 | `vpcConnectivityProfile` _string_ | VPCConnectivityProfile Path. This profile has configuration related to creating VPC transit gateway attachment. |  |  |
 | `privateIPs` _string array_ | Private IPs. |  |  |

--- a/pkg/apis/vpc/v1alpha1/subnetipreservation_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetipreservation_types.go
@@ -45,8 +45,9 @@ type SubnetIPReservationStatus struct {
 	// Conditions described if the SubnetIPReservation is configured on NSX or not.
 	// Condition type ""
 	Conditions []Condition `json:"conditions,omitempty"`
-	// List of reserved IPs.
-	// Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28"]
+	// List of reserved IPs for both IPv4 and IPv6.
+	// Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28",
+	// "2001:db8::1", "2001:db8::1-2001:db8::ff", "2001:db8::/64"]
 	IPs []string `json:"ips,omitempty"`
 }
 

--- a/pkg/controllers/subnetipreservation/subnetipreservation_controller.go
+++ b/pkg/controllers/subnetipreservation/subnetipreservation_controller.go
@@ -239,6 +239,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return common.ResultNormal, nil
 	}
 
+	// For dynamic reservations (numberOfIPs), validate that the requested IP address family is
+	// supported by the parent Subnet.
+	if ipReservationCR.Spec.NumberOfIPs > 0 {
+		if err := validateIPAddressTypeCompatibility(subnetCR.Spec.IPAddressType, ipReservationCR.Spec.IPAddressType); err != nil {
+			r.StatusUpdater.UpdateFail(ctx, ipReservationCR, err, err.Error(), setReadyStatusFalse)
+			return common.ResultNormal, nil
+		}
+	}
+
 	nsxSubnet, err := r.SubnetService.GetSubnetByCR(subnetCR)
 	if err != nil {
 		log.Error(err, "failed to get NSX Subnet", "Namespace", subnetCR.Namespace, "Subnet", subnetCR.Name)
@@ -299,6 +308,23 @@ func (r *Reconciler) validateSubnet(ctx context.Context, ns, name string) (*v1al
 		}
 	}
 	return subnetCR, nil
+}
+
+func validateIPAddressTypeCompatibility(subnetIPAddressType, reservationIPAddressType v1alpha1.IPAddressType) error {
+	if subnetIPAddressType == "" {
+		subnetIPAddressType = v1alpha1.IPAddressTypeIPv4
+	}
+	if reservationIPAddressType == "" {
+		reservationIPAddressType = v1alpha1.IPAddressTypeIPv4
+	}
+	// A dual-stack Subnet supports all reservation IP families.
+	if subnetIPAddressType == v1alpha1.IPAddressTypeIPv4IPv6 {
+		return nil
+	}
+	if subnetIPAddressType != reservationIPAddressType {
+		return fmt.Errorf("SubnetIPReservation IPAddressType %q is incompatible with Subnet IPAddressType %q", reservationIPAddressType, subnetIPAddressType)
+	}
+	return nil
 }
 
 func setReadyStatusTrue(client client.Client, ctx context.Context, obj client.Object, transitionTime metav1.Time, _ ...interface{}) {

--- a/pkg/controllers/subnetipreservation/subnetipreservation_controller_test.go
+++ b/pkg/controllers/subnetipreservation/subnetipreservation_controller_test.go
@@ -398,6 +398,32 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 			expectedResult: common.ResultNormal,
 		},
+		{
+			name: "IPAddressType incompatible with Subnet",
+			objects: []client.Object{&v1alpha1.SubnetIPReservation{
+				ObjectMeta: metav1.ObjectMeta{Name: "ipr-1", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetIPReservationSpec{
+					Subnet:      "subnet-1",
+					NumberOfIPs: 5,
+					// Use the CRD enum value ("IPV6") that Kubernetes actually stores,
+					// not the Go constant IPAddressTypeIPv6 = "IPv6".
+					IPAddressType: "IPV6",
+				},
+			}},
+			preparedFunc: func(r *Reconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "validateSubnet", func(_ *Reconciler, ctx context.Context, ns string, name string) (*v1alpha1.Subnet, *errorWithRetry) {
+					return &v1alpha1.Subnet{
+						// Use the CRD enum value ("IPV4") that Kubernetes actually stores.
+						Spec: v1alpha1.SubnetSpec{IPAddressType: "IPV4"},
+					}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.IPReservationService.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, feature int) bool {
+					return true
+				})
+				return patches
+			},
+			expectedResult: common.ResultNormal,
+		},
 	}
 	for _, tc := range tests {
 		r := createFakeReconciler(tc.objects...)
@@ -505,6 +531,87 @@ func TestReconcile_validateSubnet(t *testing.T) {
 		if patches != nil {
 			patches.Reset()
 		}
+	}
+}
+
+func TestValidateIPAddressTypeCompatibility(t *testing.T) {
+	tests := []struct {
+		name              string
+		subnetType        v1alpha1.IPAddressType
+		reservationType   v1alpha1.IPAddressType
+		expectedErrSubstr string
+	}{
+		{
+			name:            "IPv4 subnet with IPv4 reservation",
+			subnetType:      "IPv4",
+			reservationType: "IPv4",
+		},
+		{
+			name:            "IPv4 subnet with empty reservation defaults to IPv4",
+			subnetType:      "IPv4",
+			reservationType: "",
+		},
+		{
+			name:              "IPv4 subnet with IPv6 reservation - incompatible",
+			subnetType:        "IPv4",
+			reservationType:   "IPv6",
+			expectedErrSubstr: "incompatible",
+		},
+		{
+			name:              "IPv4 subnet with dual-stack reservation - incompatible",
+			subnetType:        "IPv4",
+			reservationType:   "IPv4IPv6",
+			expectedErrSubstr: "incompatible",
+		},
+		{
+			name:            "IPv6 subnet with IPv6 reservation",
+			subnetType:      "IPv6",
+			reservationType: "IPv6",
+		},
+		{
+			name:              "IPv6 subnet with IPv4 reservation - incompatible",
+			subnetType:        "IPv6",
+			reservationType:   "IPv4",
+			expectedErrSubstr: "incompatible",
+		},
+		{
+			name:            "Dual-stack subnet with IPv4 reservation",
+			subnetType:      "IPv4IPv6",
+			reservationType: "IPv4",
+		},
+		{
+			name:            "Dual-stack subnet with IPv6 reservation",
+			subnetType:      "IPv4IPv6",
+			reservationType: "IPv6",
+		},
+		{
+			name:            "Dual-stack subnet with dual-stack reservation",
+			subnetType:      "IPv4IPv6",
+			reservationType: "IPv4IPv6",
+		},
+		{
+			name:            "Empty subnet type defaults to IPv4, IPv4 reservation",
+			subnetType:      "",
+			reservationType: "IPv4",
+		},
+		{
+			name:              "Empty subnet type defaults to IPv4, IPv6 reservation - incompatible",
+			subnetType:        "",
+			reservationType:   "IPv6",
+			expectedErrSubstr: "incompatible",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateIPAddressTypeCompatibility(tc.subnetType, tc.reservationType)
+			if tc.expectedErrSubstr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrSubstr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }
 

--- a/pkg/nsx/services/ipaddressallocation/builder.go
+++ b/pkg/nsx/services/ipaddressallocation/builder.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	controllerscommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
@@ -31,33 +32,26 @@ func convertIpAddressBlockVisibility(visibility v1alpha1.IPAddressVisibility) v1
 	return visibility
 }
 
-func ipAddressTypeToNSX(ipAddressType v1alpha1.IPAllocationAddressType) string {
-	switch ipAddressType {
-	case v1alpha1.IPAllocationIPAddressTypeIPv6:
-		return model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV6
-	case v1alpha1.IPAllocationIPAddressTypeIPv4:
-		fallthrough
-	default:
-		return model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV4
-	}
-}
-
 func (service *IPAddressAllocationService) BuildIPAddressAllocation(obj metav1.Object, subnetPortCR *v1alpha1.SubnetPort, restoreMode bool) (*model.VpcIpAddressAllocation, error) {
 	ipAddressBlockVisibility := v1alpha1.IPAddressVisibilityPrivate
 	var allocationIps *string
 	var allocationSize *int64
 	var ipAddressType string
 	var ipv6AllocationPrefixLength *int64
-	ipAddressType = model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV4
+
 	switch o := obj.(type) {
 	case *v1alpha1.IPAddressAllocation:
+		if o.Spec.IPAddressType != "" {
+			ipAddressType = controllerscommon.ConvertCRIPAddressTypeToNSX(v1alpha1.IPAddressType(o.Spec.IPAddressType))
+		} else {
+			ipAddressType = controllerscommon.ConvertCRIPAddressTypeToNSX(v1alpha1.IPAddressTypeIPv4)
+		}
 		VPCInfo := service.VPCService.ListVPCInfo(o.Namespace)
 		if len(VPCInfo) == 0 {
 			log.Error(nil, "Failed to find VPCInfo for IPAddressAllocation CR", "IPAddressAllocation", o.Name, "Namespace", o.Namespace)
 			return nil, fmt.Errorf("failed to find VPCInfo for IPAddressAllocation CR %s in Namespace %s", o.Name, o.Namespace)
 		}
 		ipAddressBlockVisibility = convertIpAddressBlockVisibility(o.Spec.IPAddressBlockVisibility)
-		ipAddressType = ipAddressTypeToNSX(o.Spec.IPAddressType)
 		if len(o.Spec.AllocationIPs) > 0 {
 			allocationIps = String(o.Spec.AllocationIPs)
 		} else if restoreMode && len(o.Status.AllocationIPs) > 0 {
@@ -80,8 +74,9 @@ func (service *IPAddressAllocationService) BuildIPAddressAllocation(obj metav1.O
 		}
 		ipAddressBlockVisibility = v1alpha1.IPAddressVisibilityExternal
 		allocationIps = &o.Status.IPAddress
+		ipAddressType = controllerscommon.ConvertCRIPAddressTypeToNSX(v1alpha1.IPAddressTypeIPv4)
 		if util.IsIPv6(o.Status.IPAddress) {
-			ipAddressType = model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV6
+			ipAddressType = controllerscommon.ConvertCRIPAddressTypeToNSX(v1alpha1.IPAddressTypeIPv6)
 		}
 	}
 	tags := service.buildIPAddressAllocationTags(obj)

--- a/pkg/nsx/services/subnet/builder_test.go
+++ b/pkg/nsx/services/subnet/builder_test.go
@@ -663,6 +663,200 @@ func TestBuildSubnetWithCustomDHCPServerAddresses(t *testing.T) {
 	assert.Equal(t, false, *nsxSubnet4.AdvancedConfig.StaticIpAllocation.Enabled)
 }
 
+// ─── IPv6 / dual-stack builder tests ────────────────────────────────────────
+func newIPv6BuildSubnetService(k8sClient client.Client) *SubnetService {
+	return &SubnetService{
+		Service: common.Service{
+			Client:    k8sClient,
+			NSXClient: &nsx.Client{},
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{Cluster: "k8scl-one:test"},
+			},
+		},
+		SubnetStore: &SubnetStore{
+			ResourceStore: common.ResourceStore{
+				Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
+					common.TagScopeSubnetCRUID:    subnetIndexFunc,
+					common.TagScopeSubnetSetCRUID: subnetSetIndexFunc,
+					common.TagScopeVMNamespace:    subnetIndexVMNamespaceFunc,
+					common.TagScopeNamespace:      subnetIndexNamespaceFunc,
+				}),
+				BindingType: model.VpcSubnetBindingType(),
+			},
+		},
+	}
+}
+
+func TestBuildSubnetWithIPv6(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mockClient.NewMockClient(mockCtl)
+	defer mockCtl.Finish()
+
+	patches := gomonkey.ApplyFunc(controllerscommon.IsNamespaceInTepLessMode,
+		func(_ client.Client, _ string) (bool, error) { return false, nil })
+	patches.ApplyMethodFunc(&nsx.Client{}, "NSXCheckVersion", func(feature int) bool {
+		return true
+	})
+	defer patches.Reset()
+
+	service := newIPv6BuildSubnetService(k8sClient)
+	tags := []model.Tag{{Scope: common.String("nsx-op/namespace"), Tag: common.String("ns-1")}}
+
+	subnetCR := &v1alpha1.Subnet{
+		ObjectMeta: v1.ObjectMeta{Name: "subnet-ipv6", Namespace: "ns-1"},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType:    "IPv6",
+			IPv6PrefixLength: 64,
+			AccessMode:       v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
+			AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+				StaticIPAllocation: v1alpha1.StaticIPAllocation{Enabled: common.Bool(true)},
+			},
+		},
+	}
+
+	nsxSubnet, err := service.buildSubnet(subnetCR, tags, []string{})
+	assert.Nil(t, err)
+	assert.NotNil(t, nsxSubnet.IpAddressType)
+	assert.Equal(t, "IPV6", *nsxSubnet.IpAddressType)
+	assert.NotNil(t, nsxSubnet.Ipv6PrefixLength)
+	assert.Equal(t, int64(64), *nsxSubnet.Ipv6PrefixLength)
+	assert.Nil(t, nsxSubnet.Ipv4SubnetSize)
+	assert.NotNil(t, nsxSubnet.SubnetDhcpv6Config)
+	assert.NotNil(t, nsxSubnet.SubnetDhcpv6Config.Mode)
+	assert.Equal(t, "DHCP_DEACTIVATED", *nsxSubnet.SubnetDhcpv6Config.Mode)
+}
+
+func TestBuildSubnetWithDualStack(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mockClient.NewMockClient(mockCtl)
+	defer mockCtl.Finish()
+
+	patches := gomonkey.ApplyFunc(controllerscommon.IsNamespaceInTepLessMode,
+		func(_ client.Client, _ string) (bool, error) { return false, nil })
+	patches.ApplyMethodFunc(&nsx.Client{}, "NSXCheckVersion", func(feature int) bool {
+		return true
+	})
+	defer patches.Reset()
+
+	service := newIPv6BuildSubnetService(k8sClient)
+	tags := []model.Tag{{Scope: common.String("nsx-op/namespace"), Tag: common.String("ns-1")}}
+
+	subnetCR := &v1alpha1.Subnet{
+		ObjectMeta: v1.ObjectMeta{Name: "subnet-dual", Namespace: "ns-1"},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType:    "IPv4IPv6",
+			IPv4SubnetSize:   64,
+			IPv6PrefixLength: 64,
+			AccessMode:       v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
+			AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+				StaticIPAllocation: v1alpha1.StaticIPAllocation{Enabled: common.Bool(true)},
+			},
+		},
+	}
+
+	nsxSubnet, err := service.buildSubnet(subnetCR, tags, []string{})
+	assert.Nil(t, err)
+	assert.NotNil(t, nsxSubnet.IpAddressType)
+	assert.Equal(t, "IPV4_IPV6", *nsxSubnet.IpAddressType)
+	assert.NotNil(t, nsxSubnet.Ipv4SubnetSize)
+	assert.Equal(t, int64(64), *nsxSubnet.Ipv4SubnetSize)
+	assert.NotNil(t, nsxSubnet.Ipv6PrefixLength)
+	assert.Equal(t, int64(64), *nsxSubnet.Ipv6PrefixLength)
+}
+
+func TestBuildSubnetIPv4DefaultAndExplicit(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mockClient.NewMockClient(mockCtl)
+	defer mockCtl.Finish()
+
+	patches := gomonkey.ApplyFunc(controllerscommon.IsNamespaceInTepLessMode,
+		func(_ client.Client, _ string) (bool, error) { return false, nil })
+	patches.ApplyMethodFunc(&nsx.Client{}, "NSXCheckVersion", func(feature int) bool {
+		return true
+	})
+	defer patches.Reset()
+
+	service := newIPv6BuildSubnetService(k8sClient)
+	tags := []model.Tag{{Scope: common.String("nsx-op/namespace"), Tag: common.String("ns-1")}}
+
+	// When IPAddressType is empty, IpAddressType should not be set (let NSX default to IPV4).
+	subnetCR := &v1alpha1.Subnet{
+		ObjectMeta: v1.ObjectMeta{Name: "subnet-ipv4-default", Namespace: "ns-1"},
+		Spec: v1alpha1.SubnetSpec{
+			IPv4SubnetSize: 32,
+			AccessMode:     v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
+			AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+				StaticIPAllocation: v1alpha1.StaticIPAllocation{Enabled: common.Bool(true)},
+			},
+		},
+	}
+
+	nsxSubnet, err := service.buildSubnet(subnetCR, tags, []string{})
+	assert.Nil(t, err)
+	assert.Nil(t, nsxSubnet.IpAddressType, "IpAddressType should be nil when not specified")
+	assert.Nil(t, nsxSubnet.Ipv6PrefixLength)
+
+	// Explicit "IPv4" should be passed to NSX.
+	subnetCR.Spec.IPAddressType = "IPv4"
+	nsxSubnet, err = service.buildSubnet(subnetCR, tags, []string{})
+	assert.Nil(t, err)
+	assert.NotNil(t, nsxSubnet.IpAddressType)
+	assert.Equal(t, "IPV4", *nsxSubnet.IpAddressType)
+}
+
+func TestBuildSubnetWithDHCPv6Config(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mockClient.NewMockClient(mockCtl)
+	defer mockCtl.Finish()
+
+	patches := gomonkey.ApplyFunc(controllerscommon.IsNamespaceInTepLessMode,
+		func(_ client.Client, _ string) (bool, error) { return false, nil })
+	patches.ApplyMethodFunc(&nsx.Client{}, "NSXCheckVersion", func(feature int) bool {
+		return true
+	})
+	defer patches.Reset()
+
+	service := newIPv6BuildSubnetService(k8sClient)
+	tags := []model.Tag{{Scope: common.String("nsx-op/namespace"), Tag: common.String("ns-1")}}
+
+	subnetCR := &v1alpha1.Subnet{
+		ObjectMeta: v1.ObjectMeta{Name: "subnet-dhcpv6", Namespace: "ns-1"},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType:    "IPv6",
+			IPv6PrefixLength: 64,
+			AccessMode:       v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
+			AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+				StaticIPAllocation: v1alpha1.StaticIPAllocation{Enabled: common.Bool(false)},
+			},
+			SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+				Mode: v1alpha1.DHCPv6ConfigModeServer,
+				DHCPv6ServerAdditionalConfig: v1alpha1.DHCPv6ServerAdditionalConfig{
+					ReservedIPRanges: []string{"2001:db8::10-2001:db8::20"},
+				},
+			},
+		},
+	}
+
+	nsxSubnet, err := service.buildSubnet(subnetCR, tags, []string{})
+	assert.Nil(t, err)
+	assert.NotNil(t, nsxSubnet.IpAddressType)
+	assert.Equal(t, "IPV6", *nsxSubnet.IpAddressType)
+	assert.NotNil(t, nsxSubnet.SubnetDhcpv6Config)
+	assert.NotNil(t, nsxSubnet.SubnetDhcpv6Config.Mode)
+	assert.Equal(t, "DHCP_SERVER", *nsxSubnet.SubnetDhcpv6Config.Mode)
+	assert.NotNil(t, nsxSubnet.SubnetDhcpv6Config.Dhcpv6ServerAdditionalConfig)
+	assert.Equal(t, []string{"2001:db8::10-2001:db8::20"},
+		nsxSubnet.SubnetDhcpv6Config.Dhcpv6ServerAdditionalConfig.ReservedIpRanges)
+
+	// No DHCPv6 mode → SubnetDhcpv6Config mode should be DHCP_DEACTIVATED.
+	subnetCR.Spec.SubnetDHCPv6Config = v1alpha1.SubnetDHCPv6Config{}
+	nsxSubnet, err = service.buildSubnet(subnetCR, tags, []string{})
+	assert.Nil(t, err)
+	assert.NotNil(t, nsxSubnet.SubnetDhcpv6Config)
+	assert.NotNil(t, nsxSubnet.SubnetDhcpv6Config.Mode)
+	assert.Equal(t, "DHCP_DEACTIVATED", *nsxSubnet.SubnetDhcpv6Config.Mode)
+}
+
 func TestBuildSubnetMixedModeIPAM(t *testing.T) {
 	mockCtl := gomock.NewController(t)
 	k8sClient := mockClient.NewMockClient(mockCtl)

--- a/pkg/nsx/services/subnetipreservation/builder.go
+++ b/pkg/nsx/services/subnetipreservation/builder.go
@@ -6,6 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	controllerscommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
@@ -17,6 +19,10 @@ func (s *IPReservationService) buildDynamicIPReservation(ipReservation *v1alpha1
 		Tags:        tags,
 		Id:          common.String(s.buildIPReservationID(ipReservation, subnetPath)),
 		DisplayName: common.String(ipReservation.Name),
+	}
+	if ipReservation.Spec.IPAddressType != "" && s.NSXClient.NSXCheckVersion(nsx.IPv6) {
+		ipAddressType := controllerscommon.ConvertCRIPAddressTypeToNSX(ipReservation.Spec.IPAddressType)
+		nsxIPReservation.IpAddressType = &ipAddressType
 	}
 	return nsxIPReservation
 }

--- a/pkg/nsx/services/subnetipreservation/builder_test.go
+++ b/pkg/nsx/services/subnetipreservation/builder_test.go
@@ -3,58 +3,22 @@ package subnetipreservation
 import (
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	controllerscommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
-func TestBuildDynamicIPReservation(t *testing.T) {
-	ipReservationCR := &v1alpha1.SubnetIPReservation{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "ipr-1",
-			Namespace: "ns-1",
-			UID:       "ipr-uid-1",
-		},
-		Spec: v1alpha1.SubnetIPReservationSpec{
-			Subnet:      "subnet-1",
-			NumberOfIPs: 10,
-		},
-	}
-
-	expectedNSXIPReservation := &model.DynamicIpAddressReservation{
-		Id:          common.String("ipr-1_3yw4m"),
-		DisplayName: common.String("ipr-1"),
-		NumberOfIps: common.Int64(10),
-		Tags: []model.Tag{
-			{
-				Scope: common.String(common.TagScopeCluster),
-				Tag:   common.String("fake_cluster"),
-			},
-			{
-				Scope: common.String(common.TagScopeVersion),
-				Tag:   common.String("1.0.0"),
-			},
-			{
-				Scope: common.String(common.TagScopeNamespace),
-				Tag:   common.String("ns-1"),
-			},
-			{
-				Scope: common.String(common.TagScopeSubnetIPReservationCRName),
-				Tag:   common.String("ipr-1"),
-			},
-			{
-				Scope: common.String(common.TagScopeSubnetIPReservationCRUID),
-				Tag:   common.String("ipr-uid-1"),
-			},
-		},
-	}
-
-	service := &IPReservationService{
+func newTestService() *IPReservationService {
+	return &IPReservationService{
 		Service: common.Service{
+			NSXClient: &nsx.Client{},
 			NSXConfig: &config.NSXOperatorConfig{
 				CoeConfig: &config.CoeConfig{
 					Cluster: "fake_cluster",
@@ -64,8 +28,94 @@ func TestBuildDynamicIPReservation(t *testing.T) {
 		DynamicIPReservationStore: SetupDynamicIPReservationStore(),
 		StaticIPReservationStore:  SetupStaticIPReservationStore(),
 	}
-	nsxIPReservation := service.buildDynamicIPReservation(ipReservationCR, "/orgs/default/projects/default/vpcs/ns-1/subnets/subnet-1")
-	require.Equal(t, expectedNSXIPReservation, nsxIPReservation)
+}
+
+func baseTags(namespace, name, uid string) []model.Tag {
+	return []model.Tag{
+		{Scope: common.String(common.TagScopeCluster), Tag: common.String("fake_cluster")},
+		{Scope: common.String(common.TagScopeVersion), Tag: common.String("1.0.0")},
+		{Scope: common.String(common.TagScopeNamespace), Tag: common.String(namespace)},
+		{Scope: common.String(common.TagScopeSubnetIPReservationCRName), Tag: common.String(name)},
+		{Scope: common.String(common.TagScopeSubnetIPReservationCRUID), Tag: common.String(uid)},
+	}
+}
+
+func TestBuildDynamicIPReservation(t *testing.T) {
+	subnetPath := "/orgs/default/projects/default/vpcs/ns-1/subnets/subnet-1"
+	// Covers both the current mixed-case CRD enum values ("IPv4"/"IPv6"/"IPv4IPv6") and
+	// legacy all-caps values ("IPV4"/"IPV6"/"IPV4IPV6") that may exist in older Subnet CRs,
+	// as well as the empty / unset case.
+	strPtr := func(s string) *string { return &s }
+	tests := []struct {
+		name              string
+		ipAddressType     v1alpha1.IPAddressType
+		expectedNSXFamily *string
+	}{
+		// Feature supported: IpAddressType is set in the NSX request.
+		{
+			name:              "Supported_DefaultIPv4WhenUnset",
+			ipAddressType:     "",
+			expectedNSXFamily: nil,
+		},
+		{
+			name:              "Supported_MixedCase_IPv4",
+			ipAddressType:     "IPv4",
+			expectedNSXFamily: strPtr(controllerscommon.ConvertCRIPAddressTypeToNSX(v1alpha1.IPAddressTypeIPv4)),
+		},
+		{
+			name:              "Supported_MixedCase_IPv6",
+			ipAddressType:     "IPv6",
+			expectedNSXFamily: strPtr(controllerscommon.ConvertCRIPAddressTypeToNSX(v1alpha1.IPAddressTypeIPv6)),
+		},
+		{
+			name:              "Supported_MixedCase_DualStack",
+			ipAddressType:     "IPv4IPv6",
+			expectedNSXFamily: strPtr(controllerscommon.ConvertCRIPAddressTypeToNSX(v1alpha1.IPAddressTypeIPv4IPv6)),
+		},
+		{
+			name:              "Supported_AllCaps_IPV4",
+			ipAddressType:     "IPV4",
+			expectedNSXFamily: strPtr(controllerscommon.ConvertCRIPAddressTypeToNSX(v1alpha1.IPAddressType("IPV4"))),
+		},
+		{
+			name:              "Supported_AllCaps_IPV6",
+			ipAddressType:     "IPV6",
+			expectedNSXFamily: strPtr(controllerscommon.ConvertCRIPAddressTypeToNSX(v1alpha1.IPAddressType("IPV6"))),
+		},
+		{
+			name:              "Supported_AllCaps_DualStack",
+			ipAddressType:     "IPV4IPV6",
+			expectedNSXFamily: strPtr(controllerscommon.ConvertCRIPAddressTypeToNSX(v1alpha1.IPAddressType("IPV4IPV6"))),
+		},
+	}
+
+	service := newTestService()
+	patches := gomonkey.ApplyMethodFunc(&nsx.Client{}, "NSXCheckVersion", func(feature int) bool {
+		return true
+	})
+	defer patches.Reset()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipReservationCR := &v1alpha1.SubnetIPReservation{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "ipr-1",
+					Namespace: "ns-1",
+					UID:       "ipr-uid-1",
+				},
+				Spec: v1alpha1.SubnetIPReservationSpec{
+					Subnet:        "subnet-1",
+					NumberOfIPs:   10,
+					IPAddressType: tt.ipAddressType,
+				},
+			}
+			nsxIPReservation := service.buildDynamicIPReservation(ipReservationCR, subnetPath)
+			require.Equal(t, tt.expectedNSXFamily, nsxIPReservation.IpAddressType)
+			require.Equal(t, int64(10), *nsxIPReservation.NumberOfIps)
+			require.Equal(t, "ipr-1", *nsxIPReservation.DisplayName)
+			require.Equal(t, baseTags("ns-1", "ipr-1", "ipr-uid-1"), nsxIPReservation.Tags)
+		})
+	}
 }
 
 func TestBuildStaticIPReservation(t *testing.T) {


### PR DESCRIPTION
Add IPv6 and dual-stack support for SubnetIPReservation

Extend SubnetIPReservation to support IPv6 and dual-stack IP
address families for dynamic reservations (numberOfIPs mode).

Static reservations (reservedIPs mode) already pass IP strings
through to NSX as-is, so IPv6 addresses work without a new field;
only docs/comments are updated for that path.

TestDone:

IPv4 SubnetIPReservation:

1. Create IPv4-only Subnet

```yaml
# subnet-ipv4.yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: subnet-ipv4
  namespace: test-ns
spec:
  ipAddressType: IPv4
  ipv4SubnetSize: 64
  accessMode: Private
  advancedConfig:
    staticIPAllocation:
      enabled: true
```

**Wait Subnet Ready：**

```bash
kubectl apply -f subnet-ipv4.yaml -n $NS
kubectl wait subnet subnet-ipv4 -n $NS --for=condition=Ready --timeout=120s

# Record NetworkAddresses in the Subnet 
kubectl get subnet -n $NS -o wide
```
<img width="1476" height="1090" alt="098dea7d-54ca-439c-95cf-ba0a52e017d7" src="https://github.com/user-attachments/assets/6e61817b-c23f-4872-9704-ba1bbbdabdf1" />



2. Create Dynamic IPv4 SubnetIPReservation

```bash
kubectl apply -n $NS -f - <<EOF
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetIPReservation
metadata:
  name: ipr-dynamic-ipv4-default
spec:
  subnet: subnet-ipv4
  numberOfIPs: 5
EOF
```


```bash
# 1. subnetipreservation CR become Ready
kubectl wait subnetipreservation ipr-dynamic-ipv4-default \
  -n $NS --for=condition=Ready --timeout=60s

# 2. There are 5 IPv4 addresses in the Status.IPs 
kubectl get subnetipreservation ipr-dynamic-ipv4-default \
  -n $NS -o jsonpath='{.status.ips}'

# 3. verify in the NSX：
SUBNET_PATH=$(kubectl get subnet subnet-ipv4 -n $NS \
  -o jsonpath='{.status.networkAddresses[0]}')
# Query dynamic-ip-reservations via NSX API to confirm resource existence
# expect that  ip_address_type value is "IPV4"
```

**expected result：**
- CR Ready=True
- `status.ips`  IPv4 address range

<img width="1414" height="670" alt="1cb431fd-ef34-4e4d-ba37-e3c233affdd7" src="https://github.com/user-attachments/assets/537c0a9c-ffa7-460a-b14e-ad4fd4ec0179" />

```
kubectl get subnetipreservation -n test-ns -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  kind: SubnetIPReservation
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetIPReservation","metadata":{"annotations":{},"name":"ipr-dynamic-ipv4-default","namespace":"test-ns"},"spec":{"numberOfIPs":5,"subnet":"subnet-ipv4"}}
    creationTimestamp: "2026-05-20T02:23:03Z"
    generation: 1
    name: ipr-dynamic-ipv4-default
    namespace: test-ns
    resourceVersion: "207903"
    uid: 861c7265-765b-4637-a975-8353267db43a
  spec:
    numberOfIPs: 5
    subnet: subnet-ipv4
  status:
    conditions:
    - lastTransitionTime: "2026-05-20T02:23:04Z"
      message: NSX SubnetIPReservation has been successfully created/updated
      reason: SubnetIPReservationReady
      status: "True"
      type: Ready
    ips:
    - 172.26.0.2-172.26.0.6
kind: List
metadata:
  resourceVersion: ""
```


IPv6 SubnetIPReservation:

1. Create IPv6-only Subnet

```yaml
# subnet-ipv6.yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: subnet-ipv6
  namespace: test-ns
spec:
  ipAddressType: IPv6
  ipv6PrefixLength: 64
  accessMode: Private
  advancedConfig:
    staticIPAllocation:
      enabled: true
```

**Wait Subnet Ready：**

```bash
kubectl apply -f subnet-ipv6-test.yaml -n $NS
kubectl wait subnet subnet-ipv6-test -n $NS --for=condition=Ready --timeout=120s

# Record NetworkAddresses in the Subnet 
kubectl get subnet -n $NS -o wide
```

<img width="1332" height="1110" alt="478063cd-3e4d-48fc-b96e-17d86d57b5dd" src="https://github.com/user-attachments/assets/4767e380-ca98-44ea-b5de-cd305a8e22c7" />


2. Create Dynamic IPv6 SubnetIPReservation

```bash
kubectl apply -n $NS -f - <<EOF
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetIPReservation
metadata:
  name: ipr-dynamic-ipv6
spec:
  subnet: subnet-ipv6
  numberOfIPs: 5
  ipAddressType: IPv6
EOF
```

```bash
# 1. subnetipreservation CR become Ready
kubectl wait subnetipreservation ipr-dynamic-ipv6 \
  -n $NS --for=condition=Ready --timeout=60s

# 2. There are IPv6 addresses in the Status.IPs 
kubectl get subnetipreservation ipr-dynamic-ipv6 \
  -n $NS -o jsonpath='{.status.ips}'


# 3. verify in the NSX：
SUBNET_PATH=$(kubectl get subnet subnet-ipv6 -n $NS \
  -o jsonpath='{.status.networkAddresses[0]}')
# Query dynamic-ip-reservations via NSX API to confirm resource existence
# expect that  ip_address_type value is "IPV6"
```

```
kubectl get subnetipreservation ipr-dynamic-ipv6  -oyaml -n test-ns
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetIPReservation
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetIPReservation","metadata":{"annotations":{},"name":"ipr-dynamic-ipv6","namespace":"test-ns"},"spec":{"ipAddressType":"IPv6","numberOfIPs":5,"subnet":"subnet-ipv6"}}
  creationTimestamp: "2026-06-15T04:17:52Z"
  generation: 1
  name: ipr-dynamic-ipv6
  namespace: test-ns
  resourceVersion: "3437047"
  uid: abb91fb4-ae16-4ea9-b1d9-9afef36a9094
spec:
  ipAddressType: IPv6
  numberOfIPs: 5
  subnet: subnet-ipv6
status:
  conditions:
  - lastTransitionTime: "2026-06-15T04:17:52Z"
    message: NSX SubnetIPReservation has been successfully created/updated
    reason: SubnetIPReservationReady
    status: "True"
    type: Ready
  ips:
  - 2001:db8::ffff:ffff:ffff:fc30-2001:db8::ffff:ffff:ffff:fc34
```

<img width="1764" height="576" alt="e3a3374b-3875-4e5d-8ee5-ca3190374774" src="https://github.com/user-attachments/assets/cc2b72bf-7d31-4752-b21a-de18e66d2f30" />


```
 curl -k -u "${NSX_USER}:${NSX_PASS}"   -X GET   -H "Content-Type: application/json"   "${NSX_MANAGER}/policy/api/v1/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/subnets/subnet-ipv6_lk9kr/dynamic-ip-reservations/ipr-dynamic-ipv6_ppltw"
{
  "ip_address_type" : "IPV6",
  "number_of_ips" : 5,
  "ips" : [ "2001:db8::ffff:ffff:ffff:fc30-2001:db8::ffff:ffff:ffff:fc34" ],
  "resource_type" : "DynamicIpAddressReservation",
  "id" : "ipr-dynamic-ipv6_ppltw",
  "display_name" : "ipr-dynamic-ipv6",
  "tags" : [ {
    "scope" : "nsx-op/cluster",
    "tag" : "6b11585d-9e43-42b2-bc87-9adfbb565b39"
  }, {
    "scope" : "nsx-op/version",
    "tag" : "1.0.0"
  }, {
    "scope" : "nsx-op/namespace",
    "tag" : "test-ns"
  }, {
    "scope" : "nsx-op/subnetipreservation_name",
    "tag" : "ipr-dynamic-ipv6"
  }, {
    "scope" : "nsx-op/subnetipreservation_uid",
    "tag" : "abb91fb4-ae16-4ea9-b1d9-9afef36a9094"
  } ],
  "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/subnets/subnet-ipv6_lk9kr/dynamic-ip-reservations/ipr-dynamic-ipv6_ppltw",
  "relative_path" : "ipr-dynamic-ipv6_ppltw",
  "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/subnets/subnet-ipv6_lk9kr",
  "remote_path" : "",
  "unique_id" : "86610a87-c1da-40a0-9ab1-3e545025e205",
  "realization_id" : "86610a87-c1da-40a0-9ab1-3e545025e205",
  "owner_id" : "5062b9e8-e133-44cf-82d7-301e13f59ed4",
  "marked_for_delete" : false,
  "overridden" : false,
  "_protection" : "REQUIRE_OVERRIDE",
  "_system_owned" : false,
  "_create_time" : 1781497072221,
  "_create_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
  "_last_modified_time" : 1781497072221,
  "_last_modified_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
  "_revision" : 0
}
```



**expected result：**
- CR Ready=True
- `status.ips`  IPv6 address range

