### PR TITLE
IPAlllocation support in staticroute CR

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_staticroutes.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_staticroutes.yaml
@@ -19,6 +19,10 @@ spec:
       jsonPath: .spec.network
       name: Network
       type: string
+    - description: IPAddressAllocation CR name
+      jsonPath: .spec.networkIpAllocation
+      name: NetworkIPAllocation
+      type: string
     - description: Next Hops
       jsonPath: .spec.nextHops[*].ipAddress
       name: NextHops
@@ -49,8 +53,15 @@ spec:
             description: StaticRouteSpec defines static routes configuration on VPC.
             properties:
               network:
-                description: Specify network address in CIDR format.
+                description: |-
+                  Specify network address in CIDR format.
+                  Mutually exclusive with networkIpAllocation.
                 format: cidr
+                type: string
+              networkIpAllocation:
+                description: |-
+                  Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as
+                  the static route network. Mutually exclusive with network.
                 type: string
               nextHops:
                 description: Next hop gateway
@@ -67,9 +78,11 @@ spec:
                 minItems: 1
                 type: array
             required:
-            - network
             - nextHops
             type: object
+            x-kubernetes-validations:
+            - message: spec.network and spec.networkIpAllocation are mutually exclusive
+              rule: '!has(self.network) || !has(self.networkIpAllocation)'
           status:
             description: StaticRouteStatus defines the observed state of StaticRoute.
             properties:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -187,7 +187,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			log.Error(err, "Failed to initialize node commonService", "controller", "Node")
 			os.Exit(1)
 		}
