### PR TITLE
Support IPv6 for Subnet/SubnetSet 

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_ipaddressallocations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_ipaddressallocations.yaml
@@ -91,9 +91,9 @@ spec:
                 - message: Value is immutable
                   rule: self == oldSelf
               ipv6AllocationPrefixLength:
-                description: IPv6AllocationPrefixLength specifies the prefix length
-                  of IPv6 addresses. Defaults to 64 when ipAddressType is IPv6 and
-                  this field is not specified.
+                description: |-
+                  IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses.
+                  Defaults to 64 when ipAddressType is IPv6 and this field is not specified.
                 maximum: 128
                 minimum: 64
                 type: integer
@@ -120,9 +120,10 @@ spec:
                 is IPv6
               rule: '!has(self.ipv6AllocationPrefixLength) || self.ipAddressType ==
                 ''IPv6'''
-            - message: ipAddressBlockVisibility cannot be set when ipAddressType is IPv6
-              rule: '!has(self.ipAddressBlockVisibility) || !has(self.ipAddressType) || self.ipAddressType
-                != ''IPv6'''
+            - message: ipAddressBlockVisibility cannot be set when ipAddressType is
+                IPv6
+              rule: '!has(self.ipAddressBlockVisibility) || !has(self.ipAddressType)
+                || self.ipAddressType != ''IPv6'''
           status:
             description: IPAddressAllocationStatus defines the observed state of IPAddressAllocation.
             properties:

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
@@ -197,6 +197,7 @@ spec:
                     - DHCPServer
                     - DHCPRelay
                     - DHCPDeactivated
+                    - DHCPServerStateless
                     type: string
                 type: object
                 x-kubernetes-validations:

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
@@ -146,6 +146,7 @@ spec:
                     - DHCPServer
                     - DHCPRelay
                     - DHCPDeactivated
+                    - DHCPServerStateless
                     type: string
                 type: object
                 x-kubernetes-validations:

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -207,6 +207,7 @@ _Appears in:_
 | `DHCPDeactivated` |  |
 | `DHCPServer` |  |
 | `DHCPRelay` |  |
+| `DHCPServerStateless` |  |
 
 
 #### DHCPv6ServerAdditionalConfig
@@ -258,10 +259,10 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. | Private | Enum: [External Private PrivateTGW] <br /> |
+| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br /> |
 | `allocationSize` _integer_ | AllocationSize specifies the size of IPv4 allocationIPs to be allocated.<br />It should be a power of 2. |  | Minimum: 1 <br /> |
 | `allocationIPs` _string_ | AllocationIPs specifies the Allocated IP addresses in CIDR or single IP Address format. |  |  |
-| `ipv6AllocationPrefixLength` _integer_ | IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses. |  | Maximum: 128 <br />Minimum: 64 <br /> |
+| `ipv6AllocationPrefixLength` _integer_ | IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses.<br />Defaults to 64 when ipAddressType is IPv6 and this field is not specified. |  | Maximum: 128 <br />Minimum: 64 <br /> |
 | `ipAddressType` _[IPAllocationAddressType](#ipallocationaddresstype)_ | IPAddressType specifies the IP address type of the IPAddressAllocation. | IPv4 | Enum: [IPv4 IPv6] <br /> |
 
 
@@ -926,7 +927,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `mode` _[DHCPv6ConfigMode](#dhcpv6configmode)_ | DHCPv6 Mode. DHCPDeactivated will be used if it is not defined. |  | Enum: [DHCPServer DHCPRelay DHCPDeactivated] <br /> |
+| `mode` _[DHCPv6ConfigMode](#dhcpv6configmode)_ | DHCPv6 Mode. DHCPDeactivated will be used if it is not defined. |  | Enum: [DHCPServer DHCPRelay DHCPDeactivated DHCPServerStateless] <br /> |
 | `dhcpv6ServerAdditionalConfig` _[DHCPv6ServerAdditionalConfig](#dhcpv6serveradditionalconfig)_ | Additional DHCPv6 server config for a VPC Subnet. |  |  |
 
 
@@ -1236,7 +1237,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize takes effect, other fields are ignored. |  |  |
+| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  |  |
 | `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  |  |
 | `nsxProject` _string_ | NSX Project the Namespace is associated with. |  |  |
 | `vpcConnectivityProfile` _string_ | VPCConnectivityProfile Path. This profile has configuration related to creating VPC transit gateway attachment. |  |  |

--- a/pkg/apis/vpc/v1alpha1/subnet_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnet_types.go
@@ -14,21 +14,22 @@ type ConnectivityState string
 type IPAddressType string
 
 const (
-	AccessModePublic              string            = "Public"
-	AccessModePrivate             string            = "Private"
-	AccessModeProject             string            = "PrivateTGW"
-	AccessModeL2Only              string            = "L2Only"
-	DHCPConfigModeDeactivated     string            = "DHCPDeactivated"
-	DHCPConfigModeServer          string            = "DHCPServer"
-	DHCPConfigModeRelay           string            = "DHCPRelay"
-	DHCPv6ConfigModeDeactivated   DHCPv6ConfigMode  = "DHCPDeactivated"
-	DHCPv6ConfigModeServer        DHCPv6ConfigMode  = "DHCPServer"
-	DHCPv6ConfigModeRelay         DHCPv6ConfigMode  = "DHCPRelay"
-	ConnectivityStateConnected    ConnectivityState = "Connected"
-	ConnectivityStateDisconnected ConnectivityState = "Disconnected"
-	IPAddressTypeIPv4             IPAddressType     = "IPv4"
-	IPAddressTypeIPv6             IPAddressType     = "IPv6"
-	IPAddressTypeIPv4IPv6         IPAddressType     = "IPv4IPv6"
+	AccessModePublic                string            = "Public"
+	AccessModePrivate               string            = "Private"
+	AccessModeProject               string            = "PrivateTGW"
+	AccessModeL2Only                string            = "L2Only"
+	DHCPConfigModeDeactivated       string            = "DHCPDeactivated"
+	DHCPConfigModeServer            string            = "DHCPServer"
+	DHCPConfigModeRelay             string            = "DHCPRelay"
+	DHCPv6ConfigModeDeactivated     DHCPv6ConfigMode  = "DHCPDeactivated"
+	DHCPv6ConfigModeServer          DHCPv6ConfigMode  = "DHCPServer"
+	DHCPv6ConfigModeRelay           DHCPv6ConfigMode  = "DHCPRelay"
+	DHCPv6ConfigModeServerStateless DHCPv6ConfigMode  = "DHCPServerStateless"
+	ConnectivityStateConnected      ConnectivityState = "Connected"
+	ConnectivityStateDisconnected   ConnectivityState = "Disconnected"
+	IPAddressTypeIPv4               IPAddressType     = "IPv4"
+	IPAddressTypeIPv6               IPAddressType     = "IPv6"
+	IPAddressTypeIPv4IPv6           IPAddressType     = "IPv4IPv6"
 )
 
 // SubnetSpec defines the desired state of Subnet.
@@ -181,7 +182,7 @@ type DHCPv6ServerAdditionalConfig struct {
 // +kubebuilder:validation:XValidation:rule="(!has(self.mode) || self.mode=='DHCPDeactivated' || self.mode=='DHCPRelay') && (!has(self.dhcpv6ServerAdditionalConfig) || !has(self.dhcpv6ServerAdditionalConfig.reservedIPRanges) || size(self.dhcpv6ServerAdditionalConfig.reservedIPRanges)==0) || has(self.mode) && self.mode=='DHCPServer'", message="DHCPv6ServerAdditionalConfig must be cleared when Subnet has DHCP relay enabled or DHCP is deactivated."
 type SubnetDHCPv6Config struct {
 	// DHCPv6 Mode. DHCPDeactivated will be used if it is not defined.
-	// +kubebuilder:validation:Enum=DHCPServer;DHCPRelay;DHCPDeactivated
+	// +kubebuilder:validation:Enum=DHCPServer;DHCPRelay;DHCPDeactivated;DHCPServerStateless
 	Mode DHCPv6ConfigMode `json:"mode,omitempty"`
 	// Additional DHCPv6 server config for a VPC Subnet.
 	DHCPv6ServerAdditionalConfig DHCPv6ServerAdditionalConfig `json:"dhcpv6ServerAdditionalConfig,omitempty"`

--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -25,6 +25,13 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
+const (
+	// NSX API IP Address Types
+	NSXIPAddressTypeIPv4     = "IPV4"
+	NSXIPAddressTypeIPv6     = "IPV6"
+	NSXIPAddressTypeIPv4IPv6 = "IPV4_IPV6"
+)
+
 var (
 	log                     = logger.Log
 	SubnetSetLocks          sync.Map
@@ -615,4 +622,68 @@ func PodIsDeleted(pod *v1.Pod) bool {
 	}
 	return pod.Status.Phase == v1.PodSucceeded ||
 		pod.Status.Phase == v1.PodFailed
+}
+
+// ConvertCRIPAddressTypeToNSX converts CR IPAddressType to NSX API format
+// v1alpha1 format: IPv4, IPv6, IPv4IPv6
+// NSX format: IPV4, IPV6, IPV4_IPV6
+func ConvertCRIPAddressTypeToNSX(crType v1alpha1.IPAddressType) string {
+	switch crType {
+	case v1alpha1.IPAddressTypeIPv4:
+		return NSXIPAddressTypeIPv4
+	case v1alpha1.IPAddressTypeIPv6:
+		return NSXIPAddressTypeIPv6
+	case v1alpha1.IPAddressTypeIPv4IPv6:
+		return NSXIPAddressTypeIPv4IPv6
+	default:
+		log.Warn("Unknown IP address type, defaulting to IPv4", "unknownType", string(crType))
+		return NSXIPAddressTypeIPv4
+	}
+}
+
+// ConvertNSXIPAddressTypeToCR converts NSX API IPAddressType to CR format
+// NSX format: IPV4, IPV6, IPV4_IPV6
+// v1alpha1 format: IPV4, IPV6, IPV4IPV6
+func ConvertNSXIPAddressTypeToCR(nsxType string) v1alpha1.IPAddressType {
+	switch nsxType {
+	case NSXIPAddressTypeIPv4:
+		return v1alpha1.IPAddressTypeIPv4
+	case NSXIPAddressTypeIPv6:
+		return v1alpha1.IPAddressTypeIPv6
+	case NSXIPAddressTypeIPv4IPv6:
+		return v1alpha1.IPAddressTypeIPv4IPv6
+	default:
+		log.Warn("Unknown IP address type, defaulting to IPv4", "unknownType", string(nsxType))
+		return v1alpha1.IPAddressTypeIPv4
+	}
+}
+
+// IntersectIPAddressTypes computes the intersection of multiple IP address types
+// Returns the most restrictive common type, or error if no intersection
+// Example:
+// intersection of [IPv4IPv6, IPv6] should equal IPv6
+// intersection of [IPv4IPv6, IPv4] should equal IPv4
+func IntersectIPAddressTypes(types []v1alpha1.IPAddressType) (v1alpha1.IPAddressType, error) {
+	if len(types) == 0 {
+		return "", fmt.Errorf("no IP address types provided")
+	}
+
+	result := types[0]
+
+	for _, t := range types[1:] {
+		if result == t {
+			continue
+		}
+
+		if result == v1alpha1.IPAddressTypeIPv4IPv6 {
+			result = t // Dual-stack intersects to the more specific type
+		} else if t == v1alpha1.IPAddressTypeIPv4IPv6 {
+			// Dual-stack with single-stack: keep single-stack (more restrictive)
+			continue
+		} else {
+			return "", fmt.Errorf("no intersection between IP address types %s and %s", result, t)
+		}
+	}
+
+	return result, nil
 }

--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -1174,3 +1174,154 @@ func TestPodIsDeleted(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertCRIPAddressTypeToNSX(t *testing.T) {
+	tests := []struct {
+		name     string
+		crType   v1alpha1.IPAddressType
+		expected string
+	}{
+		{
+			name:     "IPv4 conversion",
+			crType:   v1alpha1.IPAddressTypeIPv4,
+			expected: "IPV4",
+		},
+		{
+			name:     "IPv6 conversion",
+			crType:   v1alpha1.IPAddressTypeIPv6,
+			expected: "IPV6",
+		},
+		{
+			name:     "IPv4IPv6 conversion",
+			crType:   v1alpha1.IPAddressTypeIPv4IPv6,
+			expected: "IPV4_IPV6",
+		},
+		{
+			name:     "empty type defaults to IPv4",
+			crType:   v1alpha1.IPAddressType(""),
+			expected: "IPV4",
+		},
+		{
+			name:     "unknown type defaults to IPv4",
+			crType:   v1alpha1.IPAddressType("Unknown"),
+			expected: "IPV4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertCRIPAddressTypeToNSX(tt.crType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConvertNSXIPAddressTypeToCR(t *testing.T) {
+	tests := []struct {
+		name     string
+		nsxType  string
+		expected v1alpha1.IPAddressType
+	}{
+		{
+			name:     "IPV4 conversion",
+			nsxType:  "IPV4",
+			expected: v1alpha1.IPAddressTypeIPv4,
+		},
+		{
+			name:     "IPV6 conversion",
+			nsxType:  "IPV6",
+			expected: v1alpha1.IPAddressTypeIPv6,
+		},
+		{
+			name:     "IPV4_IPV6 conversion",
+			nsxType:  "IPV4_IPV6",
+			expected: v1alpha1.IPAddressTypeIPv4IPv6,
+		},
+		{
+			name:     "empty type defaults to IPv4",
+			nsxType:  "",
+			expected: v1alpha1.IPAddressTypeIPv4,
+		},
+		{
+			name:     "unknown type defaults to IPv4",
+			nsxType:  "UNKNOWN",
+			expected: v1alpha1.IPAddressTypeIPv4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertNSXIPAddressTypeToCR(tt.nsxType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIntersectIPAddressTypes(t *testing.T) {
+	tests := []struct {
+		name        string
+		types       []v1alpha1.IPAddressType
+		expected    v1alpha1.IPAddressType
+		expectedErr bool
+		errMsg      string
+	}{
+		{
+			name:        "single IPv4 type",
+			types:       []v1alpha1.IPAddressType{v1alpha1.IPAddressTypeIPv4},
+			expected:    v1alpha1.IPAddressTypeIPv4,
+			expectedErr: false,
+		},
+		{
+			name:        "IPv4IPv6 with IPv4 returns IPv4",
+			types:       []v1alpha1.IPAddressType{v1alpha1.IPAddressTypeIPv4IPv6, v1alpha1.IPAddressTypeIPv4},
+			expected:    v1alpha1.IPAddressTypeIPv4,
+			expectedErr: false,
+		},
+		{
+			name:        "IPv4IPv6 with IPv6 returns IPv6",
+			types:       []v1alpha1.IPAddressType{v1alpha1.IPAddressTypeIPv4IPv6, v1alpha1.IPAddressTypeIPv6},
+			expected:    v1alpha1.IPAddressTypeIPv6,
+			expectedErr: false,
+		},
+		{
+			name:        "IPv4 with IPv4 same type",
+			types:       []v1alpha1.IPAddressType{v1alpha1.IPAddressTypeIPv4, v1alpha1.IPAddressTypeIPv4},
+			expected:    v1alpha1.IPAddressTypeIPv4,
+			expectedErr: false,
+		},
+		{
+			name:        "IPv4 with IPv6 no intersection",
+			types:       []v1alpha1.IPAddressType{v1alpha1.IPAddressTypeIPv4, v1alpha1.IPAddressTypeIPv6},
+			expected:    "",
+			expectedErr: true,
+			errMsg:      "no intersection",
+		},
+		{
+			name:        "IPv4 with IPv6 with IPv4IPv6 returns IPv4",
+			types:       []v1alpha1.IPAddressType{v1alpha1.IPAddressTypeIPv4, v1alpha1.IPAddressTypeIPv6, v1alpha1.IPAddressTypeIPv4IPv6},
+			expected:    "",
+			expectedErr: true,
+			errMsg:      "no intersection",
+		},
+		{
+			name:        "empty slice",
+			types:       []v1alpha1.IPAddressType{},
+			expected:    "",
+			expectedErr: true,
+			errMsg:      "no IP address types provided",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := IntersectIPAddressTypes(tt.types)
+			if tt.expectedErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -56,6 +56,8 @@ const (
 	NSReasonVPCNetConfigNotReady string = "VPCNetworkConfigurationNotReady"
 	NSReasonVPCNotReady          string = "VPCNotReady"
 	NSReasonVPCSnatNotReady      string = "VPCSnatNotReady"
+
+	IPAddressTypeNone v1alpha1.IPAddressType = ""
 )
 
 var (
@@ -116,7 +118,41 @@ func (r *NetworkInfoReconciler) GetVpcConnectivityProfilePathByVpcPath(vpcPath s
 	return r.Service.GetVpcConnectivityProfilePathByVpcPath(vpcPath)
 }
 
-func (r *NetworkInfoReconciler) updateDefaultSubnetSet(ctx context.Context, subnetSetType string, ns string, nc *v1alpha1.VPCNetworkConfiguration, hasCIDR bool, hasPrecreatedSubnet bool) error {
+// computeSubnetSetIPAddressType computes the intersection of supervisor IP family and VPC connectivity profile capability
+func (r *NetworkInfoReconciler) computeSubnetSetIPAddressType(hasIPv4CIDR, hasIPv6CIDR bool) v1alpha1.IPAddressType {
+	var ipTypes []v1alpha1.IPAddressType
+	supervisorIPFamily := r.Service.NSXConfig.K8sConfig.GetIPAddressType()
+	ipTypes = append(ipTypes, supervisorIPFamily)
+
+	// Determine VPC profile capabilities
+	var vpcIPFamily v1alpha1.IPAddressType
+	if hasIPv4CIDR && hasIPv6CIDR {
+		vpcIPFamily = v1alpha1.IPAddressTypeIPv4IPv6
+	} else if hasIPv6CIDR {
+		vpcIPFamily = v1alpha1.IPAddressTypeIPv6
+	} else if hasIPv4CIDR {
+		vpcIPFamily = v1alpha1.IPAddressTypeIPv4
+	}
+	if vpcIPFamily != "" {
+		ipTypes = append(ipTypes, vpcIPFamily)
+	}
+
+	// Compute intersection using common utility
+	intersectedType, err := common.IntersectIPAddressTypes(ipTypes)
+	if err != nil {
+		// If no intersection, return empty IPAddressType
+		log.Info("No intersection of IP address types found between supervisor and VPC profile", "error", err, "supervisor", supervisorIPFamily, "vpc", vpcIPFamily)
+		return IPAddressTypeNone
+	}
+
+	return intersectedType
+}
+
+// updateDefaultSubnetSet creates or updates the default SubnetSet for a network type.
+// autoCreatedIPAddressType: empty string means no compatible IP address type was found;
+//                           this triggers deletion of the auto-created SubnetSet if it exists.
+
+func (r *NetworkInfoReconciler) updateDefaultSubnetSet(ctx context.Context, subnetSetType string, ns string, nc *v1alpha1.VPCNetworkConfiguration, hasPrecreatedSubnet bool, autoCreatedIPAddressType v1alpha1.IPAddressType) error {
 	var name string
 	var accessMode v1alpha1.AccessMode
 	// TODO: remove this old Label when all other dependencies consume the new label
@@ -129,8 +165,6 @@ func (r *NetworkInfoReconciler) updateDefaultSubnetSet(ctx context.Context, subn
 		accessMode = v1alpha1.AccessMode(v1alpha1.AccessModePrivate)
 	}
 
-	ipFamily := r.Service.NSXConfig.K8sConfig.GetIPAddressType()
-
 	if err := retry.OnError(retry.DefaultRetry, func(err error) bool {
 		return err != nil
 	}, func() error {
@@ -140,23 +174,24 @@ func (r *NetworkInfoReconciler) updateDefaultSubnetSet(ctx context.Context, subn
 		}
 		if subnetSetCR != nil {
 			// Delete the default SubnetSet if it is created with auto-created Subnets and there is no cidr
-			if !hasCIDR && subnetSetCR.Spec.SubnetNames == nil {
+			if autoCreatedIPAddressType == IPAddressTypeNone && subnetSetCR.Spec.SubnetNames == nil {
 				log.Debug("Delete default SubnetSet", commonservice.LabelDefaultNetwork, subnetSetType, "Namespace", ns)
 				return r.Client.Delete(ctx, subnetSetCR)
 			}
-			// Do nothing if the default SubnetSet already exists. IPv6PrefixLength is immutable in NSX
-			// once subnets are created, so changes in VPCNetworkConfiguration must not be propagated
-			// to existing SubnetSets.
+			// Do nothing if the default SubnetSet already exists.
 			log.Debug("Default SubnetSet already exists", commonservice.LabelDefaultNetwork, subnetSetType, "Namespace", ns, "auto-created", subnetSetCR.Spec.SubnetNames == nil)
 			return nil
 		}
 		// Only create the auto-created SubnetSet if there is no pre-created Subnet for default network
-		if !hasPrecreatedSubnet && hasCIDR {
-			spec := v1alpha1.SubnetSetSpec{AccessMode: accessMode}
-			if util.IPAddressTypeIncludesIPv4(ipFamily) {
+		if !hasPrecreatedSubnet && autoCreatedIPAddressType != IPAddressTypeNone {
+			spec := v1alpha1.SubnetSetSpec{
+				IPAddressType: autoCreatedIPAddressType,
+				AccessMode:    accessMode,
+			}
+			if util.IPAddressTypeIncludesIPv4(autoCreatedIPAddressType) {
 				spec.IPv4SubnetSize = nc.Spec.DefaultSubnetSize
 			}
-			if util.IPAddressTypeIncludesIPv6(ipFamily) {
+			if util.IPAddressTypeIncludesIPv6(autoCreatedIPAddressType) {
 				spec.IPv6PrefixLength = nc.Spec.DefaultIPv6PrefixLength
 			}
 			obj := &v1alpha1.SubnetSet{
@@ -318,16 +353,6 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		nsxLBSPath = r.Service.GetDefaultNSXLBSPathByVPC(*createdVpc.Id)
 	}
 
-	// Check private cidr to determine if create default SubnetSet for VM
-	if namespaceType == common.NormalNs {
-		hasPrivateCidr := len(privateIPs) > 0
-		if err := r.updateDefaultSubnetSet(ctx, commonservice.DefaultVMNetwork, req.Namespace, nc, hasPrivateCidr, hasVMDefaultSubnets(nc.Spec.Subnets)); err != nil {
-			r.StatusUpdater.UpdateFail(ctx, networkInfoCR, err, "Failed to create or update default SubnetSet for VM", setNetworkInfoVPCStatusWithError, nil)
-			setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCCreateUpdateError.getNSNetworkCondition(err))
-			return common.ResultNormal, err
-		}
-	}
-
 	snatIP, aviSubnetPath, lbIP := "", "", ""
 	var lbBackendIPs []string
 	var networkStack v1alpha1.NetworkStackType
@@ -338,22 +363,14 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return common.ResultRequeueAfter10sec, err
 	}
 
+	var vpcConnectivityProfile *model.VpcConnectivityProfile
 	// Only process vpcConnectivityProfile-dependent logic if path exists
 	if len(vpcConnectivityProfilePath) > 0 {
-		vpcConnectivityProfile, err := r.Service.GetVpcConnectivityProfile(nc, vpcConnectivityProfilePath)
+		vpcConnectivityProfile, err = r.Service.GetVpcConnectivityProfile(nc, vpcConnectivityProfilePath)
 		if err != nil {
 			r.StatusUpdater.UpdateFail(ctx, networkInfoCR, err, "Failed to get VPC connectivity profile", setNetworkInfoVPCStatusWithError, nil)
 			setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCGetExtIPBlockError.getNSNetworkCondition(err))
 			return common.ResultRequeueAfter10sec, err
-		}
-		// Check privatetgw IP blocks to determine if create default SubnetSet for Pod
-		if namespaceType == common.NormalNs {
-			hasPrivateTgwCidr := len(vpcConnectivityProfile.PrivateTgwIpBlocks) > 0
-			if err := r.updateDefaultSubnetSet(ctx, commonservice.DefaultPodNetwork, req.Namespace, nc, hasPrivateTgwCidr, hasPodDefaultSubnets(nc.Spec.Subnets)); err != nil {
-				r.StatusUpdater.UpdateFail(ctx, networkInfoCR, err, "Failed to create or update default SubnetSet for Pod", setNetworkInfoVPCStatusWithError, nil)
-				setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCCreateUpdateError.getNSNetworkCondition(err))
-				return common.ResultNormal, err
-			}
 		}
 
 		// Check external IP blocks on system VPC network config.
@@ -392,6 +409,35 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				log.Info("Requeue NetworkInfo CR because VPCNetworkConfiguration system is not ready", "autoSnatEnabled", autoSnatEnabled, "networkStack", networkStack, "req", req)
 				retryWithSystemVPC = true
 				systemNSCondition = nsMsgVPCAutoSNATDisabled.getNSNetworkCondition()
+			}
+		}
+	}
+
+	if namespaceType == common.NormalNs {
+		// Check private cidr to determine if create default SubnetSet for VM
+		hasPrivateCidr := len(privateIPs) > 0
+		var hasIPv6Blocks bool
+		if vpcConnectivityProfile != nil {
+			hasIPv6Blocks = len(vpcConnectivityProfile.Ipv6Blocks) > 0
+		} else {
+			hasIPv6Blocks = false
+		}
+		autoCreatedVMIPAddressType := r.computeSubnetSetIPAddressType(hasPrivateCidr, hasIPv6Blocks)
+		log.Debug("IPAddressType for vm default SubnetSet is calculated", "autoCreatedVMIPAddressType", autoCreatedVMIPAddressType, "Namespace", req.Namespace)
+		if err := r.updateDefaultSubnetSet(ctx, commonservice.DefaultVMNetwork, req.Namespace, nc, hasVMDefaultSubnets(nc.Spec.Subnets), autoCreatedVMIPAddressType); err != nil {
+			r.StatusUpdater.UpdateFail(ctx, networkInfoCR, err, "Failed to create or update default SubnetSet for VM", setNetworkInfoVPCStatusWithError, nil)
+			setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCCreateUpdateError.getNSNetworkCondition(err))
+			return common.ResultNormal, err
+		}
+		// Check privatetgw IP blocks to determine if create default SubnetSet for Pod
+		if vpcConnectivityProfile != nil {
+			hasPrivateTgwCidr := len(vpcConnectivityProfile.PrivateTgwIpBlocks) > 0
+			autoCreatedPodIPAddressType := r.computeSubnetSetIPAddressType(hasPrivateTgwCidr, hasIPv6Blocks)
+			log.Debug("IPAddressType for pod default SubnetSet is calculated", "autoCreatedPodIPAddressType", autoCreatedPodIPAddressType, "Namespace", req.Namespace)
+			if err := r.updateDefaultSubnetSet(ctx, commonservice.DefaultPodNetwork, req.Namespace, nc, hasPodDefaultSubnets(nc.Spec.Subnets), autoCreatedPodIPAddressType); err != nil {
+				r.StatusUpdater.UpdateFail(ctx, networkInfoCR, err, "Failed to create or update default SubnetSet for Pod", setNetworkInfoVPCStatusWithError, nil)
+				setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCCreateUpdateError.getNSNetworkCondition(err))
+				return common.ResultNormal, err
 			}
 		}
 	}

--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -2215,6 +2215,124 @@ func TestNetworkInfoReconciler_RestoreReconcile(t *testing.T) {
 	}
 }
 
+func TestNetworkInfoReconciler_ComputeSubnetSetIPAddressType(t *testing.T) {
+	tests := []struct {
+		name               string
+		supervisorIPFamily v1alpha1.IPAddressType
+		hasIPv4CIDR        bool
+		hasIPv6CIDR        bool
+		expected           v1alpha1.IPAddressType
+		expectedErr        bool
+	}{
+		{
+			name:               "Both supervisor and VPC support IPv4 and IPv6",
+			supervisorIPFamily: v1alpha1.IPAddressTypeIPv4IPv6,
+			hasIPv4CIDR:        true,
+			hasIPv6CIDR:        true,
+			expected:           v1alpha1.IPAddressTypeIPv4IPv6,
+			expectedErr:        false,
+		},
+		{
+			name:               "Supervisor IPv4IPv6 with VPC IPv4 only",
+			supervisorIPFamily: v1alpha1.IPAddressTypeIPv4IPv6,
+			hasIPv4CIDR:        true,
+			hasIPv6CIDR:        false,
+			expected:           v1alpha1.IPAddressTypeIPv4,
+			expectedErr:        false,
+		},
+		{
+			name:               "Supervisor IPv4IPv6 with VPC IPv6 only",
+			supervisorIPFamily: v1alpha1.IPAddressTypeIPv4IPv6,
+			hasIPv4CIDR:        false,
+			hasIPv6CIDR:        true,
+			expected:           v1alpha1.IPAddressTypeIPv6,
+			expectedErr:        false,
+		},
+		{
+			name:               "Supervisor IPv4 with VPC IPv4 and IPv6",
+			supervisorIPFamily: v1alpha1.IPAddressTypeIPv4,
+			hasIPv4CIDR:        true,
+			hasIPv6CIDR:        true,
+			expected:           v1alpha1.IPAddressTypeIPv4,
+			expectedErr:        false,
+		},
+		{
+			name:               "Supervisor IPv4 with VPC IPv6 only - no intersection",
+			supervisorIPFamily: v1alpha1.IPAddressTypeIPv4,
+			hasIPv4CIDR:        false,
+			hasIPv6CIDR:        true,
+			expected:           "",
+			expectedErr:        true,
+		},
+		{
+			name:               "Supervisor IPv6 with VPC IPv4 only - no intersection",
+			supervisorIPFamily: v1alpha1.IPAddressTypeIPv6,
+			hasIPv4CIDR:        true,
+			hasIPv6CIDR:        false,
+			expected:           "",
+			expectedErr:        true,
+		},
+		{
+			name:               "Supervisor IPv4 with VPC IPv4 only",
+			supervisorIPFamily: v1alpha1.IPAddressTypeIPv4,
+			hasIPv4CIDR:        true,
+			hasIPv6CIDR:        false,
+			expected:           v1alpha1.IPAddressTypeIPv4,
+			expectedErr:        false,
+		},
+		{
+			name:               "Supervisor IPv6 with VPC IPv6 only",
+			supervisorIPFamily: v1alpha1.IPAddressTypeIPv6,
+			hasIPv4CIDR:        false,
+			hasIPv6CIDR:        true,
+			expected:           v1alpha1.IPAddressTypeIPv6,
+			expectedErr:        false,
+		},
+		{
+			name:               "VPC has no CIDR blocks",
+			supervisorIPFamily: v1alpha1.IPAddressTypeIPv4IPv6,
+			hasIPv4CIDR:        false,
+			hasIPv6CIDR:        false,
+			expected:           v1alpha1.IPAddressTypeIPv4IPv6,
+			expectedErr:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reconciler := &NetworkInfoReconciler{
+				Service: &vpc.VPCService{
+					Service: servicecommon.Service{
+						NSXConfig: &config.NSXOperatorConfig{
+							NsxConfig: &config.NsxConfig{
+								EnforcementPoint: "test-ep",
+							},
+						},
+					},
+				},
+			}
+
+			// Mock the GetIPAddressType method
+			patches := gomonkey.ApplyMethod(
+				reflect.TypeOf(reconciler.Service.NSXConfig.K8sConfig),
+				"GetIPAddressType",
+				func(_ *config.K8sConfig) v1alpha1.IPAddressType {
+					return tt.supervisorIPFamily
+				},
+			)
+			defer patches.Reset()
+
+			result := reconciler.computeSubnetSetIPAddressType(tt.hasIPv4CIDR, tt.hasIPv6CIDR)
+
+			if tt.expectedErr {
+				assert.Equal(t, v1alpha1.IPAddressType(""), result, "Expected empty result for error case")
+			} else {
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
 func TestNetworkInfoReconciler_UpdateDefaultSubnetSet(t *testing.T) {
 	subnetSet := &v1alpha1.SubnetSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2228,34 +2346,44 @@ func TestNetworkInfoReconciler_UpdateDefaultSubnetSet(t *testing.T) {
 		},
 	}
 	testCases := []struct {
-		name                string
-		hasCIDR             bool
-		hasPrecreatedSubnet bool
-		subnetSetList       []client.Object
-		expectErrStr        string
+		name                     string
+		autoCreatedIPAddressType v1alpha1.IPAddressType
+		hasPrecreatedSubnet      bool
+		subnetSetList            []client.Object
+		expectErrStr             string
 	}{
 		{
-			name:                "Create default SubnetSet",
-			hasCIDR:             true,
-			hasPrecreatedSubnet: false,
+			name:                     "Create default SubnetSet",
+			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv4,
+			hasPrecreatedSubnet:      false,
 		},
 		{
-			name:                "Delete default SubnetSet 1",
-			hasCIDR:             false,
-			hasPrecreatedSubnet: false,
-			subnetSetList:       []client.Object{subnetSet},
+			name:                     "Delete default SubnetSet 1",
+			autoCreatedIPAddressType: "",
+			hasPrecreatedSubnet:      false,
+			subnetSetList:            []client.Object{subnetSet},
 		},
 		{
-			name:                "Delete default SubnetSet 2",
-			hasCIDR:             false,
-			hasPrecreatedSubnet: true,
-			subnetSetList:       []client.Object{subnetSet},
+			name:                     "Delete default SubnetSet 2",
+			autoCreatedIPAddressType: "",
+			hasPrecreatedSubnet:      true,
+			subnetSetList:            []client.Object{subnetSet},
 		},
 		{
-			name:                "Existing default SubnetSet",
-			hasCIDR:             true,
-			hasPrecreatedSubnet: false,
-			subnetSetList:       []client.Object{subnetSet},
+			name:                     "Existing default SubnetSet",
+			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv4,
+			hasPrecreatedSubnet:      false,
+			subnetSetList:            []client.Object{subnetSet},
+		},
+		{
+			name:                     "Create default SubnetSet with IPv6",
+			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv6,
+			hasPrecreatedSubnet:      false,
+		},
+		{
+			name:                     "Create default SubnetSet with dual stack",
+			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv4IPv6,
+			hasPrecreatedSubnet:      false,
 		},
 	}
 
@@ -2270,7 +2398,7 @@ func TestNetworkInfoReconciler_UpdateDefaultSubnetSet(t *testing.T) {
 					DefaultIPv6PrefixLength: 80,
 				},
 			}
-			err := r.updateDefaultSubnetSet(ctx, "pod", "ns-1", nc, tc.hasCIDR, tc.hasPrecreatedSubnet)
+			err := r.updateDefaultSubnetSet(ctx, "pod", "ns-1", nc, tc.hasPrecreatedSubnet, tc.autoCreatedIPAddressType)
 			if tc.expectErrStr != "" {
 				assert.ErrorContains(t, err, tc.expectErrStr)
 			} else {

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	stderrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
@@ -341,15 +342,41 @@ func (r *SubnetReconciler) handleSharedSubnet(ctx context.Context, subnetCR *v1a
 
 func setSubnetReadyStatusTrue(client client.Client, ctx context.Context, obj client.Object, transitionTime metav1.Time, _ ...interface{}) {
 	subnetCR := obj.(*v1alpha1.Subnet)
-	dhcpMode := subnetCR.Spec.SubnetDHCPConfig.Mode
-	if dhcpMode == "" {
-		dhcpMode = v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated)
+
+	// Build DHCP mode strings only for enabled address types
+	var statusMsgs []string
+
+	// Check DHCPv4 if IPv4 is enabled
+	if util.IPAddressTypeIncludesIPv4(subnetCR.Spec.IPAddressType) {
+		dhcpMode := subnetCR.Spec.SubnetDHCPConfig.Mode
+		if dhcpMode == "" {
+			dhcpMode = v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated)
+		}
+		statusMsgs = append(statusMsgs, fmt.Sprintf("DHCPv4: %s", dhcpMode))
 	}
+
+	// Check DHCPv6 if IPv6 is enabled
+	if util.IPAddressTypeIncludesIPv6(subnetCR.Spec.IPAddressType) {
+		dhcpv6Mode := subnetCR.Spec.SubnetDHCPv6Config.Mode
+		if dhcpv6Mode == "" {
+			dhcpv6Mode = v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeDeactivated)
+		}
+		statusMsgs = append(statusMsgs, fmt.Sprintf("DHCPv6: %s", dhcpv6Mode))
+	}
+
+	// Build the message
+	var message string
+	if len(statusMsgs) > 0 {
+		message = fmt.Sprintf("NSX Subnet with %s has been successfully created/updated", strings.Join(statusMsgs, ", "))
+	} else {
+		message = "NSX Subnet has been successfully created/updated"
+	}
+
 	newConditions := []v1alpha1.Condition{
 		{
 			Type:               v1alpha1.Ready,
 			Status:             v1.ConditionTrue,
-			Message:            fmt.Sprintf("NSX Subnet with %s has been successfully created/updated", dhcpMode),
+			Message:            message,
 			Reason:             "SubnetReady",
 			LastTransitionTime: transitionTime,
 		},

--- a/pkg/controllers/subnet/subnet_controller_test.go
+++ b/pkg/controllers/subnet/subnet_controller_test.go
@@ -804,6 +804,127 @@ func TestSubnetReconciler_Reconcile(t *testing.T) {
 			expectErrStr:     "vpc not found",
 			expectRes:        ResultNormal,
 		},
+		{
+			name: "Create Subnet with IPv6",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
+			patches: func(r *SubnetReconciler) *gomonkey.Patches {
+				vpcnetworkConfig := &v1alpha1.VPCNetworkConfiguration{Spec: v1alpha1.VPCNetworkConfigurationSpec{DefaultIPv6PrefixLength: 64}}
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*v1alpha1.VPCNetworkConfiguration, error) {
+					return vpcnetworkConfig, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetNetworkStackFromNC", func(_ *vpc.VPCService, config *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
+					return v1alpha1.FullStackVPC, nil
+				})
+				patches.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnet", func(_ *SubnetReconciler, _ context.Context, _ *v1alpha1.Subnet) []v1alpha1.SubnetConnectionBindingMap {
+					return []v1alpha1.SubnetConnectionBindingMap{}
+				})
+				tags := []model.Tag{{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-tag")}}
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "GenerateSubnetNSTags", func(_ *subnet.SubnetService, obj client.Object) []model.Tag {
+					return tags
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "ListVPCInfo", func(_ *vpc.VPCService, ns string) []common.VPCResourceInfo {
+					return []common.VPCResourceInfo{
+						{OrgID: "org-id", ProjectID: "project-id", VPCID: "vpc-id", ID: "fake-id"},
+					}
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (*model.VpcSubnet, error) {
+					return nil, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "IsDefaultNSXProject", func(_ *vpc.VPCService, orgID, projectID string) (bool, error) {
+					return false, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService.SubnetStore), "GetByIndex", func(_ *subnet.SubnetStore, key string, value string) []*model.VpcSubnet {
+					id1 := "fake-id"
+					path := "/orgs/default/projects/project-id/vpcs/vpc-id/subnets/subnet_fake-path"
+					tags := []model.Tag{
+						{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-subnet-uid-2")},
+						{Scope: common.String(common.TagScopeSubnetCRName), Tag: common.String("test-subnet")},
+					}
+					return []*model.VpcSubnet{{Id: &id1, Path: &path, Tags: tags}}
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetStatus", func(_ *subnet.SubnetService, _ *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
+					fakeStatus := model.VpcSubnetStatus{}
+					value := ""
+					fakeStatus.GatewayAddress = &value
+					fakeStatus.DhcpServerAddress = &value
+					fakeStatus.NetworkAddress = &value
+					return []model.VpcSubnetStatus{fakeStatus}, nil
+				})
+				return patches
+			},
+			existingSubnetCR: &v1alpha1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-subnet", Namespace: "default"},
+				Spec: v1alpha1.SubnetSpec{
+					IPAddressType:    v1alpha1.IPAddressTypeIPv6,
+					IPv6PrefixLength: 64,
+					SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+						Mode: v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeServer),
+					},
+				},
+			},
+			expectRes: ResultNormal,
+		},
+		{
+			name: "Create Subnet with IPv4IPv6 and DHCPv6 Stateless",
+			req:  ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-subnet"}},
+			patches: func(r *SubnetReconciler) *gomonkey.Patches {
+				vpcnetworkConfig := &v1alpha1.VPCNetworkConfiguration{Spec: v1alpha1.VPCNetworkConfigurationSpec{DefaultSubnetSize: 24, DefaultIPv6PrefixLength: 80}}
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*v1alpha1.VPCNetworkConfiguration, error) {
+					return vpcnetworkConfig, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetNetworkStackFromNC", func(_ *vpc.VPCService, config *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
+					return v1alpha1.FullStackVPC, nil
+				})
+				patches.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBindingCRsBySubnet", func(_ *SubnetReconciler, _ context.Context, _ *v1alpha1.Subnet) []v1alpha1.SubnetConnectionBindingMap {
+					return []v1alpha1.SubnetConnectionBindingMap{}
+				})
+				tags := []model.Tag{{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-tag")}}
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "GenerateSubnetNSTags", func(_ *subnet.SubnetService, obj client.Object) []model.Tag {
+					return tags
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "ListVPCInfo", func(_ *vpc.VPCService, ns string) []common.VPCResourceInfo {
+					return []common.VPCResourceInfo{
+						{OrgID: "org-id", ProjectID: "project-id", VPCID: "vpc-id", ID: "fake-id"},
+					}
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "CreateOrUpdateSubnet", func(_ *subnet.SubnetService, obj client.Object, vpcInfo common.VPCResourceInfo, tags []model.Tag) (*model.VpcSubnet, error) {
+					return nil, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "IsDefaultNSXProject", func(_ *vpc.VPCService, orgID, projectID string) (bool, error) {
+					return false, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService.SubnetStore), "GetByIndex", func(_ *subnet.SubnetStore, key string, value string) []*model.VpcSubnet {
+					id1 := "fake-id"
+					path := "/orgs/default/projects/project-id/vpcs/vpc-id/subnets/subnet_fake-path"
+					tags := []model.Tag{
+						{Scope: common.String(common.TagScopeSubnetCRUID), Tag: common.String("fake-subnet-uid-2")},
+						{Scope: common.String(common.TagScopeSubnetCRName), Tag: common.String("test-subnet")},
+					}
+					return []*model.VpcSubnet{{Id: &id1, Path: &path, Tags: tags}}
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetStatus", func(_ *subnet.SubnetService, _ *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
+					fakeStatus := model.VpcSubnetStatus{}
+					value := ""
+					fakeStatus.GatewayAddress = &value
+					fakeStatus.DhcpServerAddress = &value
+					fakeStatus.NetworkAddress = &value
+					return []model.VpcSubnetStatus{fakeStatus}, nil
+				})
+				return patches
+			},
+			existingSubnetCR: &v1alpha1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-subnet", Namespace: "default"},
+				Spec: v1alpha1.SubnetSpec{
+					IPAddressType:    v1alpha1.IPAddressTypeIPv4IPv6,
+					IPv4SubnetSize:   24,
+					IPv6PrefixLength: 80,
+					SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+						Mode: v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeServerStateless),
+					},
+				},
+			},
+			expectRes: ResultNormal,
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -67,14 +67,40 @@ func (r *SubnetSetReconciler) UpdateSubnetSetForSubnetNames(ctx context.Context,
 			specChanged = true
 		}
 	}
+	subnetsetCR.Spec.SubnetNames = &dedupSubnetNames
+
+	if subnetsetCR.Spec.IPAddressType == "" {
+		// IPAddressType should be the intersection of subnet types and supervisor IP family
+		supervisorIPFamily := r.SubnetService.NSXConfig.K8sConfig.GetIPAddressType()
+		var subnetIPTypes []v1alpha1.IPAddressType
+		subnetIPTypes = append(subnetIPTypes, supervisorIPFamily)
+
+		// Collect IP address types from all referenced subnets
+		for _, subnetName := range *subnetsetCR.Spec.SubnetNames {
+			subnet := &v1alpha1.Subnet{}
+			if err := r.Client.Get(ctx, types.NamespacedName{Namespace: subnetsetCR.Namespace, Name: subnetName}, subnet); err != nil {
+				return err
+			}
+			subnetIPTypes = append(subnetIPTypes, subnet.Spec.IPAddressType)
+		}
+
+		// Compute intersection and update SubnetSet
+		intersectedType, err := common.IntersectIPAddressTypes(subnetIPTypes)
+		if err != nil {
+			return fmt.Errorf("IP address types of Subnets in SubnetSet do not have intersection: %v, ipTypes: %v", err, subnetIPTypes)
+		}
+		subnetsetCR.Spec.IPAddressType = intersectedType
+		specChanged = true
+	}
+
 	if specChanged {
-		subnetsetCR.Spec.SubnetNames = &dedupSubnetNames
 		err := r.Client.Update(ctx, subnetsetCR)
 		if err != nil {
 			r.StatusUpdater.UpdateFail(ctx, subnetsetCR, err, "Failed to update SubnetSet", setSubnetSetReadyStatusFalse)
 			return err
 		}
 	}
+
 	// Update Subnet Info on SubnetSet
 	var subnetInfoList []v1alpha1.SubnetInfo
 	for _, subnetName := range *subnetsetCR.Spec.SubnetNames {
@@ -215,6 +241,11 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		subnetsetCR.Spec.IPv6PrefixLength = vpcNetworkConfig.Spec.DefaultIPv6PrefixLength
 		specChanged = true
 	}
+	// Set explicit IPv4 default for auto-created SubnetSets when IPAddressType is not set
+	if subnetsetCR.Spec.IPAddressType == "" {
+		subnetsetCR.Spec.IPAddressType = v1alpha1.IPAddressTypeIPv4
+		specChanged = true
+	}
 	isSystemNs, err := util.IsVPCSystemNamespace(r.Client, subnetsetCR.Namespace, nil)
 	if err != nil {
 		r.StatusUpdater.UpdateFail(ctx, subnetsetCR, err, "Failed to update SubnetSet", setSubnetSetReadyStatusFalse)
@@ -256,7 +287,7 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			r.StatusUpdater.UpdateSuccess(ctx, subnetsetCR, setSubnetSetReadyStatusTrue)
 			return ResultNormal, nil
 		}
-		if err := r.SubnetService.UpdateSubnetSet(subnetsetCR.Namespace, nsxSubnets, tags, string(subnetsetCR.Spec.SubnetDHCPConfig.Mode)); err != nil {
+		if err := r.SubnetService.UpdateSubnetSet(subnetsetCR.Namespace, nsxSubnets, tags, subnetsetCR); err != nil {
 			r.StatusUpdater.UpdateFail(ctx, subnetsetCR, err, "Failed to update SubnetSet", setSubnetSetReadyStatusFalse)
 			return ResultNormal, err
 		}

--- a/pkg/controllers/subnetset/subnetset_controller_test.go
+++ b/pkg/controllers/subnetset/subnetset_controller_test.go
@@ -112,7 +112,9 @@ func createFakeSubnetSetReconciler(objs []client.Object) *SubnetSetReconciler {
 					EnforcementPoint:   "vmc-enforcementpoint",
 					UseAVILoadBalancer: false,
 				},
-				K8sConfig: &config.K8sConfig{},
+				K8sConfig: &config.K8sConfig{
+					IPFamily: "IPv4",
+				},
 			},
 		},
 		SubnetStore: &subnet.SubnetStore{},
@@ -301,7 +303,7 @@ func TestReconcile(t *testing.T) {
 					vpcSubnet3 := model.VpcSubnet{Id: &id1, Path: &path, Tags: basicTags2}
 					return []*model.VpcSubnet{&vpcSubnet1, &vpcSubnet2, &vpcSubnet3}
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "UpdateSubnetSet", func(_ *subnet.SubnetService, ns string, vpcSubnets []*model.VpcSubnet, tags []model.Tag, dhcpMode string) error {
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "UpdateSubnetSet", func(_ *subnet.SubnetService, ns string, vpcSubnets []*model.VpcSubnet, tags []model.Tag, subnetsetCR *v1alpha1.SubnetSet) error {
 					return nil
 				})
 				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetNetworkStackFromNC", func(_ *vpc.VPCService, config *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
@@ -349,7 +351,7 @@ func TestReconcile(t *testing.T) {
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "RestoreSubnetSet", func(_ *subnet.SubnetService, obj *v1alpha1.SubnetSet, vpcInfo common.VPCResourceInfo, tags []model.Tag) error {
 					return nil
 				})
-				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "UpdateSubnetSet", func(_ *subnet.SubnetService, ns string, vpcSubnets []*model.VpcSubnet, tags []model.Tag, dhcpMode string) error {
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "UpdateSubnetSet", func(_ *subnet.SubnetService, ns string, vpcSubnets []*model.VpcSubnet, tags []model.Tag, subnetsetCR *v1alpha1.SubnetSet) error {
 					return nil
 				})
 				patches.ApplyMethod(reflect.TypeOf(r.VPCService), "GetVPCNetworkConfigByNamespace", func(_ *vpc.VPCService, ns string) (*v1alpha1.VPCNetworkConfiguration, error) {
@@ -405,6 +407,9 @@ func TestUpdateSubnetSetForSubnetNames(t *testing.T) {
 			subnets: []*v1alpha1.Subnet{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "subnet-1", Namespace: "ns-1"},
+					Spec: v1alpha1.SubnetSpec{
+						IPAddressType: v1alpha1.IPAddressTypeIPv4,
+					},
 					Status: v1alpha1.SubnetStatus{
 						Conditions:       []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: v12.ConditionTrue}},
 						GatewayAddresses: []string{"10.0.0.1/28"},
@@ -412,6 +417,9 @@ func TestUpdateSubnetSetForSubnetNames(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "subnet-2", Namespace: "ns-1"},
+					Spec: v1alpha1.SubnetSpec{
+						IPAddressType: v1alpha1.IPAddressTypeIPv4,
+					},
 					Status: v1alpha1.SubnetStatus{
 						Conditions:       []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: v12.ConditionTrue}},
 						GatewayAddresses: []string{"10.0.0.17/28"},
@@ -437,6 +445,9 @@ func TestUpdateSubnetSetForSubnetNames(t *testing.T) {
 						Name:      "subnet-1",
 						Namespace: "ns-1",
 					},
+					Spec: v1alpha1.SubnetSpec{
+						IPAddressType: v1alpha1.IPAddressTypeIPv4,
+					},
 					Status: v1alpha1.SubnetStatus{
 						Conditions:       []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: v12.ConditionTrue}},
 						GatewayAddresses: []string{"10.0.0.1/28"},
@@ -447,6 +458,9 @@ func TestUpdateSubnetSetForSubnetNames(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "subnet-2",
 						Namespace: "ns-1",
+					},
+					Spec: v1alpha1.SubnetSpec{
+						IPAddressType: v1alpha1.IPAddressTypeIPv4,
 					},
 					Status: v1alpha1.SubnetStatus{
 						Conditions:          []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: v12.ConditionTrue}},
@@ -475,6 +489,9 @@ func TestUpdateSubnetSetForSubnetNames(t *testing.T) {
 						Name:      "subnet-1",
 						Namespace: "ns-1",
 					},
+					Spec: v1alpha1.SubnetSpec{
+						IPAddressType: v1alpha1.IPAddressTypeIPv4,
+					},
 					Status: v1alpha1.SubnetStatus{
 						Conditions:       []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: v12.ConditionTrue}},
 						GatewayAddresses: []string{"10.0.0.1/28"},
@@ -485,6 +502,9 @@ func TestUpdateSubnetSetForSubnetNames(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "subnet-2",
 						Namespace: "ns-1",
+					},
+					Spec: v1alpha1.SubnetSpec{
+						IPAddressType: v1alpha1.IPAddressTypeIPv4,
 					},
 					Status: v1alpha1.SubnetStatus{},
 				},
@@ -547,6 +567,7 @@ func TestReconcileWithSubnetConnectionBindingMaps(t *testing.T) {
 			AccessMode:       v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
 			IPv4SubnetSize:   16,
 			IPv6PrefixLength: testSubnetSetIPv6PrefixLen,
+			IPAddressType:    v1alpha1.IPAddressTypeIPv4,
 		},
 	}
 	testSubnetSet2 := &v1alpha1.SubnetSet{
@@ -561,6 +582,7 @@ func TestReconcileWithSubnetConnectionBindingMaps(t *testing.T) {
 			AccessMode:       v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
 			IPv4SubnetSize:   16,
 			IPv6PrefixLength: testSubnetSetIPv6PrefixLen,
+			IPAddressType:    v1alpha1.IPAddressTypeIPv4,
 		},
 	}
 	deleteTime := metav1.Now()

--- a/pkg/controllers/subnetset/subnetset_webhook.go
+++ b/pkg/controllers/subnetset/subnetset_webhook.go
@@ -60,14 +60,14 @@ func defaultSubnetSetLabelChanged(oldSubnetSet, subnetSet *v1alpha1.SubnetSet) b
 }
 
 func hasExclusiveFields(s *v1alpha1.SubnetSet) bool {
-	return s.Spec.SubnetNames != nil && (s.Spec.IPv4SubnetSize != 0 || s.Spec.IPv6PrefixLength != 0 || s.Spec.AccessMode != "" || s.Spec.SubnetDHCPConfig.Mode != "")
+	return s.Spec.SubnetNames != nil && (s.Spec.IPv4SubnetSize != 0 || s.Spec.IPv6PrefixLength != 0 || s.Spec.AccessMode != "" || s.Spec.SubnetDHCPConfig.Mode != "" || s.Spec.SubnetDHCPv6Config.Mode != "")
 }
 
 func subnetSetType(s *v1alpha1.SubnetSet) SubnetSetType {
 	if s.Spec.SubnetNames != nil {
 		return SubnetSetTypePreCreated
 	}
-	if s.Spec.IPv4SubnetSize != 0 || s.Spec.IPv6PrefixLength != 0 || s.Spec.AccessMode != "" || s.Spec.SubnetDHCPConfig.Mode != "" {
+	if s.Spec.IPv4SubnetSize != 0 || s.Spec.IPv6PrefixLength != 0 || s.Spec.AccessMode != "" || s.Spec.SubnetDHCPConfig.Mode != "" || s.Spec.SubnetDHCPv6Config.Mode != "" {
 		return SubnetSetTypeAutoCreated
 	}
 	return SubnetSetTypeNone
@@ -113,6 +113,9 @@ func (v *SubnetSetValidator) Handle(ctx context.Context, req admission.Request) 
 		if controllercommon.IsDefaultSubnetSet(subnetSet) && req.UserInfo.Username != NSXOperatorSA {
 			return admission.Denied("default SubnetSet only can be created by nsx-operator")
 		}
+		if subnetSet.Spec.SubnetNames != nil && subnetSet.Spec.IPAddressType != "" && req.UserInfo.Username != NSXOperatorSA {
+			return admission.Denied("Pre-created SubnetSet spec.ipAddressType can only be set by NSX Operator")
+		}
 		deny, err := v.validateSubnets(ctx, subnetSet.Namespace, subnetSet.Spec.SubnetNames, subnetSet.Name)
 		if err != nil {
 			if deny {
@@ -133,6 +136,10 @@ func (v *SubnetSetValidator) Handle(ctx context.Context, req admission.Request) 
 		if defaultSubnetSetLabelChanged(oldSubnetSet, subnetSet) && req.UserInfo.Username != NSXOperatorSA {
 			log.Debug("Default SubnetSet label change detected", "oldLabels", oldSubnetSet.ObjectMeta.Labels, "newLabels", subnetSet.ObjectMeta.Labels, "username", req.UserInfo.Username)
 			return admission.Denied(fmt.Sprintf("SubnetSet label %s can only be updated by NSX Operator", common.LabelDefaultNetwork))
+		}
+		if subnetSet.Spec.SubnetNames != nil && subnetSet.Spec.IPAddressType != oldSubnetSet.Spec.IPAddressType && req.UserInfo.Username != NSXOperatorSA {
+			log.Debug("Pre-created SubnetSet spec.ipAddressType is updated by user", "oldIPAddressType", oldSubnetSet.Spec.IPAddressType, "newIPAddressType", subnetSet.Spec.IPAddressType, "username", req.UserInfo.Username)
+			return admission.Denied("Pre-created SubnetSet spec.ipAddressType can only be set by NSX Operator")
 		}
 		deny, err := v.validateSubnets(ctx, subnetSet.Namespace, subnetSet.Spec.SubnetNames, subnetSet.Name)
 		if err != nil {
@@ -327,6 +334,7 @@ func (v *SubnetSetValidator) validateSubnets(ctx context.Context, ns string, sub
 	var existingVPC string
 	firstAccessMode := ""
 	firstDHCPMode := ""
+	firstDHCPv6Mode := ""
 	var firstEffectiveStaticIPAllocation bool
 	isFirstSubnet := true
 	if subnetNames == nil {
@@ -341,9 +349,13 @@ func (v *SubnetSetValidator) validateSubnets(ctx context.Context, ns string, sub
 		if crdSubnet.Spec.SubnetDHCPConfig.Mode == v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeRelay) {
 			return true, fmt.Errorf("DHCPRelay Subnet %s/%s is not supported in SubnetSet", crdSubnet.Namespace, crdSubnet.Name)
 		}
+		if crdSubnet.Spec.SubnetDHCPv6Config.Mode == v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeRelay) {
+			return true, fmt.Errorf("DHCPRelay Subnet %s/%s is not supported in SubnetSet", crdSubnet.Namespace, crdSubnet.Name)
+		}
 		if isFirstSubnet {
 			firstAccessMode = string(crdSubnet.Spec.AccessMode)
 			firstDHCPMode = string(crdSubnet.Spec.SubnetDHCPConfig.Mode)
+			firstDHCPv6Mode = string(crdSubnet.Spec.SubnetDHCPv6Config.Mode)
 			firstEffectiveStaticIPAllocation = getEffectiveStaticIPAllocation(crdSubnet)
 			isFirstSubnet = false
 		} else {
@@ -352,6 +364,9 @@ func (v *SubnetSetValidator) validateSubnets(ctx context.Context, ns string, sub
 			}
 			if firstDHCPMode != string(crdSubnet.Spec.SubnetDHCPConfig.Mode) {
 				return true, fmt.Errorf("Subnets in SubnetSet %s/%s must have the same DHCPConfigMode, found different DHCPConfigModes: [%s, %s]", ns, subnetSet, firstDHCPMode, crdSubnet.Spec.SubnetDHCPConfig.Mode)
+			}
+			if firstDHCPv6Mode != string(crdSubnet.Spec.SubnetDHCPv6Config.Mode) {
+				return true, fmt.Errorf("Subnets in SubnetSet %s/%s must have the same DHCPv6ConfigMode, found different DHCPv6ConfigModes: [%s, %s]", ns, subnetSet, firstDHCPv6Mode, crdSubnet.Spec.SubnetDHCPv6Config.Mode)
 			}
 			currentEffectiveStaticIPAllocation := getEffectiveStaticIPAllocation(crdSubnet)
 			if firstEffectiveStaticIPAllocation != currentEffectiveStaticIPAllocation {

--- a/pkg/controllers/subnetset/subnetset_webhook_test.go
+++ b/pkg/controllers/subnetset/subnetset_webhook_test.go
@@ -174,6 +174,17 @@ func TestSubnetSetValidator(t *testing.T) {
 	})
 	fakeClient.Create(context.TODO(), &v1alpha1.Subnet{
 		ObjectMeta: metav1.ObjectMeta{
+			Name:      "subnet-5",
+			Namespace: "ns-1",
+		},
+		Spec: v1alpha1.SubnetSpec{
+			SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+				Mode: v1alpha1.DHCPv6ConfigModeRelay,
+			},
+		},
+	})
+	fakeClient.Create(context.TODO(), &v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:        "subnet-public",
 			Namespace:   "ns-accessmode",
 			Annotations: map[string]string{common.AnnotationAssociatedResource: "default:ns-accessmode:subnet-public"},
@@ -213,6 +224,30 @@ func TestSubnetSetValidator(t *testing.T) {
 		Spec: v1alpha1.SubnetSpec{
 			SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
 				Mode: v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeServer),
+			},
+		},
+	})
+	fakeClient.Create(context.TODO(), &v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "subnet-dhcpv6-1",
+			Namespace:   "ns-dhcp",
+			Annotations: map[string]string{common.AnnotationAssociatedResource: "default:ns-dhcp:subnet-dhcpv6-1"},
+		},
+		Spec: v1alpha1.SubnetSpec{
+			SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+				Mode: v1alpha1.DHCPv6ConfigModeDeactivated,
+			},
+		},
+	})
+	fakeClient.Create(context.TODO(), &v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "subnet-dhcpv6-2",
+			Namespace:   "ns-dhcp",
+			Annotations: map[string]string{common.AnnotationAssociatedResource: "default:ns-dhcp:subnet-dhcpv6-2"},
+		},
+		Spec: v1alpha1.SubnetSpec{
+			SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+				Mode: v1alpha1.DHCPv6ConfigModeServer,
 			},
 		},
 	})
@@ -421,6 +456,21 @@ func TestSubnetSetValidator(t *testing.T) {
 			isAllowed: false,
 		},
 		{
+			name: "Create SubnetSet with DHCPv6Relay Subnets",
+			op:   admissionv1.Create,
+			subnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subnetset-1",
+					Namespace: "ns-1",
+				},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames: &[]string{"subnet-5"},
+				},
+			},
+			user:      "fake-user",
+			isAllowed: false,
+		},
+		{
 			name: "Create SubnetSet with different AccessModes",
 			op:   admissionv1.Create,
 			subnetSet: &v1alpha1.SubnetSet{
@@ -451,6 +501,22 @@ func TestSubnetSetValidator(t *testing.T) {
 			user:      "fake-user",
 			isAllowed: false,
 			msg:       "Subnets in SubnetSet ns-dhcp/subnetset-dhcp must have the same DHCPConfigMode, found different DHCPConfigModes: [DHCPDeactivated, DHCPServer]",
+		},
+		{
+			name: "Create SubnetSet with different DHCPv6Modes",
+			op:   admissionv1.Create,
+			subnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subnetset-dhcpv6",
+					Namespace: "ns-dhcp",
+				},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames: &[]string{"subnet-dhcpv6-1", "subnet-dhcpv6-2"},
+				},
+			},
+			user:      "fake-user",
+			isAllowed: false,
+			msg:       "Subnets in SubnetSet ns-dhcp/subnetset-dhcpv6 must have the same DHCPv6ConfigMode, found different DHCPv6ConfigModes: [DHCPDeactivated, DHCPServer]",
 		},
 		{
 			name: "Create SubnetSet with different StaticIPAllocations",
@@ -1183,6 +1249,181 @@ func TestGetSubnetPortsID(t *testing.T) {
 			results, err := v.getSubnetPortsID(context.Background(), tc.subnetSet)
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tc.expectedUIDs, results)
+		})
+	}
+}
+
+func TestSubnetSetValidator_IPAddressTypeValidation(t *testing.T) {
+	newScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(newScheme))
+	utilruntime.Must(v1alpha1.AddToScheme(newScheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme).Build()
+	nsxClient := &nsx.Client{}
+	cluster, _ := nsx.NewCluster(&nsx.Config{})
+	nsxClient.Cluster = cluster
+	validator := &SubnetSetValidator{
+		Client:    fakeClient,
+		decoder:   admission.NewDecoder(newScheme),
+		nsxClient: nsxClient,
+		vpcService: &vpc.VPCService{
+			Service: common.Service{},
+		},
+	}
+
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(validator.vpcService), "ListVPCInfo", func(_ common.VPCServiceProvider, ns string) []common.VPCResourceInfo {
+		return []common.VPCResourceInfo{{OrgID: "default", ProjectID: "default", VPCID: "ns-1"}}
+	})
+	defer patches.Reset()
+
+	patches.ApplyPrivateMethod(reflect.TypeOf(validator), "validateSubnets",
+		func(_ *SubnetSetValidator, _ context.Context, _ string, _ *[]string, _ string) (bool, error) {
+			return true, nil
+		})
+
+	patches.ApplyPrivateMethod(reflect.TypeOf(validator), "validateRemovedSubnets",
+		func(_ *SubnetSetValidator, _ context.Context, _ *v1alpha1.SubnetSet, subnetNames []string) (bool, error) {
+			return true, nil
+		})
+
+	testCases := []struct {
+		name         string
+		username     string
+		operation    admissionv1.Operation
+		oldSubnetSet *v1alpha1.SubnetSet
+		newSubnetSet *v1alpha1.SubnetSet
+		isAllowed    bool
+		msg          string
+	}{
+		{
+			name:      "Create - NSX Operator can set IPAddressType for pre-created SubnetSet",
+			username:  NSXOperatorSA,
+			operation: admissionv1.Create,
+			newSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames:   &[]string{"subnet-1"},
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
+				},
+			},
+			isAllowed: true,
+		},
+		{
+			name:      "Create - Regular user cannot set IPAddressType for pre-created SubnetSet",
+			username:  "user-1",
+			operation: admissionv1.Create,
+			newSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames:   &[]string{"subnet-1"},
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
+				},
+			},
+			isAllowed: false,
+			msg:       "Pre-created SubnetSet spec.ipAddressType can only be set by NSX Operator",
+		},
+		{
+			name:      "Create - Regular user can create pre-created SubnetSet without IPAddressType",
+			username:  "user-1",
+			operation: admissionv1.Create,
+			newSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames: &[]string{"subnet-1"},
+				},
+			},
+			isAllowed: true,
+		},
+		{
+			name:      "Update - NSX Operator can update IPAddressType",
+			username:  NSXOperatorSA,
+			operation: admissionv1.Update,
+			oldSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames:   &[]string{"subnet-1"},
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
+				},
+			},
+			newSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames:   &[]string{"subnet-1"},
+					IPAddressType: v1alpha1.IPAddressTypeIPv6,
+				},
+			},
+			isAllowed: true,
+		},
+		{
+			name:      "Update - Regular user cannot update IPAddressType of pre-created SubnetSet",
+			username:  "user-1",
+			operation: admissionv1.Update,
+			oldSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames:   &[]string{"subnet-1"},
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
+				},
+			},
+			newSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames:   &[]string{"subnet-1"},
+					IPAddressType: v1alpha1.IPAddressTypeIPv6,
+				},
+			},
+			isAllowed: false,
+			msg:       "Pre-created SubnetSet spec.ipAddressType can only be set by NSX Operator",
+		},
+		{
+			name:      "Update - No change in IPAddressType is allowed",
+			username:  "user-1",
+			operation: admissionv1.Update,
+			oldSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames:   &[]string{"subnet-1"},
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
+				},
+			},
+			newSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames:   &[]string{"subnet-1"},
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
+				},
+			},
+			isAllowed: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			req := admission.Request{}
+			jsonData, err := json.Marshal(testCase.newSubnetSet)
+			assert.NoError(t, err)
+			req.Object.Raw = jsonData
+
+			oldJsonData, err := json.Marshal(testCase.oldSubnetSet)
+			assert.NoError(t, err)
+			req.OldObject.Raw = oldJsonData
+
+			patches := gomonkey.ApplyMethod(reflect.TypeOf(validator.nsxClient.Cluster), "GetVersion", func(_ *nsx.Cluster) (*nsx.NsxVersion, error) {
+				return &nsx.NsxVersion{
+					NodeVersion: "9.0.0.0.12345",
+				}, nil
+			})
+			patches.ApplyFunc(controllercommon.CheckAccessModeOrVisibility, func(_ client.Client, ctx context.Context, ns string, accessMode string, resourceType string) error {
+				return nil
+			})
+			defer patches.Reset()
+
+			req.Operation = testCase.operation
+			req.UserInfo.Username = testCase.username
+			response := validator.Handle(context.TODO(), req)
+			assert.Equal(t, testCase.isAllowed, response.Allowed, "Allowed mismatch for test: "+testCase.name)
+			if testCase.msg != "" {
+				assert.Contains(t, response.Result.Message, testCase.msg, "Message mismatch for test: "+testCase.name)
+			}
 		})
 	}
 }

--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -126,23 +126,49 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag, i
 				nsxSubnet.AdvancedConfig.ConnectivityState = String("DISCONNECTED")
 			}
 		}
-		dhcpMode := string(o.Spec.SubnetDHCPConfig.Mode)
-		if dhcpMode == "" {
-			dhcpMode = v1alpha1.DHCPConfigModeDeactivated
+
+		// Only set DHCPv4 config and IPv4 subnet size when IPv4 is enabled
+		if util.IPAddressTypeIncludesIPv4(o.Spec.IPAddressType) {
+			dhcpMode := string(o.Spec.SubnetDHCPConfig.Mode)
+			if dhcpMode == "" {
+				dhcpMode = v1alpha1.DHCPConfigModeDeactivated
+			}
+			var dhcpServerAdditionalConfig *model.DhcpServerAdditionalConfig
+			if len(o.Spec.SubnetDHCPConfig.DHCPServerAdditionalConfig.ReservedIPRanges) > 0 {
+				dhcpServerAdditionalConfig = &model.DhcpServerAdditionalConfig{}
+				dhcpServerAdditionalConfig.ReservedIpRanges = o.Spec.SubnetDHCPConfig.DHCPServerAdditionalConfig.ReservedIPRanges
+			}
+			nsxSubnet.SubnetDhcpConfig = service.buildSubnetDHCPConfig(dhcpMode, dhcpServerAdditionalConfig)
+			if o.Spec.IPv4SubnetSize > 0 {
+				nsxSubnet.Ipv4SubnetSize = Int64(int64(o.Spec.IPv4SubnetSize))
+			}
 		}
-		var dhcpServerAdditionalConfig *model.DhcpServerAdditionalConfig
-		if len(o.Spec.SubnetDHCPConfig.DHCPServerAdditionalConfig.ReservedIPRanges) > 0 {
-			dhcpServerAdditionalConfig = &model.DhcpServerAdditionalConfig{}
-			dhcpServerAdditionalConfig.ReservedIpRanges = o.Spec.SubnetDHCPConfig.DHCPServerAdditionalConfig.ReservedIPRanges
+		// Only set DHCPv6 config and IPv6 prefix length when IPv6 is enabled
+		if util.IPAddressTypeIncludesIPv6(o.Spec.IPAddressType) {
+			dhcpv6Mode := string(o.Spec.SubnetDHCPv6Config.Mode)
+			if dhcpv6Mode == "" {
+				dhcpv6Mode = string(v1alpha1.DHCPv6ConfigModeDeactivated)
+			}
+			var dhcpv6ServerAdditionalConfig *model.DhcpV6ServerAdditionalConfig
+			if len(o.Spec.SubnetDHCPv6Config.DHCPv6ServerAdditionalConfig.ReservedIPRanges) > 0 {
+				dhcpv6ServerAdditionalConfig = &model.DhcpV6ServerAdditionalConfig{}
+				dhcpv6ServerAdditionalConfig.ReservedIpRanges = o.Spec.SubnetDHCPv6Config.DHCPv6ServerAdditionalConfig.ReservedIPRanges
+			}
+			nsxSubnet.SubnetDhcpv6Config = service.buildSubnetDHCPv6Config(dhcpv6Mode, dhcpv6ServerAdditionalConfig)
+			if o.Spec.IPv6PrefixLength > 0 {
+				nsxSubnet.Ipv6PrefixLength = Int64(int64(o.Spec.IPv6PrefixLength))
+			}
 		}
-		nsxSubnet.SubnetDhcpConfig = service.buildSubnetDHCPConfig(dhcpMode, dhcpServerAdditionalConfig)
+
 		if len(o.Spec.IPAddresses) > 0 {
 			nsxSubnet.IpAddresses = o.Spec.IPAddresses
 		} else if len(o.Status.NetworkAddresses) > 0 {
 			nsxSubnet.IpAddresses = o.Status.NetworkAddresses
 		}
-		if o.Spec.IPv4SubnetSize > 0 {
-			nsxSubnet.Ipv4SubnetSize = Int64(int64(o.Spec.IPv4SubnetSize))
+
+		// Set IP address type
+		if o.Spec.IPAddressType != "" {
+			nsxSubnet.IpAddressType = String(controllerscommon.ConvertCRIPAddressTypeToNSX(o.Spec.IPAddressType))
 		}
 		// Support custom gateway addresses when provided
 		if len(o.Spec.AdvancedConfig.GatewayAddresses) > 0 {
@@ -157,22 +183,45 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag, i
 		// value on a random UUID string.
 		index := util.GetRandomIndexString()
 		nsxSubnet = &model.VpcSubnet{
-			Id:             String(service.buildSubnetSetID(objForIdGeneration, index)),
-			AccessMode:     String(convertAccessMode(util.Capitalize(string(o.Spec.AccessMode)))),
-			Ipv4SubnetSize: Int64(int64(o.Spec.IPv4SubnetSize)),
-			DisplayName:    String(service.buildSubnetSetName(objForIdGeneration, index)),
-			Tags:           tags,
+			Id:          String(service.buildSubnetSetID(objForIdGeneration, index)),
+			AccessMode:  String(convertAccessMode(util.Capitalize(string(o.Spec.AccessMode)))),
+			DisplayName: String(service.buildSubnetSetName(objForIdGeneration, index)),
+			Tags:        tags,
 			AdvancedConfig: &model.SubnetAdvancedConfig{
 				StaticIpAllocation: &model.StaticIpAllocation{
 					Enabled: &staticIpAllocation,
 				},
 			},
 		}
-		dhcpMode := string(o.Spec.SubnetDHCPConfig.Mode)
-		if dhcpMode == "" {
-			dhcpMode = v1alpha1.DHCPConfigModeDeactivated
+		// Set IP address type
+		if o.Spec.IPAddressType != "" {
+			nsxSubnet.IpAddressType = String(controllerscommon.ConvertCRIPAddressTypeToNSX(o.Spec.IPAddressType))
 		}
-		nsxSubnet.SubnetDhcpConfig = service.buildSubnetDHCPConfig(dhcpMode, nil)
+
+		if util.IPAddressTypeIncludesIPv4(o.Spec.IPAddressType) {
+			// Add DHCPv4 configuration only when IPv4 is enabled
+			dhcpMode := string(o.Spec.SubnetDHCPConfig.Mode)
+			if dhcpMode == "" {
+				dhcpMode = v1alpha1.DHCPConfigModeDeactivated
+			}
+			nsxSubnet.SubnetDhcpConfig = service.buildSubnetDHCPConfig(dhcpMode, nil)
+			// Set IPv4 subnet size only when IPv4 is enabled
+			if o.Spec.IPv4SubnetSize > 0 {
+				nsxSubnet.Ipv4SubnetSize = Int64(int64(o.Spec.IPv4SubnetSize))
+			}
+		}
+		if util.IPAddressTypeIncludesIPv6(o.Spec.IPAddressType) {
+			// Add DHCPv6 configuration only when IPv6 is enabled
+			dhcpv6Mode := string(o.Spec.SubnetDHCPv6Config.Mode)
+			if dhcpv6Mode == "" {
+				dhcpv6Mode = string(v1alpha1.DHCPv6ConfigModeDeactivated)
+			}
+			nsxSubnet.SubnetDhcpv6Config = service.buildSubnetDHCPv6Config(dhcpv6Mode, nil)
+			// Set IPv6 prefix length if IPv6 is enabled
+			if o.Spec.IPv6PrefixLength > 0 {
+				nsxSubnet.Ipv6PrefixLength = Int64(int64(o.Spec.IPv6PrefixLength))
+			}
+		}
 		if len(ipAddresses) > 0 {
 			nsxSubnet.IpAddresses = ipAddresses
 		}
@@ -189,6 +238,15 @@ func (service *SubnetService) buildSubnetDHCPConfig(mode string, dhcpServerAddit
 		Mode:                       &nsxMode,
 	}
 	return subnetDhcpConfig
+}
+
+func (service *SubnetService) buildSubnetDHCPv6Config(mode string, dhcpServerAdditionalConfig *model.DhcpV6ServerAdditionalConfig) *model.SubnetDhcpv6Config {
+	nsxMode := nsxutil.ParseDHCPMode(mode)
+	subnetDhcpv6Config := &model.SubnetDhcpv6Config{
+		Dhcpv6ServerAdditionalConfig: dhcpServerAdditionalConfig,
+		Mode:                         &nsxMode,
+	}
+	return subnetDhcpv6Config
 }
 
 func (service *SubnetService) buildBasicTags(obj client.Object) []model.Tag {

--- a/pkg/nsx/services/subnet/builder_test.go
+++ b/pkg/nsx/services/subnet/builder_test.go
@@ -113,27 +113,111 @@ func TestBuildSubnetForSubnetSet(t *testing.T) {
 		},
 	}
 
-	subnetSet := &v1alpha1.SubnetSet{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "subnetset-1",
-			Namespace: "ns-1",
-			UID:       types.UID("1828a1d3-4d10-48d2-a8e8-dceb9bd66502"),
+	testCases := []struct {
+		name             string
+		ipAddressType    v1alpha1.IPAddressType
+		ipv4SubnetSize   int
+		ipv6PrefixLength int
+		dhcpMode         v1alpha1.DHCPConfigMode
+		dhcpv6Mode       v1alpha1.DHCPv6ConfigMode
+		expectIPv4Config bool
+		expectIPv6Config bool
+	}{
+		{
+			name:             "IPv4 SubnetSet",
+			ipAddressType:    v1alpha1.IPAddressTypeIPv4,
+			ipv4SubnetSize:   24,
+			ipv6PrefixLength: 0,
+			dhcpMode:         "",
+			dhcpv6Mode:       "",
+			expectIPv4Config: true,
+			expectIPv6Config: false,
+		},
+		{
+			name:             "IPv6 SubnetSet",
+			ipAddressType:    v1alpha1.IPAddressTypeIPv6,
+			ipv4SubnetSize:   0,
+			ipv6PrefixLength: 64,
+			dhcpMode:         "",
+			dhcpv6Mode:       v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeServer),
+			expectIPv4Config: false,
+			expectIPv6Config: true,
+		},
+		{
+			name:             "IPv4IPv6 dual stack",
+			ipAddressType:    v1alpha1.IPAddressTypeIPv4IPv6,
+			ipv4SubnetSize:   24,
+			ipv6PrefixLength: 64,
+			dhcpMode:         v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeServer),
+			dhcpv6Mode:       v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeServerStateless),
+			expectIPv4Config: true,
+			expectIPv6Config: true,
 		},
 	}
 
-	subnet, err := service.buildSubnet(subnetSet, tags, []string{})
-	assert.Nil(t, err)
-	assert.Equal(t, "DHCP_DEACTIVATED", *subnet.SubnetDhcpConfig.Mode)
-	if subnet.AdvancedConfig != nil {
-		assert.Equal(t, true, *subnet.AdvancedConfig.StaticIpAllocation.Enabled)
-	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			subnetSet := &v1alpha1.SubnetSet{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "subnetset-1",
+					Namespace: "ns-1",
+					UID:       types.UID("1828a1d3-4d10-48d2-a8e8-dceb9bd66502"),
+				},
+				Spec: v1alpha1.SubnetSetSpec{
+					IPAddressType:    tc.ipAddressType,
+					IPv4SubnetSize:   tc.ipv4SubnetSize,
+					IPv6PrefixLength: tc.ipv6PrefixLength,
+					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
+						Mode: tc.dhcpMode,
+					},
+					SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+						Mode: tc.dhcpv6Mode,
+					},
+				},
+			}
 
-	subnet.ParentPath = String(fakeVpcPath)
-	err = service.SubnetStore.Add(subnet)
-	require.NoError(t, err)
-	newIdx := "abcdef01"
-	newId := service.buildSubnetSetID(subnetSet, newIdx)
-	assert.Equal(t, "subnetset-1-abcdef01_5tnj0", newId)
+			subnet, err := service.buildSubnet(subnetSet, tags, []string{})
+			assert.Nil(t, err)
+			assert.NotNil(t, subnet)
+
+			// Verify IP address type is set correctly
+			assert.NotNil(t, subnet.IpAddressType)
+			expectedIPType := controllerscommon.ConvertCRIPAddressTypeToNSX(tc.ipAddressType)
+			assert.Equal(t, expectedIPType, *subnet.IpAddressType)
+
+			// Verify IPv4 subnet size
+			if tc.ipv4SubnetSize > 0 {
+				assert.NotNil(t, subnet.Ipv4SubnetSize)
+				assert.Equal(t, int64(tc.ipv4SubnetSize), *subnet.Ipv4SubnetSize)
+			} else {
+				assert.Nil(t, subnet.Ipv4SubnetSize)
+			}
+
+			// Verify IPv6 prefix length
+			if tc.ipv6PrefixLength > 0 {
+				assert.NotNil(t, subnet.Ipv6PrefixLength)
+				assert.Equal(t, int64(tc.ipv6PrefixLength), *subnet.Ipv6PrefixLength)
+			} else {
+				assert.Nil(t, subnet.Ipv6PrefixLength)
+			}
+
+			// Verify DHCPv4 configuration
+			if tc.expectIPv4Config {
+				assert.NotNil(t, subnet.SubnetDhcpConfig)
+				assert.NotNil(t, subnet.SubnetDhcpConfig.Mode)
+			} else {
+				assert.Nil(t, subnet.SubnetDhcpConfig)
+			}
+
+			// Verify DHCPv6 configuration
+			if tc.expectIPv6Config {
+				assert.NotNil(t, subnet.SubnetDhcpv6Config)
+				assert.NotNil(t, subnet.SubnetDhcpv6Config.Mode)
+			} else {
+				assert.Nil(t, subnet.SubnetDhcpv6Config)
+			}
+		})
+	}
 }
 
 func TestBuildSubnetForSubnet(t *testing.T) {
@@ -180,7 +264,8 @@ func TestBuildSubnetForSubnet(t *testing.T) {
 			Namespace: "ns-1",
 		},
 		Spec: v1alpha1.SubnetSpec{
-			IPAddresses: []string{"10.0.0.0/28"},
+			IPAddressType: v1alpha1.IPAddressTypeIPv4,
+			IPAddresses:   []string{"10.0.0.0/28"},
 			AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
 				StaticIPAllocation: v1alpha1.StaticIPAllocation{
 					Enabled: common.Bool(true),
@@ -202,7 +287,8 @@ func TestBuildSubnetForSubnet(t *testing.T) {
 			Namespace: "ns-1",
 		},
 		Spec: v1alpha1.SubnetSpec{
-			IPAddresses: []string{"10.0.0.0/28"},
+			IPAddressType: v1alpha1.IPAddressTypeIPv4,
+			IPAddresses:   []string{"10.0.0.0/28"},
 			SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
 				Mode: v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeServer),
 				DHCPServerAdditionalConfig: v1alpha1.DHCPServerAdditionalConfig{
@@ -242,7 +328,8 @@ func TestBuildSubnetForSubnet(t *testing.T) {
 			Namespace: "ns-1",
 		},
 		Spec: v1alpha1.SubnetSpec{
-			IPAddresses: []string{"10.0.0.0/28"},
+			IPAddressType: v1alpha1.IPAddressTypeIPv4,
+			IPAddresses:   []string{"10.0.0.0/28"},
 			AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
 				StaticIPAllocation: v1alpha1.StaticIPAllocation{
 					Enabled: common.Bool(true),
@@ -756,4 +843,112 @@ func TestBuildSubnetTagsExceedMaxTags(t *testing.T) {
 	var exceedTagsErr nsxutil.ExceedTagsError
 	assert.True(t, errors.As(err, &exceedTagsErr))
 	assert.Contains(t, exceedTagsErr.Desc, "tags cannot exceed maximum size 26")
+}
+
+func TestBuildSubnetForSubnet_IPv6(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mockClient.NewMockClient(mockCtl)
+	defer mockCtl.Finish()
+
+	patches := gomonkey.ApplyFunc(controllerscommon.IsNamespaceInTepLessMode,
+		func(_ client.Client, _ string) (bool, error) {
+			return false, nil
+		})
+	defer patches.Reset()
+
+	service := &SubnetService{
+		Service: common.Service{
+			Client: k8sClient,
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{
+					Cluster: "k8scl-one:test",
+				},
+			},
+		},
+		SubnetStore: &SubnetStore{
+			ResourceStore: common.ResourceStore{
+				Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
+					common.TagScopeSubnetCRUID:    subnetIndexFunc,
+					common.TagScopeSubnetSetCRUID: subnetSetIndexFunc,
+					common.TagScopeVMNamespace:    subnetIndexVMNamespaceFunc,
+					common.TagScopeNamespace:      subnetIndexNamespaceFunc,
+				}),
+				BindingType: model.VpcSubnetBindingType(),
+			},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		ipAddressType    v1alpha1.IPAddressType
+		dhcpv6Mode       v1alpha1.DHCPv6ConfigMode
+		ipv6PrefixLength int
+		expectedDHCPv6   bool
+	}{
+		{
+			name:             "IPv6 subnet with DHCPv6 Server",
+			ipAddressType:    v1alpha1.IPAddressTypeIPv6,
+			dhcpv6Mode:       v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeServer),
+			ipv6PrefixLength: 64,
+			expectedDHCPv6:   true,
+		},
+		{
+			name:             "IPv4IPv6 dual stack with DHCPv6",
+			ipAddressType:    v1alpha1.IPAddressTypeIPv4IPv6,
+			dhcpv6Mode:       v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeServerStateless),
+			ipv6PrefixLength: 80,
+			expectedDHCPv6:   true,
+		},
+		{
+			name:             "IPv6 subnet without DHCPv6 config",
+			ipAddressType:    v1alpha1.IPAddressTypeIPv6,
+			dhcpv6Mode:       "",
+			ipv6PrefixLength: 64,
+			expectedDHCPv6:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnet := &v1alpha1.Subnet{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-ipv6-subnet",
+					Namespace: "ns-1",
+				},
+				Spec: v1alpha1.SubnetSpec{
+					IPAddressType:    tt.ipAddressType,
+					IPv6PrefixLength: tt.ipv6PrefixLength,
+					IPAddresses:      []string{"fd00:1234:5678:9abc::/64"},
+					SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+						Mode: tt.dhcpv6Mode,
+					},
+				},
+			}
+
+			tags := []model.Tag{}
+
+			// Call buildSubnet to test IPv6 and DHCPv6 configuration handling
+			nsxSubnet, err := service.buildSubnet(subnet, tags, []string{})
+			assert.NoError(t, err)
+			assert.NotNil(t, nsxSubnet)
+
+			// Verify IPv6PrefixLength is set
+			if tt.ipv6PrefixLength > 0 {
+				assert.NotNil(t, nsxSubnet.Ipv6PrefixLength)
+				assert.Equal(t, int64(tt.ipv6PrefixLength), *nsxSubnet.Ipv6PrefixLength)
+			}
+
+			// Verify IPAddressType is set
+			assert.NotNil(t, nsxSubnet.IpAddressType)
+			expectedIPType := controllerscommon.ConvertCRIPAddressTypeToNSX(tt.ipAddressType)
+			assert.Equal(t, expectedIPType, *nsxSubnet.IpAddressType)
+
+			// Verify DHCPv6 config if present
+			if tt.expectedDHCPv6 && tt.dhcpv6Mode != "" {
+				assert.NotNil(t, nsxSubnet.SubnetDhcpv6Config)
+				// For DHCPv6 modes, verify the mode is set (not empty)
+				assert.NotEmpty(t, *nsxSubnet.SubnetDhcpv6Config.Mode)
+			}
+		})
+	}
 }

--- a/pkg/nsx/services/subnet/compare.go
+++ b/pkg/nsx/services/subnet/compare.go
@@ -19,7 +19,7 @@ func (subnet *Subnet) Key() string {
 
 func (subnet *Subnet) Value() data.DataValue {
 	// IPv4SubnetSize/AccessMode/IPAddresses are immutable field,
-	// Changes of tags and subnetDHCPConfig are considered as changed.
+	// Changes of tags, subnetDHCPConfig, subnetDHCPv6Config, and IPAddressType are considered as changed.
 	// TODO AccessMode may also need to be compared in future.
 	var advancedConfig *model.SubnetAdvancedConfig
 	if subnet.AdvancedConfig != nil {
@@ -45,10 +45,27 @@ func (subnet *Subnet) Value() data.DataValue {
 			DhcpServerAdditionalConfig: dhcpServerAdditionalConfig,
 		}
 	}
+	var subnetDhcpv6Config *model.SubnetDhcpv6Config
+	// Only compare Mode and Dhcpv6ServerAdditionalConfig from SubnetDhcpv6Config
+	if subnet.SubnetDhcpv6Config != nil {
+		var dhcpv6ServerAdditionalConfig *model.DhcpV6ServerAdditionalConfig
+		// Only compare ReservedIpRanges from DhcpV6ServerAdditionalConfig
+		if subnet.SubnetDhcpv6Config.Dhcpv6ServerAdditionalConfig != nil {
+			dhcpv6ServerAdditionalConfig = &model.DhcpV6ServerAdditionalConfig{
+				ReservedIpRanges: subnet.SubnetDhcpv6Config.Dhcpv6ServerAdditionalConfig.ReservedIpRanges,
+			}
+		}
+		subnetDhcpv6Config = &model.SubnetDhcpv6Config{
+			Mode:                         subnet.SubnetDhcpv6Config.Mode,
+			Dhcpv6ServerAdditionalConfig: dhcpv6ServerAdditionalConfig,
+		}
+	}
 	s := &Subnet{
-		Tags:             subnet.Tags,
-		SubnetDhcpConfig: subnetDhcpConfig,
-		AdvancedConfig:   advancedConfig,
+		Tags:               subnet.Tags,
+		SubnetDhcpConfig:   subnetDhcpConfig,
+		SubnetDhcpv6Config: subnetDhcpv6Config,
+		IpAddressType:      subnet.IpAddressType,
+		AdvancedConfig:     advancedConfig,
 	}
 	dataValue, _ := (*model.VpcSubnet)(s).GetDataValue__()
 	return dataValue

--- a/pkg/nsx/services/subnet/compare_test.go
+++ b/pkg/nsx/services/subnet/compare_test.go
@@ -206,6 +206,75 @@ func TestSubnetToComparable(t *testing.T) {
 			},
 			expectChanged: true,
 		},
+		{
+			name: "SubnetDhcpv6Config added",
+			nsxSubnet: &model.VpcSubnet{
+				Id: &id1,
+				SubnetDhcpv6Config: &model.SubnetDhcpv6Config{
+					Mode: common.String("DHCP_SERVER"),
+				},
+			},
+			existingSubnet: &model.VpcSubnet{
+				Id: &id1,
+			},
+			expectChanged: true,
+		},
+		{
+			name: "SubnetDhcpv6Config mode changed",
+			nsxSubnet: &model.VpcSubnet{
+				Id: &id1,
+				SubnetDhcpv6Config: &model.SubnetDhcpv6Config{
+					Mode: common.String("DHCP_SERVER_STATELESS"),
+				},
+			},
+			existingSubnet: &model.VpcSubnet{
+				Id: &id1,
+				SubnetDhcpv6Config: &model.SubnetDhcpv6Config{
+					Mode: common.String("DHCP_SERVER"),
+				},
+			},
+			expectChanged: true,
+		},
+		{
+			name: "SubnetDhcpv6Config same",
+			nsxSubnet: &model.VpcSubnet{
+				Id: &id1,
+				SubnetDhcpv6Config: &model.SubnetDhcpv6Config{
+					Mode: common.String("DHCP_RELAY"),
+				},
+			},
+			existingSubnet: &model.VpcSubnet{
+				Id: &id1,
+				SubnetDhcpv6Config: &model.SubnetDhcpv6Config{
+					Mode: common.String("DHCP_RELAY"),
+				},
+			},
+			expectChanged: false,
+		},
+		{
+			name: "IPAddressType changed",
+			nsxSubnet: &model.VpcSubnet{
+				Id:            &id1,
+				IpAddressType: common.String("IPV6"),
+			},
+			existingSubnet: &model.VpcSubnet{
+				Id:            &id1,
+				IpAddressType: common.String("IPV4"),
+			},
+			expectChanged: true,
+		},
+		{
+			name: "IPAddressType same IPv4IPv6",
+			nsxSubnet: &model.VpcSubnet{
+				Id:            &id1,
+				IpAddressType: common.String("IPV4_IPV6"),
+			},
+			existingSubnet: &model.VpcSubnet{
+				Id:            &id1,
+				IpAddressType: common.String("IPV4_IPV6"),
+			},
+			expectChanged: false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	controllercommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/realizestate"
@@ -113,6 +114,8 @@ func (service *SubnetService) RestoreSubnetSet(obj *v1alpha1.SubnetSet, vpcInfo 
 					updatedSubnet := *existingSubnet
 					updatedSubnet.Tags = nsxSubnet.Tags
 					updatedSubnet.SubnetDhcpConfig = nsxSubnet.SubnetDhcpConfig
+					updatedSubnet.SubnetDhcpv6Config = nsxSubnet.SubnetDhcpv6Config
+					updatedSubnet.IpAddressType = nsxSubnet.IpAddressType
 					nsxSubnet = &updatedSubnet
 				} else {
 					changed = false
@@ -163,16 +166,27 @@ func (service *SubnetService) CreateOrUpdateSubnet(obj client.Object, vpcInfo co
 			nsxSubnet.Id = common.String(*existingSubnet.Id)
 			nsxSubnet.DisplayName = common.String(*existingSubnet.DisplayName)
 
-			// TODO: In some cases, the existingSubnet has GatewayAddresses and DhcpServerAddresses and the built nsxSubnet doesn't, but they are actually should be recognized as not changed.
+			// In some cases, the existingSubnet has GatewayAddresses and DhcpServerAddresses and the built nsxSubnet doesn't, but they are actually should be recognized as not changed.
+			// If gateway_addresses / dhcp_server_address is not explicitly specified, keep the original value
+			if nsxSubnet.AdvancedConfig != nil && existingSubnet.AdvancedConfig != nil {
+				if len(nsxSubnet.AdvancedConfig.GatewayAddresses) == 0 {
+					nsxSubnet.AdvancedConfig.GatewayAddresses = existingSubnet.AdvancedConfig.GatewayAddresses
+				}
+				if len(nsxSubnet.AdvancedConfig.DhcpServerAddresses) == 0 {
+					nsxSubnet.AdvancedConfig.DhcpServerAddresses = existingSubnet.AdvancedConfig.DhcpServerAddresses
+				}
+			}
 			changed = common.CompareResource(SubnetToComparable(existingSubnet), SubnetToComparable(nsxSubnet))
 			if changed {
-				// Only tags, dhcp and specific advancedConfig fields are expected to be updated
+				// Only ipAddressType, tags, dhcp and specific advancedConfig fields are expected to be updated
 				// inherit other fields from the existing Subnet
 				// Avoid modification on existingSubnet to ensure
 				// Subnet store is only updated after the updating succeeds.
 				updatedSubnet := *existingSubnet
 				updatedSubnet.Tags = nsxSubnet.Tags
 				updatedSubnet.SubnetDhcpConfig = nsxSubnet.SubnetDhcpConfig
+				updatedSubnet.SubnetDhcpv6Config = nsxSubnet.SubnetDhcpv6Config
+				updatedSubnet.IpAddressType = nsxSubnet.IpAddressType
 				// Only update gateway_addresses, dhcp_server_address, and connectivity_state from AdvancedConfig
 				if nsxSubnet.AdvancedConfig != nil {
 					updatedSubnet.AdvancedConfig = &model.SubnetAdvancedConfig{
@@ -488,10 +502,16 @@ func (service *SubnetService) GenerateSubnetNSTags(obj client.Object) []model.Ta
 	return tags
 }
 
-func (service *SubnetService) UpdateSubnetSet(ns string, vpcSubnets []*model.VpcSubnet, tags []model.Tag, dhcpMode string) error {
-	if dhcpMode == "" {
+func (service *SubnetService) UpdateSubnetSet(ns string, vpcSubnets []*model.VpcSubnet, tags []model.Tag, subnetsetCR *v1alpha1.SubnetSet) error {
+	dhcpMode := string(subnetsetCR.Spec.SubnetDHCPConfig.Mode)
+	dhcpv6Mode := string(subnetsetCR.Spec.SubnetDHCPv6Config.Mode)
+	if subnetsetCR.Spec.SubnetDHCPConfig.Mode == "" {
 		dhcpMode = v1alpha1.DHCPConfigModeDeactivated
 	}
+	if subnetsetCR.Spec.SubnetDHCPv6Config.Mode == "" {
+		dhcpv6Mode = string(v1alpha1.DHCPv6ConfigModeDeactivated)
+	}
+
 	for i, vpcSubnet := range vpcSubnets {
 		subnetSet := &v1alpha1.SubnetSet{}
 		var name string
@@ -528,11 +548,21 @@ func (service *SubnetService) UpdateSubnetSet(ns string, vpcSubnets []*model.Vpc
 		// is only updated after the updating succeeds.
 		updatedSubnet := *vpcSubnets[i] // #nosec G602
 		updatedSubnet.Tags = newTags
+		updatedSubnet.IpAddressType = String(controllercommon.ConvertCRIPAddressTypeToNSX(subnetsetCR.Spec.IPAddressType))
 		// Update the SubnetSet DHCP Config
 		if updatedSubnet.SubnetDhcpConfig != nil {
 			// Generate a new SubnetDhcpConfig for updatedSubnet to
 			// avoid changing vpcSubnets[i].SubnetDhcpConfig
 			updatedSubnet.SubnetDhcpConfig = service.buildSubnetDHCPConfig(dhcpMode, updatedSubnet.SubnetDhcpConfig.DhcpServerAdditionalConfig)
+		} else if util.IPAddressTypeIncludesIPv4(subnetsetCR.Spec.IPAddressType) {
+			// When IPAddressType contains IPv4, generate a new SubnetDhcpConfig for updatedSubnet even if SubnetDhcpConfig is nil
+			updatedSubnet.SubnetDhcpConfig = service.buildSubnetDHCPConfig(dhcpMode, nil)
+		}
+		if updatedSubnet.SubnetDhcpv6Config != nil {
+			updatedSubnet.SubnetDhcpv6Config = service.buildSubnetDHCPv6Config(dhcpv6Mode, updatedSubnet.SubnetDhcpv6Config.Dhcpv6ServerAdditionalConfig)
+		} else if util.IPAddressTypeIncludesIPv6(subnetsetCR.Spec.IPAddressType) {
+			// When IPAddressType contains IPv6, generate a new SubnetDhcpv6Config for updatedSubnet even if SubnetDhcpv6Config is nil
+			updatedSubnet.SubnetDhcpv6Config = service.buildSubnetDHCPv6Config(dhcpv6Mode, nil)
 		}
 		changed := common.CompareResource(SubnetToComparable(vpcSubnets[i]), SubnetToComparable(&updatedSubnet)) // #nosec G602
 		if !changed {
@@ -596,13 +626,24 @@ func (service *SubnetService) MapNSXSubnetToSubnetCR(subnetCR *v1alpha1.Subnet, 
 		default:
 			subnetCR.Spec.AccessMode = v1alpha1.AccessMode(accessMode)
 		}
-	} else {
-		subnetCR.Spec.AccessMode = v1alpha1.AccessMode(v1alpha1.AccessModePublic)
 	}
 
 	// Map IPv4SubnetSize
 	if nsxSubnet.Ipv4SubnetSize != nil {
 		subnetCR.Spec.IPv4SubnetSize = int(*nsxSubnet.Ipv4SubnetSize)
+	}
+
+	// Map IPv6PrefixLength
+	if nsxSubnet.Ipv6PrefixLength != nil {
+		subnetCR.Spec.IPv6PrefixLength = int(*nsxSubnet.Ipv6PrefixLength)
+	}
+
+	// Map IpAddressType
+	if nsxSubnet.IpAddressType != nil {
+		subnetCR.Spec.IPAddressType = controllercommon.ConvertNSXIPAddressTypeToCR(*nsxSubnet.IpAddressType)
+	} else {
+		// Default to IPv4 if not specified
+		subnetCR.Spec.IPAddressType = v1alpha1.IPAddressTypeIPv4
 	}
 
 	// Map IPAddresses
@@ -624,8 +665,29 @@ func (service *SubnetService) MapNSXSubnetToSubnetCR(subnetCR *v1alpha1.Subnet, 
 		default:
 			subnetCR.Spec.SubnetDHCPConfig.Mode = v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated)
 		}
-	} else {
+	} else if util.IPAddressTypeIncludesIPv4(subnetCR.Spec.IPAddressType) {
 		subnetCR.Spec.SubnetDHCPConfig.Mode = v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated)
+	}
+
+	// Map SubnetDHCPv6Config
+	if nsxSubnet.SubnetDhcpv6Config != nil && nsxSubnet.SubnetDhcpv6Config.Mode != nil {
+		dhcpv6Mode := *nsxSubnet.SubnetDhcpv6Config.Mode
+		// Convert from NSX format to v1alpha1 format
+		switch dhcpv6Mode {
+		case "DHCP_SERVER":
+			subnetCR.Spec.SubnetDHCPv6Config.Mode = v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeServer)
+			if nsxSubnet.SubnetDhcpv6Config.Dhcpv6ServerAdditionalConfig != nil && len(nsxSubnet.SubnetDhcpv6Config.Dhcpv6ServerAdditionalConfig.ReservedIpRanges) > 0 {
+				subnetCR.Spec.SubnetDHCPv6Config.DHCPv6ServerAdditionalConfig.ReservedIPRanges = nsxSubnet.SubnetDhcpv6Config.Dhcpv6ServerAdditionalConfig.ReservedIpRanges
+			}
+		case "DHCP_RELAY":
+			subnetCR.Spec.SubnetDHCPv6Config.Mode = v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeRelay)
+		case "DHCP_SERVER_STATELESS":
+			subnetCR.Spec.SubnetDHCPv6Config.Mode = v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeServerStateless)
+		default:
+			subnetCR.Spec.SubnetDHCPv6Config.Mode = v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeDeactivated)
+		}
+	} else if util.IPAddressTypeIncludesIPv6(subnetCR.Spec.IPAddressType) {
+		subnetCR.Spec.SubnetDHCPv6Config.Mode = v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeDeactivated)
 	}
 
 	// Map VlanConnectionName from NSX Subnet

--- a/pkg/nsx/services/subnet/subnet_test.go
+++ b/pkg/nsx/services/subnet/subnet_test.go
@@ -372,6 +372,7 @@ func TestSubnetService_GetSubnetByCR(t *testing.T) {
 	service := &SubnetService{
 		Service: common.Service{},
 	}
+
 	testCases := []struct {
 		name           string
 		prepareFunc    func() *gomonkey.Patches
@@ -566,7 +567,7 @@ func TestSubnetService_UpdateSubnetSet(t *testing.T) {
 	})
 
 	patchesCreateOrUpdateSubnet := gomonkey.ApplyFunc((*SubnetService).createOrUpdateSubnet,
-		func(r *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo) (*model.VpcSubnet, error) {
+		func(r *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo, restoreMode bool) (*model.VpcSubnet, error) {
 			return &model.VpcSubnet{Path: &fakeSubnetPath}, nil
 		})
 	defer patchesCreateOrUpdateSubnet.Reset()
@@ -574,7 +575,7 @@ func TestSubnetService_UpdateSubnetSet(t *testing.T) {
 		func(_ client.Client, _ string) (bool, error) {
 			return false, nil
 		})
-	err := service.UpdateSubnetSet("ns-1", vpcSubnets, tags, "")
+	err := service.UpdateSubnetSet("ns-1", vpcSubnets, tags, &v1alpha1.SubnetSet{})
 	assert.Nil(t, err)
 }
 
@@ -853,7 +854,7 @@ func TestSubnetService_RestoreSubnetSet(t *testing.T) {
 					}
 					return []*model.VpcSubnet{}
 				})
-				patches.ApplyFunc((*SubnetService).createOrUpdateSubnet, func(service *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo) (*model.VpcSubnet, error) {
+				patches.ApplyFunc((*SubnetService).createOrUpdateSubnet, func(service *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo, restoreMode bool) (*model.VpcSubnet, error) {
 					return nil, nil
 				})
 				return patches
@@ -884,7 +885,7 @@ func TestSubnetService_RestoreSubnetSet(t *testing.T) {
 					}
 					return []*model.VpcSubnet{}
 				})
-				patches.ApplyFunc((*SubnetService).createOrUpdateSubnet, func(service *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo) (*model.VpcSubnet, error) {
+				patches.ApplyFunc((*SubnetService).createOrUpdateSubnet, func(service *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo, restoreMode bool) (*model.VpcSubnet, error) {
 					return nil, nil
 				})
 				return patches
@@ -912,7 +913,7 @@ func TestSubnetService_RestoreSubnetSet(t *testing.T) {
 					}
 					return []*model.VpcSubnet{}
 				})
-				patches.ApplyFunc((*SubnetService).createOrUpdateSubnet, func(service *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo) (*model.VpcSubnet, error) {
+				patches.ApplyFunc((*SubnetService).createOrUpdateSubnet, func(service *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo, restoreMode bool) (*model.VpcSubnet, error) {
 					return nil, fmt.Errorf("mocked error")
 				})
 				return patches
@@ -968,6 +969,7 @@ func TestBuildSubnetCR(t *testing.T) {
 					VPCName:        "proj-1:vpc-1",
 					AccessMode:     v1alpha1.AccessMode(v1alpha1.AccessModeProject),
 					IPv4SubnetSize: 24,
+					IPAddressType:  v1alpha1.IPAddressTypeIPv4,
 					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
 						Mode: v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated),
 					},
@@ -1003,6 +1005,7 @@ func TestBuildSubnetCR(t *testing.T) {
 					VPCName:        "proj-1:vpc-1",
 					AccessMode:     v1alpha1.AccessMode(v1alpha1.AccessModePublic),
 					IPv4SubnetSize: 16,
+					IPAddressType:  v1alpha1.IPAddressTypeIPv4,
 					IPAddresses:    []string{"192.168.0.80/28"},
 					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
 						Mode: v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated),
@@ -1067,6 +1070,7 @@ func TestMapNSXSubnetToSubnetCR(t *testing.T) {
 			expectedSubnet: &v1alpha1.Subnet{
 				Spec: v1alpha1.SubnetSpec{
 					AccessMode:     v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+					IPAddressType:  v1alpha1.IPAddressTypeIPv4,
 					IPv4SubnetSize: 24,
 					IPAddresses:    []string{"192.168.1.0/24"},
 					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
@@ -1097,6 +1101,7 @@ func TestMapNSXSubnetToSubnetCR(t *testing.T) {
 			expectedSubnet: &v1alpha1.Subnet{
 				Spec: v1alpha1.SubnetSpec{
 					AccessMode:     v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+					IPAddressType:  v1alpha1.IPAddressTypeIPv4,
 					IPv4SubnetSize: 24,
 					IPAddresses:    []string{"192.168.1.0/24"},
 					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
@@ -1123,6 +1128,7 @@ func TestMapNSXSubnetToSubnetCR(t *testing.T) {
 			expectedSubnet: &v1alpha1.Subnet{
 				Spec: v1alpha1.SubnetSpec{
 					AccessMode:     v1alpha1.AccessMode(v1alpha1.AccessModeProject),
+					IPAddressType:  v1alpha1.IPAddressTypeIPv4,
 					IPv4SubnetSize: 24,
 					IPAddresses:    []string{"192.168.1.0/24"},
 					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
@@ -1142,7 +1148,8 @@ func TestMapNSXSubnetToSubnetCR(t *testing.T) {
 			},
 			expectedSubnet: &v1alpha1.Subnet{
 				Spec: v1alpha1.SubnetSpec{
-					AccessMode: v1alpha1.AccessMode(v1alpha1.AccessModeL2Only),
+					AccessMode:    v1alpha1.AccessMode(v1alpha1.AccessModeL2Only),
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
 					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
 						Mode: v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated),
 					},
@@ -1161,7 +1168,8 @@ func TestMapNSXSubnetToSubnetCR(t *testing.T) {
 			},
 			expectedSubnet: &v1alpha1.Subnet{
 				Spec: v1alpha1.SubnetSpec{
-					AccessMode:     v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+					AccessMode:     v1alpha1.AccessMode(""),
+					IPAddressType:  v1alpha1.IPAddressTypeIPv4,
 					IPv4SubnetSize: 24,
 					IPAddresses:    []string{"192.168.1.0/24"},
 					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
@@ -1182,6 +1190,7 @@ func TestMapNSXSubnetToSubnetCR(t *testing.T) {
 			expectedSubnet: &v1alpha1.Subnet{
 				Spec: v1alpha1.SubnetSpec{
 					AccessMode:     v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+					IPAddressType:  v1alpha1.IPAddressTypeIPv4,
 					IPv4SubnetSize: 0,
 					IPAddresses:    []string{"192.168.1.0/24"},
 					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
@@ -1208,6 +1217,7 @@ func TestMapNSXSubnetToSubnetCR(t *testing.T) {
 			expectedSubnet: &v1alpha1.Subnet{
 				Spec: v1alpha1.SubnetSpec{
 					AccessMode:     v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+					IPAddressType:  v1alpha1.IPAddressTypeIPv4,
 					IPv4SubnetSize: 0,
 					IPAddresses:    []string{"192.168.1.0/24"},
 					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
@@ -1241,8 +1251,9 @@ func TestMapNSXSubnetToSubnetCR(t *testing.T) {
 			},
 			expectedSubnet: &v1alpha1.Subnet{
 				Spec: v1alpha1.SubnetSpec{
-					AccessMode:  v1alpha1.AccessMode(v1alpha1.AccessModePublic),
-					IPAddresses: []string{"10.0.1.3/24"},
+					AccessMode:    v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
+					IPAddresses:   []string{"10.0.1.3/24"},
 					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
 						Mode: v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated),
 					},
@@ -1251,6 +1262,133 @@ func TestMapNSXSubnetToSubnetCR(t *testing.T) {
 							Enabled: common.Bool(false),
 						},
 						GatewayAddresses: []string{"10.0.1.1/24"},
+					},
+				},
+			},
+		},
+		{
+			name: "Map NSX Subnet with IPv6PrefixLength",
+			subnetCR: &v1alpha1.Subnet{
+				Spec: v1alpha1.SubnetSpec{},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				AccessMode:       common.String("Public"),
+				Ipv6PrefixLength: common.Int64(80),
+				IpAddresses:      []string{"fd00:1234:5678:9abc::/80"},
+			},
+			expectedSubnet: &v1alpha1.Subnet{
+				Spec: v1alpha1.SubnetSpec{
+					AccessMode:       v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+					IPAddressType:    v1alpha1.IPAddressTypeIPv4,
+					IPv6PrefixLength: 80,
+					IPAddresses:      []string{"fd00:1234:5678:9abc::/80"},
+					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
+						Mode: v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated),
+					},
+				},
+			},
+		},
+		{
+			name: "Map NSX Subnet with IPAddressType IPv4",
+			subnetCR: &v1alpha1.Subnet{
+				Spec: v1alpha1.SubnetSpec{},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				AccessMode:     common.String("Public"),
+				IpAddressType:  common.String("IPV4"),
+				Ipv4SubnetSize: common.Int64(24),
+				IpAddresses:    []string{"192.168.1.0/24"},
+			},
+			expectedSubnet: &v1alpha1.Subnet{
+				Spec: v1alpha1.SubnetSpec{
+					AccessMode:     v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+					IPAddressType:  v1alpha1.IPAddressTypeIPv4,
+					IPv4SubnetSize: 24,
+					IPAddresses:    []string{"192.168.1.0/24"},
+					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
+						Mode: v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated),
+					},
+				},
+			},
+		},
+		{
+			name: "Map NSX Subnet with IPAddressType IPv4IPv6",
+			subnetCR: &v1alpha1.Subnet{
+				Spec: v1alpha1.SubnetSpec{},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				AccessMode:       common.String("Public"),
+				IpAddressType:    common.String("IPV4_IPV6"),
+				Ipv4SubnetSize:   common.Int64(25),
+				Ipv6PrefixLength: common.Int64(64),
+				IpAddresses:      []string{"192.168.1.0/25", "fd00:1234:5678:9abc::/64"},
+			},
+			expectedSubnet: &v1alpha1.Subnet{
+				Spec: v1alpha1.SubnetSpec{
+					AccessMode:       v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+					IPAddressType:    v1alpha1.IPAddressTypeIPv4IPv6,
+					IPv4SubnetSize:   25,
+					IPv6PrefixLength: 64,
+					IPAddresses:      []string{"192.168.1.0/25", "fd00:1234:5678:9abc::/64"},
+					SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{
+						Mode: v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated),
+					},
+					SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+						Mode: v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeDeactivated),
+					},
+				},
+			},
+		},
+		{
+			name: "Map NSX Subnet with DHCPv6 DHCP_SERVER mode",
+			subnetCR: &v1alpha1.Subnet{
+				Spec: v1alpha1.SubnetSpec{},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				AccessMode:       common.String("Public"),
+				IpAddressType:    common.String("IPV6"),
+				Ipv6PrefixLength: common.Int64(64),
+				SubnetDhcpv6Config: &model.SubnetDhcpv6Config{
+					Mode: common.String("DHCP_SERVER"),
+					Dhcpv6ServerAdditionalConfig: &model.DhcpV6ServerAdditionalConfig{
+						ReservedIpRanges: []string{"fd00:1234:5678:9abc::1-fd00:1234:5678:9abc::10"},
+					},
+				},
+			},
+			expectedSubnet: &v1alpha1.Subnet{
+				Spec: v1alpha1.SubnetSpec{
+					AccessMode:       v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+					IPAddressType:    v1alpha1.IPAddressTypeIPv6,
+					IPv6PrefixLength: 64,
+					SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+						Mode: v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeServer),
+						DHCPv6ServerAdditionalConfig: v1alpha1.DHCPv6ServerAdditionalConfig{
+							ReservedIPRanges: []string{"fd00:1234:5678:9abc::1-fd00:1234:5678:9abc::10"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Map NSX Subnet with DHCPv6 DHCP_SERVER_STATELESS mode",
+			subnetCR: &v1alpha1.Subnet{
+				Spec: v1alpha1.SubnetSpec{},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				AccessMode:       common.String("Public"),
+				IpAddressType:    common.String("IPV6"),
+				Ipv6PrefixLength: common.Int64(64),
+				SubnetDhcpv6Config: &model.SubnetDhcpv6Config{
+					Mode: common.String("DHCP_SERVER_STATELESS"),
+				},
+			},
+			expectedSubnet: &v1alpha1.Subnet{
+				Spec: v1alpha1.SubnetSpec{
+					AccessMode:       v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+					IPAddressType:    v1alpha1.IPAddressTypeIPv6,
+					IPv6PrefixLength: 64,
+					SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+						Mode: v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeServerStateless),
 					},
 				},
 			},
@@ -1269,8 +1407,13 @@ func TestMapNSXSubnetToSubnetCR(t *testing.T) {
 			// Check the result
 			assert.Equal(t, tt.expectedSubnet.Spec.AccessMode, subnetCR.Spec.AccessMode)
 			assert.Equal(t, tt.expectedSubnet.Spec.IPv4SubnetSize, subnetCR.Spec.IPv4SubnetSize)
+			assert.Equal(t, tt.expectedSubnet.Spec.IPv6PrefixLength, subnetCR.Spec.IPv6PrefixLength)
+			assert.Equal(t, tt.expectedSubnet.Spec.IPAddressType, subnetCR.Spec.IPAddressType)
 			assert.Equal(t, tt.expectedSubnet.Spec.IPAddresses, subnetCR.Spec.IPAddresses)
 			assert.Equal(t, tt.expectedSubnet.Spec.SubnetDHCPConfig.Mode, subnetCR.Spec.SubnetDHCPConfig.Mode)
+			assert.Equal(t, tt.expectedSubnet.Spec.SubnetDHCPv6Config.Mode, subnetCR.Spec.SubnetDHCPv6Config.Mode)
+			assert.Equal(t, tt.expectedSubnet.Spec.SubnetDHCPv6Config.DHCPv6ServerAdditionalConfig.ReservedIPRanges,
+				subnetCR.Spec.SubnetDHCPv6Config.DHCPv6ServerAdditionalConfig.ReservedIPRanges)
 
 			// Check StaticIPAllocation if expected
 			if tt.expectedSubnet.Spec.AdvancedConfig.StaticIPAllocation.Enabled != nil {
@@ -2170,7 +2313,7 @@ func TestSubnetService_CreateOrUpdateSubnet_ConnectivityState(t *testing.T) {
 			}
 
 			updateCalled := false
-			patches := gomonkey.ApplyFunc((*SubnetService).createOrUpdateSubnet, func(service *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo) (*model.VpcSubnet, error) {
+			patches := gomonkey.ApplyFunc((*SubnetService).createOrUpdateSubnet, func(service *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo, restoreMode bool) (*model.VpcSubnet, error) {
 				updateCalled = true
 				// Verify the connectivity state is correctly set
 				if tc.expectedConnectivityState != nil {
@@ -2306,7 +2449,7 @@ func TestSubnetService_CreateOrUpdateSubnet_Consistency(t *testing.T) {
 				require.NoError(t, service.SubnetStore.Apply(tc.existingSubnet))
 			}
 
-			patches := gomonkey.ApplyFunc((*SubnetService).createOrUpdateSubnet, func(service *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo) (*model.VpcSubnet, error) {
+			patches := gomonkey.ApplyFunc((*SubnetService).createOrUpdateSubnet, func(service *SubnetService, obj client.Object, nsxSubnet *model.VpcSubnet, vpcInfo *common.VPCResourceInfo, restoreMode bool) (*model.VpcSubnet, error) {
 				for _, tags := range nsxSubnet.Tags {
 					fmt.Printf("tags scope %s tag %s\n", *tags.Scope, *tags.Tag)
 				}

--- a/pkg/nsx/util/utils.go
+++ b/pkg/nsx/util/utils.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 )
 
@@ -770,12 +771,17 @@ func IsInvalidLicense(err error) bool {
 }
 
 func ParseDHCPMode(mode string) string {
-	// Transfer DHCPDeactivated to DHCP_DEACTIVATED
-	nsxMode := strings.ToUpper(mode)
-	if len(nsxMode) <= 4 {
+	switch mode {
+	case v1alpha1.DHCPConfigModeDeactivated:
+		return "DHCP_DEACTIVATED"
+	case v1alpha1.DHCPConfigModeServer:
+		return "DHCP_SERVER"
+	case v1alpha1.DHCPConfigModeRelay:
+		return "DHCP_RELAY"
+	case string(v1alpha1.DHCPv6ConfigModeServerStateless):
+		return "DHCP_SERVER_STATELESS"
+	default:
 		log.Error(nil, "Failed to parse DHCP mode", "mode", mode)
 		return ""
 	}
-	nsxMode = nsxMode[:4] + "_" + nsxMode[4:]
-	return nsxMode
 }

--- a/pkg/nsx/util/utils_test.go
+++ b/pkg/nsx/util/utils_test.go
@@ -1082,17 +1082,44 @@ func TestTransNSXApiError(t *testing.T) {
 }
 
 func TestParseDHCPMode(t *testing.T) {
-	nsxMode := ParseDHCPMode("DHCPDeactivated")
-	assert.Equal(t, "DHCP_DEACTIVATED", nsxMode)
+	tests := []struct {
+		name     string
+		mode     string
+		expected string
+	}{
+		{
+			name:     "DHCPDeactivated conversion",
+			mode:     "DHCPDeactivated",
+			expected: "DHCP_DEACTIVATED",
+		},
+		{
+			name:     "DHCPServer conversion",
+			mode:     "DHCPServer",
+			expected: "DHCP_SERVER",
+		},
+		{
+			name:     "DHCPRelay conversion",
+			mode:     "DHCPRelay",
+			expected: "DHCP_RELAY",
+		},
+		{
+			name:     "DHCPServerStateless conversion",
+			mode:     "DHCPServerStateless",
+			expected: "DHCP_SERVER_STATELESS",
+		},
+		{
+			name:     "unknown mode returns empty",
+			mode:     "UnknownMode",
+			expected: "",
+		},
+	}
 
-	nsxMode = ParseDHCPMode("DHCPServer")
-	assert.Equal(t, "DHCP_SERVER", nsxMode)
-
-	nsxMode = ParseDHCPMode("DHCPRelay")
-	assert.Equal(t, "DHCP_RELAY", nsxMode)
-
-	nsxMode = ParseDHCPMode("None")
-	assert.Equal(t, "", nsxMode)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseDHCPMode(tt.mode)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 func TestUpdateURL(t *testing.T) {


### PR DESCRIPTION
This PR focus on the happy path for IPv6 support on Subnet/SubnetSet.
It covers the following topics
- Supports IPv6 and daul stack Subnet CR
- Supports shared Subnet with IPv6 or dual stack
- Supports auto-scaled IPv6 and dual stack SubnetSet CR
- Supports pre-created SubnetSet with IPv6 or/and dual stack Subnets
- Supports auto-scaled default SubnetSet for Pod/VM in IPv6/Dual stack supervisor

Testing done:
IPv6 Subnet is not fully support at NSX side so the testing done only covers some simple cases.

Add IPv6 blocks to vpcconnectivityprofile and mock sv ipfamily to DualStack
Created ns-3 and observed the default SubnetSet are IPv4IPv6

```
kubectl get subnetset -n ns-3        
NAME          ACCESSMODE   IPADDRESSTYPE   IPV4SUBNETSIZE   IPV6PREFIXLENGTH   NETWORKADDRESSES
pod-default   PrivateTGW   IPv4IPv6        32               64                 
vm-default    Private      IPv4IPv6        32               64                 
```

Create a IPv6 Subnet

```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"Subnet","metadata":{"annotations":{},"name":"subnet-2","namespace":"ns-3"},"spec":{"advancedConfig":{"staticIPAllocation":{"enabled":false}},"ipAddressType":"IPv6"}}
  creationTimestamp: "2026-05-18T05:58:46Z"
  generation: 2
  name: subnet-2
  namespace: ns-3
  resourceVersion: "2986477"
  uid: c0ce19bc-da4d-49aa-9d59-53405ef0c1c7
spec:
  advancedConfig:
    connectivityState: Connected
    staticIPAllocation:
      enabled: false
  ipAddressType: IPv6
  ipv6PrefixLength: 64
  subnetDHCPConfig:
    dhcpServerAdditionalConfig: {}
  subnetDHCPv6Config:
    dhcpv6ServerAdditionalConfig: {}
  vpcName: project-quality:ns-3_ax2p2
status:
  conditions:
  - lastTransitionTime: "2026-05-18T05:58:47Z"
    message: 'NSX Subnet with DHCPv6: DHCPDeactivated has been successfully created/updated'
    reason: SubnetReady
    status: "True"
    type: Ready
  gatewayAddresses:
  - 2001:db8:0:0:0:0:0:1/64
  networkAddresses:
  - 2001:db8::/64
  shared: false
  vlanExtension: {}
```

Create a dual stack Subnet

```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"Subnet","metadata":{"annotations":{},"name":"subnet-4","namespace":"ns-3"},"spec":{"advancedConfig":{"staticIPAllocation":{"enabled":false}},"ipAddressType":"IPv4IPv6","subnetDHCPConfig":{"mode":"DHCPServer"},"subnetDHCPv6Config":{"mode":"DHCPServer"}}}
  creationTimestamp: "2026-05-18T05:58:47Z"
  generation: 2
  name: subnet-4
  namespace: ns-3
  resourceVersion: "2986506"
  uid: e4a3b692-9e3a-45e0-8f1f-7b6db9b32e69
spec:
  accessMode: Private
  advancedConfig:
    connectivityState: Connected
    staticIPAllocation:
      enabled: false
  ipAddressType: IPv4IPv6
  ipv4SubnetSize: 32
  ipv6PrefixLength: 64
  subnetDHCPConfig:
    dhcpServerAdditionalConfig: {}
    mode: DHCPServer
  subnetDHCPv6Config:
    dhcpv6ServerAdditionalConfig: {}
    mode: DHCPServer
  vpcName: project-quality:ns-3_ax2p2
status:
  DHCPServerAddresses:
  - 172.26.0.34/27 <—— NSX API still has bug to show multiple addresses in status
  conditions:
  - lastTransitionTime: "2026-05-18T05:58:50Z"
    message: 'NSX Subnet with DHCPv4: DHCPServer, DHCPv6: DHCPServer has been successfully
      created/updated'
    reason: SubnetReady
    status: "True"
    type: Ready
  gatewayAddresses:
  - 172.26.0.33/27
  networkAddresses:
  - 172.26.0.32/27
  shared: false
  vlanExtension: {}
```

Create a subnet in nsx and shared through vpcenetworkconfiguration

```
kubectl get subnet -n ns-3 -o yaml test
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  annotations:
    nsx.vmware.com/associated-resource: project-quality:ns-1_1dkmu:test
  creationTimestamp: "2026-05-18T08:48:49Z"
  generation: 1
  name: test
  namespace: ns-3
  resourceVersion: "3084001"
  uid: 3ebbc94b-7f61-44ee-89be-7d817f2d497f
spec:
  accessMode: Private
  advancedConfig:
    connectivityState: Connected
    dhcpServerAddresses:
    - 2001:db8:0:4:0:0:0:2/64
    gatewayAddresses:
    - 2001:db8:0:4::1/64
    staticIPAllocation:
      enabled: false
  ipAddressType: IPv6
  ipAddresses:
  - 2001:db8:0:4::/64
  ipv6PrefixLength: 64
  subnetDHCPConfig:
    dhcpServerAdditionalConfig: {}
    mode: DHCPDeactivated
  subnetDHCPv6Config:
    dhcpv6ServerAdditionalConfig: {}
    mode: DHCPServer
  vpcName: project-quality:ns-1_1dkmu
status:
```

Create a pre-created SubnetSet with IPv6 subnet and IPv4IPv6 Subnet

```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetSet
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetSet","metadata":{"annotations":{},"name":"subnetset-2","namespace":"ns-3"},"spec":{"subnetNames":["subnet-2","subnet-4"]}}
  creationTimestamp: "2026-05-18T07:34:19Z"
  generation: 5
  name: subnetset-2
  namespace: ns-3
  resourceVersion: "3056260"
  uid: cdeb5ed7-0392-49f1-acbc-e297e7ecb1ed
spec:
  ipAddressType: IPv6
  subnetDHCPConfig:
    dhcpServerAdditionalConfig: {}
  subnetDHCPv6Config:
    dhcpv6ServerAdditionalConfig: {}
  subnetNames:
  - subnet-2
  - subnet-4
status:
  conditions:
  - lastTransitionTime: "2026-05-18T07:34:19Z"
    message: SubnetSet CR has been successfully created/updated
    reason: SubnetSetReady
    status: "True"
    type: Ready
  subnets:
  - gatewayAddresses:
    - 2001:db8:0:0:0:0:0:1/64
    networkAddresses:
    - 2001:db8::/64
  - DHCPServerAddresses:
    - 172.26.0.34/27
    gatewayAddresses:
    - 172.26.0.33/27
    networkAddresses:
    - 172.26.0.32/27
```