-		staticRouteService, err := staticroute.InitializeStaticRoute(commonService, vpcService)
+		staticRouteService, err := staticroute.InitializeStaticRoute(commonService, vpcService, ipAddressAllocationService)
 		if err != nil {
 			log.Error(err, "Failed to initialize staticroute commonService", "controller", "StaticRoute")
 			os.Exit(1)

--- a/pkg/apis/vpc/v1alpha1/staticroute_types.go
+++ b/pkg/apis/vpc/v1alpha1/staticroute_types.go
@@ -13,10 +13,17 @@ type StaticRouteStatusCondition string
 type StaticRouteCondition Condition
 
 // StaticRouteSpec defines static routes configuration on VPC.
+// +kubebuilder:validation:XValidation:rule="!has(self.network) || !has(self.networkIpAllocation)",message="spec.network and spec.networkIpAllocation are mutually exclusive"
 type StaticRouteSpec struct {
 	// Specify network address in CIDR format.
+	// Mutually exclusive with networkIpAllocation.
 	// +kubebuilder:validation:Format=cidr
-	Network string `json:"network"`
+	// +optional
+	Network string `json:"network,omitempty"`
+	// Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as
+	// the static route network. Mutually exclusive with network.
+	// +optional
+	NetworkIPAllocation string `json:"networkIpAllocation,omitempty"`
 	// Next hop gateway
 	// +kubebuilder:validation:MinItems=1
 	NextHops []NextHop `json:"nextHops"`
@@ -41,6 +48,7 @@ type StaticRouteStatus struct {
 
 // StaticRoute is the Schema for the staticroutes API.
 // +kubebuilder:printcolumn:name="Network",type=string,JSONPath=`.spec.network`,description="Network in CIDR format"
+// +kubebuilder:printcolumn:name="NetworkIPAllocation",type=string,JSONPath=`.spec.networkIpAllocation`,description="IPAddressAllocation CR name"
 // +kubebuilder:printcolumn:name="NextHops",type=string,JSONPath=`.spec.nextHops[*].ipAddress`,description="Next Hops"
 type StaticRoute struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/clean/clean.go
+++ b/pkg/clean/clean.go
@@ -146,7 +146,7 @@ func InitializeCleanupService(cf *config.NSXOperatorConfig, nsxClient *nsx.Clien
 
 	wrapInitializeStaticRoute := func(service common.Service) cleanupFunc {
 		return func() (interface{}, error) {
-			return sr.InitializeStaticRoute(service, vpcService)
+			return sr.InitializeStaticRoute(service, vpcService, nil)
 		}
 	}
 

--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook.go
@@ -75,6 +75,15 @@ func (v *IPAddressAllocationValidator) Handle(ctx context.Context, req admission
 		if len(existingAddressBindingList.Items) > 0 {
 			return admission.Denied(fmt.Sprintf("IPAddressAllocation %s is used by AddressBinding %s", ipAddressAllocation.Name, existingAddressBindingList.Items[0].Name))
 		}
+
+		existingStaticRouteList := &v1alpha1.StaticRouteList{}
+		if err := v.Client.List(context.TODO(), existingStaticRouteList, client.InNamespace(ipAddressAllocation.Namespace), client.MatchingFields{util.StaticRouteIPAddressAllocationNameIndexKey: ipAddressAllocation.Name}); err != nil {
+			log.Error(err, "failed to list StaticRoute", "Namespace", ipAddressAllocation.Namespace)
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		if len(existingStaticRouteList.Items) > 0 {
+			return admission.Denied(fmt.Sprintf("IPAddressAllocation %s is used by StaticRoute %s", ipAddressAllocation.Name, existingStaticRouteList.Items[0].Name))
+		}
 		return v.validateServiceVIP(ctx, req, ipAddressAllocation)
 	}
 	return admission.Allowed("")

--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook_test.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook_test.go
@@ -34,6 +34,14 @@ func TestIPAddressAllocationValidator_Handle(t *testing.T) {
 			return []string{ab.Spec.IPAddressAllocationName}
 		}
 	}
+	indexFunc2 := func(obj client.Object) []string {
+		if sr, ok := obj.(*v1alpha1.StaticRoute); !ok {
+			log.Info("Invalid object", "type", reflect.TypeOf(obj))
+			return []string{}
+		} else {
+			return []string{sr.Spec.NetworkIPAllocation}
+		}
+	}
 	reqDelete, _ := json.Marshal(&v1alpha1.IPAddressAllocation{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ns1",
@@ -108,6 +116,23 @@ func TestIPAddressAllocationValidator_Handle(t *testing.T) {
 				return nil
 			},
 			want: admission.Denied("IPAddressAllocation ip1 is used by AddressBinding ab1"),
+		},
+		{
+			name: "delete with existing static route",
+			args: args{req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{Raw: reqDelete},
+			}}},
+			prepareFunc: func(t *testing.T, client client.Client, ctx context.Context) *gomonkey.Patches {
+				client.Create(ctx, &v1alpha1.StaticRoute{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "sr1"},
+					Spec: v1alpha1.StaticRouteSpec{
+						NetworkIPAllocation: "ip1",
+					},
+				})
+				return nil
+			},
+			want: admission.Denied("IPAddressAllocation ip1 is used by StaticRoute sr1"),
 		},
 		{
 			name: "delete without address binding",
@@ -238,7 +263,7 @@ func TestIPAddressAllocationValidator_Handle(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			scheme := clientgoscheme.Scheme
 			v1alpha1.AddToScheme(scheme)
-			client := fake.NewClientBuilder().WithScheme(scheme).WithIndex(&v1alpha1.AddressBinding{}, util.AddressBindingIPAddressAllocationNameIndexKey, indexFunc).Build()
+			client := fake.NewClientBuilder().WithScheme(scheme).WithIndex(&v1alpha1.AddressBinding{}, util.AddressBindingIPAddressAllocationNameIndexKey, indexFunc).WithIndex(&v1alpha1.StaticRoute{}, util.StaticRouteIPAddressAllocationNameIndexKey, indexFunc2).Build()
 			decoder := admission.NewDecoder(scheme)
 			ctx := context.TODO()
 			if tt.prepareFunc != nil {

--- a/pkg/controllers/staticroute/staticroute_controller.go
+++ b/pkg/controllers/staticroute/staticroute_controller.go
@@ -6,6 +6,7 @@ package staticroute
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 
 	v1 "k8s.io/api/core/v1"
@@ -28,6 +29,7 @@ import (
 	commonservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/staticroute"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
+	pkgUtil "github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
 var (
@@ -80,7 +82,7 @@ func (r *StaticRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if obj.ObjectMeta.DeletionTimestamp.IsZero() {
 		r.StatusUpdater.IncreaseUpdateTotal()
-		if err := r.Service.CreateOrUpdateStaticRoute(req.Namespace, obj); err != nil {
+		if err := r.Service.CreateOrUpdateStaticRoute(ctx, req.Namespace, obj); err != nil {
 			r.StatusUpdater.UpdateFail(ctx, obj, err, "", setStaticRouteReadyStatusFalse)
 			// TODO: if error is not retriable, not requeue
 			apierror, errortype := util.DumpAPIError(err)
@@ -266,6 +268,30 @@ func NewStaticRouteReconciler(mgr ctrl.Manager, staticRouteService *staticroute.
 		Recorder: mgr.GetEventRecorderFor("staticroute-controller"), //nolint:staticcheck // record.EventRecorder; StatusUpdater not on events.EventRecorder yet
 	}
 	staticRouteReconcile.Service = staticRouteService
+	err := staticRouteReconcile.SetupFieldIndexers(mgr)
+	if err != nil {
+		log.Error(err, "Failed to setup field indexers for the staticRouteReconcile controller")
+		os.Exit(1)
+	}
 	staticRouteReconcile.StatusUpdater = common.NewStatusUpdater(staticRouteReconcile.Client, staticRouteReconcile.Service.NSXConfig, staticRouteReconcile.Recorder, MetricResTypeStaticRoute, "StaticRoute", "StaticRoute")
 	return staticRouteReconcile
+}
+
+func staticrouteAssociatedResourceIndexFunc(obj client.Object) []string {
+	if staticRoute, ok := obj.(*v1alpha1.StaticRoute); !ok {
+		log.Info("Invalid object", "type", reflect.TypeOf(obj))
+		return []string{}
+	} else {
+		if staticRoute.Spec.NetworkIPAllocation == "" {
+			return []string{}
+		}
+		return []string{staticRoute.Spec.NetworkIPAllocation}
+	}
+}
+
+func (r *StaticRouteReconciler) SetupFieldIndexers(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &v1alpha1.StaticRoute{}, pkgUtil.StaticRouteIPAddressAllocationNameIndexKey, staticrouteAssociatedResourceIndexFunc); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/controllers/staticroute/staticroute_controller_test.go
+++ b/pkg/controllers/staticroute/staticroute_controller_test.go
@@ -231,7 +231,7 @@ func TestStaticRouteReconciler_Reconcile(t *testing.T) {
 		return nil
 	})
 
-	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "CreateOrUpdateStaticRoute", func(_ *staticroute.StaticRouteService, namespace string, obj *v1alpha1.StaticRoute) error {
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "CreateOrUpdateStaticRoute", func(_ *staticroute.StaticRouteService, ctx context.Context, namespace string, obj *v1alpha1.StaticRoute) error {
 		return errors.New("create failed")
 	})
 	k8sClient.EXPECT().Status().Times(1).Return(fakewriter)
@@ -246,7 +246,7 @@ func TestStaticRouteReconciler_Reconcile(t *testing.T) {
 		return nil
 	})
 
-	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "CreateOrUpdateStaticRoute", func(_ *staticroute.StaticRouteService, namespace string, obj *v1alpha1.StaticRoute) error {
+	patch = gomonkey.ApplyMethod(reflect.TypeOf(service), "CreateOrUpdateStaticRoute", func(_ *staticroute.StaticRouteService, ctx context.Context, namespace string, obj *v1alpha1.StaticRoute) error {
 		return nil
 	})
 	_, ret = r.Reconcile(ctx, req)
@@ -367,6 +367,9 @@ func TestStaticRouteReconciler_StartController(t *testing.T) {
 	})
 	patches.ApplyFunc(ctlcommon.GenericGarbageCollector, func(cancel chan bool, timeout time.Duration, f func(ctx context.Context) error) {
 	})
+	patches.ApplyFunc((*StaticRouteReconciler).SetupFieldIndexers, func(r *StaticRouteReconciler, mgr manager.Manager) error {
+		return nil
+	})
 	r := NewStaticRouteReconciler(mockMgr, staticRouteService)
 	err := r.StartController(mockMgr, nil)
 	assert.Nil(t, err)
@@ -378,6 +381,9 @@ func TestStaticRouteReconciler_StartController(t *testing.T) {
 	})
 	patches.ApplyFunc(ctlcommon.GenericGarbageCollector, func(cancel chan bool, timeout time.Duration, f func(ctx context.Context) error) {
 	})
+	patches.ApplyFunc((*StaticRouteReconciler).SetupFieldIndexers, func(r *StaticRouteReconciler, mgr manager.Manager) error {
+		return nil
+	})
 	defer patches.Reset()
 	r = NewStaticRouteReconciler(mockMgr, staticRouteService)
 	err = r.StartController(mockMgr, nil)
@@ -388,6 +394,9 @@ func TestStaticRouteReconciler_StartController(t *testing.T) {
 		return nil
 	})
 	patches.ApplyFunc(ctlcommon.GenericGarbageCollector, func(cancel chan bool, timeout time.Duration, f func(ctx context.Context) error) {
+	})
+	patches.ApplyFunc((*StaticRouteReconciler).SetupFieldIndexers, func(r *StaticRouteReconciler, mgr manager.Manager) error {
+		return nil
 	})
 	defer patches.Reset()
 	hookServer := webhook.NewServer(webhook.Options{})
@@ -472,4 +481,145 @@ func TestStaticRouteReconciler_deleteStaticRouteByName(t *testing.T) {
 	err := r.deleteStaticRouteByName("dummy-name", "dummy-ns")
 	assert.Error(t, err)
 	patch.Reset()
+}
+
+func Test_staticrouteAssociatedResourceIndexFunc(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "Valid StaticRoute with NetworkIPAllocation",
+			obj: &v1alpha1.StaticRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.StaticRouteSpec{
+					NetworkIPAllocation: "/orgs/default/projects/p1/vpcs/v1/ip-address-allocations/ipa-1",
+				},
+			},
+			want: []string{"/orgs/default/projects/p1/vpcs/v1/ip-address-allocations/ipa-1"},
+		},
+		{
+			name: "StaticRoute with empty NetworkIPAllocation",
+			obj: &v1alpha1.StaticRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route-empty",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.StaticRouteSpec{
+					NetworkIPAllocation: "",
+				},
+			},
+			want: []string{},
+		},
+		{
+			name: "Invalid object type passed to indexer",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "not-a-static-route",
+					Namespace: "default",
+				},
+			},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := staticrouteAssociatedResourceIndexFunc(tt.obj)
+
+			// DeepEqual checks slice contents accurately even if empty
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("staticrouteAssociatedResourceIndexFunc() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// 1. Define a Mock for the FieldIndexer to intercept the registration
+type mockFieldIndexer struct {
+	client.FieldIndexer // Embed interface to implicitly satisfy unused methods
+	capturedObj         client.Object
+	capturedField       string
+	capturedFunc        client.IndexerFunc
+	returnErr           error
+}
+
+func (m *mockFieldIndexer) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	m.capturedObj = obj
+	m.capturedField = field
+	m.capturedFunc = extractValue
+	return m.returnErr
+}
+
+// 2. Define a Mock for the Manager that returns our mock FieldIndexer
+type mockManager struct {
+	manager.Manager // Embed interface
+	indexer         client.FieldIndexer
+}
+
+func (m *mockManager) GetFieldIndexer() client.FieldIndexer {
+	return m.indexer
+}
+
+// 3. The Unit Test implementation
+func TestStaticRouteReconciler_SetupFieldIndexers(t *testing.T) {
+	tests := []struct {
+		name       string
+		mockErr    error
+		wantErr    bool
+		verifyArgs bool
+	}{
+		{
+			name:       "Successful index registration",
+			mockErr:    nil,
+			wantErr:    false,
+			verifyArgs: true,
+		},
+		{
+			name:       "Registration fails on internal FieldIndexer error",
+			mockErr:    errors.New("failed to register index"),
+			wantErr:    true,
+			verifyArgs: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Initialize the mock indexer and manager wrapper
+			indexerMock := &mockFieldIndexer{returnErr: tt.mockErr}
+			mgrMock := &mockManager{indexer: indexerMock}
+
+			r := &StaticRouteReconciler{}
+			err := r.SetupFieldIndexers(mgrMock)
+
+			// Verify error behavior
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetupFieldIndexers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Verify exact arguments were forwarded correctly to controller-runtime cache layer
+			if tt.verifyArgs {
+				// Verify object type registration target
+				if _, ok := indexerMock.capturedObj.(*v1alpha1.StaticRoute); !ok {
+					t.Errorf("SetupFieldIndexers() registered wrong object type. Expected *v1alpha1.StaticRoute")
+				}
+
+				// Verify index key string integrity
+				if indexerMock.capturedField != util.StaticRouteIPAddressAllocationNameIndexKey {
+					t.Errorf("SetupFieldIndexers() field string mismatch = %v, want %v",
+						indexerMock.capturedField, util.StaticRouteIPAddressAllocationNameIndexKey)
+				}
+
+				// Verify function pointer maps to the target calculation method
+				if indexerMock.capturedFunc == nil {
+					t.Errorf("SetupFieldIndexers() did not pass an index function")
+				}
+			}
+		})
+	}
 }

--- a/pkg/nsx/services/staticroute/builder.go
+++ b/pkg/nsx/services/staticroute/builder.go
@@ -32,12 +32,21 @@ func validateStaticRoute(obj *v1alpha1.StaticRoute) error {
 	return nil
 }
 
-func (service *StaticRouteService) buildStaticRoute(obj *v1alpha1.StaticRoute) (*model.StaticRoutes, error) {
+// buildStaticRoute converts a StaticRoute CR into a model.StaticRoutes for the NSX API.
+// networkIPAllocationPath, when non-empty, is the NSX policy path of a VpcIpAddressAllocation
+// (spec.networkIpAllocation mode): NSX resolves the allocated IP and treats it as a /32 network.
+// When empty, spec.network (a CIDR string) is used directly (spec.network mode).
+// The two fields are mutually exclusive on the NSX side.
+func (service *StaticRouteService) buildStaticRoute(obj *v1alpha1.StaticRoute, networkIPAllocationPath string) (*model.StaticRoutes, error) {
 	if err := validateStaticRoute(obj); err != nil {
 		return nil, err
 	}
 	sr := &model.StaticRoutes{}
-	sr.Network = &obj.Spec.Network
+	if networkIPAllocationPath != "" {
+		sr.NetworkIpAllocationPath = String(networkIPAllocationPath)
+	} else {
+		sr.Network = String(obj.Spec.Network)
+	}
 	dis := int64(1)
 	for index := range obj.Spec.NextHops {
 		nexthop := model.RouterNexthop{AdminDistance: &dis}

--- a/pkg/nsx/services/staticroute/builder_test.go
+++ b/pkg/nsx/services/staticroute/builder_test.go
@@ -14,6 +14,43 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
+// TestBuildStaticRoute_NetworkIPAllocationPath verifies that buildStaticRoute sets
+// NetworkIpAllocationPath (not Network) when a non-empty networkIPAllocationPath is
+// provided, and sets Network (not NetworkIpAllocationPath) when it is empty.
+func TestBuildStaticRoute_NetworkIPAllocationPath(t *testing.T) {
+	service := &StaticRouteService{Service: common.Service{}, StaticRouteStore: buildStaticRouteStore()}
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(&service.Service), "GetNamespaceUID",
+		func(_ *common.Service, _ string) types.UID { return types.UID("nsUUID") })
+	defer patches.Reset()
+
+	service.NSXConfig = &config.NSXOperatorConfig{CoeConfig: &config.CoeConfig{Cluster: "test_1"}}
+
+	obj := &v1alpha1.StaticRoute{}
+	obj.Name = "testroute"
+	obj.Namespace = "ns1"
+	obj.UID = "uid-abc"
+	obj.Spec.NextHops = []v1alpha1.NextHop{{IPAddress: "192.168.1.1"}}
+
+	allocPath := "/orgs/default/projects/p1/vpcs/v1/ip-address-allocations/alloc-1"
+
+	t.Run("networkIPAllocationPath sets NetworkIpAllocationPath only", func(t *testing.T) {
+		sr, err := service.buildStaticRoute(obj, allocPath)
+		assert.NoError(t, err)
+		assert.NotNil(t, sr.NetworkIpAllocationPath)
+		assert.Equal(t, allocPath, *sr.NetworkIpAllocationPath)
+		assert.Nil(t, sr.Network, "Network must be nil when NetworkIpAllocationPath is used")
+	})
+
+	t.Run("empty path falls back to spec.network", func(t *testing.T) {
+		obj.Spec.Network = "10.0.0.0/24"
+		sr, err := service.buildStaticRoute(obj, "")
+		assert.NoError(t, err)
+		assert.NotNil(t, sr.Network)
+		assert.Equal(t, "10.0.0.0/24", *sr.Network)
+		assert.Nil(t, sr.NetworkIpAllocationPath, "NetworkIpAllocationPath must be nil when Network CIDR is used")
+	})
+}
+
 func TestValidateStaticRoute(t *testing.T) {
 	obj := &v1alpha1.StaticRoute{}
 	err := validateStaticRoute(obj)
@@ -49,7 +86,7 @@ func TestBuildStaticRoute(t *testing.T) {
 	service.NSXConfig = &config.NSXOperatorConfig{}
 	service.NSXConfig.CoeConfig = &config.CoeConfig{}
 	service.NSXConfig.Cluster = "test_1"
-	staticroutes, err := service.buildStaticRoute(obj)
+	staticroutes, err := service.buildStaticRoute(obj, "")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(staticroutes.NextHops), 2)
 	expName := "teststaticroute"

--- a/pkg/nsx/services/staticroute/staticroute.go
+++ b/pkg/nsx/services/staticroute/staticroute.go
@@ -1,11 +1,14 @@
 package staticroute
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
@@ -17,9 +20,10 @@ import (
 
 type StaticRouteService struct {
 	common.Service
-	StaticRouteStore *StaticRouteStore
-	VPCService       common.VPCServiceProvider
-	builder          *common.PolicyTreeBuilder[*model.StaticRoutes]
+	StaticRouteStore    *StaticRouteStore
+	VPCService          common.VPCServiceProvider
+	IPAllocationService common.IPAddressAllocationServiceProvider
+	builder             *common.PolicyTreeBuilder[*model.StaticRoutes]
 }
 
 var (
@@ -28,7 +32,7 @@ var (
 )
 
 // InitializeStaticRoute sync NSX resources
-func InitializeStaticRoute(commonService common.Service, vpcService common.VPCServiceProvider) (*StaticRouteService, error) {
+func InitializeStaticRoute(commonService common.Service, vpcService common.VPCServiceProvider, ipAllocationService common.IPAddressAllocationServiceProvider) (*StaticRouteService, error) {
 	builder, _ := common.PolicyPathVpcStaticRoutes.NewPolicyTreeBuilder()
 
 	wg := sync.WaitGroup{}
@@ -40,6 +44,7 @@ func InitializeStaticRoute(commonService common.Service, vpcService common.VPCSe
 	staticRouteService.StaticRouteStore = buildStaticRouteStore()
 	staticRouteService.NSXConfig = commonService.NSXConfig
 	staticRouteService.VPCService = vpcService
+	staticRouteService.IPAllocationService = ipAllocationService
 
 	go staticRouteService.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypeStaticRoutes, nil, staticRouteService.StaticRouteStore)
 
@@ -67,8 +72,44 @@ func isStaticRouteReady(staticRoute *v1alpha1.StaticRoute) bool {
 	return false
 }
 
-func (service *StaticRouteService) CreateOrUpdateStaticRoute(namespace string, obj *v1alpha1.StaticRoute) error {
-	nsxStaticRoute, err := service.buildStaticRoute(obj)
+// resolveNetworkIPAllocationPath fetches the IPAddressAllocation CR by name and looks up
+// the corresponding NSX VpcIpAddressAllocation from the local store to obtain its policy path.
+// The path is used as the network field on the NSX static route (network_ip_allocation_path).
+func (service *StaticRouteService) resolveNetworkIPAllocationPath(ctx context.Context, namespace, ipAllocCRName string) (string, error) {
+	ipAllocCR := &v1alpha1.IPAddressAllocation{}
+	if err := service.Client.Get(ctx, k8sclient.ObjectKey{Namespace: namespace, Name: ipAllocCRName}, ipAllocCR); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("IPAddressAllocation CR %s/%s not found", namespace, ipAllocCRName)
+		}
+		return "", fmt.Errorf("failed to get IPAddressAllocation CR %s/%s: %w", namespace, ipAllocCRName, err)
+	}
+
+	nsxAllocation, err := service.IPAllocationService.GetIPAddressAllocationByOwner(ipAllocCR)
+	if err != nil {
+		return "", fmt.Errorf("failed to look up NSX allocation for IPAddressAllocation CR %s/%s: %w", namespace, ipAllocCRName, err)
+	}
+	if nsxAllocation == nil {
+		return "", fmt.Errorf("NSX allocation for IPAddressAllocation CR %s/%s not found in store", namespace, ipAllocCRName)
+	}
+	if nsxAllocation.Path == nil || *nsxAllocation.Path == "" {
+		return "", fmt.Errorf("NSX allocation for IPAddressAllocation CR %s/%s has no policy path", namespace, ipAllocCRName)
+	}
+	return *nsxAllocation.Path, nil
+}
+
+func (service *StaticRouteService) CreateOrUpdateStaticRoute(ctx context.Context, namespace string, obj *v1alpha1.StaticRoute) error {
+	// Resolve the network: either a static CIDR (spec.network) or a reference to an
+	// IPAddressAllocation CR whose NSX policy path becomes the network_ip_allocation_path.
+	var networkIPAllocationPath string
+	if obj.Spec.NetworkIPAllocation != "" {
+		var err error
+		networkIPAllocationPath, err = service.resolveNetworkIPAllocationPath(ctx, namespace, obj.Spec.NetworkIPAllocation)
+		if err != nil {
+			return err
+		}
+	}
+
+	nsxStaticRoute, err := service.buildStaticRoute(obj, networkIPAllocationPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/nsx/services/staticroute/staticroute_test.go
+++ b/pkg/nsx/services/staticroute/staticroute_test.go
@@ -15,11 +15,14 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	mock_org_root "github.com/vmware-tanzu/nsx-operator/pkg/mock/orgrootclient"
 	mocks "github.com/vmware-tanzu/nsx-operator/pkg/mock/staticrouteclient"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
@@ -30,6 +33,30 @@ import (
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
+
+// fakeIPAllocationService is a minimal configurable stub for
+// common.IPAddressAllocationServiceProvider used in staticroute tests.
+type fakeIPAllocationService struct {
+	allocation *model.VpcIpAddressAllocation
+	err        error
+}
+
+func (f *fakeIPAllocationService) GetIPAddressAllocationByOwner(_ v1.Object) (*model.VpcIpAddressAllocation, error) {
+	return f.allocation, f.err
+}
+func (f *fakeIPAllocationService) CreateIPAddressAllocationForAddressBinding(_ *v1alpha1.AddressBinding, _ *v1alpha1.SubnetPort, _ bool) error {
+	return nil
+}
+func (f *fakeIPAllocationService) DeleteIPAddressAllocationForAddressBinding(_ v1.Object) error {
+	return nil
+}
+func (f *fakeIPAllocationService) BuildIPAddressAllocationID(_ v1.Object) string { return "" }
+func (f *fakeIPAllocationService) DeleteIPAddressAllocationByNSXResource(_ *model.VpcIpAddressAllocation) error {
+	return nil
+}
+func (f *fakeIPAllocationService) ListIPAddressAllocationWithAddressBinding() []*model.VpcIpAddressAllocation {
+	return nil
+}
 
 var (
 	staticrouteName1          = "ns1-staticroute-1"
@@ -104,7 +131,7 @@ func Test_InitializeStaticRouteStore(t *testing.T) {
 
 	vpcService := &vpc.VPCService{}
 
-	_, err := InitializeStaticRoute(commonService, vpcService)
+	_, err := InitializeStaticRoute(commonService, vpcService, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -127,7 +154,7 @@ func TestStaticRouteService_DeleteStaticRouteByCR(t *testing.T) {
 		})
 	defer patches2.Reset()
 	vpcService := &vpc.VPCService{}
-	returnservice, err := InitializeStaticRoute(service.Service, vpcService)
+	returnservice, err := InitializeStaticRoute(service.Service, vpcService, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -392,19 +419,19 @@ func TestStaticRouteService_CreateOrUpdateStaticRoute(t *testing.T) {
 
 	// Patch buildStaticRoute to return error
 	t.Run("buildStaticRoute retruns error", func(t *testing.T) {
-		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute) (*model.StaticRoutes, error) {
+		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute, networkIPAllocationPath string) (*model.StaticRoutes, error) {
 			return nil, fmt.Errorf("build error")
 		})
 		defer patchBuild.Reset()
 
-		err := service.CreateOrUpdateStaticRoute("ns", &v1alpha1.StaticRoute{})
+		err := service.CreateOrUpdateStaticRoute(context.Background(), "ns", &v1alpha1.StaticRoute{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "build error")
 	})
 
 	t.Run("no update occurs if the StaticRoute is not modified", func(t *testing.T) {
 		// Patch buildStaticRoute to return valid static route
-		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute) (*model.StaticRoutes, error) {
+		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute, networkIPAllocationPath string) (*model.StaticRoutes, error) {
 			return nsxStaticRoute, nil
 		})
 		defer patchBuild.Reset()
@@ -423,7 +450,7 @@ func TestStaticRouteService_CreateOrUpdateStaticRoute(t *testing.T) {
 		defer patchCompare.Reset()
 		// Add existing static route to store
 		service.StaticRouteStore.Add(nsxStaticRoute)
-		err := service.CreateOrUpdateStaticRoute("ns", &v1alpha1.StaticRoute{
+		err := service.CreateOrUpdateStaticRoute(context.Background(), "ns", &v1alpha1.StaticRoute{
 			Status: v1alpha1.StaticRouteStatus{
 				Conditions: []v1alpha1.StaticRouteCondition{
 					{
@@ -437,7 +464,7 @@ func TestStaticRouteService_CreateOrUpdateStaticRoute(t *testing.T) {
 	})
 
 	t.Run("update failed if VPC is not found", func(t *testing.T) {
-		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute) (*model.StaticRoutes, error) {
+		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute, networkIPAllocationPath string) (*model.StaticRoutes, error) {
 			return nsxStaticRoute, nil
 		})
 		defer patchBuild.Reset()
@@ -460,13 +487,13 @@ func TestStaticRouteService_CreateOrUpdateStaticRoute(t *testing.T) {
 		})
 		defer patchVPC.Reset()
 
-		err := service.CreateOrUpdateStaticRoute("ns", &v1alpha1.StaticRoute{})
+		err := service.CreateOrUpdateStaticRoute(context.Background(), "ns", &v1alpha1.StaticRoute{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no vpc found for ns ns")
 	})
 
 	t.Run("update failed NSX patch error", func(t *testing.T) {
-		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute) (*model.StaticRoutes, error) {
+		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute, networkIPAllocationPath string) (*model.StaticRoutes, error) {
 			return nsxStaticRoute, nil
 		})
 		defer patchBuild.Reset()
@@ -495,13 +522,13 @@ func TestStaticRouteService_CreateOrUpdateStaticRoute(t *testing.T) {
 		})
 		defer patchPatch.Reset()
 
-		err := service.CreateOrUpdateStaticRoute("ns", &v1alpha1.StaticRoute{})
+		err := service.CreateOrUpdateStaticRoute(context.Background(), "ns", &v1alpha1.StaticRoute{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "patch error")
 	})
 
 	t.Run("update failed with StaticRouteClient error", func(t *testing.T) {
-		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute) (*model.StaticRoutes, error) {
+		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute, networkIPAllocationPath string) (*model.StaticRoutes, error) {
 			return nsxStaticRoute, nil
 		})
 		defer patchBuild.Reset()
@@ -531,13 +558,13 @@ func TestStaticRouteService_CreateOrUpdateStaticRoute(t *testing.T) {
 		defer patchPatch.Reset()
 
 		mockStaticRouteclient.EXPECT().Get("org1", "proj1", "vpc1", staticRouteID).Return(model.StaticRoutes{}, fmt.Errorf("get error")).Times(1)
-		err := service.CreateOrUpdateStaticRoute("ns", &v1alpha1.StaticRoute{})
+		err := service.CreateOrUpdateStaticRoute(context.Background(), "ns", &v1alpha1.StaticRoute{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "get error")
 	})
 
 	t.Run("update failed with realization check error", func(t *testing.T) {
-		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute) (*model.StaticRoutes, error) {
+		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute, networkIPAllocationPath string) (*model.StaticRoutes, error) {
 			return nsxStaticRoute, nil
 		})
 		defer patchBuild.Reset()
@@ -577,14 +604,14 @@ func TestStaticRouteService_CreateOrUpdateStaticRoute(t *testing.T) {
 		})
 		defer patchDelete.Reset()
 
-		err := service.CreateOrUpdateStaticRoute("ns", &v1alpha1.StaticRoute{})
+		err := service.CreateOrUpdateStaticRoute(context.Background(), "ns", &v1alpha1.StaticRoute{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "realization check failed")
 		assert.Contains(t, err.Error(), "deletion failed")
 	})
 
 	t.Run("update failed and successfully delete the failed route", func(t *testing.T) {
-		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute) (*model.StaticRoutes, error) {
+		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute, networkIPAllocationPath string) (*model.StaticRoutes, error) {
 			return nsxStaticRoute, nil
 		})
 		defer patchBuild.Reset()
@@ -624,13 +651,13 @@ func TestStaticRouteService_CreateOrUpdateStaticRoute(t *testing.T) {
 			return nil
 		})
 		defer patchDelete.Reset()
-		err := service.CreateOrUpdateStaticRoute("ns", &v1alpha1.StaticRoute{})
+		err := service.CreateOrUpdateStaticRoute(context.Background(), "ns", &v1alpha1.StaticRoute{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "realized error")
 	})
 
 	t.Run("successfully patch static route", func(t *testing.T) {
-		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute) (*model.StaticRoutes, error) {
+		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(service), "buildStaticRoute", func(_ *StaticRouteService, obj *v1alpha1.StaticRoute, networkIPAllocationPath string) (*model.StaticRoutes, error) {
 			return nsxStaticRoute, nil
 		})
 		defer patchBuild.Reset()
@@ -664,7 +691,7 @@ func TestStaticRouteService_CreateOrUpdateStaticRoute(t *testing.T) {
 			})
 		defer patchRealize.Reset()
 		mockStaticRouteclient.EXPECT().Get("org1", "proj1", "vpc1", staticRouteID).Return(*nsxStaticRoute, nil).Times(1)
-		err := service.CreateOrUpdateStaticRoute("ns", &v1alpha1.StaticRoute{})
+		err := service.CreateOrUpdateStaticRoute(context.Background(), "ns", &v1alpha1.StaticRoute{})
 		assert.NoError(t, err)
 	})
 }
@@ -701,4 +728,174 @@ func Test_isStaticRouteReady(t *testing.T) {
 		},
 	}
 	assert.False(t, isStaticRouteReady(staticRouteUnready))
+}
+
+func TestResolveNetworkIPAllocationPath(t *testing.T) {
+	const ns = "test-ns"
+	const crName = "my-alloc"
+	const nsxPath = "/orgs/default/projects/p1/vpcs/v1/ip-address-allocations/alloc-1"
+
+	allocCR := &v1alpha1.IPAddressAllocation{
+		ObjectMeta: v1.ObjectMeta{Name: crName, Namespace: ns, UID: "cr-uid-1"},
+	}
+
+	scheme := apimachineryruntime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+
+	// makeService builds a StaticRouteService whose k8s client is pre-loaded with objs
+	// and whose IPAllocationService is set to ipSvc.
+	makeService := func(ipSvc *fakeIPAllocationService, objs ...apimachineryruntime.Object) *StaticRouteService {
+		svc, ctrl, _ := createService(t)
+		defer ctrl.Finish()
+		svc.Client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+		svc.IPAllocationService = ipSvc
+		return svc
+	}
+
+	t.Run("CR not found returns error", func(t *testing.T) {
+		svc := makeService(&fakeIPAllocationService{}) // no CR pre-loaded
+		_, err := svc.resolveNetworkIPAllocationPath(context.Background(), ns, crName)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("k8s client returns unexpected error", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		svc, _, _ := createService(t)
+		mockK8s := mock_client.NewMockClient(mockCtrl)
+		mockK8s.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(fmt.Errorf("connection refused"))
+		svc.Client = mockK8s
+		svc.IPAllocationService = &fakeIPAllocationService{}
+
+		_, err := svc.resolveNetworkIPAllocationPath(context.Background(), ns, crName)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get IPAddressAllocation CR")
+		assert.Contains(t, err.Error(), "connection refused")
+	})
+
+	t.Run("NSX allocation lookup fails", func(t *testing.T) {
+		svc := makeService(&fakeIPAllocationService{err: fmt.Errorf("store error")}, allocCR)
+		_, err := svc.resolveNetworkIPAllocationPath(context.Background(), ns, crName)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to look up NSX allocation")
+		assert.Contains(t, err.Error(), "store error")
+	})
+
+	t.Run("NSX allocation not in store returns error", func(t *testing.T) {
+		svc := makeService(&fakeIPAllocationService{allocation: nil, err: nil}, allocCR)
+		_, err := svc.resolveNetworkIPAllocationPath(context.Background(), ns, crName)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in store")
+	})
+
+	t.Run("NSX allocation has nil path returns error", func(t *testing.T) {
+		svc := makeService(&fakeIPAllocationService{
+			allocation: &model.VpcIpAddressAllocation{Path: nil},
+		}, allocCR)
+		_, err := svc.resolveNetworkIPAllocationPath(context.Background(), ns, crName)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "has no policy path")
+	})
+
+	t.Run("NSX allocation has empty path returns error", func(t *testing.T) {
+		emptyPath := ""
+		svc := makeService(&fakeIPAllocationService{
+			allocation: &model.VpcIpAddressAllocation{Path: &emptyPath},
+		}, allocCR)
+		_, err := svc.resolveNetworkIPAllocationPath(context.Background(), ns, crName)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "has no policy path")
+	})
+
+	t.Run("success returns NSX allocation path", func(t *testing.T) {
+		path := nsxPath
+		svc := makeService(&fakeIPAllocationService{
+			allocation: &model.VpcIpAddressAllocation{Path: &path},
+		}, allocCR)
+		got, err := svc.resolveNetworkIPAllocationPath(context.Background(), ns, crName)
+		assert.NoError(t, err)
+		assert.Equal(t, nsxPath, got)
+	})
+}
+
+// TestCreateOrUpdateStaticRoute_WithNetworkIPAllocation verifies that when
+// spec.networkIpAllocation is set, CreateOrUpdateStaticRoute resolves the
+// IPAddressAllocation CR before calling buildStaticRoute.
+func TestCreateOrUpdateStaticRoute_WithNetworkIPAllocation(t *testing.T) {
+	const ns = "test-ns"
+	const crName = "my-alloc"
+	const nsxPath = "/orgs/default/projects/p1/vpcs/v1/ip-address-allocations/alloc-1"
+
+	scheme := apimachineryruntime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+
+	staticRouteCR := &v1alpha1.StaticRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "sr1", Namespace: ns},
+		Spec: v1alpha1.StaticRouteSpec{
+			NetworkIPAllocation: crName,
+			NextHops:            []v1alpha1.NextHop{{IPAddress: "10.1.1.1"}},
+		},
+	}
+
+	t.Run("CR not found aborts without calling NSX", func(t *testing.T) {
+		svc, ctrl, _ := createService(t)
+		defer ctrl.Finish()
+		// Fake client has NO IPAddressAllocation pre-loaded → returns NotFound.
+		svc.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+		svc.IPAllocationService = &fakeIPAllocationService{}
+
+		err := svc.CreateOrUpdateStaticRoute(context.Background(), ns, staticRouteCR)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("NSX allocation not in store aborts without calling NSX", func(t *testing.T) {
+		allocCR := &v1alpha1.IPAddressAllocation{
+			ObjectMeta: v1.ObjectMeta{Name: crName, Namespace: ns, UID: "cr-uid-1"},
+		}
+		svc, ctrl, _ := createService(t)
+		defer ctrl.Finish()
+		svc.Client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(allocCR).Build()
+		svc.IPAllocationService = &fakeIPAllocationService{allocation: nil, err: nil}
+
+		err := svc.CreateOrUpdateStaticRoute(context.Background(), ns, staticRouteCR)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in store")
+	})
+
+	t.Run("resolved path is forwarded to buildStaticRoute", func(t *testing.T) {
+		allocCR := &v1alpha1.IPAddressAllocation{
+			ObjectMeta: v1.ObjectMeta{Name: crName, Namespace: ns, UID: "cr-uid-2"},
+		}
+		path := nsxPath
+		svc, ctrl, _ := createService(t)
+		defer ctrl.Finish()
+		svc.Client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(allocCR).Build()
+		svc.IPAllocationService = &fakeIPAllocationService{
+			allocation: &model.VpcIpAddressAllocation{Path: &path},
+		}
+
+		// Patch buildStaticRoute to capture the path argument and return a minimal route.
+		var capturedPath string
+		patchBuild := gomonkey.ApplyPrivateMethod(reflect.TypeOf(svc), "buildStaticRoute",
+			func(_ *StaticRouteService, _ *v1alpha1.StaticRoute, networkIPAllocationPath string) (*model.StaticRoutes, error) {
+				capturedPath = networkIPAllocationPath
+				id := "sr-id"
+				return &model.StaticRoutes{Id: &id}, nil
+			})
+		defer patchBuild.Reset()
+
+		// Patch the downstream NSX calls so the test doesn't need a real NSX server.
+		patchVPC := gomonkey.ApplyMethod(reflect.TypeOf(svc.VPCService), "ListVPCInfo",
+			func(_ common.VPCServiceProvider, _ string) []common.VPCResourceInfo {
+				return []common.VPCResourceInfo{}
+			})
+		defer patchVPC.Reset()
+
+		_ = svc.CreateOrUpdateStaticRoute(context.Background(), ns, staticRouteCR)
+		// Regardless of the downstream result, the path must have been forwarded.
+		assert.Equal(t, nsxPath, capturedPath)
+	})
 }

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -6,3 +6,5 @@ const AddressBindingNamespaceVMIndexKey = "index/AddressBinding/NamespaceVM"
 const AddressBindingIPAddressAllocationNameIndexKey = "spec.ipAddressAllocationName"
 const SubnetPortMACInNeed = "index/subnetport/macInNeed"
 const SubnetAssociatedResource = "index/subnet/associatedResource"
+
+const StaticRouteIPAddressAllocationNameIndexKey = "spec.networkIpAllocation"


### PR DESCRIPTION
In StaticRoute CR, add a new property netwokrIpAllocation, its value is IPAddressAllocation CR name in the namespace. This propety and the original network property can not be set at the same time.

When networkIPAllocation is set, get the IPAllocation CR and use the CR UUID to find the matching IPAllcation object in nsx, then set the nsx ipalloction resource path on nsx staticroute.network_ip_allocation.

When network is set, keep original process for creating static route.

Testing Done:

1. using network to create staticroute,  the created staticroute crd and nsx static route as follow:
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: StaticRoute
metadata:
  name: test-1
  namespace: sean-ns
spec:
  network: 45.1.2.0/24
  nextHops:
  - ipAddress: 172.10.0.2
  - ipAddress: 172.10.0.1

{
            "network": "45.1.2.0/24",
            "next_hops": [
                {
                    "ip_address": "172.10.0.2",
                    "admin_distance": 1
                },
                {
                    "ip_address": "172.10.0.1",
                    "admin_distance": 1
                }
            ],
            "enabled_on_secondary": false,
            "resource_type": "StaticRoutes",
            "id": "test-1_r1d6z",
            "display_name": "test-1",
      ...
            "path": "/orgs/default/projects/project-quality/vpcs/sean-ns_r1d6z/static-routes/test-1_r1d6z",
            "relative_path": "test-1_r1d6z",
            "parent_path": "/orgs/default/projects/project-quality/vpcs/sean-ns_r1d6z",
        }
```
2. use ipallocation for creating static route
```
 {
            "network_ip_allocation_path": "/orgs/default/projects/project-quality/vpcs/sean-ns_r1d6z/ip-address-allocations/ipa-1_r1d6z",
            "next_hops": [
                {
                    "ip_address": "172.10.0.6",
                    "admin_distance": 1
                },
                {
                    "ip_address": "172.10.0.5",
                    "admin_distance": 1
                }
            ],
            "enabled_on_secondary": false,
            "resource_type": "StaticRoutes",
            "id": "test-4_r1d6z",
            "display_name": "test-4",
            "tags": [
                {
                    "scope": "nsx-op/cluster",
                    "tag": "7fbde391-08c5-4126-9289-8c24a519a4e3"
                },
                {
                    "scope": "nsx-op/version",
                    "tag": "1.0.0"
                },
                {
                    "scope": "nsx-op/namespace",
                    "tag": "sean-ns"
                },
                {
                    "scope": "nsx-op/static_route_name",
                    "tag": "test-4"
                },
                {
                    "scope": "nsx-op/static_route_uid",
                    "tag": "2beafd30-3d1d-40d7-a5ab-8fa33f8a6e02"
                },
                {
                    "scope": "nsx-op/namespace_uid",
                    "tag": "3b92b2f4-bc11-435a-92a6-78c6f61c2b18"
                }
            ],
            "path": "/orgs/default/projects/project-quality/vpcs/sean-ns_r1d6z/static-routes/test-4_r1d6z",
            "relative_path": "test-4_r1d6z",
            "parent_path": "/orgs/default/projects/project-quality/vpcs/sean-ns_r1d6z",
            "remote_path": "",
            "unique_id": "81b8f4f6-46c3-42cb-b08c-a2b5ed277f85",
            "realization_id": "81b8f4f6-46c3-42cb-b08c-a2b5ed277f85",
            "owner_id": "953bdfea-f516-4285-929a-88bddb8c96df",
            "marked_for_delete": false,
            "overridden": false,
            "_system_owned": false,
            "_protection": "REQUIRE_OVERRIDE",
            "_create_time": 1780523525174,
            "_create_user": "wcp-cluster-user-7fbde391-08c5-4126-9289-8c24a519a4e3-bfc2f543-4e76-4df2-8729-fc19b2b866e3",
            "_last_modified_time": 1780523525174,
            "_last_modified_user": "wcp-cluster-user-7fbde391-08c5-4126-9289-8c24a519a4e3-bfc2f543-4e76-4df2-8729-fc19b2b866e3",
            "_revision": 0
        },
```
3. try delete referenced ipaddressallocation , webhook will block the delete operation
```
root@4230f2037da66ae466aaeb060277ae43 [ /tmp ]# k delete ipaddressallocations ipa-1 -n sean-ns
Error from server (Forbidden): admission webhook "ipaddressallocation.validating.crd.nsx.vmware.com" denied the request: IPAddressAllocation ipa-1 is used by StaticRoute test-2
```


Jira: #NCP-705