### PR TITLE
Support IPv6 for SubnetPort 

### DIFF
--- a/docs/ref/apis/legacy.md
+++ b/docs/ref/apis/legacy.md
@@ -29,7 +29,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -117,7 +117,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 
@@ -260,7 +260,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br />Optional: \{\} <br /> |
+| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br /> |
 | `allocationSize` _integer_ | AllocationSize specifies the size of IPv4 allocationIPs to be allocated.<br />It should be a power of 2. |  | Minimum: 1 <br /> |
 | `allocationIPs` _string_ | AllocationIPs specifies the Allocated IP addresses in CIDR or single IP Address format. |  |  |
 | `ipv6AllocationPrefixLength` _integer_ | IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses.<br />Defaults to 64 when ipAddressType is IPv6 and this field is not specified. |  | Maximum: 128 <br />Minimum: 64 <br /> |
@@ -766,7 +766,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 
@@ -784,8 +784,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `network` _string_ | Specify network address in CIDR format.<br />Mutually exclusive with networkIpAllocation. |  | Format: cidr <br />Optional: \{\} <br /> |
-| `networkIpAllocation` _string_ | Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as<br />the static route network. Mutually exclusive with network. |  | Optional: \{\} <br /> |
+| `network` _string_ | Specify network address in CIDR format.<br />Mutually exclusive with networkIpAllocation. |  | Format: cidr <br /> |
+| `networkIpAllocation` _string_ | Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as<br />the static route network. Mutually exclusive with network. |  |  |
 | `nextHops` _[NextHop](#nexthop) array_ | Next hop gateway |  | MinItems: 1 <br /> |
 
 
@@ -1241,8 +1241,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  | Optional: \{\} <br /> |
-| `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  | Optional: \{\} <br /> |
+| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  |  |
+| `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  |  |
 | `nsxProject` _string_ | NSX Project the Namespace is associated with. |  |  |
 | `vpcConnectivityProfile` _string_ | VPCConnectivityProfile Path. This profile has configuration related to creating VPC transit gateway attachment. |  |  |
 | `privateIPs` _string array_ | Private IPs. |  |  |

--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -30,6 +30,7 @@ const (
 	NSXIPAddressTypeIPv4     = "IPV4"
 	NSXIPAddressTypeIPv6     = "IPV6"
 	NSXIPAddressTypeIPv4IPv6 = "IPV4_IPV6"
+	NSXIPAddressTypeNone     = "NONE"
 )
 
 var (
@@ -104,7 +105,7 @@ func getSubnetFromVPCNetworkConfiguration(vpcService servicecommon.VPCServicePro
 }
 
 // Get a Subnet with available IPs from the pre-created SubnetSet
-func GetSubnetFromSubnetSet(client k8sclient.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider) (string, error) {
+func GetSubnetFromSubnetSet(client k8sclient.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType) (string, error) {
 	var errList []error
 	defaultSubnetSetFor := util.GetSubnetSetKind(subnetSet)
 	subnetPathsFromConfig := sets.New[string]()
@@ -140,7 +141,7 @@ func GetSubnetFromSubnetSet(client k8sclient.Client, subnetSet *v1alpha1.SubnetS
 				continue
 			}
 		}
-		canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, servicecommon.IsSharedSubnet(subnetCR))
+		canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, servicecommon.IsSharedSubnet(subnetCR), interfaceIPType)
 		if err != nil {
 			log.Error(err, "Failed to check capacity of NSX Subnet", "Subnet", subnetName, "SubnetSet", subnetSet.Name, "Namespace", subnetSet.Namespace, "NSXSubnet", nsxSubnet.Id)
 			errList = append(errList, err)
@@ -184,7 +185,7 @@ func IsNamespaceInTepLessMode(client k8sclient.Client, namespace string) (bool, 
 	return networkInfo.VPCs[0].NetworkStack == v1alpha1.VLANBackedVPC, nil
 }
 
-func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider) (string, *types.UID, *sync.RWMutex, error) {
+func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType) (string, *types.UID, *sync.RWMutex, error) {
 	if subnetSet.Spec.SubnetDHCPConfig.Mode == v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeRelay) {
 		// From NSX Operator 9.1.1, DHCPRelay SubnetSet is no longer supported.
 		return "", nil, nil, fmt.Errorf("Creating SubnetPort on DHCPRelay SubnetSet is not supported")
@@ -197,7 +198,7 @@ func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Re
 		if err := apiReader.Get(context.Background(), types.NamespacedName{Namespace: subnetSet.Namespace, Name: subnetSet.Name}, subnetSet); err != nil {
 			return "", &subnetSet.UID, subnetSetLock, err
 		}
-		nsxSubnet, err := GetSubnetFromSubnetSet(client, subnetSet, vpcService, subnetService, subnetPortService)
+		nsxSubnet, err := GetSubnetFromSubnetSet(client, subnetSet, vpcService, subnetService, subnetPortService, interfaceIPType)
 		return nsxSubnet, &subnetSet.UID, subnetSetLock, err
 	}
 	// Use SubnetSet uuid lock to make sure when multiple ports are created on the same SubnetSet, only one Subnet will be created
@@ -205,7 +206,7 @@ func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Re
 	defer WUnlockSubnetSet(subnetSet.GetUID(), subnetSetLock)
 	subnetList := subnetService.GetSubnetsByIndex(servicecommon.TagScopeSubnetSetCRUID, string(subnetSet.GetUID()))
 	for _, nsxSubnet := range subnetList {
-		canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, false)
+		canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, false, interfaceIPType)
 		if err != nil {
 			return "", nil, nil, err
 		}
@@ -228,7 +229,7 @@ func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Re
 	if err != nil {
 		return "", nil, nil, err
 	}
-	canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, false)
+	canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, false, interfaceIPType)
 	if err != nil {
 		return "", nil, nil, err
 	}
@@ -636,6 +637,25 @@ func ConvertCRIPAddressTypeToNSX(crType v1alpha1.IPAddressType) string {
 		return NSXIPAddressTypeIPv6
 	case v1alpha1.IPAddressTypeIPv4IPv6:
 		return NSXIPAddressTypeIPv4IPv6
+	default:
+		log.Warn("Unknown IP address type, defaulting to IPv4", "unknownType", string(crType))
+		return NSXIPAddressTypeIPv4
+	}
+}
+
+// ConvertCRStaticIPAddressTypeToNSX converts CR StaticIPAddressType to NSX API format
+// v1alpha1 format: IPv4, IPv6, IPv4IPv6, None
+// NSX format: IPV4, IPV6, IPV4_IPV6, NONE
+func ConvertCRStaticIPAddressTypeToNSX(crType v1alpha1.StaticIPAllocationType) string {
+	switch crType {
+	case v1alpha1.StaticIPAllocationTypeIPv4:
+		return NSXIPAddressTypeIPv4
+	case v1alpha1.StaticIPAllocationTypeIPv6:
+		return NSXIPAddressTypeIPv6
+	case v1alpha1.StaticIPAllocationTypeIPv4IPv6:
+		return NSXIPAddressTypeIPv4IPv6
+	case v1alpha1.StaticIPAllocationTypeNone:
+		return NSXIPAddressTypeNone
 	default:
 		log.Warn("Unknown IP address type, defaulting to IPv4", "unknownType", string(crType))
 		return NSXIPAddressTypeIPv4

--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -98,7 +98,7 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 		},
 	}
 	k8sclient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(subnetSet).Build()
-	patches := gomonkey.ApplyFunc(GetSubnetFromSubnetSet, func(client client.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider) (string, error) {
+	patches := gomonkey.ApplyFunc(GetSubnetFromSubnetSet, func(client client.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType) (string, error) {
 		return expectedSubnetPath, nil
 	})
 	defer patches.Reset()
@@ -122,7 +122,7 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 						},
 					})
 				spsp.(*pkg_mock.MockSubnetPortServiceProvider).On("GetPortsOfSubnet", mock.Anything).Return([]*model.VpcSubnetPort{})
-				spsp.(*pkg_mock.MockSubnetPortServiceProvider).On("AllocatePortFromSubnet", mock.Anything, mock.Anything).Return(true, nil)
+				spsp.(*pkg_mock.MockSubnetPortServiceProvider).On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 			},
 			expectedResult: expectedSubnetPath,
 			subnetSet:      subnetSet,
@@ -146,7 +146,7 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 				ssp.(*pkg_mock.MockSubnetServiceProvider).On("GenerateSubnetNSTags", mock.Anything)
 				vsp.(*pkg_mock.MockVPCServiceProvider).On("ListVPCInfo", mock.Anything).Return([]servicecommon.VPCResourceInfo{{}})
 				ssp.(*pkg_mock.MockSubnetServiceProvider).On("CreateOrUpdateSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&model.VpcSubnet{Path: &expectedSubnetPath}, nil)
-				spsp.(*pkg_mock.MockSubnetPortServiceProvider).On("AllocatePortFromSubnet", mock.Anything, mock.Anything).Return(true, nil)
+				spsp.(*pkg_mock.MockSubnetPortServiceProvider).On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 			},
 			expectedResult: expectedSubnetPath,
 			subnetSet: &v1alpha1.SubnetSet{
@@ -197,7 +197,7 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 			ssp := &pkg_mock.MockSubnetServiceProvider{}
 			spsp := &pkg_mock.MockSubnetPortServiceProvider{}
 			tt.prepareFunc(t, vps, ssp, spsp)
-			subnetPath, subnetSetUID, subnetSetLock, err := AllocateSubnetFromSubnetSet(k8sclient, k8sclient, tt.subnetSet, vps, ssp, spsp)
+			subnetPath, subnetSetUID, subnetSetLock, err := AllocateSubnetFromSubnetSet(k8sclient, k8sclient, tt.subnetSet, vps, ssp, spsp, "")
 			if subnetSetLock != nil {
 				RUnlockSubnetSet(*subnetSetUID, subnetSetLock)
 			}
@@ -733,7 +733,7 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			mockSetup: func(ms *pkg_mock.MockSubnetServiceProvider, mp *pkg_mock.MockSubnetPortServiceProvider) *gomonkey.Patches {
 				// We use mock.Anything here to avoid pointer address issues
 				ms.On("GetSubnetByCR", mock.Anything).Return(nsxSubnet1, nil)
-				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything).Return(true, nil)
+				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 				return nil
 			},
 			expectedPath: path1,
@@ -752,8 +752,8 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			mockSetup: func(ms *pkg_mock.MockSubnetServiceProvider, mp *pkg_mock.MockSubnetPortServiceProvider) *gomonkey.Patches {
 				ms.On("GetSubnetByCR", mock.Anything).Return(nsxSubnet1, nil)
 				// First call returns false (full), second call returns true
-				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything).Return(false, nil).Once()
-				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything).Return(true, nil).Once()
+				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Once()
+				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Once()
 				return nil
 			},
 			expectedPath: path1,
@@ -778,7 +778,7 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			mockSetup: func(ms *pkg_mock.MockSubnetServiceProvider, mp *pkg_mock.MockSubnetPortServiceProvider) *gomonkey.Patches {
 				ms.On("GetSubnetByCR", mock.Anything).Return(nsxSubnet1, nil).Once()
 				ms.On("GetSubnetByCR", mock.Anything).Return(nsxSubnet2, nil).Once()
-				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything).Return(true, nil).Once()
+				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Once()
 				patches := gomonkey.ApplyFunc(GetVpcNetworkConfig, func(service servicecommon.VPCServiceProvider, ns string) (*v1alpha1.VPCNetworkConfiguration, error) {
 					return &v1alpha1.VPCNetworkConfiguration{
 						Spec: v1alpha1.VPCNetworkConfigurationSpec{
@@ -805,7 +805,7 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			},
 			mockSetup: func(ms *pkg_mock.MockSubnetServiceProvider, mp *pkg_mock.MockSubnetPortServiceProvider) *gomonkey.Patches {
 				ms.On("GetSubnetByCR", mock.Anything).Return(nsxSubnet1, nil)
-				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything).Return(false, nil)
+				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
 				return nil
 			},
 			expectedPath: "",
@@ -851,7 +851,7 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			},
 			mockSetup: func(ms *pkg_mock.MockSubnetServiceProvider, mp *pkg_mock.MockSubnetPortServiceProvider) *gomonkey.Patches {
 				ms.On("GetSubnetByCR", mock.Anything).Return(nsxSubnet1, nil)
-				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything).Return(false, errors.New("capacity-check-failed"))
+				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(false, errors.New("capacity-check-failed"))
 				return nil
 			},
 			wantErr:     true,
@@ -872,7 +872,7 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			}
 
 			// Execute
-			result, err := GetSubnetFromSubnetSet(client, tt.subnetSet, mockVpcSvc, mockSubnetSvc, mockPortSvc)
+			result, err := GetSubnetFromSubnetSet(client, tt.subnetSet, mockVpcSvc, mockSubnetSvc, mockPortSvc, "")
 
 			// Assert
 			if tt.wantErr {

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -86,7 +86,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	if !common.PodIsDeleted(pod) {
 		r.StatusUpdater.IncreaseUpdateTotal()
-		isExisting, nsxSubnetPath, subnetSetUID, subnetSetLock, err := r.GetSubnetPathForPod(ctx, pod)
+		isExisting, nsxSubnetPath, subnetSetUID, subnetSetLock, interfaceIPType, err := r.GetSubnetPathForPod(ctx, pod)
 		if subnetSetLock != nil {
 			defer common.RUnlockSubnetSet(*subnetSetUID, subnetSetLock)
 		}
@@ -96,7 +96,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return common.ResultRequeue, err
 		}
 		if !isExisting {
-			defer r.SubnetPortService.ReleasePortInSubnet(nsxSubnetPath)
+			defer r.SubnetPortService.ReleasePortInSubnet(nsxSubnetPath, interfaceIPType)
 		}
 		log.Info("Got NSX Subnet for Pod", "NSX Subnet path", nsxSubnetPath, "pod.Name", pod.Name, "pod.UID", pod.UID)
 		node, err := r.GetNodeByName(pod.Spec.NodeName)
@@ -116,7 +116,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			r.StatusUpdater.UpdateFail(ctx, pod, err, "", nil)
 			return common.ResultRequeue, err
 		}
-		nsxSubnetPortState, _, err := r.SubnetPortService.CreateOrUpdateSubnetPort(pod, nsxSubnet, contextID, &pod.ObjectMeta.Labels, false, r.restoreMode)
+		nsxSubnetPortState, err := r.SubnetPortService.CreateOrUpdateSubnetPort(pod, nsxSubnet, contextID, &pod.ObjectMeta.Labels, false, r.restoreMode, interfaceIPType)
 		if err != nil {
 			r.StatusUpdater.UpdateFail(ctx, pod, err, "", nil)
 			return common.ResultRequeue, err
@@ -403,17 +403,17 @@ func (r *PodReconciler) getSubnetByPod(pod *v1.Pod, subnetSet *v1alpha1.SubnetSe
 	return common.GetSubnetByIP(subnets, net.ParseIP(pod.Status.PodIP))
 }
 
-func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, error) {
+func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
 	var subnetSetLock *sync.RWMutex
 	var subnetSetUID *types.UID
 	subnetPath := r.SubnetPortService.GetSubnetPathForSubnetPortFromStore(pod.GetUID())
 	if len(subnetPath) > 0 {
 		log.Debug("NSX SubnetPort had been created, returning the existing NSX Subnet path", "pod.UID", pod.UID, "subnetPath", subnetPath)
-		return true, subnetPath, subnetSetUID, subnetSetLock, nil
+		return true, subnetPath, subnetSetUID, subnetSetLock, "", nil
 	}
 	subnetSet, err := common.GetDefaultSubnetSetByNamespace(r.SubnetPortService.Client, pod.Namespace, servicecommon.DefaultPodNetwork)
 	if err != nil {
-		return false, "", subnetSetUID, subnetSetLock, err
+		return false, "", subnetSetUID, subnetSetLock, "", err
 	}
 	log.Info("Got default SubnetSet for Pod, allocating the NSX Subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "pod.Name", pod.Name, "pod.UID", pod.UID)
 	if r.restoreMode {
@@ -422,18 +422,23 @@ func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (b
 			subnetPath, err = r.getSubnetByPod(pod, subnetSet)
 			if err != nil {
 				log.Error(err, "Failed to find Subnet for restored Pod", "Pod", pod)
-				return false, "", subnetSetUID, subnetSetLock, err
+				return false, "", subnetSetUID, subnetSetLock, "", err
 			}
 			log.Debug("NSX SubnetPort will be restored on the existing NSX Subnet", "pod.UID", pod.UID, "subnetPath", subnetPath)
-			return true, subnetPath, subnetSetUID, subnetSetLock, nil
+			return true, subnetPath, subnetSetUID, subnetSetLock, "", nil
 		}
 	}
-	subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService)
+	// SubnetSet can be created without IPAddressType, we need to wait for the value initialized by subnetset controller
+	if subnetSet.Spec.IPAddressType == "" {
+		return false, "", subnetSetUID, subnetSetLock, "", fmt.Errorf("default Pod SubnetSet IPAddressType is under calculation")
+	}
+	interfacetype := subnetport.GetDefaultInterfaceIPType(subnetSet.Spec.IPAddressType, subnetSet.Spec.IPAddressType)
+	subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfacetype)
 	if err != nil {
-		return false, subnetPath, subnetSetUID, subnetSetLock, err
+		return false, subnetPath, subnetSetUID, subnetSetLock, interfacetype, err
 	}
 	log.Info("Allocated NSX Subnet for Pod", "nsxSubnetPath", subnetPath, "pod.Name", pod.Name, "pod.UID", pod.UID)
-	return false, subnetPath, subnetSetUID, subnetSetLock, nil
+	return false, subnetPath, subnetSetUID, subnetSetLock, interfacetype, nil
 }
 
 func (r *PodReconciler) deleteSubnetPortByPodName(ctx context.Context, ns string, name string) error {

--- a/pkg/controllers/pod/pod_controller_test.go
+++ b/pkg/controllers/pod/pod_controller_test.go
@@ -132,8 +132,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 				})
 
 				patchesGetSubnetPathForPod := gomonkey.ApplyFunc((*PodReconciler).GetSubnetPathForPod,
-					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, error) {
-						return false, "", nil, nil, errors.New("failed to get subnet path")
+					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+						return false, "", nil, nil, "", errors.New("failed to get subnet path")
 					})
 
 				return patchesGetSubnetPathForPod
@@ -158,8 +158,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 					return nil
 				})
 				patches := gomonkey.ApplyFunc((*PodReconciler).GetSubnetPathForPod,
-					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, error) {
-						return false, "subnet-path-1", nil, nil, nil
+					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+						return false, "subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 					})
 				patches.ApplyFunc((*PodReconciler).GetNodeByName,
 					func(r *PodReconciler, nodeName string) (*model.HostTransportNode, error) {
@@ -179,8 +179,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 					return nil
 				})
 				patches := gomonkey.ApplyFunc((*PodReconciler).GetSubnetPathForPod,
-					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, error) {
-						return false, "subnet-path-1", nil, nil, nil
+					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+						return false, "subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 					})
 				patches.ApplyFunc((*PodReconciler).GetNodeByName,
 					func(r *PodReconciler, nodeName string) (*model.HostTransportNode, error) {
@@ -208,8 +208,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 					return nil
 				})
 				patches := gomonkey.ApplyFunc((*PodReconciler).GetSubnetPathForPod,
-					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, error) {
-						return false, "subnet-path-1", nil, nil, nil
+					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+						return false, "subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 					})
 				patches.ApplyFunc((*PodReconciler).GetNodeByName,
 					func(r *PodReconciler, nodeName string) (*model.HostTransportNode, error) {
@@ -223,8 +223,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 						return &model.VpcSubnet{}, nil
 					})
 				patches.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
-					func(r *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
-						return nil, false, errors.New("failed to create subnetport")
+					func(r *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+						return nil, errors.New("failed to create subnetport")
 					})
 				return patches
 			},
@@ -241,8 +241,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 					return nil
 				})
 				patches := gomonkey.ApplyFunc((*PodReconciler).GetSubnetPathForPod,
-					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, error) {
-						return false, "subnet-path-1", nil, nil, nil
+					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+						return false, "subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 					})
 				patches.ApplyFunc((*PodReconciler).GetNodeByName,
 					func(r *PodReconciler, nodeName string) (*model.HostTransportNode, error) {
@@ -256,7 +256,7 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 						return &model.VpcSubnet{}, nil
 					})
 				patches.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
-					func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string) (*model.SegmentPortState, bool, error) {
+					func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
 						return &model.SegmentPortState{
 							RealizedBindings: []model.AddressBindingEntry{
 								{
@@ -268,7 +268,7 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 							Attachment: &model.SegmentPortAttachmentState{
 								Id: servicecommon.String("attachment-id"),
 							},
-						}, false, nil
+						}, nil
 					})
 
 				k8sClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
@@ -291,8 +291,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 					return nil
 				})
 				patches := gomonkey.ApplyFunc((*PodReconciler).GetSubnetPathForPod,
-					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, error) {
-						return false, "/orgs/default/projects/default/vpcs/ns-1/subnets/subnet-path-1", nil, nil, nil
+					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+						return false, "/orgs/default/projects/default/vpcs/ns-1/subnets/subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 					})
 				patches.ApplyFunc(common.IsSharedSubnetPath, func(ctx context.Context, client client.Client, path string, ns string) (bool, error) {
 					return false, nil
@@ -306,7 +306,7 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 						return &model.VpcSubnet{}, nil
 					})
 				patches.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
-					func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string) (*model.SegmentPortState, bool, error) {
+					func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
 						return &model.SegmentPortState{
 							RealizedBindings: []model.AddressBindingEntry{
 								{
@@ -315,7 +315,7 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 									},
 								},
 							},
-						}, false, nil
+						}, nil
 					})
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetPortService.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
 					return false
@@ -549,12 +549,13 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 	}
 
 	tests := []struct {
-		name               string
-		prepareFunc        func(*testing.T, *PodReconciler) *gomonkey.Patches
-		expectedErr        string
-		expectedSubnetPath string
-		expectedIsExisting bool
-		restoreMode        bool
+		name                    string
+		prepareFunc             func(*testing.T, *PodReconciler) *gomonkey.Patches
+		expectedErr             string
+		expectedSubnetPath      string
+		expectedIsExisting      bool
+		expectedInterfaceIPType v1alpha1.IPAddressType
+		restoreMode             bool
 	}{
 		{
 			name: "SubnetExisted",
@@ -565,8 +566,9 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 					})
 				return patches
 			},
-			expectedSubnetPath: subnetPath,
-			expectedIsExisting: true,
+			expectedSubnetPath:      subnetPath,
+			expectedIsExisting:      true,
+			expectedInterfaceIPType: "",
 		},
 		{
 			name: "NoGetDefaultSubnetSet",
@@ -584,6 +586,29 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 			expectedErr: "failed to get default SubnetSet",
 		},
 		{
+			name: "SubnetSetIPAddressTypeUnderCalculation",
+			prepareFunc: func(t *testing.T, pr *PodReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc((*subnetport.SubnetPortService).GetSubnetPathForSubnetPortFromStore,
+					func(s *subnetport.SubnetPortService, uid types.UID) string {
+						return ""
+					})
+				patches.ApplyFunc(common.GetDefaultSubnetSetByNamespace,
+					func(client client.Client, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
+						return &v1alpha1.SubnetSet{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "subnetset-1",
+								UID:  "uid-1",
+							},
+							Spec: v1alpha1.SubnetSetSpec{
+								IPAddressType: "",
+							},
+						}, nil
+					})
+				return patches
+			},
+			expectedErr: "default Pod SubnetSet IPAddressType is under calculation",
+		},
+		{
 			name: "CreateSubnetFailure",
 			prepareFunc: func(t *testing.T, pr *PodReconciler) *gomonkey.Patches {
 				patches := gomonkey.ApplyFunc((*subnetport.SubnetPortService).GetSubnetPathForSubnetPortFromStore,
@@ -597,15 +622,19 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 								Name: "subnetset-1",
 								UID:  "uid-1",
 							},
+							Spec: v1alpha1.SubnetSetSpec{
+								IPAddressType: v1alpha1.IPAddressTypeIPv4, // Added to pass check
+							},
 						}, nil
 					})
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider) (string, *types.UID, *sync.RWMutex, error) {
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType) (string, *types.UID, *sync.RWMutex, error) {
 						return "", nil, nil, errors.New("failed to create subnet")
 					})
 				return patches
 			},
-			expectedErr: "failed to create subnet",
+			expectedErr:             "failed to create subnet",
+			expectedInterfaceIPType: v1alpha1.IPAddressTypeIPv4,
 		},
 		{
 			name: "CreateSubnetSuccess",
@@ -621,15 +650,19 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 								Name: "subnetset-1",
 								UID:  "uid-1",
 							},
+							Spec: v1alpha1.SubnetSetSpec{
+								IPAddressType: v1alpha1.IPAddressTypeIPv4, // Added to pass check
+							},
 						}, nil
 					})
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider) (string, *types.UID, *sync.RWMutex, error) {
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType) (string, *types.UID, *sync.RWMutex, error) {
 						return subnetPath, nil, nil, nil
 					})
 				return patches
 			},
-			expectedSubnetPath: subnetPath,
+			expectedSubnetPath:      subnetPath,
+			expectedInterfaceIPType: v1alpha1.IPAddressTypeIPv4,
 		},
 		{
 			name: "GetSubnetFromPrecreatedSubnetSet",
@@ -646,18 +679,19 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 								UID:  "uid-1",
 							},
 							Spec: v1alpha1.SubnetSetSpec{
-								SubnetNames: &[]string{"subnet-1"},
+								IPAddressType: v1alpha1.IPAddressTypeIPv4, // Added to pass check
+								SubnetNames:   &[]string{"subnet-1"},
 							},
 						}, nil
 					})
-				patches.ApplyFunc(common.GetSubnetFromSubnetSet,
-					func(client client.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider) (string, error) {
-						return subnetPath, nil
+				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType) (string, *types.UID, *sync.RWMutex, error) {
+						return subnetPath, nil, nil, nil
 					})
-				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				return patches
 			},
-			expectedSubnetPath: subnetPath,
+			expectedSubnetPath:      subnetPath,
+			expectedInterfaceIPType: v1alpha1.IPAddressTypeIPv4,
 		},
 		{
 			name: "Restore",
@@ -673,6 +707,9 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 								Name: "subnetset-1",
 								UID:  "uid-1",
 							},
+							Spec: v1alpha1.SubnetSetSpec{
+								IPAddressType: v1alpha1.IPAddressTypeIPv4,
+							},
 						}, nil
 					})
 				patches.ApplyFunc((*PodReconciler).getSubnetByPod, func(r *PodReconciler, pod *v1.Pod, subnetSet *v1alpha1.SubnetSet) (string, error) {
@@ -681,9 +718,10 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 				})
 				return patches
 			},
-			expectedSubnetPath: subnetPath,
-			expectedIsExisting: true,
-			restoreMode:        true,
+			expectedSubnetPath:      subnetPath,
+			expectedIsExisting:      true,
+			expectedInterfaceIPType: "",
+			restoreMode:             true,
 		},
 	}
 	for _, tt := range tests {
@@ -691,7 +729,7 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 			patches := tt.prepareFunc(t, r)
 			defer patches.Reset()
 			r.restoreMode = tt.restoreMode
-			isExisting, path, _, _, err := r.GetSubnetPathForPod(context.TODO(), &v1.Pod{
+			isExisting, path, _, _, interfaceType, err := r.GetSubnetPathForPod(context.TODO(), &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod-1",
 					Namespace: "ns-1",
@@ -701,11 +739,13 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 				},
 			})
 			if tt.expectedErr != "" {
+				assert.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {
 				assert.Nil(t, err)
-				assert.Equal(t, subnetPath, path)
+				assert.Equal(t, tt.expectedSubnetPath, path)
 				assert.Equal(t, tt.expectedIsExisting, isExisting)
+				assert.Equal(t, tt.expectedInterfaceIPType, interfaceType)
 			}
 		})
 	}

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -106,7 +106,7 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		r.StatusUpdater.IncreaseUpdateTotal()
 
 		old_status := subnetPort.Status.DeepCopy()
-		isExisting, isParentResourceTerminating, nsxSubnetPath, subnetSetUID, subnetSetLock, err := r.CheckAndGetSubnetPathForSubnetPort(ctx, subnetPort)
+		isExisting, isParentResourceTerminating, nsxSubnetPath, subnetSetUID, subnetSetLock, interfaceIPType, err := r.CheckAndGetSubnetPathForSubnetPort(ctx, subnetPort)
 		if subnetSetLock != nil {
 			defer common.RUnlockSubnetSet(*subnetSetUID, subnetSetLock)
 		}
@@ -120,7 +120,7 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return common.ResultRequeue, err
 		}
 		if !isExisting {
-			defer r.SubnetPortService.ReleasePortInSubnet(nsxSubnetPath)
+			defer r.SubnetPortService.ReleasePortInSubnet(nsxSubnetPath, interfaceIPType)
 		}
 
 		var labels *map[string]string
@@ -152,6 +152,10 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			r.StatusUpdater.UpdateFail(ctx, subnetPort, err, fmt.Sprintf("Failed to get Subnet by path: %s", nsxSubnetPath), setSubnetPortReadyStatusFalse, r.SubnetPortService, r.restoreMode)
 			return common.ResultRequeue, err
 		}
+		err = r.updateSubnetPortIPType(ctx, subnetPort, interfaceIPType, nsxSubnet)
+		if err != nil {
+			return common.ResultNormal, err
+		}
 
 		isVmSubnetPort := true
 		if value, exists := subnetPort.Labels[servicecommon.LabelImageFetcher]; exists && value == "true" {
@@ -167,7 +171,7 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			r.StatusUpdater.UpdateFail(ctx, subnetPort, err, "Failed to create NSX IPAddressAllocation for AddressBinding restore", setSubnetPortReadyStatusFalse, r.SubnetPortService, r.restoreMode)
 			return common.ResultRequeue, err
 		}
-		nsxSubnetPortState, enableDHCP, err := r.SubnetPortService.CreateOrUpdateSubnetPort(subnetPort, nsxSubnet, "", labels, isVmSubnetPort, r.restoreMode)
+		nsxSubnetPortState, err := r.SubnetPortService.CreateOrUpdateSubnetPort(subnetPort, nsxSubnet, "", labels, isVmSubnetPort, r.restoreMode, interfaceIPType)
 		if err != nil {
 			r.StatusUpdater.UpdateFail(ctx, subnetPort, err, "", setSubnetPortReadyStatusFalse, r.SubnetPortService, r.restoreMode)
 			if nsxutil.IsRealizeStateError(err) {
@@ -191,13 +195,43 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 						Gateway: "",
 					},
 				},
-				DHCPDeactivatedOnSubnet: !enableDHCP,
+				DHCPDeactivatedOnSubnet:   !util.NSXSubnetDHCPEnabled(nsxSubnet),
+				DHCPv6DeactivatedOnSubnet: !util.NSXSubnetDHCPv6Enabled(nsxSubnet),
+			}
+			// Append one more ipaddress for dual stack SubnetPort
+			if subnetPort.Spec.InterfaceIPType == v1alpha1.IPAddressTypeIPv4IPv6 {
+				subnetPort.Status.NetworkInterfaceConfig.IPAddresses = append(
+					subnetPort.Status.NetworkInterfaceConfig.IPAddresses,
+					v1alpha1.NetworkInterfaceIPAddress{Gateway: ""},
+				)
 			}
 			if util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) || len(subnetPort.Spec.AddressBindings) > 0 {
 				if len(nsxSubnetPortState.RealizedBindings) > 0 {
-					subnetPort.Status.NetworkInterfaceConfig.IPAddresses[0].IPAddress = *nsxSubnetPortState.RealizedBindings[0].Binding.IpAddress
-					// The MAC address is updated here when the SubnetPort's StaticIPAllocation is enabled or spec.AddressBindings is specific. For the other cases, the MAC address will be updated in the VIF polling.
-					subnetPort.Status.NetworkInterfaceConfig.MACAddress = strings.Trim(*nsxSubnetPortState.RealizedBindings[0].Binding.MacAddress, "\"")
+					// Process all realized bindings and populate IPAddresses array
+					// RealizedBindings can contain up to 2 entries (IPv4 and IPv6)
+					// The MAC address is updated here when the SubnetPort's StaticIPAllocation
+					// is enabled or spec.AddressBindings is specific. For the other cases, the MAC
+					// address will be updated in the VIF polling.
+					macAddress := ""
+					for i, binding := range nsxSubnetPortState.RealizedBindings {
+						if binding.Binding != nil && binding.Binding.IpAddress != nil {
+							if macAddress == "" && binding.Binding.MacAddress != nil {
+								macAddress = strings.Trim(*binding.Binding.MacAddress, "\"")
+							}
+							if len(subnetPort.Status.NetworkInterfaceConfig.IPAddresses) <= i {
+								// TODO: revisit this when supporting multiple addressbindings per IPAddressType
+								log.Warn("More IPs are realized on SubnetPort", "Namespace", subnetPort.Namespace, "SubnetPort", subnetPort.Name, "RealizedBindings", nsxSubnetPortState.RealizedBindings)
+								subnetPort.Status.NetworkInterfaceConfig.IPAddresses = append(
+									subnetPort.Status.NetworkInterfaceConfig.IPAddresses,
+									v1alpha1.NetworkInterfaceIPAddress{Gateway: "", IPAddress: *binding.Binding.IpAddress},
+								)
+							} else {
+								subnetPort.Status.NetworkInterfaceConfig.IPAddresses[i].IPAddress = *binding.Binding.IpAddress
+							}
+						}
+					}
+					// MAC address is consistent across all bindings, set it once
+					subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
 				} else if !util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) && len(subnetPort.Spec.AddressBindings) > 0 {
 					// If StaticIPAllocation is disabled, propagate the MAC from spec.addressBinding to status
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = subnetPort.Spec.AddressBindings[0].MACAddress
@@ -211,9 +245,7 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				if subnetPort.Status.NetworkInterfaceConfig.MACAddress == "" && old_status.NetworkInterfaceConfig.MACAddress != "" {
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = old_status.NetworkInterfaceConfig.MACAddress
 				}
-				if subnetPort.Status.NetworkInterfaceConfig.IPAddresses[0].IPAddress == "" && old_status.NetworkInterfaceConfig.IPAddresses[0].IPAddress != "" {
-					subnetPort.Status.NetworkInterfaceConfig.IPAddresses[0].IPAddress = old_status.NetworkInterfaceConfig.IPAddresses[0].IPAddress
-				}
+				subnetPort.Status.NetworkInterfaceConfig.IPAddresses = old_status.NetworkInterfaceConfig.IPAddresses
 			}
 			err = r.updateSubnetStatusOnSubnetPort(subnetPort, nsxSubnet)
 			if err != nil {
@@ -294,6 +326,34 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		setAddressBindingStatusBySubnetPort(r.Client, ctx, subnetPort, r.SubnetPortService, metav1.Now(), vmOrInterfaceNotFoundError)
 	}
 	return common.ResultNormal, nil
+}
+
+func (r *SubnetPortReconciler) updateSubnetPortIPType(ctx context.Context, subnetPort *v1alpha1.SubnetPort, interfaceIPType v1alpha1.IPAddressType, nsxSubnet *model.VpcSubnet) error {
+	specChanged := false
+	if subnetPort.Spec.InterfaceIPType == "" {
+		subnetPort.Spec.InterfaceIPType = interfaceIPType
+		specChanged = true
+	}
+	// If staticIPAllocationType are not set
+	//     staticIPAllocationType is the same as interfaceIPType if static ip allocation is enabled
+	//     staticIPAllocationType is None if static ip allocation is disabled
+	// TODO: Add check for DHCP/SLAAC when mixed mode Subnet is supported
+	if subnetPort.Spec.StaticIPAllocationType == "" {
+		if util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) {
+			subnetPort.Spec.StaticIPAllocationType = v1alpha1.StaticIPAllocationType(subnetPort.Spec.InterfaceIPType)
+		} else {
+			subnetPort.Spec.StaticIPAllocationType = v1alpha1.StaticIPAllocationTypeNone
+		}
+		specChanged = true
+	}
+	if specChanged {
+		err := r.Client.Update(ctx, subnetPort)
+		if err != nil {
+			r.StatusUpdater.UpdateFail(ctx, subnetPort, err, "Failed to update SubnetPort InterfaceIPType or StaticIPAllocationType", setSubnetPortReadyStatusFalse, r.SubnetPortService, r.restoreMode)
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *SubnetPortReconciler) getSubnetCR(ctx context.Context, subnetPort *v1alpha1.SubnetPort) (*v1alpha1.Subnet, bool, error) {
@@ -738,22 +798,29 @@ func setSubnetPortReadyStatusFalse(client client.Client, ctx context.Context, ob
 }
 
 func updateSubnetPortStatusConditions(client client.Client, ctx context.Context, subnetPort *v1alpha1.SubnetPort, newConditions []v1alpha1.Condition) {
-	conditionsUpdated := false
-	for i := range newConditions {
-		if mergeSubnetPortStatusCondition(subnetPort, &newConditions[i]) {
-			conditionsUpdated = true
+	retry.OnError(util.K8sClientRetry, func(err error) bool {
+		log.Error(err, "Failed to update SubnetPort Status, will retry", "Namespace", subnetPort.Namespace, "SubnetPort", subnetPort.Name)
+		return err != nil
+	}, func() error {
+		latestSubnetPort := &v1alpha1.SubnetPort{}
+		if err := client.Get(ctx, types.NamespacedName{Namespace: subnetPort.Namespace, Name: subnetPort.Name}, latestSubnetPort); err != nil {
+			return err
 		}
-	}
-	if conditionsUpdated {
-		retry.OnError(util.K8sClientRetry, func(err error) bool {
-			log.Error(err, "Failed to update SubnetPort Status, will retry", "Namespace", subnetPort.Namespace, "SubnetPort", subnetPort.Name)
-			return err != nil
-		}, func() error {
-			return client.Status().Update(ctx, subnetPort)
-		})
-		log.Debug("Updated SubnetPort CR", "Name", subnetPort.Name, "Namespace", subnetPort.Namespace,
-			"New Conditions", newConditions)
-	}
+		conditionsUpdated := false
+		for i := range newConditions {
+			if mergeSubnetPortStatusCondition(latestSubnetPort, &newConditions[i]) {
+				conditionsUpdated = true
+			}
+		}
+		if conditionsUpdated {
+			latestSubnetPort.Status.Attachment = subnetPort.Status.Attachment
+			latestSubnetPort.Status.NetworkInterfaceConfig = subnetPort.Status.NetworkInterfaceConfig
+			return client.Status().Update(ctx, latestSubnetPort)
+		}
+		return nil
+	})
+	log.Debug("Updated SubnetPort CR", "Name", subnetPort.Name, "Namespace", subnetPort.Namespace,
+		"New Conditions", newConditions)
 }
 
 func mergeSubnetPortStatusCondition(subnetPort *v1alpha1.SubnetPort, newCondition *v1alpha1.Condition) bool {
@@ -829,7 +896,7 @@ func (r *SubnetPortReconciler) getSubnetBySubnetPort(subnetPort *v1alpha1.Subnet
 	return common.GetSubnetByIP(subnets, gatewayIP)
 }
 
-func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Context, subnetPort *v1alpha1.SubnetPort) (existing bool, isStale bool, subnetPath string, subnetSetUID *types.UID, subnetSetLock *sync.RWMutex, err error) {
+func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Context, subnetPort *v1alpha1.SubnetPort) (existing bool, isStale bool, subnetPath string, subnetSetUID *types.UID, subnetSetLock *sync.RWMutex, interfaceType v1alpha1.IPAddressType, err error) {
 	var subnetCR *v1alpha1.Subnet
 	subnetCR, isStale, err = r.getSubnetCR(ctx, subnetPort)
 	if err != nil {
@@ -839,7 +906,7 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 	existingSubnetPort, err := r.SubnetPortService.SubnetPortStore.GetVpcSubnetPortByUID(subnetPort.GetUID())
 	if err != nil {
 		log.Error(err, "failed to use the SubnetPort CR to search VpcSubnetPort", "CR UID", subnetPort.GetUID())
-		return false, false, "", nil, nil, err
+		return false, false, "", nil, nil, "", err
 	}
 	if existingSubnetPort != nil && existingSubnetPort.ParentPath != nil && len(*existingSubnetPort.ParentPath) > 0 {
 		subnetPath = *existingSubnetPort.ParentPath
@@ -872,7 +939,8 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 			return
 		}
 		var canAllocate bool
-		canAllocate, err = r.SubnetPortService.AllocatePortFromSubnet(nsxSubnet, servicecommon.IsSharedSubnet(subnetCR))
+		interfaceType = subnetport.GetDefaultInterfaceIPType(subnetPort.Spec.InterfaceIPType, subnetCR.Spec.IPAddressType)
+		canAllocate, err = r.SubnetPortService.AllocatePortFromSubnet(nsxSubnet, servicecommon.IsSharedSubnet(subnetCR), interfaceType)
 		if err != nil {
 			return
 		}
@@ -896,8 +964,13 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 			err = fmt.Errorf("subnetset %s is being deleted, cannot operate subnetport %s", namespacedName, subnetPort.Name)
 			return
 		}
+		if subnetPort.Spec.InterfaceIPType == "" && subnetSet.Spec.IPAddressType == "" {
+			err = fmt.Errorf("Waiting for SubnetSet %s/%s IPAddressType calculation", subnetSet.Namespace, subnetSet.Name)
+			return
+		}
+		interfaceType = subnetport.GetDefaultInterfaceIPType(subnetPort.Spec.InterfaceIPType, subnetSet.Spec.IPAddressType)
 		log.Info("Got SubnetSet for SubnetPort CR, allocating the NSX subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
-		subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService)
+		subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfaceType)
 		log.Info("Allocated Subnet for SubnetPort", "subnetPath", subnetPath, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 		if err != nil {
 			return
@@ -913,8 +986,13 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 			err = fmt.Errorf("default subnetset %s is being deleted, cannot operate subnetport %s", subnetSet.Name, subnetPort.Name)
 			return
 		}
+		if subnetPort.Spec.InterfaceIPType == "" && subnetSet.Spec.IPAddressType == "" {
+			err = fmt.Errorf("Waiting for SubnetSet %s/%s IPAddressType calculation", subnetSet.Namespace, subnetSet.Name)
+			return
+		}
 		log.Info("Got default SubnetSet for SubnetPort CR, allocating the NSX Subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
-		subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService)
+		interfaceType = subnetport.GetDefaultInterfaceIPType(subnetPort.Spec.InterfaceIPType, subnetSet.Spec.IPAddressType)
+		subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfaceType)
 		if err != nil {
 			return
 		}
@@ -924,19 +1002,99 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 }
 
 func (r *SubnetPortReconciler) updateSubnetStatusOnSubnetPort(subnetPort *v1alpha1.SubnetPort, nsxSubnet *model.VpcSubnet) error {
-	gateway, prefix, err := r.SubnetService.GetGatewayPrefixOfSubnet(nsxSubnet)
+	subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = *nsxSubnet.RealizationId
+	// Get all gateways from the subnet (may be IPv4, IPv6, or both for dual-stack)
+	gatewaysWithPrefixes, err := r.SubnetService.GetAllGatewayPrefixesOfSubnet(nsxSubnet)
 	if err != nil {
 		return err
 	}
-	// For now, we have an assumption that one subnetport only have one IP address
-	if len(subnetPort.Status.NetworkInterfaceConfig.IPAddresses[0].IPAddress) > 0 && prefix > 0 {
-		subnetPort.Status.NetworkInterfaceConfig.IPAddresses[0].IPAddress += fmt.Sprintf("/%d", prefix)
-	}
 	// The gateway can be empty for L2_Only Subnet which has the vlan_connection without gateway
-	if len(gateway) > 0 {
-		subnetPort.Status.NetworkInterfaceConfig.IPAddresses[0].Gateway = gateway
+	if len(gatewaysWithPrefixes) == 0 {
+		return nil
 	}
-	subnetPort.Status.NetworkInterfaceConfig.LogicalSwitchUUID = *nsxSubnet.RealizationId
+
+	var newIPAddresses []v1alpha1.NetworkInterfaceIPAddress
+	usedGateways := make([]bool, len(gatewaysWithPrefixes))
+
+	// First pass: Process non-empty IPs and/or non-empty Gateways
+	for _, ipConfig := range subnetPort.Status.NetworkInterfaceConfig.IPAddresses {
+		// In restore mode, the prefix may already set
+		if strings.Contains(ipConfig.IPAddress, "/") {
+			// If the IPAddress already has the prefix, just mark gateway as used
+			newIPAddresses = append(newIPAddresses, ipConfig)
+			for i, gwInfo := range gatewaysWithPrefixes {
+				if gwInfo.Gateway == ipConfig.Gateway {
+					usedGateways[i] = true
+					break
+				}
+			}
+			continue
+		}
+
+		if len(ipConfig.IPAddress) > 0 {
+			// Update the gateway and prefix in IPAddress
+			ip := net.ParseIP(ipConfig.IPAddress)
+			if ip == nil {
+				return fmt.Errorf("invalid IP address %s", ipConfig.IPAddress)
+			}
+
+			for i, gwInfo := range gatewaysWithPrefixes {
+				gwCIDR := fmt.Sprintf("%s/%d", gwInfo.Gateway, gwInfo.Prefix)
+				_, ipNet, err := net.ParseCIDR(gwCIDR)
+				if err != nil {
+					// Should not reach here
+					return fmt.Errorf("invalid gateway CIDR %s", gwCIDR)
+				}
+				// Observed for IPv6 single stack SubnetPort, there will be another IPAddress
+				// not matching the gateway CIDR in realized state like fe80::650:56ff:fe00:8401,
+				// thus we need to filter the ip
+				if ipNet.Contains(ip) {
+					// Match found
+					ipConfig.IPAddress += fmt.Sprintf("/%d", gwInfo.Prefix)
+					ipConfig.Gateway = gwInfo.Gateway
+					newIPAddresses = append(newIPAddresses, ipConfig)
+					usedGateways[i] = true
+					break
+				}
+			}
+		} else if len(ipConfig.Gateway) > 0 {
+			// For DHCP case, we can have empty IPAddress with non-empty Gateway.
+			// If Gateway is already filled, we should keep it in the SubnetPort status.
+			newIPAddresses = append(newIPAddresses, ipConfig)
+			for i, gwInfo := range gatewaysWithPrefixes {
+				if gwInfo.Gateway == ipConfig.Gateway {
+					usedGateways[i] = true
+					break
+				}
+			}
+		}
+	}
+
+	// Second pass: Process empty IPs and empty Gateways
+	// For DHCP case, the IPAddress will be empty. We set the unused Gateway in IPAddresses
+	for _, ipConfig := range subnetPort.Status.NetworkInterfaceConfig.IPAddresses {
+		if len(ipConfig.IPAddress) == 0 && ipConfig.Gateway == "" {
+			// Find first unused gateway
+			for i, gwInfo := range gatewaysWithPrefixes {
+				if !usedGateways[i] {
+					ipConfig.Gateway = gwInfo.Gateway
+					newIPAddresses = append(newIPAddresses, ipConfig)
+					usedGateways[i] = true
+					break
+				}
+			}
+		}
+	}
+
+	slices.SortFunc(newIPAddresses, func(a, b v1alpha1.NetworkInterfaceIPAddress) int {
+		if a.Gateway != b.Gateway {
+			return strings.Compare(a.Gateway, b.Gateway)
+		}
+		return strings.Compare(a.IPAddress, b.IPAddress)
+	})
+
+	log.Debug("updateSubnetStatusOnSubnetPort IPAddresses", "before", subnetPort.Status.NetworkInterfaceConfig.IPAddresses, "after", newIPAddresses)
+	subnetPort.Status.NetworkInterfaceConfig.IPAddresses = newIPAddresses
 	return nil
 }
 

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
+	pkgutil "github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
 type fakeRecorder struct {
@@ -91,6 +92,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		SubnetPortStore: &subnetport.SubnetPortStore{},
 	}
 	subnetService := &mock.MockSubnetServiceProvider{}
+	ipAllocationService := &mock.MockIPAddressAllocationProvider{}
+
 	r := &SubnetPortReconciler{
 		Client:                     k8sClient,
 		APIReader:                  k8sClient,
@@ -98,12 +101,13 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		SubnetPortService:          service,
 		SubnetService:              subnetService,
 		Recorder:                   fakeRecorder{},
-		IpAddressAllocationService: &mock.MockIPAddressAllocationProvider{},
+		IpAddressAllocationService: ipAllocationService,
 		restoreMode:                false,
 	}
 	r.StatusUpdater = common.NewStatusUpdater(k8sClient, service.NSXConfig, r.Recorder, MetricResTypeSubnetPort, "SubnetPort", "SubnetPort")
 	ctx := context.Background()
 	req := controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "dummy", Name: "dummy"}}
+
 	patchesGetSubnetByPath := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetByPath",
 		func(s *mock.MockSubnetServiceProvider, nsxSubnetPath string, sharedSubnet bool) (*model.VpcSubnet, error) {
 			nsxSubnet := &model.VpcSubnet{
@@ -113,11 +117,30 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			return nsxSubnet, nil
 		})
 	defer patchesGetSubnetByPath.Reset()
+
 	patchesGetSubnetCR := gomonkey.ApplyFunc((*SubnetPortReconciler).getSubnetCR,
 		func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (*v1alpha1.Subnet, bool, error) {
 			return &v1alpha1.Subnet{}, false, nil
 		})
 	defer patchesGetSubnetCR.Reset()
+
+	patchesCreateIPAllocation := gomonkey.ApplyFunc((*mock.MockIPAddressAllocationProvider).CreateIPAddressAllocationForAddressBinding,
+		func(_ *mock.MockIPAddressAllocationProvider, _ *v1alpha1.AddressBinding, _ *v1alpha1.SubnetPort, _ bool) error {
+			return nil
+		})
+	defer patchesCreateIPAllocation.Reset()
+
+	patchesDeleteIPAllocation := gomonkey.ApplyFunc((*mock.MockIPAddressAllocationProvider).DeleteIPAddressAllocationForAddressBinding,
+		func(_ *mock.MockIPAddressAllocationProvider, _ interface{}) error {
+			return nil
+		})
+	defer patchesDeleteIPAllocation.Reset()
+
+	patchesUpdateSubnetPortIPType := gomonkey.ApplyFunc((*SubnetPortReconciler).updateSubnetPortIPType,
+		func(_ *SubnetPortReconciler, _ context.Context, _ *v1alpha1.SubnetPort, _ v1alpha1.IPAddressType, _ *model.VpcSubnet) error {
+			return nil
+		})
+	defer patchesUpdateSubnetPortIPType.Reset()
 
 	attachmentID := "attachment-id"
 
@@ -159,11 +182,10 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 
 	// CheckAndGetSubnetPathForSubnetPort fails
 	t.Run("failed with CheckAndGetSubnetPathForSubnetPort", func(t *testing.T) {
-		sp := &v1alpha1.SubnetPort{}
 		err := errors.New("CheckAndGetSubnetPathForSubnetPort failed")
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, error) {
-				return false, false, "", nil, nil, err
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+				return false, false, "", nil, nil, "", err
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 
@@ -172,12 +194,17 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 				return nil, nil
 			})
 		defer patchesGetByKey.Reset()
-		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
+
+		// 1st: Reconciler fetching the resource
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
 			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 				v1sp := obj.(*v1alpha1.SubnetPort)
 				v1sp.Spec.Subnet = "subnet1"
 				return nil
 			})
+		// 2nd: Triggered by updateSubnetPortStatusConditions inside StatusUpdater.UpdateFail
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil)
+
 		k8sClient.EXPECT().Status().Return(fakewriter)
 		_, ret := r.Reconcile(ctx, req)
 		assert.Equal(t, err, ret)
@@ -185,11 +212,10 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 
 	// getVirtualMachine fails
 	t.Run("failed with getVirtualMachine", func(t *testing.T) {
-		sp := &v1alpha1.SubnetPort{}
 		err := errors.New("getVirtualMachine failed")
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, error) {
-				return true, false, "", nil, nil, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetByUID := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
@@ -198,16 +224,21 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			})
 		defer patchesGetByUID.Reset()
 		patchesGetVirtualMachine := gomonkey.ApplyFunc((*SubnetPortReconciler).getVirtualMachine,
-			func(r *SubnetPortReconciler, ctx context.Context, obj *v1alpha1.SubnetPort) (*vmv1alpha1.VirtualMachine, string, error) {
+			func(r *SubnetPortReconciler, ctx context.Context, obj *v1alpha1.SubnetPort, restoreMode bool) (*vmv1alpha1.VirtualMachine, string, error) {
 				return nil, "", err
 			})
 		defer patchesGetVirtualMachine.Reset()
-		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
+
+		// 1st: Fetch in Reconcile
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
 			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 				v1sp := obj.(*v1alpha1.SubnetPort)
 				v1sp.Spec.Subnet = "subnet1"
 				return nil
 			})
+		// 2nd: Fetch inside updateSubnetPortStatusConditions
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil)
+
 		k8sClient.EXPECT().Status().Return(fakewriter)
 		_, ret := r.Reconcile(ctx, req)
 		assert.Equal(t, err, ret)
@@ -215,15 +246,14 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 
 	// CreateOrUpdateSubnetPort fails
 	t.Run("failed with CreateOrUpdateSubnetPort", func(t *testing.T) {
-		sp := &v1alpha1.SubnetPort{}
 		patchesGetVirtualMachine := gomonkey.ApplyFunc((*SubnetPortReconciler).getVirtualMachine,
-			func(r *SubnetPortReconciler, ctx context.Context, obj *v1alpha1.SubnetPort) (*vmv1alpha1.VirtualMachine, string, error) {
+			func(r *SubnetPortReconciler, ctx context.Context, obj *v1alpha1.SubnetPort, restoreMode bool) (*vmv1alpha1.VirtualMachine, string, error) {
 				return nil, "", nil
 			})
 		defer patchesGetVirtualMachine.Reset()
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, error) {
-				return true, false, "", nil, nil, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetByUID := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
@@ -237,20 +267,26 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 				return requests
 			})
 		defer patchesVmMapFunc.Reset()
-		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
+
+		// 1st: Fetch in Reconcile
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
 			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 				v1sp := obj.(*v1alpha1.SubnetPort)
 				v1sp.Spec.Subnet = "subnet1"
 				return nil
 			})
+		// 2nd: Fetch inside updateSubnetPortStatusConditions
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil)
+
 		patchesIsSharedSubnetPath := gomonkey.ApplyFunc(common.IsSharedSubnetPath, func(ctx context.Context, client client.Client, path string, ns string) (bool, error) {
 			return false, nil
 		})
 		defer patchesIsSharedSubnetPath.Reset()
 		err := errors.New("CreateOrUpdateSubnetPort failed")
+
 		patchesCreateOrUpdateSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
-			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
-				return nil, false, err
+			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+				return nil, err
 			})
 		defer patchesCreateOrUpdateSubnetPort.Reset()
 		patchesGetAddressBindingBySubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).GetAddressBindingBySubnetPort, func(_ *subnetport.SubnetPortService, _ *v1alpha1.SubnetPort) *v1alpha1.AddressBinding {
@@ -263,16 +299,15 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 	})
 
 	// CreateOrUpdateSubnetPort fails with RealizeStateError
-	t.Run("failed with CreateOrUpdateSubnetPort", func(t *testing.T) {
-		sp := &v1alpha1.SubnetPort{}
+	t.Run("failed with CreateOrUpdateSubnetPort with RealizeStateError", func(t *testing.T) {
 		patchesGetVirtualMachine := gomonkey.ApplyFunc((*SubnetPortReconciler).getVirtualMachine,
-			func(r *SubnetPortReconciler, ctx context.Context, obj *v1alpha1.SubnetPort) (*vmv1alpha1.VirtualMachine, string, error) {
+			func(r *SubnetPortReconciler, ctx context.Context, obj *v1alpha1.SubnetPort, restoreMode bool) (*vmv1alpha1.VirtualMachine, string, error) {
 				return nil, "", nil
 			})
 		defer patchesGetVirtualMachine.Reset()
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, error) {
-				return true, false, "", nil, nil, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetByUID := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
@@ -286,20 +321,25 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 				return requests
 			})
 		defer patchesVmMapFunc.Reset()
-		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
+
+		// 1st: Fetch in Reconcile
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
 			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 				v1sp := obj.(*v1alpha1.SubnetPort)
 				v1sp.Spec.Subnet = "subnet1"
 				return nil
 			})
+		// 2nd: Fetch inside updateSubnetPortStatusConditions
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil)
+
 		patchesIsSharedSubnetPath := gomonkey.ApplyFunc(common.IsSharedSubnetPath, func(ctx context.Context, client client.Client, path string, ns string) (bool, error) {
 			return false, nil
 		})
 		defer patchesIsSharedSubnetPath.Reset()
 		err := util.NewRealizeStateError("CreateOrUpdateSubnetPort failed", 0)
 		patchesCreateOrUpdateSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
-			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
-				return nil, false, err
+			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+				return nil, err
 			})
 		defer patchesCreateOrUpdateSubnetPort.Reset()
 		patchesGetAddressBindingBySubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).GetAddressBindingBySubnetPort, func(_ *subnetport.SubnetPortService, _ *v1alpha1.SubnetPort) *v1alpha1.AddressBinding {
@@ -313,13 +353,12 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 
 	// happy path
 	t.Run("succeeded with create or update SubnetPort", func(t *testing.T) {
-		sp := &v1alpha1.SubnetPort{}
-		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
 			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 				v1sp := obj.(*v1alpha1.SubnetPort)
 				v1sp.Spec.Subnet = "subnet1"
 				return nil
-			})
+			}).Times(2)
 		portIP := "1.2.3.4"
 		portMac := "aa:bb:cc:dd"
 		portState := &model.SegmentPortState{
@@ -336,8 +375,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, error) {
-				return true, false, "", nil, nil, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesIsSharedSubnetPath := gomonkey.ApplyFunc(common.IsSharedSubnetPath, func(ctx context.Context, client client.Client, path string, ns string) (bool, error) {
@@ -345,8 +384,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		})
 		defer patchesIsSharedSubnetPath.Reset()
 		patchesCreateOrUpdateSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
-			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
-				return portState, false, nil
+			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+				return portState, nil
 			})
 		defer patchesCreateOrUpdateSubnetPort.Reset()
 		patchesSetAddressBindingStatus := gomonkey.ApplyFunc(setAddressBindingStatusBySubnetPort,
@@ -363,7 +402,7 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		assert.Equal(t, nil, ret)
 
 		// happy path - dhcp subnetport with mac only
-		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
 			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 				v1sp := obj.(*v1alpha1.SubnetPort)
 				v1sp.Spec.Subnet = "subnet1"
@@ -373,7 +412,7 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 					},
 				}
 				return nil
-			})
+			}).Times(2)
 		portState2 := &model.SegmentPortState{
 			RealizedBindings: []model.AddressBindingEntry{},
 			Attachment: &model.SegmentPortAttachmentState{
@@ -395,8 +434,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			})
 		defer patchesGetSubnetByPath.Reset()
 		patchesCreateOrUpdateSubnetPort.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
-			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
-				return portState2, false, nil
+			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+				return portState2, nil
 			})
 		k8sClient.EXPECT().Status().Return(fakewriter)
 		_, ret = r.Reconcile(ctx, req)
@@ -426,9 +465,9 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			})
 		defer patchesDeleteSubnetPort.Reset()
 		patchesCreateOrUpdateSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
-			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
+			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
 				assert.FailNow(t, "should not be called")
-				return nil, false, nil
+				return nil, nil
 			})
 		defer patchesCreateOrUpdateSubnetPort.Reset()
 		_, ret := r.Reconcile(ctx, req)
@@ -505,16 +544,12 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 				v1sp.Status = subnetPort.Status
 				v1sp.ObjectMeta = subnetPort.ObjectMeta
 				return nil
-			})
+			}).Times(2)
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, error) {
-				return true, false, "", nil, nil, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
-		patchesGetSubnetByIP := gomonkey.ApplyFunc((*SubnetPortReconciler).getSubnetBySubnetPort, func(r *SubnetPortReconciler, subnetPort *v1alpha1.SubnetPort) (string, error) {
-			return "subnet-path", nil
-		})
-		defer patchesGetSubnetByIP.Reset()
 		patchesGetSubnetByPath := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetByPath",
 			func(s *mock.MockSubnetServiceProvider, nsxSubnetPath string, sharedSubnet bool) (*model.VpcSubnet, error) {
 				nsxSubnet := &model.VpcSubnet{
@@ -533,9 +568,10 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			return false, nil
 		})
 		defer patchesIsSharedSubnetPath.Reset()
+
 		patchesCreateOrUpdateSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
-			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
-				return portState, false, nil
+			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+				return portState, nil
 			})
 		defer patchesCreateOrUpdateSubnetPort.Reset()
 		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
@@ -583,18 +619,18 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 	}
 	// Restore case without IP/MAC in state
 	t.Run("restore without IP in state", func(t *testing.T) {
-		sp := &v1alpha1.SubnetPort{}
 		r.restoreMode = true
-		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
+
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
 			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 				v1sp := obj.(*v1alpha1.SubnetPort)
 				v1sp.Status = subnetPort.Status
 				v1sp.ObjectMeta = subnetPort.ObjectMeta
 				return nil
-			})
+			}).Times(2)
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, error) {
-				return true, false, "", nil, nil, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetSubnetByIP := gomonkey.ApplyFunc((*SubnetPortReconciler).getSubnetBySubnetPort, func(r *SubnetPortReconciler, subnetPort *v1alpha1.SubnetPort) (string, error) {
@@ -620,11 +656,11 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		})
 		defer patchesIsSharedSubnetPath.Reset()
 		patchesCreateOrUpdateSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
-			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
-				return portStateNoIP, false, nil
+			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+				return portStateNoIP, nil
 			})
 		defer patchesCreateOrUpdateSubnetPort.Reset()
-		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
 			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 				v1sp := obj.(*v1alpha1.SubnetPort)
 				v1sp.Status = subnetPort.Status
@@ -698,10 +734,11 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 				v1sp.Status = dhcpSubnetPort.Status
 				v1sp.ObjectMeta = dhcpSubnetPort.ObjectMeta
 				return nil
-			})
+			}).Times(2)
+
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, error) {
-				return true, false, "", nil, nil, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetSubnetByIP := gomonkey.ApplyFunc((*SubnetPortReconciler).getSubnetBySubnetPort, func(r *SubnetPortReconciler, subnetPort *v1alpha1.SubnetPort) (string, error) {
@@ -736,8 +773,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		})
 		defer patchesIsSharedSubnetPath.Reset()
 		patchesCreateOrUpdateSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
-			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
-				return dhcpPortState, true, nil
+			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+				return dhcpPortState, nil
 			})
 		defer patchesCreateOrUpdateSubnetPort.Reset()
 		patchesSetAddressBindingStatus := gomonkey.ApplyFunc(setAddressBindingStatusBySubnetPort,
@@ -783,18 +820,19 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 
 	// Restore case with update failure
 	t.Run("restore with update failure", func(t *testing.T) {
-		sp := &v1alpha1.SubnetPort{}
 		r.restoreMode = true
-		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
+
+		// Return original attachment ID to trigger failure mismatch inside APIReader checker
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
 			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 				v1sp := obj.(*v1alpha1.SubnetPort)
 				v1sp.Status = subnetPort.Status
 				v1sp.ObjectMeta = subnetPort.ObjectMeta
 				return nil
-			})
+			}).Times(2)
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, error) {
-				return true, false, "", nil, nil, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetSubnetByIP := gomonkey.ApplyFunc((*SubnetPortReconciler).getSubnetBySubnetPort, func(r *SubnetPortReconciler, subnetPort *v1alpha1.SubnetPort) (string, error) {
@@ -821,11 +859,11 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			})
 		defer patchesGetSubnetByPath.Reset()
 		patchesCreateOrUpdateSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
-			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
-				return portState, false, nil
+			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+				return portState, nil
 			})
 		defer patchesCreateOrUpdateSubnetPort.Reset()
-		k8sClient.EXPECT().Get(ctx, gomock.Any(), sp).Return(nil).Do(
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
 			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
 				v1sp := obj.(*v1alpha1.SubnetPort)
 				v1sp.Status = subnetPort.Status
@@ -1323,6 +1361,7 @@ func TestSubnetPortReconciler_setReadyStatusTrue(t *testing.T) {
 	defer patchesGetAddressBindingBySubnetPort.Reset()
 
 	fakewriter := fakeStatusWriter{}
+	k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	k8sClient.EXPECT().Status().Return(fakewriter)
 
 	patches := gomonkey.ApplyFunc(setAddressBindingStatusBySubnetPort, func(client client.Client, ctx context.Context, subnetPort *v1alpha1.SubnetPort, subnetPortService *subnetport.SubnetPortService, transitionTime metav1.Time, e error) {
@@ -1363,6 +1402,7 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 		expectedErr        string
 		expectedSubnetPath string
 		expectedIsExisting bool
+		expectedIPType     v1alpha1.IPAddressType
 		restoreMode        bool
 		subnetport         *v1alpha1.SubnetPort
 		subnet             *v1alpha1.Subnet
@@ -1391,6 +1431,7 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 				},
 			},
 			expectedIsExisting: true,
+			expectedIPType:     "",
 		},
 		{
 			name: "SpecificSubnetSuccess",
@@ -1401,7 +1442,11 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 					})
 				patches.ApplyFunc((*SubnetPortReconciler).getSubnetCR,
 					func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (*v1alpha1.Subnet, bool, error) {
-						return &v1alpha1.Subnet{}, false, nil
+						return &v1alpha1.Subnet{
+							Spec: v1alpha1.SubnetSpec{
+								IPAddressType: v1alpha1.IPAddressTypeIPv4, // Prevents blank resolution fallthrough
+							},
+						}, false, nil
 					})
 				patches.ApplyFunc((*subnet.SubnetService).GetSubnetsByIndex,
 					func(s *subnet.SubnetService, key string, value string) []*model.VpcSubnet {
@@ -1412,7 +1457,7 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 						}}
 					})
 				patches.ApplyFunc((*subnetport.SubnetPortService).AllocatePortFromSubnet,
-					func(s *subnetport.SubnetPortService, nsxSubnet *model.VpcSubnet, sharedSubnet bool) (bool, error) {
+					func(s *subnetport.SubnetPortService, nsxSubnet *model.VpcSubnet, sharedSubnet bool, interfaceType v1alpha1.IPAddressType) (bool, error) {
 						return true, nil
 					})
 				return patches
@@ -1433,6 +1478,7 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 					Subnet: "subnet-1",
 				},
 			},
+			expectedIPType: v1alpha1.IPAddressTypeIPv4,
 		},
 		{
 			name: "SpecificSubnetSetNotExisted",
@@ -1482,6 +1528,34 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 			},
 		},
 		{
+			name: "SpecificSubnetSetWaitingIPCalculation",
+			prepareFunc: func(t *testing.T, spr *SubnetPortReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
+					func(s *subnetport.SubnetPortStore, uid types.UID) (*model.VpcSubnetPort, error) {
+						return nil, nil
+					})
+				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+					subnetSetCR := obj.(*v1alpha1.SubnetSet)
+					subnetSetCR.Namespace = "ns-1"
+					subnetSetCR.Name = "subnetset-1"
+					subnetSetCR.Spec.IPAddressType = ""
+					return nil
+				})
+				return patches
+			},
+			expectedErr: "Waiting for SubnetSet ns-1/subnetset-1 IPAddressType calculation",
+			subnetport: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subnetport-1",
+					Namespace: "ns-1",
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					SubnetSet:       "subnetset-1",
+					InterfaceIPType: "",
+				},
+			},
+		},
+		{
 			name: "SpecificSubnetSetSuccess",
 			prepareFunc: func(t *testing.T, spr *SubnetPortReconciler) *gomonkey.Patches {
 				patches := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
@@ -1492,10 +1566,12 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 					subnetSetCR := obj.(*v1alpha1.SubnetSet)
 					subnetSetCR.Name = "subnetset-1"
 					subnetSetCR.UID = "subnetset-id-1"
+					subnetSetCR.Spec.IPAddressType = v1alpha1.IPAddressTypeIPv4
 					return nil
 				})
+
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider) (string, *types.UID, *sync.RWMutex, error) {
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType) (string, *types.UID, *sync.RWMutex, error) {
 						return "subnet-path-1", nil, nil, nil
 					})
 				return patches
@@ -1510,6 +1586,7 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 					SubnetSet: "subnetset-1",
 				},
 			},
+			expectedIPType: v1alpha1.IPAddressTypeIPv4,
 		},
 		{
 			name: "DefaultSubnetDeleted",
@@ -1547,10 +1624,12 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 					func(client client.Client, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
 						subnetSetCR := &v1alpha1.SubnetSet{}
 						subnetSetCR.Name = "default-subnetset"
+						subnetSetCR.Spec.IPAddressType = v1alpha1.IPAddressTypeIPv4 // Ensure validation bypass
 						return subnetSetCR, nil
 					})
+
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider) (string, *types.UID, *sync.RWMutex, error) {
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType) (string, *types.UID, *sync.RWMutex, error) {
 						return "subnet-path-1", nil, nil, nil
 					})
 				return patches
@@ -1562,6 +1641,7 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 					Namespace: "ns-1",
 				},
 			},
+			expectedIPType: v1alpha1.IPAddressTypeIPv4,
 		},
 		{
 			name: "RestoreSubnetPortSuccess",
@@ -1594,6 +1674,7 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 			},
 			restoreMode:        true,
 			expectedIsExisting: true,
+			expectedIPType:     "",
 		},
 		{
 			name: "NoSubnetForRestoredSubnetPort",
@@ -1634,55 +1715,171 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 			patches := tt.prepareFunc(t, r)
 			defer patches.Reset()
 			r.restoreMode = tt.restoreMode
-			isExisting, isStale, subnetPath, _, _, err := r.CheckAndGetSubnetPathForSubnetPort(ctx, tt.subnetport)
+			// Expanded to consume 7 returns values properly
+			isExisting, isStale, subnetPath, _, _, interfaceType, err := r.CheckAndGetSubnetPathForSubnetPort(ctx, tt.subnetport)
 			assert.Equal(t, tt.expectedIsStale, isStale)
 			assert.Equal(t, tt.expectedIsExisting, isExisting)
 			if tt.expectedErr != "" {
+				assert.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {
+				assert.Nil(t, err)
 				assert.Equal(t, tt.expectedSubnetPath, subnetPath)
+				assert.Equal(t, tt.expectedIPType, interfaceType)
 			}
 		})
 	}
 }
 
 func TestSubnetPortReconciler_updateSubnetStatusOnSubnetPort(t *testing.T) {
-	patchesGetGatewayPrefixOfSubnet := gomonkey.ApplyFunc((*subnet.SubnetService).GetGatewayPrefixOfSubnet,
-		func(s *subnet.SubnetService, obj *model.VpcSubnet) (string, int, error) {
-			return "10.0.0.1", 28, nil
-		})
-	defer patchesGetGatewayPrefixOfSubnet.Reset()
-	sp := &v1alpha1.SubnetPort{
-		Status: v1alpha1.SubnetPortStatus{
-			NetworkInterfaceConfig: v1alpha1.NetworkInterfaceConfig{
-				IPAddresses: []v1alpha1.NetworkInterfaceIPAddress{
-					{IPAddress: "10.0.0.2"},
-				},
-			},
-		},
-	}
 	r := &SubnetPortReconciler{
 		SubnetPortService: &subnetport.SubnetPortService{},
 		SubnetService:     &subnet.SubnetService{},
 	}
-	err := r.updateSubnetStatusOnSubnetPort(sp, &model.VpcSubnet{
-		RealizationId: servicecommon.String("realization-id-1"),
-	})
-	assert.Nil(t, err)
-	expectedSp := &v1alpha1.SubnetPort{
-		Status: v1alpha1.SubnetPortStatus{
-			NetworkInterfaceConfig: v1alpha1.NetworkInterfaceConfig{
-				IPAddresses: []v1alpha1.NetworkInterfaceIPAddress{
-					{
-						IPAddress: "10.0.0.2/28",
-						Gateway:   "10.0.0.1",
-					},
-				},
-				LogicalSwitchUUID: "realization-id-1",
+
+	tests := []struct {
+		name        string
+		gateways    []servicecommon.GatewayPrefixInfo
+		initialIPs  []v1alpha1.NetworkInterfaceIPAddress
+		expectedIPs []v1alpha1.NetworkInterfaceIPAddress
+	}{
+		{
+			name: "Pre-set Gateway",
+			gateways: []servicecommon.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 28},
+			},
+			initialIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.2/28", Gateway: "10.0.0.1"},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.2/28", Gateway: "10.0.0.1"},
+			},
+		},
+		{
+			name: "Pre-set Gateway without prefix",
+			gateways: []servicecommon.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 28},
+			},
+			initialIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.2", Gateway: "10.0.0.1"},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.2/28", Gateway: "10.0.0.1"},
+			},
+		},
+		{
+			name: "Single IPv4 address binding",
+			gateways: []servicecommon.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 28},
+			},
+			initialIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.2"},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.2/28", Gateway: "10.0.0.1"},
+			},
+		},
+		{
+			name: "Multiple address bindings - Dual Stack IPv4 and IPv6",
+			gateways: []servicecommon.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 24},
+				{Gateway: "2001:db8::1", Prefix: 64},
+			},
+			initialIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "2001:db8::2"},
+				{IPAddress: "10.0.0.5"},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.5/24", Gateway: "10.0.0.1"},
+				{IPAddress: "2001:db8::2/64", Gateway: "2001:db8::1"},
+			},
+		},
+		{
+			name: "Empty IP configuration",
+			gateways: []servicecommon.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 24},
+			},
+			initialIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: ""},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "", Gateway: "10.0.0.1"},
+			},
+		},
+		{
+			name: "Empty IP configuration - Dual Stack IPv4 and IPv6",
+			gateways: []servicecommon.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 24},
+				{Gateway: "2001:db8::1", Prefix: 64},
+			},
+			initialIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: ""},
+				{IPAddress: ""},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "", Gateway: "10.0.0.1"},
+				{IPAddress: "", Gateway: "2001:db8::1"},
+			},
+		},
+		{
+			name: "Extra IPv6 Address",
+			gateways: []servicecommon.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 24},
+				{Gateway: "2001:db8::1", Prefix: 64},
+			},
+			initialIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.5"},
+				{IPAddress: "2002:db8::2"}, // Mismatch
+				{IPAddress: "2001:db8::2"},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.5/24", Gateway: "10.0.0.1"},
+				{IPAddress: "2001:db8::2/64", Gateway: "2001:db8::1"},
+			},
+		},
+		{
+			name: "Empty IP configuration without update",
+			gateways: []servicecommon.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 24},
+				{Gateway: "2001:db8::1", Prefix: 64},
+			},
+			initialIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "", Gateway: "10.0.0.1"},
+				{IPAddress: "", Gateway: "2001:db8::1"},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "", Gateway: "10.0.0.1"},
+				{IPAddress: "", Gateway: "2001:db8::1"},
 			},
 		},
 	}
-	assert.Equal(t, expectedSp, sp)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock the SubnetService method inside the scope of this subtest
+			patchesGetAllGatewayPrefixesOfSubnet := gomonkey.ApplyFunc((*subnet.SubnetService).GetAllGatewayPrefixesOfSubnet,
+				func(s *subnet.SubnetService, obj *model.VpcSubnet) ([]servicecommon.GatewayPrefixInfo, error) {
+					return tt.gateways, nil
+				})
+			defer patchesGetAllGatewayPrefixesOfSubnet.Reset()
+
+			sp := &v1alpha1.SubnetPort{
+				Status: v1alpha1.SubnetPortStatus{
+					NetworkInterfaceConfig: v1alpha1.NetworkInterfaceConfig{
+						IPAddresses: tt.initialIPs,
+					},
+				},
+			}
+
+			err := r.updateSubnetStatusOnSubnetPort(sp, &model.VpcSubnet{
+				RealizationId: servicecommon.String("realization-id-1"),
+			})
+
+			assert.Nil(t, err)
+			assert.Equal(t, "realization-id-1", sp.Status.NetworkInterfaceConfig.LogicalSwitchUUID)
+			assert.Equal(t, tt.expectedIPs, sp.Status.NetworkInterfaceConfig.IPAddresses)
+		})
+	}
 }
 
 func TestSubnetPortReconciler_getVirtualMachine(t *testing.T) {
@@ -2759,4 +2956,113 @@ func TestSubnetAssociatedResourceIndexFunc(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestSubnetPortReconciler_UpdateSubnetPortIPType(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+
+	service := &subnetport.SubnetPortService{}
+	r := &SubnetPortReconciler{
+		Client:            k8sClient,
+		SubnetPortService: service,
+		restoreMode:       false,
+	}
+	r.StatusUpdater = common.NewStatusUpdater(k8sClient, nil, fakeRecorder{}, MetricResTypeSubnetPort, "SubnetPort", "SubnetPort")
+	ctx := context.Background()
+
+	// Case 1: No fields are empty -> No spec change, no k8s client update should be called
+	t.Run("no spec changes required", func(t *testing.T) {
+		subMockCtl := gomock.NewController(t)
+		defer subMockCtl.Finish()
+		subClient := mock_client.NewMockClient(subMockCtl)
+		r.Client = subClient
+
+		subnetPort := &v1alpha1.SubnetPort{
+			Spec: v1alpha1.SubnetPortSpec{
+				InterfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+				StaticIPAllocationType: v1alpha1.StaticIPAllocationType(v1alpha1.IPAddressTypeIPv4),
+			},
+		}
+		nsxSubnet := &model.VpcSubnet{}
+
+		err := r.updateSubnetPortIPType(ctx, subnetPort, v1alpha1.IPAddressTypeIPv6, nsxSubnet)
+		assert.NoError(t, err)
+		assert.Equal(t, v1alpha1.IPAddressTypeIPv4, subnetPort.Spec.InterfaceIPType)
+	})
+
+	// Case 2: InterfaceIPType is empty -> should default to interfaceIPType passed in
+	t.Run("default empty InterfaceIPType", func(t *testing.T) {
+		subMockCtl := gomock.NewController(t)
+		defer subMockCtl.Finish()
+		subClient := mock_client.NewMockClient(subMockCtl)
+		r.Client = subClient
+
+		subnetPort := &v1alpha1.SubnetPort{
+			Spec: v1alpha1.SubnetPortSpec{
+				InterfaceIPType:        "",
+				StaticIPAllocationType: v1alpha1.StaticIPAllocationType(v1alpha1.IPAddressTypeIPv4),
+			},
+		}
+		nsxSubnet := &model.VpcSubnet{}
+
+		subClient.EXPECT().Update(ctx, subnetPort).Return(nil)
+
+		err := r.updateSubnetPortIPType(ctx, subnetPort, v1alpha1.IPAddressTypeIPv4IPv6, nsxSubnet)
+		assert.NoError(t, err)
+		assert.Equal(t, v1alpha1.IPAddressTypeIPv4IPv6, subnetPort.Spec.InterfaceIPType)
+	})
+
+	// Case 3: StaticIPAllocationType is empty AND Static IP Allocation is ENABLED on Subnet
+	t.Run("default empty StaticIPAllocationType with static IP enabled", func(t *testing.T) {
+		subMockCtl := gomock.NewController(t)
+		defer subMockCtl.Finish()
+		subClient := mock_client.NewMockClient(subMockCtl)
+		r.Client = subClient
+
+		subnetPort := &v1alpha1.SubnetPort{
+			Spec: v1alpha1.SubnetPortSpec{
+				InterfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+				StaticIPAllocationType: "",
+			},
+		}
+
+		patchesStaticIPEnabled := gomonkey.ApplyFunc(pkgutil.NSXSubnetStaticIPAllocationEnabled, func(_ *model.VpcSubnet) bool {
+			return true
+		})
+		defer patchesStaticIPEnabled.Reset()
+
+		subClient.EXPECT().Update(ctx, subnetPort).Return(nil)
+
+		err := r.updateSubnetPortIPType(ctx, subnetPort, v1alpha1.IPAddressTypeIPv4, &model.VpcSubnet{})
+		assert.NoError(t, err)
+		assert.Equal(t, v1alpha1.StaticIPAllocationType(v1alpha1.IPAddressTypeIPv4), subnetPort.Spec.StaticIPAllocationType)
+	})
+
+	// Case 4: StaticIPAllocationType is empty AND Static IP Allocation is DISABLED on Subnet
+	t.Run("default empty StaticIPAllocationType with static IP disabled", func(t *testing.T) {
+		subMockCtl := gomock.NewController(t)
+		defer subMockCtl.Finish()
+		subClient := mock_client.NewMockClient(subMockCtl)
+		r.Client = subClient
+
+		subnetPort := &v1alpha1.SubnetPort{
+			Spec: v1alpha1.SubnetPortSpec{
+				InterfaceIPType:        v1alpha1.IPAddressTypeIPv6,
+				StaticIPAllocationType: "",
+			},
+		}
+
+		patchesStaticIPEnabled := gomonkey.ApplyFunc(pkgutil.NSXSubnetStaticIPAllocationEnabled, func(_ *model.VpcSubnet) bool {
+			return false
+		})
+		defer patchesStaticIPEnabled.Reset()
+
+		subClient.EXPECT().Update(ctx, subnetPort).Return(nil)
+
+		err := r.updateSubnetPortIPType(ctx, subnetPort, v1alpha1.IPAddressTypeIPv6, &model.VpcSubnet{})
+		assert.NoError(t, err)
+		assert.Equal(t, v1alpha1.StaticIPAllocationTypeNone, subnetPort.Spec.StaticIPAllocationType)
+	})
 }

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -121,16 +121,8 @@ func (m *MockSubnetServiceProvider) GetSubnetStatus(subnet *model.VpcSubnet) ([]
 	return nil, nil
 }
 
-func (m *MockSubnetServiceProvider) GetGatewayPrefixOfSubnet(nsxSubnet *model.VpcSubnet) (string, int, error) {
-	return "", 0, nil
-}
-
-func (m *MockSubnetServiceProvider) GetGatewayPrefixFromNSXSubnet(nsxSubnet *model.VpcSubnet) (string, int, error) {
-	return "", 0, nil
-}
-
-func (m *MockSubnetServiceProvider) GetGatewayPrefixFromNSXSubnetStatus(nsxSubnet *model.VpcSubnet) (string, int, error) {
-	return "", 0, nil
+func (m *MockSubnetServiceProvider) GetAllGatewayPrefixesOfSubnet(nsxSubnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
+	return nil, nil
 }
 
 func (m *MockSubnetServiceProvider) GetAllVIFs() ([]mpmodel.VirtualNetworkInterface, error) {
@@ -149,12 +141,12 @@ func (m *MockSubnetPortServiceProvider) GetPortsOfSubnet(subnetPath string) (por
 	return args.Get(0).([]*model.VpcSubnetPort)
 }
 
-func (m *MockSubnetPortServiceProvider) AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool) (bool, error) {
-	args := m.Called(subnet, sharedSubnet)
+func (m *MockSubnetPortServiceProvider) AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool, interfaceIPType v1alpha1.IPAddressType) (bool, error) {
+	args := m.Called(subnet, sharedSubnet, interfaceIPType)
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *MockSubnetPortServiceProvider) ReleasePortInSubnet(path string) {
+func (m *MockSubnetPortServiceProvider) ReleasePortInSubnet(path string, interfaceIPType v1alpha1.IPAddressType) {
 }
 
 func (m *MockSubnetPortServiceProvider) IsEmptySubnet(path string) bool {

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -37,15 +37,13 @@ type SubnetServiceProvider interface {
 	GetSubnetByCR(subnet *v1alpha1.Subnet) (*model.VpcSubnet, error)
 	GetNSXSubnetFromCacheOrAPI(associatedResource string, forceAPI bool) (*model.VpcSubnet, error)
 	GetSubnetStatus(subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error)
-	GetGatewayPrefixFromNSXSubnet(nsxSubnet *model.VpcSubnet) (string, int, error)
-	GetGatewayPrefixFromNSXSubnetStatus(nsxSubnet *model.VpcSubnet) (string, int, error)
-	GetGatewayPrefixOfSubnet(nsxSubnet *model.VpcSubnet) (string, int, error)
+	GetAllGatewayPrefixesOfSubnet(nsxSubnet *model.VpcSubnet) ([]GatewayPrefixInfo, error)
 }
 
 type SubnetPortServiceProvider interface {
 	GetPortsOfSubnet(subnetPath string) (ports []*model.VpcSubnetPort)
-	AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool) (bool, error)
-	ReleasePortInSubnet(path string)
+	AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool, interfaceIPType v1alpha1.IPAddressType) (bool, error)
+	ReleasePortInSubnet(path string, interfaceIPType v1alpha1.IPAddressType)
 	IsEmptySubnet(path string) bool
 	DeletePortCount(path string)
 	GetSubnetPathForSubnetPortFromStore(crUid types.UID) string

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -291,3 +291,8 @@ type VPCConnectionStatus struct {
 	ServiceClusterReady     bool
 	ServiceClusterReason    string
 }
+
+type GatewayPrefixInfo struct {
+	Gateway string
+	Prefix  int
+}

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -908,71 +908,92 @@ func (service *SubnetService) RemoveSharedSubnetFromResourceMap(associatedResour
 	}
 }
 
-func (service *SubnetService) GetGatewayPrefixOfSubnet(nsxSubnet *model.VpcSubnet) (string, int, error) {
-	gateway, prefix, errFromSubnet := service.GetGatewayPrefixFromNSXSubnet(nsxSubnet)
-	if errFromSubnet == nil && prefix > 0 {
-		return gateway, prefix, nil
+// GetAllGatewayPrefixesOfSubnet returns all gateways (IPv4 and/or IPv6) with their prefixes for the subnet
+// This is used for dual-stack subnet support where both IPv4 and IPv6 gateways may be present
+func (service *SubnetService) GetAllGatewayPrefixesOfSubnet(nsxSubnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
+	var gateways []common.GatewayPrefixInfo
+
+	gateways, errFromSubnet := service.getAllGatewayPrefixesFromNSXSubnet(nsxSubnet)
+	if errFromSubnet == nil && len(gateways) > 0 {
+		return gateways, nil
 	}
+
 	// For the VLAN Extension Subnet, there's no gateway in NSX Subnet GET API. We need to get it from NSX Subnet Status.
-	gateway, prefix, errFromStatus := service.GetGatewayPrefixFromNSXSubnetStatus(nsxSubnet)
+	gateways, errFromStatus := service.getAllGatewayPrefixesFromNSXSubnetStatus(nsxSubnet)
 	if errFromStatus == nil {
-		return gateway, prefix, nil
+		return gateways, nil
 	}
+
 	err := fmt.Errorf("errFromSubnet: %v, errFromStatus: %v", errFromSubnet, errFromStatus)
 	log.Error(err, "Failed to get gateway of Subnet", "nsxSubnet.Id", *nsxSubnet.Id)
-	return "", -1, err
+	return []common.GatewayPrefixInfo{}, err
 }
 
-func (service *SubnetService) GetGatewayPrefixFromNSXSubnet(nsxSubnet *model.VpcSubnet) (string, int, error) {
+// getAllGatewayPrefixesFromNSXSubnet extracts all gateways from AdvancedConfig.GatewayAddresses
+func (service *SubnetService) getAllGatewayPrefixesFromNSXSubnet(nsxSubnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
 	if nsxSubnet == nil {
-		err := fmt.Errorf("empty NSX Subnet")
-		return "", -1, err
+		return nil, fmt.Errorf("empty NSX Subnet")
 	}
 	if nsxSubnet.AdvancedConfig == nil {
 		log.Warn("Nil AdvancedConfig in NSX Subnet", "nsxSubnet.Id", *nsxSubnet.Id)
-		return "", -1, nil
+		return nil, nil
 	}
+
 	gatewayAddresses := nsxSubnet.AdvancedConfig.GatewayAddresses
 	if len(gatewayAddresses) == 0 {
 		log.Warn("Empty gateway addresses in NSX Subnet AdvancedConfig", "nsxSubnet.Id", *nsxSubnet.Id)
-		return "", -1, nil
+		return nil, nil
 	}
-	gateway, err := util.RemoveIPPrefix(gatewayAddresses[0])
-	if err != nil {
-		return "", -1, err
+
+	var results []common.GatewayPrefixInfo
+	for _, gwAddr := range gatewayAddresses {
+		gateway, err := util.RemoveIPPrefix(gwAddr)
+		if err != nil {
+			return nil, err
+		}
+		prefix, err := util.GetIPPrefix(gwAddr)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, common.GatewayPrefixInfo{Gateway: gateway, Prefix: prefix})
 	}
-	prefix, err := util.GetIPPrefix(gatewayAddresses[0])
-	if err != nil {
-		return "", -1, err
-	}
-	log.Debug("Got gateway from NSX Subnet", "nsxSubnet.Id", *nsxSubnet.Id, "gateway", gateway, "prefix", prefix)
-	return gateway, prefix, nil
+
+	log.Debug("Got gateways from NSX Subnet", "nsxSubnet.Id", *nsxSubnet.Id, "gateways", results)
+	return results, nil
 }
 
-func (service *SubnetService) GetGatewayPrefixFromNSXSubnetStatus(nsxSubnet *model.VpcSubnet) (string, int, error) {
+// getAllGatewayPrefixesFromNSXSubnetStatus extracts all gateways from Subnet Status
+func (service *SubnetService) getAllGatewayPrefixesFromNSXSubnetStatus(nsxSubnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
 	statusList, err := service.GetSubnetStatus(nsxSubnet)
 	if err != nil {
-		return "", -1, err
+		return nil, err
 	}
 	if len(statusList) == 0 {
 		log.Warn("Empty status list in NSX Subnet status", "nsxSubnet.Id", *nsxSubnet.Id)
-		return "", -1, nil
+		return nil, nil
 	}
-	gatewayAddress := statusList[0].GatewayAddress
-	if gatewayAddress == nil || len(*gatewayAddress) == 0 {
-		log.Warn("Nil or empty gateway address in NSX Subnet status", "nsxSubnet.Id", *nsxSubnet.Id)
-		return "", -1, nil
+
+	var results []common.GatewayPrefixInfo
+	for _, status := range statusList {
+		gatewayAddress := status.GatewayAddress
+		if gatewayAddress == nil || len(*gatewayAddress) == 0 {
+			log.Warn("Nil or empty gateway address in NSX Subnet status", "nsxSubnet.Id", *nsxSubnet.Id)
+			return nil, nil
+		}
+
+		gateway, err := util.RemoveIPPrefix(*gatewayAddress)
+		if err != nil {
+			return nil, err
+		}
+		prefix, err := util.GetIPPrefix(*gatewayAddress)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, common.GatewayPrefixInfo{Gateway: gateway, Prefix: prefix})
 	}
-	gateway, err := util.RemoveIPPrefix(*gatewayAddress)
-	if err != nil {
-		return "", -1, err
-	}
-	prefix, err := util.GetIPPrefix(*gatewayAddress)
-	if err != nil {
-		return "", -1, err
-	}
-	log.Debug("Got gateway from NSX Subnet status", "nsxSubnet.Id", *nsxSubnet.Id, "gateway", gateway, "prefix", prefix)
-	return gateway, prefix, nil
+
+	log.Debug("Got gateways from NSX Subnet status", "nsxSubnet.Id", *nsxSubnet.Id, "gateways", results)
+	return results, nil
 }
 
 func (service *SubnetService) updateSubnetSetConditionOnFail(obj client.Object, err error) {

--- a/pkg/nsx/services/subnet/subnet_test.go
+++ b/pkg/nsx/services/subnet/subnet_test.go
@@ -2504,39 +2504,53 @@ func Test_isSubnetReady(t *testing.T) {
 	}
 	assert.False(t, isSubnetReady(subnetUnready))
 }
-
-func TestSubnetService_GetGatewayPrefixFromNSXSubnet(t *testing.T) {
+func TestSubnetService_GetAllGatewayPrefixesFromNSXSubnet(t *testing.T) {
 	subnetId := "subnet-id-1"
-	gatewayAddress := "10.0.0.1/26"
+	gatewayAddressIPv4 := "10.0.0.1/26"
+	gatewayAddressIPv6 := "2001:db8::1/64"
 	invalidGatewayAddress1 := "10.0.0.256"
 	invalidGatewayAddress2 := "10.0.0.1/a"
+
 	tests := []struct {
 		name            string
 		nsxSubnet       model.VpcSubnet
 		wantErr         bool
-		expectedGateway string
-		expectedPrefix  int
+		expectedResults []common.GatewayPrefixInfo
 	}{
 		{
-			name: "Success",
+			name: "Success - Single IPv4",
 			nsxSubnet: model.VpcSubnet{
 				Id: &subnetId,
 				AdvancedConfig: &model.SubnetAdvancedConfig{
-					GatewayAddresses: []string{gatewayAddress},
+					GatewayAddresses: []string{gatewayAddressIPv4},
 				},
 			},
-			wantErr:         false,
-			expectedGateway: "10.0.0.1",
-			expectedPrefix:  26,
+			wantErr: false,
+			expectedResults: []common.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 26},
+			},
 		},
 		{
-			name: "EmptySubnetGatewayAddress",
+			name: "Success - Dual Stack (IPv4 and IPv6)",
+			nsxSubnet: model.VpcSubnet{
+				Id: &subnetId,
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					GatewayAddresses: []string{gatewayAddressIPv4, gatewayAddressIPv6},
+				},
+			},
+			wantErr: false,
+			expectedResults: []common.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 26},
+				{Gateway: "2001:db8::1", Prefix: 64},
+			},
+		},
+		{
+			name: "NilAdvancedConfig",
 			nsxSubnet: model.VpcSubnet{
 				Id: &subnetId,
 			},
 			wantErr:         false,
-			expectedGateway: "",
-			expectedPrefix:  -1,
+			expectedResults: nil,
 		},
 		{
 			name: "NoGatewayAddress",
@@ -2547,8 +2561,7 @@ func TestSubnetService_GetGatewayPrefixFromNSXSubnet(t *testing.T) {
 				},
 			},
 			wantErr:         false,
-			expectedGateway: "",
-			expectedPrefix:  -1,
+			expectedResults: nil,
 		},
 		{
 			name: "InvalidIP",
@@ -2573,79 +2586,72 @@ func TestSubnetService_GetGatewayPrefixFromNSXSubnet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			commonService := common.Service{
-				NSXClient: &nsx.Client{
-					SubnetStatusClient: &fakeSubnetStatusClient{},
+			service := &SubnetService{
+				Service: common.Service{
+					NSXClient: &nsx.Client{
+						SubnetStatusClient: &fakeSubnetStatusClient{},
+					},
 				},
 			}
-			service := &SubnetService{
-				Service: commonService,
-			}
-			gateway, prefix, err := service.GetGatewayPrefixFromNSXSubnet(&tt.nsxSubnet)
+			results, err := service.getAllGatewayPrefixesFromNSXSubnet(&tt.nsxSubnet)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetGatewayPrefixFromNSXSubnet() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("getAllGatewayPrefixesFromNSXSubnet() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if err == nil {
-				assert.Equal(t, tt.expectedGateway, gateway)
-				assert.Equal(t, tt.expectedPrefix, prefix)
+				assert.Equal(t, tt.expectedResults, results)
 			}
 		})
 	}
 }
 
-func TestSubnetService_GetGatewayPrefixFromNSXSubnetStatus(t *testing.T) {
+func TestSubnetService_GetAllGatewayPrefixesFromNSXSubnetStatus(t *testing.T) {
 	subnetId := "subnet-id-1"
-	gatewayAddress := "10.0.0.1/26"
+	gatewayAddressIPv4 := "10.0.0.1/26"
+	gatewayAddressIPv6 := "2001:db8::1/64"
 	invalidGatewayAddress1 := "10.0.0.256"
 	invalidGatewayAddress2 := "10.0.0.1/a"
+
 	tests := []struct {
 		name            string
 		nsxSubnet       model.VpcSubnet
 		prepareFunc     func() *gomonkey.Patches
 		wantErr         bool
-		expectedGateway string
-		expectedPrefix  int
+		expectedResults []common.GatewayPrefixInfo
 	}{
 		{
-			name: "Success",
+			name: "Success - Dual Stack Status",
 			nsxSubnet: model.VpcSubnet{
 				Id: &subnetId,
-				AdvancedConfig: &model.SubnetAdvancedConfig{
-					GatewayAddresses: []string{gatewayAddress},
-				},
 			},
 			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc((*SubnetService).GetSubnetStatus, func(s *SubnetService, subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
+				return gomonkey.ApplyFunc((*SubnetService).GetSubnetStatus, func(s *SubnetService, subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
 					return []model.VpcSubnetStatus{
-						{
-							GatewayAddress: &gatewayAddress,
-						},
+						{GatewayAddress: &gatewayAddressIPv4},
+						{GatewayAddress: &gatewayAddressIPv6},
 					}, nil
 				})
-				return patches
 			},
-			wantErr:         false,
-			expectedGateway: "10.0.0.1",
-			expectedPrefix:  26,
+			wantErr: false,
+			expectedResults: []common.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 26},
+				{Gateway: "2001:db8::1", Prefix: 64},
+			},
 		},
 		{
-			name: "EmptySubnetGatewayAddress",
+			name: "EmptyOrNilGatewayAddressInStatus",
 			nsxSubnet: model.VpcSubnet{
 				Id: &subnetId,
 			},
 			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc((*SubnetService).GetSubnetStatus, func(s *SubnetService, subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
+				emptyStr := ""
+				return gomonkey.ApplyFunc((*SubnetService).GetSubnetStatus, func(s *SubnetService, subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
 					return []model.VpcSubnetStatus{
-						{
-							GatewayAddress: nil,
-						},
+						{GatewayAddress: &emptyStr},
 					}, nil
 				})
-				return patches
 			},
 			wantErr:         false,
-			expectedGateway: "",
-			expectedPrefix:  -1,
+			expectedResults: nil,
 		},
 		{
 			name: "FailToGetSubnetStatus",
@@ -2653,10 +2659,9 @@ func TestSubnetService_GetGatewayPrefixFromNSXSubnetStatus(t *testing.T) {
 				Id: &subnetId,
 			},
 			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc((*SubnetService).GetSubnetStatus, func(s *SubnetService, subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
+				return gomonkey.ApplyFunc((*SubnetService).GetSubnetStatus, func(s *SubnetService, subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
 					return nil, fmt.Errorf("API error")
 				})
-				return patches
 			},
 			wantErr: true,
 		},
@@ -2666,14 +2671,12 @@ func TestSubnetService_GetGatewayPrefixFromNSXSubnetStatus(t *testing.T) {
 				Id: &subnetId,
 			},
 			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc((*SubnetService).GetSubnetStatus, func(s *SubnetService, subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
+				return gomonkey.ApplyFunc((*SubnetService).GetSubnetStatus, func(s *SubnetService, subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
 					return []model.VpcSubnetStatus{}, nil
 				})
-				return patches
 			},
 			wantErr:         false,
-			expectedGateway: "",
-			expectedPrefix:  -1,
+			expectedResults: nil,
 		},
 		{
 			name: "InvalidIP",
@@ -2681,14 +2684,11 @@ func TestSubnetService_GetGatewayPrefixFromNSXSubnetStatus(t *testing.T) {
 				Id: &subnetId,
 			},
 			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc((*SubnetService).GetSubnetStatus, func(s *SubnetService, subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
+				return gomonkey.ApplyFunc((*SubnetService).GetSubnetStatus, func(s *SubnetService, subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
 					return []model.VpcSubnetStatus{
-						{
-							GatewayAddress: &invalidGatewayAddress1,
-						},
+						{GatewayAddress: &invalidGatewayAddress1},
 					}, nil
 				})
-				return patches
 			},
 			wantErr: true,
 		},
@@ -2698,262 +2698,11 @@ func TestSubnetService_GetGatewayPrefixFromNSXSubnetStatus(t *testing.T) {
 				Id: &subnetId,
 			},
 			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc((*SubnetService).GetSubnetStatus, func(s *SubnetService, subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
+				return gomonkey.ApplyFunc((*SubnetService).GetSubnetStatus, func(s *SubnetService, subnet *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
 					return []model.VpcSubnetStatus{
-						{
-							GatewayAddress: &invalidGatewayAddress2,
-						},
+						{GatewayAddress: &invalidGatewayAddress2},
 					}, nil
 				})
-				return patches
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			commonService := common.Service{
-				NSXClient: &nsx.Client{
-					SubnetStatusClient: &fakeSubnetStatusClient{},
-				},
-			}
-			service := &SubnetService{
-				Service: commonService,
-			}
-			var patches *gomonkey.Patches
-			if tt.prepareFunc != nil {
-				patches = tt.prepareFunc()
-				defer patches.Reset()
-			}
-			gateway, prefix, err := service.GetGatewayPrefixFromNSXSubnetStatus(&tt.nsxSubnet)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetGatewayPrefixFromNSXSubnetStatus() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if err == nil {
-				assert.Equal(t, tt.expectedGateway, gateway)
-				assert.Equal(t, tt.expectedPrefix, prefix)
-			}
-		})
-	}
-}
-
-func TestSubnetService_GetGatewayPrefixOfSubnet(t *testing.T) {
-	subnetId := "subnet-id-1"
-	nsxSubnet := &model.VpcSubnet{
-		Id: &subnetId,
-	}
-	tests := []struct {
-		name            string
-		nsxSubnet       *model.VpcSubnet
-		prepareFunc     func() *gomonkey.Patches
-		wantErr         bool
-		expectedGateway string
-		expectedPrefix  int
-	}{
-		{
-			name:      "SuccessWithGetGatewayPrefixFromNSXSubnet",
-			nsxSubnet: nsxSubnet,
-			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(&SubnetService{}), "GetGatewayPrefixFromNSXSubnet", func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "10.0.0.1", 26, nil
-				})
-				return patches
-			},
-			wantErr:         false,
-			expectedGateway: "10.0.0.1",
-			expectedPrefix:  26,
-		},
-		{
-			name:      "SuccessWithGetGatewayPrefixFromNSXSubnetStatus",
-			nsxSubnet: nsxSubnet,
-			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(&SubnetService{}), "GetGatewayPrefixFromNSXSubnet", func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", 0, fmt.Errorf("API error from subnet")
-				})
-				patches.ApplyFunc((*SubnetService).GetGatewayPrefixFromNSXSubnetStatus, func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "10.0.0.1", 26, nil
-				})
-				return patches
-			},
-			wantErr:         false,
-			expectedGateway: "10.0.0.1",
-			expectedPrefix:  26,
-		},
-		{
-			name:      "FailBothMethods",
-			nsxSubnet: nsxSubnet,
-			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(&SubnetService{}), "GetGatewayPrefixFromNSXSubnet", func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", 0, fmt.Errorf("API error from subnet")
-				})
-				patches.ApplyFunc((*SubnetService).GetGatewayPrefixFromNSXSubnetStatus, func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", 0, fmt.Errorf("API error from status")
-				})
-				return patches
-			},
-			wantErr: true,
-		},
-		{
-			name:      "SubnetReturnsNoErrorButPrefixNegative_FallsThrough",
-			nsxSubnet: nsxSubnet,
-			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(&SubnetService{}), "GetGatewayPrefixFromNSXSubnet", func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", -1, nil
-				})
-				patches.ApplyFunc((*SubnetService).GetGatewayPrefixFromNSXSubnetStatus, func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "10.0.0.1", 16, nil
-				})
-				return patches
-			},
-			wantErr:         false,
-			expectedGateway: "10.0.0.1",
-			expectedPrefix:  16,
-		},
-		{
-			name:      "SubnetReturnsNoErrorButPrefixZero_FallsThrough",
-			nsxSubnet: nsxSubnet,
-			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(&SubnetService{}), "GetGatewayPrefixFromNSXSubnet", func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", 0, nil
-				})
-				patches.ApplyFunc((*SubnetService).GetGatewayPrefixFromNSXSubnetStatus, func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", 24, nil
-				})
-				return patches
-			},
-			wantErr:         false,
-			expectedGateway: "",
-			expectedPrefix:  24,
-		},
-		{
-			name:      "SubnetReturnsNoErrorButPrefixNegative_StatusAlsoFails",
-			nsxSubnet: nsxSubnet,
-			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(&SubnetService{}), "GetGatewayPrefixFromNSXSubnet", func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", -1, nil
-				})
-				patches.ApplyFunc((*SubnetService).GetGatewayPrefixFromNSXSubnetStatus, func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", -1, fmt.Errorf("no status")
-				})
-				return patches
-			},
-			wantErr: true,
-		},
-		{
-			name:      "StatusReturnsEmptyGatewayWithValidPrefix",
-			nsxSubnet: nsxSubnet,
-			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(&SubnetService{}), "GetGatewayPrefixFromNSXSubnet", func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", -1, nil
-				})
-				patches.ApplyFunc((*SubnetService).GetGatewayPrefixFromNSXSubnetStatus, func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", 16, nil
-				})
-				return patches
-			},
-			wantErr:         false,
-			expectedGateway: "",
-			expectedPrefix:  16,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			commonService := common.Service{
-				NSXClient: &nsx.Client{
-					SubnetStatusClient: &fakeSubnetStatusClient{},
-				},
-			}
-			service := &SubnetService{
-				Service: commonService,
-			}
-			var patches *gomonkey.Patches
-			if tt.prepareFunc != nil {
-				patches = tt.prepareFunc()
-			}
-			gateway, prefix, err := service.GetGatewayPrefixOfSubnet(tt.nsxSubnet)
-			if patches != nil {
-				patches.Reset()
-			}
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetGatewayPrefixOfSubnet() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if err == nil {
-				assert.Equal(t, tt.expectedGateway, gateway)
-				assert.Equal(t, tt.expectedPrefix, prefix)
-			}
-		})
-	}
-}
-
-func TestSubnetService_GetGatewayPrefixOfSubnet_Integration(t *testing.T) {
-	subnetId := "integration-subnet-id"
-	tests := []struct {
-		name            string
-		nsxSubnet       *model.VpcSubnet
-		prepareFunc     func() *gomonkey.Patches
-		wantErr         bool
-		expectedGateway string
-		expectedPrefix  int
-	}{
-		{
-			name: "L3 subnet with gateway in AdvancedConfig returns gateway and prefix directly",
-			nsxSubnet: &model.VpcSubnet{
-				Id: &subnetId,
-				AdvancedConfig: &model.SubnetAdvancedConfig{
-					GatewayAddresses: []string{"40.101.0.1/16"},
-				},
-				IpAddresses: []string{"40.101.0.0/16"},
-			},
-			wantErr:         false,
-			expectedGateway: "40.101.0.1",
-			expectedPrefix:  16,
-		},
-		{
-			name: "L2 subnet with empty gateway falls through to status",
-			nsxSubnet: &model.VpcSubnet{
-				Id: &subnetId,
-				AdvancedConfig: &model.SubnetAdvancedConfig{
-					GatewayAddresses: []string{},
-				},
-			},
-			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc((*SubnetService).GetGatewayPrefixFromNSXSubnetStatus, func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", 16, nil
-				})
-				return patches
-			},
-			wantErr:         false,
-			expectedGateway: "",
-			expectedPrefix:  16,
-		},
-		{
-			name: "L2 subnet with nil AdvancedConfig falls through to status",
-			nsxSubnet: &model.VpcSubnet{
-				Id: &subnetId,
-			},
-			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc((*SubnetService).GetGatewayPrefixFromNSXSubnetStatus, func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", 28, nil
-				})
-				return patches
-			},
-			wantErr:         false,
-			expectedGateway: "",
-			expectedPrefix:  28,
-		},
-		{
-			name: "Both methods fail returns error",
-			nsxSubnet: &model.VpcSubnet{
-				Id: &subnetId,
-				AdvancedConfig: &model.SubnetAdvancedConfig{
-					GatewayAddresses: []string{},
-				},
-			},
-			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc((*SubnetService).GetGatewayPrefixFromNSXSubnetStatus, func(s *SubnetService, nsxSubnet *model.VpcSubnet) (string, int, error) {
-					return "", -1, fmt.Errorf("no status")
-				})
-				return patches
 			},
 			wantErr: true,
 		},
@@ -2970,17 +2719,214 @@ func TestSubnetService_GetGatewayPrefixOfSubnet_Integration(t *testing.T) {
 			var patches *gomonkey.Patches
 			if tt.prepareFunc != nil {
 				patches = tt.prepareFunc()
+				defer patches.Reset()
 			}
-			gateway, prefix, err := service.GetGatewayPrefixOfSubnet(tt.nsxSubnet)
+			results, err := service.getAllGatewayPrefixesFromNSXSubnetStatus(&tt.nsxSubnet)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getAllGatewayPrefixesFromNSXSubnetStatus() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				assert.Equal(t, tt.expectedResults, results)
+			}
+		})
+	}
+}
+
+func TestSubnetService_GetAllGatewayPrefixesOfSubnet(t *testing.T) {
+	subnetId := "subnet-id-1"
+	nsxSubnet := &model.VpcSubnet{
+		Id: &subnetId,
+	}
+	tests := []struct {
+		name            string
+		nsxSubnet       *model.VpcSubnet
+		prepareFunc     func() *gomonkey.Patches
+		wantErr         bool
+		expectedResults []common.GatewayPrefixInfo
+	}{
+		{
+			name:      "Success via Subnet",
+			nsxSubnet: nsxSubnet,
+			prepareFunc: func() *gomonkey.Patches {
+				return gomonkey.ApplyPrivateMethod(reflect.TypeOf(&SubnetService{}), "getAllGatewayPrefixesFromNSXSubnet", func(s *SubnetService, subnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
+					return []common.GatewayPrefixInfo{{Gateway: "10.0.0.1", Prefix: 26}}, nil
+				})
+			},
+			wantErr: false,
+			expectedResults: []common.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 26},
+			},
+		},
+		{
+			name:      "Success via Status when Subnet returns empty list",
+			nsxSubnet: nsxSubnet,
+			prepareFunc: func() *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(&SubnetService{}), "getAllGatewayPrefixesFromNSXSubnet", func(s *SubnetService, subnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
+					return []common.GatewayPrefixInfo{}, nil
+				})
+				patches.ApplyPrivateMethod(reflect.TypeOf(&SubnetService{}), "getAllGatewayPrefixesFromNSXSubnetStatus", func(s *SubnetService, subnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
+					return []common.GatewayPrefixInfo{{Gateway: "2001:db8::1", Prefix: 64}}, nil
+				})
+				return patches
+			},
+			wantErr: false,
+			expectedResults: []common.GatewayPrefixInfo{
+				{Gateway: "2001:db8::1", Prefix: 64},
+			},
+		},
+		{
+			name:      "Success via Status when Subnet returns error",
+			nsxSubnet: nsxSubnet,
+			prepareFunc: func() *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(&SubnetService{}), "getAllGatewayPrefixesFromNSXSubnet", func(s *SubnetService, subnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
+					return nil, fmt.Errorf("subnet error")
+				})
+				patches.ApplyPrivateMethod(reflect.TypeOf(&SubnetService{}), "getAllGatewayPrefixesFromNSXSubnetStatus", func(s *SubnetService, subnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
+					return []common.GatewayPrefixInfo{{Gateway: "10.0.0.1", Prefix: 24}}, nil
+				})
+				return patches
+			},
+			wantErr: false,
+			expectedResults: []common.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 24},
+			},
+		},
+		{
+			name:      "FailBothMethods",
+			nsxSubnet: nsxSubnet,
+			prepareFunc: func() *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(&SubnetService{}), "getAllGatewayPrefixesFromNSXSubnet", func(s *SubnetService, subnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
+					return nil, fmt.Errorf("subnet error")
+				})
+				patches.ApplyPrivateMethod(reflect.TypeOf(&SubnetService{}), "getAllGatewayPrefixesFromNSXSubnetStatus", func(s *SubnetService, subnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
+					return nil, fmt.Errorf("status error")
+				})
+				return patches
+			},
+			wantErr:         true,
+			expectedResults: []common.GatewayPrefixInfo{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &SubnetService{
+				Service: common.Service{
+					NSXClient: &nsx.Client{
+						SubnetStatusClient: &fakeSubnetStatusClient{},
+					},
+				},
+			}
+			var patches *gomonkey.Patches
+			if tt.prepareFunc != nil {
+				patches = tt.prepareFunc()
+			}
+			results, err := service.GetAllGatewayPrefixesOfSubnet(tt.nsxSubnet)
 			if patches != nil {
 				patches.Reset()
 			}
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetGatewayPrefixOfSubnet() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetAllGatewayPrefixesOfSubnet() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if err == nil {
-				assert.Equal(t, tt.expectedGateway, gateway)
-				assert.Equal(t, tt.expectedPrefix, prefix)
+			if err == nil || !tt.wantErr {
+				assert.Equal(t, tt.expectedResults, results)
+			}
+		})
+	}
+}
+
+func TestSubnetService_GetAllGatewayPrefixesOfSubnet_Integration(t *testing.T) {
+	subnetId := "integration-subnet-id"
+	tests := []struct {
+		name            string
+		nsxSubnet       *model.VpcSubnet
+		prepareFunc     func() *gomonkey.Patches
+		wantErr         bool
+		expectedResults []common.GatewayPrefixInfo
+	}{
+		{
+			name: "L3 subnet with single gateway in AdvancedConfig returns directly",
+			nsxSubnet: &model.VpcSubnet{
+				Id: &subnetId,
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					GatewayAddresses: []string{"40.101.0.1/16"},
+				},
+			},
+			wantErr: false,
+			expectedResults: []common.GatewayPrefixInfo{
+				{Gateway: "40.101.0.1", Prefix: 16},
+			},
+		},
+		{
+			name: "L3 subnet with dual stack gateways in AdvancedConfig returns both directly",
+			nsxSubnet: &model.VpcSubnet{
+				Id: &subnetId,
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					GatewayAddresses: []string{"40.101.0.1/16", "2001:db8::1/64"},
+				},
+			},
+			wantErr: false,
+			expectedResults: []common.GatewayPrefixInfo{
+				{Gateway: "40.101.0.1", Prefix: 16},
+				{Gateway: "2001:db8::1", Prefix: 64},
+			},
+		},
+		{
+			name: "L2 subnet with empty gateway falls through to status",
+			nsxSubnet: &model.VpcSubnet{
+				Id: &subnetId,
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					GatewayAddresses: []string{},
+				},
+			},
+			prepareFunc: func() *gomonkey.Patches {
+				return gomonkey.ApplyPrivateMethod(reflect.TypeOf(&SubnetService{}), "getAllGatewayPrefixesFromNSXSubnetStatus", func(s *SubnetService, nsxSubnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
+					return []common.GatewayPrefixInfo{{Gateway: "10.0.0.1", Prefix: 16}}, nil
+				})
+			},
+			wantErr: false,
+			expectedResults: []common.GatewayPrefixInfo{
+				{Gateway: "10.0.0.1", Prefix: 16},
+			},
+		},
+		{
+			name: "Both methods fail returns error",
+			nsxSubnet: &model.VpcSubnet{
+				Id: &subnetId,
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					GatewayAddresses: []string{},
+				},
+			},
+			prepareFunc: func() *gomonkey.Patches {
+				return gomonkey.ApplyPrivateMethod(reflect.TypeOf(&SubnetService{}), "getAllGatewayPrefixesFromNSXSubnetStatus", func(s *SubnetService, nsxSubnet *model.VpcSubnet) ([]common.GatewayPrefixInfo, error) {
+					return nil, fmt.Errorf("no status available")
+				})
+			},
+			wantErr:         true,
+			expectedResults: []common.GatewayPrefixInfo{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &SubnetService{
+				Service: common.Service{
+					NSXClient: &nsx.Client{
+						SubnetStatusClient: &fakeSubnetStatusClient{},
+					},
+				},
+			}
+			var patches *gomonkey.Patches
+			if tt.prepareFunc != nil {
+				patches = tt.prepareFunc()
+			}
+			results, err := service.GetAllGatewayPrefixesOfSubnet(tt.nsxSubnet)
+			if patches != nil {
+				patches.Reset()
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAllGatewayPrefixesOfSubnet() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil || !tt.wantErr {
+				assert.Equal(t, tt.expectedResults, results)
 			}
 		})
 	}

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -30,7 +30,7 @@ var (
 	String = common.String
 )
 
-func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, labelTags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.VpcSubnetPort, error) {
+func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, labelTags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.VpcSubnetPort, error) {
 	var objNamespace, appId, allocateAddresses string
 	objMeta := getObjectMeta(obj)
 	if objMeta == nil {
@@ -45,50 +45,66 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 	var err error
 	var addressBindings []model.PortAddressBindingEntry
 	var hasMacSpecified bool
+	var staticIpAllocationType string
 	switch o := obj.(type) {
 	case *v1alpha1.SubnetPort:
 		externalAddressBinding, err = service.buildExternalAddressBinding(o, restoreMode)
 		if err != nil {
 			return nil, err
 		}
-		// NSX only supports one IP per SubnetPort
-		if restoreMode && o.Status.NetworkInterfaceConfig.IPAddresses[0].IPAddress != "" {
-			ip := strings.Split(o.Status.NetworkInterfaceConfig.IPAddresses[0].IPAddress, "/")[0]
-			addressBindings = []model.PortAddressBindingEntry{
-				{
-					IpAddress:  &ip,
-					MacAddress: &o.Status.NetworkInterfaceConfig.MACAddress,
-				},
+		if restoreMode && len(o.Status.NetworkInterfaceConfig.IPAddresses) > 0 {
+			// Restore mode: build address bindings from all IPAddresses in status
+			macAddress := o.Status.NetworkInterfaceConfig.MACAddress
+			for _, ipConfig := range o.Status.NetworkInterfaceConfig.IPAddresses {
+				if ipConfig.IPAddress != "" {
+					ip := strings.Split(ipConfig.IPAddress, "/")[0]
+					addressBindings = append(addressBindings, model.PortAddressBindingEntry{
+						IpAddress:  &ip,
+						MacAddress: &macAddress,
+					})
+				}
 			}
 			if len(o.Spec.AddressBindings) > 0 && len(o.Spec.AddressBindings[0].MACAddress) > 0 {
 				hasMacSpecified = true
 			}
 		} else if len(o.Spec.AddressBindings) > 0 {
-			addressBinding := model.PortAddressBindingEntry{}
-			if len(o.Spec.AddressBindings[0].IPAddress) > 0 {
-				addressBinding.IpAddress = &o.Spec.AddressBindings[0].IPAddress
-			}
-			// If StaticIPAllocation is disabled and no IP is specified, we do not specify the MAC in the NSX SubnetPort AddressBinding
-			if (util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) || len(o.Spec.AddressBindings[0].IPAddress) > 0) &&
-				len(o.Spec.AddressBindings[0].MACAddress) > 0 {
-				addressBinding.MacAddress = &o.Spec.AddressBindings[0].MACAddress
-				hasMacSpecified = true
-			}
-			if addressBinding.IpAddress != nil || addressBinding.MacAddress != nil {
-				addressBindings = []model.PortAddressBindingEntry{addressBinding}
+			// normal mode: process all address bindings (up to 2 for IPv4 and IPv6)
+			for _, ab := range o.Spec.AddressBindings {
+				addressBinding := model.PortAddressBindingEntry{}
+				if len(ab.IPAddress) > 0 {
+					addressBinding.IpAddress = &ab.IPAddress
+				}
+				// If StaticIPAllocation is disabled and no IP is specified, we do not specify the MAC in the NSX SubnetPort AddressBinding
+				if (util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) || len(ab.IPAddress) > 0) &&
+					len(ab.MACAddress) > 0 {
+					addressBinding.MacAddress = &ab.MACAddress
+					hasMacSpecified = true
+				}
+				if addressBinding.IpAddress != nil || addressBinding.MacAddress != nil {
+					addressBindings = append(addressBindings, addressBinding)
+				}
 			}
 		}
+		staticIpAllocationType = controllercommon.ConvertCRStaticIPAddressTypeToNSX(o.Spec.StaticIPAllocationType)
 	case *corev1.Pod:
-		if restoreMode && len(o.Status.PodIP) > 0 {
-			addressBindings = []model.PortAddressBindingEntry{
-				{IpAddress: &o.Status.PodIP},
+		if restoreMode && len(o.Status.PodIPs) > 0 {
+			addressBindings = []model.PortAddressBindingEntry{}
+			for _, ip := range o.Status.PodIPs {
+				addressBindings = append(addressBindings, model.PortAddressBindingEntry{IpAddress: &ip.IP})
 			}
 			mac, ok := o.GetAnnotations()[common.AnnotationPodMAC]
 			if ok && mac != "" {
-				addressBindings[0].MacAddress = &mac
+				for i := range addressBindings {
+					addressBindings[i].MacAddress = &mac
+				}
 			} else {
 				log.Error(nil, "MAC address annotation not found in Pod", "Pod", o)
 			}
+		}
+		if util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) {
+			staticIpAllocationType = controllercommon.ConvertCRIPAddressTypeToNSX(interfaceIPType)
+		} else {
+			staticIpAllocationType = controllercommon.NSXIPAddressTypeNone
 		}
 	}
 
@@ -181,6 +197,7 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 		Path:                   &nsxSubnetPortPath,
 		ParentPath:             nsxSubnet.Path,
 		ExternalAddressBinding: externalAddressBinding,
+		StaticIpAllocationType: &staticIpAllocationType,
 	}
 	if appId != "" {
 		nsxSubnetPort.Attachment.AppId = &appId

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	controllercommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/mock"
 	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
@@ -59,19 +60,19 @@ func TestBuildSubnetPort(t *testing.T) {
 		}).AnyTimes()
 
 	tests := []struct {
-		name          string
-		obj           interface{}
-		nsxSubnet     *model.VpcSubnet
-		contextID     string
-		labelTags     *map[string]string
-		restore       bool
-		expectedPort  *model.VpcSubnetPort
-		expectedError error
+		name            string
+		obj             interface{}
+		nsxSubnet       *model.VpcSubnet
+		contextID       string
+		labelTags       *map[string]string
+		restore         bool
+		interfaceIPType v1alpha1.IPAddressType
+		expectedPort    *model.VpcSubnetPort
+		expectedError   error
 	}{
 		{
-			// DHCP/DHCPRelay - Y; StaticIPAllocation Enabled - N;
-			// AddressBinding exists - N
-			name: "build-NSX-port-for-subnetport",
+			name:            "build-NSX-port-for-subnetport",
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			obj: &v1alpha1.SubnetPort{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1alpha1",
@@ -81,6 +82,9 @@ func TestBuildSubnetPort(t *testing.T) {
 					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
 					Name:      "fake_subnetport",
 					Namespace: "fake_ns",
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
 				},
 			},
 			nsxSubnet: &model.VpcSubnet{
@@ -95,26 +99,11 @@ func TestBuildSubnetPort(t *testing.T) {
 				DisplayName: common.String("fake_subnetport"),
 				Id:          common.String("fake_subnetport_phoia"),
 				Tags: []model.Tag{
-					{
-						Scope: common.String("nsx-op/cluster"),
-						Tag:   common.String("fake_cluster"),
-					},
-					{
-						Scope: common.String("nsx-op/version"),
-						Tag:   common.String("1.0.0"),
-					},
-					{
-						Scope: common.String("nsx-op/namespace"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_name"),
-						Tag:   common.String("fake_subnetport"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_uid"),
-						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
-					},
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("fake_cluster")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("fake_ns")},
+					{Scope: common.String("nsx-op/subnetport_name"), Tag: common.String("fake_subnetport")},
+					{Scope: common.String("nsx-op/subnetport_uid"), Tag: common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc")},
 				},
 				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
 				ParentPath: common.String("fake_path"),
@@ -124,13 +113,13 @@ func TestBuildSubnetPort(t *testing.T) {
 					Id:                common.String("32636365-6333-4239-ad37-3534362d3466"),
 					TrafficTag:        common.Int64(0),
 				},
+				StaticIpAllocationType: common.String(controllercommon.NSXIPAddressTypeNone),
 			},
 			expectedError: nil,
 		},
 		{
-			// DHCP/DHCPRelay - Y; StaticIPAllocation Enabled - N;
-			// AddressBinding exists - Y;
-			name: "build-NSX-port-in-subnet-dhcp-with-binding-in-nsx-mac-pool",
+			name:            "build-NSX-port-in-subnet-dhcp-with-binding-in-nsx-mac-pool",
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			obj: &v1alpha1.SubnetPort{
 				ObjectMeta: metav1.ObjectMeta{
 					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
@@ -145,6 +134,7 @@ func TestBuildSubnetPort(t *testing.T) {
 							MACAddress: "04:50:56:00:fa:00",
 						},
 					},
+					StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
 				},
 			},
 			nsxSubnet: &model.VpcSubnet{
@@ -164,26 +154,11 @@ func TestBuildSubnetPort(t *testing.T) {
 				DisplayName: common.String("fake_subnetport"),
 				Id:          common.String("fake_subnetport_phoia"),
 				Tags: []model.Tag{
-					{
-						Scope: common.String("nsx-op/cluster"),
-						Tag:   common.String("fake_cluster"),
-					},
-					{
-						Scope: common.String("nsx-op/version"),
-						Tag:   common.String("1.0.0"),
-					},
-					{
-						Scope: common.String("nsx-op/namespace"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_name"),
-						Tag:   common.String("fake_subnetport"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_uid"),
-						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
-					},
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("fake_cluster")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("fake_ns")},
+					{Scope: common.String("nsx-op/subnetport_name"), Tag: common.String("fake_subnetport")},
+					{Scope: common.String("nsx-op/subnetport_uid"), Tag: common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc")},
 				},
 				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
 				ParentPath: common.String("fake_path"),
@@ -199,13 +174,13 @@ func TestBuildSubnetPort(t *testing.T) {
 						MacAddress: common.String("04:50:56:00:fa:00"),
 					},
 				},
+				StaticIpAllocationType: common.String(controllercommon.NSXIPAddressTypeNone),
 			},
 			expectedError: nil,
 		},
 		{
-			// DHCP/DHCPRelay - Y; StaticIPAllocation Enabled - N;
-			// AddressBinding exists - Y (restore);
-			name: "build-NSX-port-for-restore-subnetport-dhcp",
+			name:            "build-NSX-port-for-restore-subnetport-dhcp",
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			obj: &v1alpha1.SubnetPort{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1alpha1",
@@ -223,6 +198,9 @@ func TestBuildSubnetPort(t *testing.T) {
 						},
 						MACAddress: "aa:bb:cc:dd:ee:ff",
 					},
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
 				},
 			},
 			nsxSubnet: &model.VpcSubnet{
@@ -238,26 +216,11 @@ func TestBuildSubnetPort(t *testing.T) {
 				DisplayName: common.String("fake_subnetport"),
 				Id:          common.String("fake_subnetport_phoia"),
 				Tags: []model.Tag{
-					{
-						Scope: common.String("nsx-op/cluster"),
-						Tag:   common.String("fake_cluster"),
-					},
-					{
-						Scope: common.String("nsx-op/version"),
-						Tag:   common.String("1.0.0"),
-					},
-					{
-						Scope: common.String("nsx-op/namespace"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_name"),
-						Tag:   common.String("fake_subnetport"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_uid"),
-						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
-					},
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("fake_cluster")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("fake_ns")},
+					{Scope: common.String("nsx-op/subnetport_name"), Tag: common.String("fake_subnetport")},
+					{Scope: common.String("nsx-op/subnetport_uid"), Tag: common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc")},
 				},
 				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
 				ParentPath: common.String("fake_path"),
@@ -272,13 +235,13 @@ func TestBuildSubnetPort(t *testing.T) {
 						MacAddress: common.String("aa:bb:cc:dd:ee:ff"),
 					},
 				},
+				StaticIpAllocationType: common.String(controllercommon.NSXIPAddressTypeNone),
 			},
 			expectedError: nil,
 		},
 		{
-			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - Y;
-			// AddressBinding exists - N (restore);
-			name: "build-NSX-port-for-restore-subnetport-ipam",
+			name:            "build-NSX-port-for-restore-subnetport-ipam",
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			obj: &v1alpha1.SubnetPort{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1alpha1",
@@ -296,6 +259,9 @@ func TestBuildSubnetPort(t *testing.T) {
 						},
 						MACAddress: "aa:bb:cc:dd:ee:ff",
 					},
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 				},
 			},
 			nsxSubnet: &model.VpcSubnet{
@@ -316,26 +282,11 @@ func TestBuildSubnetPort(t *testing.T) {
 				DisplayName: common.String("fake_subnetport"),
 				Id:          common.String("fake_subnetport_phoia"),
 				Tags: []model.Tag{
-					{
-						Scope: common.String("nsx-op/cluster"),
-						Tag:   common.String("fake_cluster"),
-					},
-					{
-						Scope: common.String("nsx-op/version"),
-						Tag:   common.String("1.0.0"),
-					},
-					{
-						Scope: common.String("nsx-op/namespace"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_name"),
-						Tag:   common.String("fake_subnetport"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_uid"),
-						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
-					},
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("fake_cluster")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("fake_ns")},
+					{Scope: common.String("nsx-op/subnetport_name"), Tag: common.String("fake_subnetport")},
+					{Scope: common.String("nsx-op/subnetport_uid"), Tag: common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc")},
 				},
 				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
 				ParentPath: common.String("fake_path"),
@@ -350,13 +301,14 @@ func TestBuildSubnetPort(t *testing.T) {
 						MacAddress: common.String("aa:bb:cc:dd:ee:ff"),
 					},
 				},
+				// Updated: o.Spec.StaticIPAllocationType is empty string -> converted to "" (or whatever ConvertCRStaticIPAddressTypeToNSX handles for empty strings)
+				StaticIpAllocationType: common.String(controllercommon.NSXIPAddressTypeIPv4),
 			},
 			expectedError: nil,
 		},
 		{
-			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - Y;
-			// AddressBinding exists - Y (restore);
-			name: "build-NSX-port-for-restore-subnetport-ipam-with-mac",
+			name:            "build-NSX-port-for-restore-subnetport-ipam-with-mac",
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			obj: &v1alpha1.SubnetPort{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1alpha1",
@@ -374,6 +326,7 @@ func TestBuildSubnetPort(t *testing.T) {
 							MACAddress: "aa:bb:cc:dd:ee:ff",
 						},
 					},
+					StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 				},
 				Status: v1alpha1.SubnetPortStatus{
 					NetworkInterfaceConfig: v1alpha1.NetworkInterfaceConfig{
@@ -402,26 +355,11 @@ func TestBuildSubnetPort(t *testing.T) {
 				DisplayName: common.String("fake_subnetport"),
 				Id:          common.String("fake_subnetport_phoia"),
 				Tags: []model.Tag{
-					{
-						Scope: common.String("nsx-op/cluster"),
-						Tag:   common.String("fake_cluster"),
-					},
-					{
-						Scope: common.String("nsx-op/version"),
-						Tag:   common.String("1.0.0"),
-					},
-					{
-						Scope: common.String("nsx-op/namespace"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_name"),
-						Tag:   common.String("fake_subnetport"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_uid"),
-						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
-					},
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("fake_cluster")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("fake_ns")},
+					{Scope: common.String("nsx-op/subnetport_name"), Tag: common.String("fake_subnetport")},
+					{Scope: common.String("nsx-op/subnetport_uid"), Tag: common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc")},
 				},
 				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
 				ParentPath: common.String("fake_path"),
@@ -436,13 +374,13 @@ func TestBuildSubnetPort(t *testing.T) {
 						MacAddress: common.String("aa:bb:cc:dd:ee:ff"),
 					},
 				},
+				StaticIpAllocationType: common.String(controllercommon.NSXIPAddressTypeIPv4),
 			},
 			expectedError: nil,
 		},
 		{
-			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - Y;
-			// AddressBinding exists - Y
-			name: "build-NSX-port-for-subnetport-specified-mac",
+			name:            "build-NSX-port-for-subnetport-specified-mac",
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			obj: &v1alpha1.SubnetPort{
 				ObjectMeta: metav1.ObjectMeta{
 					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
@@ -457,6 +395,7 @@ func TestBuildSubnetPort(t *testing.T) {
 							MACAddress: "aa:bb:cc:dd:ee:ff",
 						},
 					},
+					StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 				},
 			},
 			nsxSubnet: &model.VpcSubnet{
@@ -476,26 +415,11 @@ func TestBuildSubnetPort(t *testing.T) {
 				DisplayName: common.String("fake_subnetport"),
 				Id:          common.String("fake_subnetport_phoia"),
 				Tags: []model.Tag{
-					{
-						Scope: common.String("nsx-op/cluster"),
-						Tag:   common.String("fake_cluster"),
-					},
-					{
-						Scope: common.String("nsx-op/version"),
-						Tag:   common.String("1.0.0"),
-					},
-					{
-						Scope: common.String("nsx-op/namespace"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_name"),
-						Tag:   common.String("fake_subnetport"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_uid"),
-						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
-					},
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("fake_cluster")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("fake_ns")},
+					{Scope: common.String("nsx-op/subnetport_name"), Tag: common.String("fake_subnetport")},
+					{Scope: common.String("nsx-op/subnetport_uid"), Tag: common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc")},
 				},
 				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
 				ParentPath: common.String("fake_path"),
@@ -511,13 +435,13 @@ func TestBuildSubnetPort(t *testing.T) {
 						MacAddress: common.String("aa:bb:cc:dd:ee:ff"),
 					},
 				},
+				StaticIpAllocationType: common.String(controllercommon.NSXIPAddressTypeIPv4),
 			},
 			expectedError: nil,
 		},
 		{
-			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - Y;
-			// AddressBinding exists - N (pod)
-			name: "build-NSX-port-for-pod",
+			name:            "build-NSX-port-for-pod-ipv4",
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			obj: &corev1.Pod{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
@@ -549,34 +473,13 @@ func TestBuildSubnetPort(t *testing.T) {
 				DisplayName: common.String("fake_pod"),
 				Id:          common.String("fake_pod_phoia"),
 				Tags: []model.Tag{
-					{
-						Scope: common.String("nsx-op/cluster"),
-						Tag:   common.String("fake_cluster"),
-					},
-					{
-						Scope: common.String("nsx-op/version"),
-						Tag:   common.String("1.0.0"),
-					},
-					{
-						Scope: common.String("nsx-op/namespace"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("nsx-op/pod_name"),
-						Tag:   common.String("fake_pod"),
-					},
-					{
-						Scope: common.String("nsx-op/pod_uid"),
-						Tag:   common.String("c5db1800-ce4c-11de-a935-8105ba7ace78"),
-					},
-					{
-						Scope: common.String("kubernetes.io/metadata.name"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("vSphereClusterID"),
-						Tag:   common.String("domain-c11"),
-					},
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("fake_cluster")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("fake_ns")},
+					{Scope: common.String("nsx-op/pod_name"), Tag: common.String("fake_pod")},
+					{Scope: common.String("nsx-op/pod_uid"), Tag: common.String("c5db1800-ce4c-11de-a935-8105ba7ace78")},
+					{Scope: common.String("kubernetes.io/metadata.name"), Tag: common.String("fake_ns")},
+					{Scope: common.String("vSphereClusterID"), Tag: common.String("domain-c11")},
 				},
 				Path:       common.String("fake_path/ports/fake_pod_phoia"),
 				ParentPath: common.String("fake_path"),
@@ -588,13 +491,69 @@ func TestBuildSubnetPort(t *testing.T) {
 					AppId:             common.String("c5db1800-ce4c-11de-a935-8105ba7ace78"),
 					ContextId:         common.String("fake_context_id"),
 				},
+				StaticIpAllocationType: common.String(controllercommon.NSXIPAddressTypeIPv4),
 			},
 			expectedError: nil,
 		},
 		{
-			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - Y;
-			// AddressBinding exists - N (restore pod)
-			name: "build-NSX-port-for-restore-pod",
+			name:            "build-NSX-port-for-pod-ipv6",
+			interfaceIPType: v1alpha1.IPAddressTypeIPv6,
+			obj: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "c5db1800-ce4c-11de-a935-8105ba7ace78",
+					Name:      "fake_pod",
+					Namespace: "fake_ns",
+				},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					StaticIpAllocation: &model.StaticIpAllocation{
+						Enabled: common.Bool(true),
+					},
+				},
+				SubnetDhcpConfig: &model.SubnetDhcpConfig{
+					Mode: common.String("DHCP_DEACTIVATED"),
+				},
+				Path: common.String("fake_path"),
+			},
+			contextID: "fake_context_id",
+			labelTags: &map[string]string{
+				"kubernetes.io/metadata.name": "fake_ns",
+				"vSphereClusterID":            "domain-c11",
+			},
+			expectedPort: &model.VpcSubnetPort{
+				DisplayName: common.String("fake_pod"),
+				Id:          common.String("fake_pod_phoia"),
+				Tags: []model.Tag{
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("fake_cluster")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("fake_ns")},
+					{Scope: common.String("nsx-op/pod_name"), Tag: common.String("fake_pod")},
+					{Scope: common.String("nsx-op/pod_uid"), Tag: common.String("c5db1800-ce4c-11de-a935-8105ba7ace78")},
+					{Scope: common.String("kubernetes.io/metadata.name"), Tag: common.String("fake_ns")},
+					{Scope: common.String("vSphereClusterID"), Tag: common.String("domain-c11")},
+				},
+				Path:       common.String("fake_path/ports/fake_pod_phoia"),
+				ParentPath: common.String("fake_path"),
+				Attachment: &model.PortAttachment{
+					AllocateAddresses: common.String("BOTH"),
+					Type_:             common.String(model.PortAttachment_TYPE_INDEPENDENT),
+					TrafficTag:        common.Int64(0),
+					Id:                common.String("63356462-3138-4030-ad63-6534632d3131"),
+					AppId:             common.String("c5db1800-ce4c-11de-a935-8105ba7ace78"),
+					ContextId:         common.String("fake_context_id"),
+				},
+				StaticIpAllocationType: common.String(controllercommon.NSXIPAddressTypeIPv6),
+			},
+			expectedError: nil,
+		},
+		{
+			name:            "build-NSX-port-for-restore-pod",
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			obj: &corev1.Pod{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
@@ -607,7 +566,9 @@ func TestBuildSubnetPort(t *testing.T) {
 					Annotations: map[string]string{common.AnnotationPodMAC: "04:50:56:00:fa:00"},
 				},
 				Status: corev1.PodStatus{
-					PodIP: "10.0.0.1",
+					PodIPs: []corev1.PodIP{
+						{IP: "10.0.0.1"},
+					},
 				},
 			},
 			nsxSubnet: &model.VpcSubnet{
@@ -630,34 +591,13 @@ func TestBuildSubnetPort(t *testing.T) {
 				DisplayName: common.String("fake_pod"),
 				Id:          common.String("fake_pod_phoia"),
 				Tags: []model.Tag{
-					{
-						Scope: common.String("nsx-op/cluster"),
-						Tag:   common.String("fake_cluster"),
-					},
-					{
-						Scope: common.String("nsx-op/version"),
-						Tag:   common.String("1.0.0"),
-					},
-					{
-						Scope: common.String("nsx-op/namespace"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("nsx-op/pod_name"),
-						Tag:   common.String("fake_pod"),
-					},
-					{
-						Scope: common.String("nsx-op/pod_uid"),
-						Tag:   common.String("c5db1800-ce4c-11de-a935-8105ba7ace78"),
-					},
-					{
-						Scope: common.String("kubernetes.io/metadata.name"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("vSphereClusterID"),
-						Tag:   common.String("domain-c11"),
-					},
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("fake_cluster")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("fake_ns")},
+					{Scope: common.String("nsx-op/pod_name"), Tag: common.String("fake_pod")},
+					{Scope: common.String("nsx-op/pod_uid"), Tag: common.String("c5db1800-ce4c-11de-a935-8105ba7ace78")},
+					{Scope: common.String("kubernetes.io/metadata.name"), Tag: common.String("fake_ns")},
+					{Scope: common.String("vSphereClusterID"), Tag: common.String("domain-c11")},
 				},
 				Path:       common.String("fake_path/ports/fake_pod_phoia"),
 				ParentPath: common.String("fake_path"),
@@ -674,14 +614,15 @@ func TestBuildSubnetPort(t *testing.T) {
 						MacAddress: common.String("04:50:56:00:fa:00"),
 					},
 				},
+				// Updated: Uses ConvertCRIPAddressTypeToNSX(interfaceIPType)
+				StaticIpAllocationType: common.String(controllercommon.NSXIPAddressTypeIPv4),
 			},
 			expectedError: nil,
 			restore:       true,
 		},
 		{
-			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - N;
-			// AddressBinding exists - N
-			name: "build-NSX-port-for-subnetport-no-ip",
+			name:            "build-NSX-port-for-subnetport-no-ip",
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			obj: &v1alpha1.SubnetPort{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1alpha1",
@@ -691,6 +632,9 @@ func TestBuildSubnetPort(t *testing.T) {
 					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
 					Name:      "fake_subnetport",
 					Namespace: "fake_ns",
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
 				},
 			},
 			nsxSubnet: &model.VpcSubnet{
@@ -710,26 +654,11 @@ func TestBuildSubnetPort(t *testing.T) {
 				DisplayName: common.String("fake_subnetport"),
 				Id:          common.String("fake_subnetport_phoia"),
 				Tags: []model.Tag{
-					{
-						Scope: common.String("nsx-op/cluster"),
-						Tag:   common.String("fake_cluster"),
-					},
-					{
-						Scope: common.String("nsx-op/version"),
-						Tag:   common.String("1.0.0"),
-					},
-					{
-						Scope: common.String("nsx-op/namespace"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_name"),
-						Tag:   common.String("fake_subnetport"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_uid"),
-						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
-					},
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("fake_cluster")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("fake_ns")},
+					{Scope: common.String("nsx-op/subnetport_name"), Tag: common.String("fake_subnetport")},
+					{Scope: common.String("nsx-op/subnetport_uid"), Tag: common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc")},
 				},
 				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
 				ParentPath: common.String("fake_path"),
@@ -739,13 +668,13 @@ func TestBuildSubnetPort(t *testing.T) {
 					Id:                common.String("32636365-6333-4239-ad37-3534362d3466"),
 					TrafficTag:        common.Int64(0),
 				},
+				StaticIpAllocationType: common.String(controllercommon.NSXIPAddressTypeNone),
 			},
 			expectedError: nil,
 		},
 		{
-			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - N;
-			// AddressBinding exists - N
-			name: "build-NSX-port-for-subnetport-no-ip-2",
+			name:            "build-NSX-port-for-subnetport-no-ip-2",
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			obj: &v1alpha1.SubnetPort{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1alpha1",
@@ -755,6 +684,9 @@ func TestBuildSubnetPort(t *testing.T) {
 					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
 					Name:      "fake_subnetport",
 					Namespace: "fake_ns",
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
 				},
 			},
 			nsxSubnet: &model.VpcSubnet{
@@ -772,26 +704,11 @@ func TestBuildSubnetPort(t *testing.T) {
 				DisplayName: common.String("fake_subnetport"),
 				Id:          common.String("fake_subnetport_phoia"),
 				Tags: []model.Tag{
-					{
-						Scope: common.String("nsx-op/cluster"),
-						Tag:   common.String("fake_cluster"),
-					},
-					{
-						Scope: common.String("nsx-op/version"),
-						Tag:   common.String("1.0.0"),
-					},
-					{
-						Scope: common.String("nsx-op/namespace"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_name"),
-						Tag:   common.String("fake_subnetport"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_uid"),
-						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
-					},
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("fake_cluster")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("fake_ns")},
+					{Scope: common.String("nsx-op/subnetport_name"), Tag: common.String("fake_subnetport")},
+					{Scope: common.String("nsx-op/subnetport_uid"), Tag: common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc")},
 				},
 				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
 				ParentPath: common.String("fake_path"),
@@ -801,13 +718,13 @@ func TestBuildSubnetPort(t *testing.T) {
 					Id:                common.String("32636365-6333-4239-ad37-3534362d3466"),
 					TrafficTag:        common.Int64(0),
 				},
+				StaticIpAllocationType: common.String(controllercommon.NSXIPAddressTypeNone),
 			},
 			expectedError: nil,
 		},
 		{
-			// DHCP/DHCPRelay - N; StaticIPAllocation Enabled - N;
-			// AddressBinding exists - Y;
-			name: "build-NSX-port-in-subnet-no-ip-but-binding-in-nsx-mac-pool",
+			name:            "build-NSX-port-in-subnet-no-ip-but-binding-in-nsx-mac-pool",
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			obj: &v1alpha1.SubnetPort{
 				ObjectMeta: metav1.ObjectMeta{
 					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
@@ -822,6 +739,7 @@ func TestBuildSubnetPort(t *testing.T) {
 							MACAddress: "04:50:56:00:fa:00",
 						},
 					},
+					StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
 				},
 			},
 			nsxSubnet: &model.VpcSubnet{
@@ -841,26 +759,11 @@ func TestBuildSubnetPort(t *testing.T) {
 				DisplayName: common.String("fake_subnetport"),
 				Id:          common.String("fake_subnetport_phoia"),
 				Tags: []model.Tag{
-					{
-						Scope: common.String("nsx-op/cluster"),
-						Tag:   common.String("fake_cluster"),
-					},
-					{
-						Scope: common.String("nsx-op/version"),
-						Tag:   common.String("1.0.0"),
-					},
-					{
-						Scope: common.String("nsx-op/namespace"),
-						Tag:   common.String("fake_ns"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_name"),
-						Tag:   common.String("fake_subnetport"),
-					},
-					{
-						Scope: common.String("nsx-op/subnetport_uid"),
-						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
-					},
+					{Scope: common.String("nsx-op/cluster"), Tag: common.String("fake_cluster")},
+					{Scope: common.String("nsx-op/version"), Tag: common.String("1.0.0")},
+					{Scope: common.String("nsx-op/namespace"), Tag: common.String("fake_ns")},
+					{Scope: common.String("nsx-op/subnetport_name"), Tag: common.String("fake_subnetport")},
+					{Scope: common.String("nsx-op/subnetport_uid"), Tag: common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc")},
 				},
 				Path:       common.String("fake_path/ports/fake_subnetport_phoia"),
 				ParentPath: common.String("fake_path"),
@@ -876,6 +779,7 @@ func TestBuildSubnetPort(t *testing.T) {
 						MacAddress: common.String("04:50:56:00:fa:00"),
 					},
 				},
+				StaticIpAllocationType: common.String(controllercommon.NSXIPAddressTypeNone),
 			},
 			expectedError: nil,
 		},
@@ -883,13 +787,13 @@ func TestBuildSubnetPort(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			observedPort, err := service.buildSubnetPort(tt.obj, tt.nsxSubnet, tt.contextID, tt.labelTags, false, tt.restore)
+			// Passed tt.interfaceIPType explicitly into the updated method signature
+			observedPort, err := service.buildSubnetPort(tt.obj, tt.nsxSubnet, tt.contextID, tt.labelTags, false, tt.restore, tt.interfaceIPType)
 			if tt.expectedError != nil {
 				assert.Equal(t, tt.expectedError, err)
 			} else {
 				assert.Nil(t, err)
-				// Ignore attachment id for restore mode as it is random
-				if tt.restore {
+				if tt.restore && observedPort != nil && observedPort.Attachment != nil {
 					tt.expectedPort.Attachment.Id = observedPort.Attachment.Id
 				}
 				assert.Equal(t, tt.expectedPort, observedPort)
@@ -897,7 +801,6 @@ func TestBuildSubnetPort(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestGetAddressBindingBySubnetPort(t *testing.T) {

--- a/pkg/nsx/services/subnetport/compare.go
+++ b/pkg/nsx/services/subnetport/compare.go
@@ -19,10 +19,11 @@ func (sp *SubnetPort) Key() string {
 
 func (sp *SubnetPort) Value() data.DataValue {
 	s := &SubnetPort{
-		Id:          sp.Id,
-		DisplayName: sp.DisplayName,
-		Tags:        sp.Tags,
-		Attachment:  sp.Attachment,
+		Id:                     sp.Id,
+		DisplayName:            sp.DisplayName,
+		Tags:                   sp.Tags,
+		Attachment:             sp.Attachment,
+		StaticIpAllocationType: sp.StaticIpAllocationType,
 	}
 	if sp.Attachment != nil {
 		// Ignoring the fields BmsInterfaceConfig, ContextType, EvpnVlans, HyperbusMode
@@ -37,11 +38,12 @@ func (sp *SubnetPort) Value() data.DataValue {
 		}
 	}
 	if sp.AddressBindings != nil {
-		s.AddressBindings = []model.PortAddressBindingEntry{
-			{
-				IpAddress:  sp.AddressBindings[0].IpAddress,
-				MacAddress: sp.AddressBindings[0].MacAddress,
-			},
+		s.AddressBindings = make([]model.PortAddressBindingEntry, len(sp.AddressBindings))
+		for i, binding := range sp.AddressBindings {
+			s.AddressBindings[i] = model.PortAddressBindingEntry{
+				IpAddress:  binding.IpAddress,
+				MacAddress: binding.MacAddress,
+			}
 		}
 	}
 	if sp.ExternalAddressBinding != nil {

--- a/pkg/nsx/services/subnetport/compare_test.go
+++ b/pkg/nsx/services/subnetport/compare_test.go
@@ -1,0 +1,165 @@
+package subnetport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+func TestSubnetPortToComparable(t *testing.T) {
+	id1 := "fakeSubnetPortID1"
+	id2 := "fakeSubnetPortID2"
+	tagScope1 := "fakeTagScope1"
+	tagValue1 := "fakeTagValue1"
+	tag1 := model.Tag{
+		Scope: &tagScope1,
+		Tag:   &tagValue1,
+	}
+	tagScope2 := "fakeTagScope2"
+	tagValue2 := "fakeTagValue2"
+	tag2 := model.Tag{
+		Scope: &tagScope2,
+		Tag:   &tagValue2,
+	}
+
+	testCases := []struct {
+		name               string
+		existingSubnetPort *model.VpcSubnetPort
+		nsxSubnetPort      *model.VpcSubnetPort
+		expectChanged      bool
+	}{
+		{
+			name:               "SubnetPort with diff Tags",
+			expectChanged:      true,
+			nsxSubnetPort:      &model.VpcSubnetPort{Tags: []model.Tag{tag2}},
+			existingSubnetPort: &model.VpcSubnetPort{Tags: []model.Tag{tag1}},
+		},
+		{
+			name: "SubnetPort with diff Attachment",
+			nsxSubnetPort: &model.VpcSubnetPort{
+				Id: &id1,
+				Attachment: &model.PortAttachment{
+					Id: common.String("attachment1"),
+				},
+			},
+			existingSubnetPort: &model.VpcSubnetPort{
+				Id: &id2,
+				Attachment: &model.PortAttachment{
+					Id: common.String("attachment2"),
+				},
+			},
+			expectChanged: true,
+		},
+		{
+			name: "SubnetPort with diff AddressBindings",
+			nsxSubnetPort: &model.VpcSubnetPort{
+				Id: &id1,
+				AddressBindings: []model.PortAddressBindingEntry{
+					{IpAddress: common.String("1.1.1.1"), MacAddress: common.String("aa:bb:cc:dd:ee:ff")},
+				},
+			},
+			existingSubnetPort: &model.VpcSubnetPort{
+				Id: &id1,
+				AddressBindings: []model.PortAddressBindingEntry{
+					{IpAddress: common.String("2.2.2.2"), MacAddress: common.String("aa:bb:cc:dd:ee:ff")},
+				},
+			},
+			expectChanged: true,
+		},
+		{
+			name: "SubnetPort with diff ExternalAddressBinding",
+			nsxSubnetPort: &model.VpcSubnetPort{
+				Id: &id1,
+				ExternalAddressBinding: &model.ExternalAddressBinding{
+					AllocatedExternalIpPath: common.String("path1"),
+				},
+			},
+			existingSubnetPort: &model.VpcSubnetPort{
+				Id: &id1,
+				ExternalAddressBinding: &model.ExternalAddressBinding{
+					AllocatedExternalIpPath: common.String("path2"),
+				},
+			},
+			expectChanged: true,
+		},
+		{
+			name: "SubnetPort with diff StaticIpAllocationType",
+			nsxSubnetPort: &model.VpcSubnetPort{
+				Id:                     &id1,
+				StaticIpAllocationType: common.String("IPV4_IPV6"),
+			},
+			existingSubnetPort: &model.VpcSubnetPort{
+				Id:                     &id1,
+				StaticIpAllocationType: common.String("IPV4"),
+			},
+			expectChanged: true,
+		},
+		{
+			name: "SubnetPort with same fields",
+			nsxSubnetPort: &model.VpcSubnetPort{
+				Id:          &id1,
+				DisplayName: common.String("fakeDisplayName"),
+				Tags:        []model.Tag{tag1},
+				Attachment: &model.PortAttachment{
+					AllocateAddresses: common.String("fakeAllocateAddresses"),
+					AppId:             common.String("fakeAppId"),
+					ContextId:         common.String("fakeContextId"),
+					Id:                common.String("fakeAttachmentId"),
+					TrafficTag:        common.Int64(100),
+					Type_:             common.String("fakeType"),
+				},
+				StaticIpAllocationType: common.String("IPV4"),
+				AddressBindings: []model.PortAddressBindingEntry{
+					{IpAddress: common.String("1.1.1.1"), MacAddress: common.String("aa:bb:cc:dd:ee:ff")},
+				},
+				ExternalAddressBinding: &model.ExternalAddressBinding{
+					AllocatedExternalIpPath: common.String("fakePath"),
+				},
+			},
+			existingSubnetPort: &model.VpcSubnetPort{
+				Id:          &id1,
+				DisplayName: common.String("fakeDisplayName"),
+				Tags:        []model.Tag{tag1},
+				Attachment: &model.PortAttachment{
+					AllocateAddresses: common.String("fakeAllocateAddresses"),
+					AppId:             common.String("fakeAppId"),
+					ContextId:         common.String("fakeContextId"),
+					Id:                common.String("fakeAttachmentId"),
+					TrafficTag:        common.Int64(100),
+					Type_:             common.String("fakeType"),
+				},
+				StaticIpAllocationType: common.String("IPV4"),
+				AddressBindings: []model.PortAddressBindingEntry{
+					{IpAddress: common.String("1.1.1.1"), MacAddress: common.String("aa:bb:cc:dd:ee:ff")},
+				},
+				ExternalAddressBinding: &model.ExternalAddressBinding{
+					AllocatedExternalIpPath: common.String("fakePath"),
+				},
+			},
+			expectChanged: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := common.CompareResource(SubnetPortToComparable(tc.existingSubnetPort), SubnetPortToComparable(tc.nsxSubnetPort))
+			assert.Equal(t, tc.expectChanged, changed)
+		})
+	}
+}
+
+func TestSubnetPort_Key(t *testing.T) {
+	id := "fakeSubnetPortID"
+	sp := &SubnetPort{Id: &id}
+	assert.Equal(t, id, sp.Key())
+}
+
+func TestComparableToSubnetPort(t *testing.T) {
+	id := "fakeSubnetPortID"
+	sp := &model.VpcSubnetPort{Id: &id}
+	comparable := SubnetPortToComparable(sp)
+	converted := ComparableToSubnetPort(comparable)
+	assert.Equal(t, sp, converted)
+}

--- a/pkg/nsx/services/subnetport/store.go
+++ b/pkg/nsx/services/subnetport/store.go
@@ -141,11 +141,15 @@ type SubnetPortStore struct {
 }
 
 type CountInfo struct {
-	// dirtyCount defines the number of SubnetPorts under creation in the Subnet
+	// dirtyCount defines the number of SubnetPorts under creation in the Subnet (IPv4)
 	dirtyCount int
-	lock       sync.Mutex
-	// totalIP defines the number of available IP in the Subnet
-	totalIP            int
+	// dirtyCountIPv6 defines the number of SubnetPorts under creation in the Subnet (IPv6)
+	dirtyCountIPv6 int
+	lock           sync.Mutex
+	// totalIP defines the number of available IPv4 in the Subnet
+	totalIP int
+	// totalIPv6 defines the number of available IPv6 in the Subnet
+	totalIPv6          int
 	exhaustedCheckTime time.Time
 }
 

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -130,7 +130,7 @@ func (service *SubnetPortService) portAlreadyRealized(obj interface{}, nsxSubnet
 	return false
 }
 
-func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
+func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
 	var uid string
 	var attachmentID string
 	switch o := obj.(type) {
@@ -144,11 +144,10 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 		}
 	}
 	log.Info("Creating or updating subnetport", "nsxSubnetPort.Id", uid, "nsxSubnetPath", *nsxSubnet.Path)
-	enableDHCP := util.NSXSubnetDHCPEnabled(nsxSubnet)
-	nsxSubnetPort, err := service.buildSubnetPort(obj, nsxSubnet, contextID, tags, isVmSubnetPort, restoreMode)
+	nsxSubnetPort, err := service.buildSubnetPort(obj, nsxSubnet, contextID, tags, isVmSubnetPort, restoreMode, interfaceIPType)
 	if err != nil {
 		log.Error(err, "failed to build NSX subnet port", "nsxSubnetPort.Id", uid, "*nsxSubnet.Path", *nsxSubnet.Path, "contextID", contextID)
-		return nil, false, err
+		return nil, err
 	}
 	existingSubnetPort := service.SubnetPortStore.GetByKey(*nsxSubnetPort.Id)
 	isChanged := true
@@ -166,13 +165,13 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 	}
 	subnetInfo, err := servicecommon.ParseVPCResourcePath(*nsxSubnet.Path)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	if !isChanged {
 		log.Info("NSX subnet port not changed, skipping the update", "nsxSubnetPort.Id", nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)
 		if !restoreMode && service.portAlreadyRealized(obj, nsxSubnetPort) {
 			log.Debug("The subnet port is already realized, skip checking the state", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)
-			return nil, enableDHCP, nil
+			return nil, nil
 		}
 	} else {
 		log.Info("Updating the NSX subnet port", "existingSubnetPort", existingSubnetPort, "desiredSubnetPort", nsxSubnetPort)
@@ -180,11 +179,11 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 		err = nsxutil.TransNSXApiError(err)
 		if err != nil {
 			log.Error(err, "failed to create or update subnet port", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)
-			return nil, false, err
+			return nil, err
 		}
 		err = service.SubnetPortStore.Apply(nsxSubnetPort)
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
 		if existingSubnetPort != nil {
 			log.Info("Updated NSX subnet port", "nsxSubnetPort.Path", *nsxSubnetPort.Path)
@@ -199,23 +198,23 @@ func (service *SubnetPortService) CreateOrUpdateSubnetPort(obj interface{}, nsxS
 		} else {
 			log.Error(err, "check and update NSX subnet port state failed, would retry exponentially", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)
 		}
-		return nil, false, err
+		return nil, err
 	}
 	createdNSXSubnetPort, err := service.NSXClient.PortClient.Get(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, *nsxSubnetPort.Id)
 	if err != nil {
 		log.Error(err, "check and update NSX subnet port failed, would retry exponentially", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPath", *nsxSubnet.Path)
-		return nil, false, err
+		return nil, err
 	}
 	err = service.SubnetPortStore.Apply(&createdNSXSubnetPort)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	if isChanged {
 		log.Info("Successfully created or updated subnetport", "nsxSubnetPort.Id", *nsxSubnetPort.Id, "nsxSubnetPortState", nsxSubnetPortState)
 	} else {
 		log.Info("Subnetport already existed", "subnetport", *nsxSubnetPort.Id, "nsxSubnetPortState", nsxSubnetPortState)
 	}
-	return nsxSubnetPortState, enableDHCP, nil
+	return nsxSubnetPortState, nil
 }
 
 func mergeSubnetPortAddressBinding(existingAddressBinding []model.PortAddressBindingEntry, desiredAddressBinding []model.PortAddressBindingEntry) []model.PortAddressBindingEntry {
@@ -461,16 +460,58 @@ func (service *SubnetPortService) ListSubnetPortByStsUid(ns string, stsUid strin
 // AllocatePortFromSubnet checks the number of SubnetPorts on the Subnet.
 // If the Subnet has capacity for the new SubnetPorts, it will increase
 // the number of SubnetPort under creation and return true.
-func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool) (bool, error) {
-	dhcpMode := "DHCP_DEACTIVATED"
+// For dual-stack subnets, both IPv4 and IPv6 capacity must be available.
+func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool, interfaceIPType v1alpha1.IPAddressType) (bool, error) {
 	subnetInfo, _ := servicecommon.ParseVPCResourcePath(*subnet.Path)
+
+	info := &CountInfo{}
+	obj, ok := service.SubnetPortStore.PortCountInfo.LoadOrStore(*subnet.Path, info)
+	info = obj.(*CountInfo)
+
+	info.lock.Lock()
+	defer info.lock.Unlock()
+
+	// Handle IPv4 capacity check
+	if util.IPAddressTypeIncludesIPv4(interfaceIPType) {
+		hasCapacity, err := service.checkIPv4Capacity(subnet, sharedSubnet, info, ok, subnetInfo)
+		if !hasCapacity {
+			return false, err
+		}
+	}
+
+	// Handle IPv6 capacity check
+	if util.IPAddressTypeIncludesIPv6(interfaceIPType) {
+		hasCapacity, err := service.checkIPv6Capacity(subnet, sharedSubnet, info, ok, subnetInfo)
+		if !hasCapacity {
+			return false, err
+		}
+	}
+
+	// Increment counters for successful allocation
+	if util.IPAddressTypeIncludesIPv4(interfaceIPType) {
+		info.dirtyCount += 1
+		log.Trace("Allocate Subnetport to IPv4 Subnet", "Subnet", *subnet.Path, "dirtyPortCount", info.dirtyCount)
+	}
+	if util.IPAddressTypeIncludesIPv6(interfaceIPType) {
+		info.dirtyCountIPv6 += 1
+		log.Trace("Allocate Subnetport to IPv6 Subnet", "Subnet", *subnet.Path, "dirtyPortCountIPv6", info.dirtyCountIPv6)
+	}
+
+	return true, nil
+}
+
+// checkIPv4Capacity checks if the subnet has available IPv4 capacity
+func (service *SubnetPortService) checkIPv4Capacity(subnet *model.VpcSubnet, sharedSubnet bool, info *CountInfo, existedEntry bool, subnetInfo servicecommon.VPCResourceInfo) (bool, error) {
+	dhcpMode := model.SubnetDhcpConfig_MODE_DEACTIVATED
 	if subnet.SubnetDhcpConfig != nil && subnet.SubnetDhcpConfig.Mode != nil {
 		dhcpMode = *subnet.SubnetDhcpConfig.Mode
 	}
+
 	// For DHCP Deactivated mode Subnet, if staticIpAllocation enable:false, skip check IP count
 	// and always return true
+	// TODO: The logic does not cover the case for mixed mode subnet where staticIpAllocation and dhcp can be enabled at the same time.
 	staticIpAllocationEnabled := false
-	if dhcpMode == "DHCP_DEACTIVATED" {
+	if dhcpMode == model.SubnetDhcpConfig_MODE_DEACTIVATED {
 		if subnet.AdvancedConfig != nil && subnet.AdvancedConfig.StaticIpAllocation != nil && subnet.AdvancedConfig.StaticIpAllocation.Enabled != nil {
 			staticIpAllocationEnabled = *subnet.AdvancedConfig.StaticIpAllocation.Enabled
 		}
@@ -480,17 +521,10 @@ func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet
 		}
 	}
 
-	info := &CountInfo{}
-	obj, ok := service.SubnetPortStore.PortCountInfo.LoadOrStore(*subnet.Path, info)
-	info = obj.(*CountInfo)
-
-	info.lock.Lock()
-	defer info.lock.Unlock()
-
 	var allocatedIPNumber int
 	// For DHCP Server mode Subnet, get total IPs from DHCP IP Pool from NSX each time
 	// since user might update reservedIPRanges for the subnet and it impacts the DHCP Pool size
-	if dhcpMode == "DHCP_SERVER" {
+	if dhcpMode == model.SubnetDhcpConfig_MODE_SERVER {
 		dhcpServerStats, err := service.NSXClient.DhcpServerConfigStatsClient.Get(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, nil, nil, nil, nil, nil, nil, nil)
 		if err != nil {
 			log.Error(err, "Failed to get Subnet dhcp-server-config stats", "Subnet", *subnet.Path)
@@ -507,7 +541,7 @@ func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet
 	// expect the totalIP is updated from NSX ip pool API
 	// For shared Subnet, user can create IPReservation and SubnetPort from NSX side.
 	// We call NSX ip pool API to for latest total ip and requested ip.
-	if (!ok || info.totalIP == 0 || sharedSubnet) && dhcpMode == "DHCP_DEACTIVATED" {
+	if (!existedEntry || info.totalIP == 0 || sharedSubnet) && dhcpMode == model.SubnetDhcpConfig_MODE_DEACTIVATED {
 		// For DHCP Deactivated mode Subnet, get total IPs from IP pool static-ipv4-default
 		// only get Subnet total IPs from static IP Pool if staticIpAllocation enabled
 		if staticIpAllocationEnabled {
@@ -524,7 +558,8 @@ func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet
 			}
 		}
 	}
-	if !ok && dhcpMode == "DHCP_RELAY" {
+
+	if !existedEntry && dhcpMode == model.SubnetDhcpConfig_MODE_RELAY {
 		// For DHCP Relay mode Subnet, assume 4 reserved IPs
 		var totalIP int
 		if subnet.Ipv4SubnetSize != nil {
@@ -553,14 +588,62 @@ func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet
 	if sharedSubnet {
 		existingPortCount = max(existingPortCount, allocatedIPNumber)
 	}
-	// Number of SubnetPorts on the Subnet includes the SubnetPorts under creation
-	// and the SubnetPorts already created
-	if info.dirtyCount+existingPortCount < info.totalIP {
-		info.dirtyCount += 1
-		log.Trace("Allocate Subnetport to Subnet", "Subnet", *subnet.Path, "dirtyPortCount", info.dirtyCount, "existingPortCount", existingPortCount)
+
+	return info.dirtyCount+existingPortCount < info.totalIP, nil
+}
+
+// checkIPv6Capacity checks if the subnet has available IPv6 capacity
+func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sharedSubnet bool, info *CountInfo, isNewEntry bool, subnetInfo servicecommon.VPCResourceInfo) (bool, error) {
+	dhcpv6Mode := model.SubnetDhcpv6Config_MODE_DEACTIVATED
+	if subnet.SubnetDhcpv6Config != nil && subnet.SubnetDhcpv6Config.Mode != nil {
+		dhcpv6Mode = *subnet.SubnetDhcpv6Config.Mode
+	}
+
+	// For DHCP Deactivated mode Subnet, if staticIpAllocation enable:false, skip check IP count
+	staticIpAllocationEnabled := false
+	if dhcpv6Mode == model.SubnetDhcpv6Config_MODE_DEACTIVATED {
+		if subnet.AdvancedConfig != nil && subnet.AdvancedConfig.StaticIpAllocation != nil && subnet.AdvancedConfig.StaticIpAllocation.Enabled != nil {
+			staticIpAllocationEnabled = *subnet.AdvancedConfig.StaticIpAllocation.Enabled
+		}
+		if !staticIpAllocationEnabled {
+			return true, nil
+		}
+	}
+
+	var allocatedIPNumberIPv6 int
+	if dhcpv6Mode == model.SubnetDhcpv6Config_MODE_SERVER || dhcpv6Mode == model.SubnetDhcpv6Config_MODE_RELAY || dhcpv6Mode == model.SubnetDhcpv6Config_MODE_SERVER_STATELESS {
+		// TODO: Revisit when DHCPv6 is fully supported in NSX and DHCPv6 server statistics are available.
+		// For now, always allow allocation unconditionally for DHCPv6 mode.
+		log.Info("DHCPv6 mode detected; allowing allocation (DHCPv6 support pending)", "Subnet", *subnet.Path)
 		return true, nil
 	}
-	return false, nil
+
+	if (!isNewEntry || info.totalIPv6 == 0 || sharedSubnet) && dhcpv6Mode == model.SubnetDhcpv6Config_MODE_DEACTIVATED {
+		if staticIpAllocationEnabled {
+			staticIPPoolIPv6, err := service.NSXClient.IPPoolClient.Get(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, "static-ipv6-default")
+			if err != nil {
+				log.Error(err, "Failed to get Subnet static IP Pool static-ipv6-default", "Subnet", *subnet.Path)
+				return false, err
+			}
+			if staticIPPoolIPv6.PoolUsage != nil && staticIPPoolIPv6.PoolUsage.TotalIps != nil {
+				info.totalIPv6 = int(*staticIPPoolIPv6.PoolUsage.TotalIps)
+			}
+			if sharedSubnet && staticIPPoolIPv6.PoolUsage != nil && staticIPPoolIPv6.PoolUsage.RequestedIpAllocations != nil {
+				allocatedIPNumberIPv6 = int(*staticIPPoolIPv6.PoolUsage.RequestedIpAllocations)
+			}
+		}
+	}
+
+	if time.Since(info.exhaustedCheckTime) < IPReleaseTime {
+		return false, nil
+	}
+
+	existingPortCount := len(service.GetPortsOfSubnet(*subnet.Path))
+	if sharedSubnet {
+		existingPortCount = max(existingPortCount, allocatedIPNumberIPv6)
+	}
+
+	return info.dirtyCountIPv6+existingPortCount < info.totalIPv6, nil
 }
 
 func (service *SubnetPortService) updateExhaustedSubnet(path string) {
@@ -577,7 +660,7 @@ func (service *SubnetPortService) updateExhaustedSubnet(path string) {
 }
 
 // ReleasePortInSubnet decreases the number of SubnetPort under creation.
-func (service *SubnetPortService) ReleasePortInSubnet(path string) {
+func (service *SubnetPortService) ReleasePortInSubnet(path string, interfaceIPType v1alpha1.IPAddressType) {
 	obj, ok := service.SubnetPortStore.PortCountInfo.Load(path)
 	if !ok {
 		log.Error(nil, "Subnet does not have Subnetport to remove", "Subnet", path)
@@ -586,12 +669,23 @@ func (service *SubnetPortService) ReleasePortInSubnet(path string) {
 	info := obj.(*CountInfo)
 	info.lock.Lock()
 	defer info.lock.Unlock()
-	if info.dirtyCount < 1 {
-		log.Error(nil, "Subnet does not have Subnetport to remove", "Subnet", path)
-		return
+	if util.IPAddressTypeIncludesIPv4(interfaceIPType) {
+		if info.dirtyCount < 1 {
+			log.Error(nil, "Subnet does not have IPv4 IP to remove for SubnetPort", "Subnet", path)
+		} else {
+			info.dirtyCount -= 1
+			log.Trace("Release Subnetport from Subnet", "Subnet", path, "dirtyPortCount", info.dirtyCount)
+		}
 	}
-	info.dirtyCount -= 1
-	log.Trace("Release Subnetport from Subnet", "Subnet", path, "dirtyPortCount", info.dirtyCount)
+
+	if util.IPAddressTypeIncludesIPv6(interfaceIPType) {
+		if info.dirtyCountIPv6 < 1 {
+			log.Error(nil, "Subnet does not have IPv6 IP to remove for SubnetPort", "Subnet", path)
+		} else {
+			info.dirtyCountIPv6 -= 1
+			log.Trace("Release Subnetport from Subnet", "Subnet", path, "dirtyCountIPv6", info.dirtyCountIPv6)
+		}
+	}
 }
 
 // IsEmptySubnet check if there is any SubnetPort created or being creating on the Subnet.
@@ -600,7 +694,7 @@ func (service *SubnetPortService) IsEmptySubnet(path string) bool {
 	obj, ok := service.SubnetPortStore.PortCountInfo.Load(path)
 	if ok {
 		info := obj.(*CountInfo)
-		portCount += info.dirtyCount
+		portCount += info.dirtyCount + info.dirtyCountIPv6
 	}
 	return portCount < 1
 }
@@ -631,4 +725,18 @@ func (service *SubnetPortService) GetAllVIFs() (*VifStore, error) {
 	}
 	log.Info("Initialized VIF store", "count", len(allVIFs))
 	return &vifStore, nil
+}
+
+// GetDefaultInterfaceIPType returns the SubnetPort default interfaceIPType
+// when interfaceIPType is not set,
+// the default value is IPv4 if parent Subnet/SubnetSet IPAddressType is IPv4 or IPv4IPv6;
+// the default value is IPv6 if parent Subnet/SubnetSet IPAddressType is IPv6.
+func GetDefaultInterfaceIPType(interfaceIPType v1alpha1.IPAddressType, parentIPAddressType v1alpha1.IPAddressType) v1alpha1.IPAddressType {
+	if interfaceIPType != "" {
+		return interfaceIPType
+	}
+	if parentIPAddressType == v1alpha1.IPAddressTypeIPv6 {
+		return v1alpha1.IPAddressTypeIPv6
+	}
+	return v1alpha1.IPAddressTypeIPv4
 }

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -251,13 +251,12 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		prepareFunc  func(service *SubnetPortService) *gomonkey.Patches
-		wantErr      bool
-		expectedDHCP bool
-		nsxSubnet    *model.VpcSubnet
-		obj          interface{}
-		restore      bool
+		name        string
+		prepareFunc func(service *SubnetPortService) *gomonkey.Patches
+		wantErr     bool
+		nsxSubnet   *model.VpcSubnet
+		obj         interface{}
+		restore     bool
 	}{
 		{
 			name: "CreateDHCPServer",
@@ -273,10 +272,9 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 				})
 				return patches
 			},
-			wantErr:      false,
-			nsxSubnet:    nsxSubnet1,
-			expectedDHCP: true,
-			obj:          subnetPortCR,
+			wantErr:   false,
+			nsxSubnet: nsxSubnet1,
+			obj:       subnetPortCR,
 		},
 		{
 			name: "CreateDHCPDeactivated",
@@ -297,10 +295,9 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 				})
 				return patches
 			},
-			wantErr:      false,
-			nsxSubnet:    nsxSubnet2,
-			expectedDHCP: false,
-			obj:          subnetPortCR,
+			wantErr:   false,
+			nsxSubnet: nsxSubnet2,
+			obj:       subnetPortCR,
 		},
 		{
 			name: "Update",
@@ -322,10 +319,9 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 				})
 				return patches
 			},
-			wantErr:      false,
-			nsxSubnet:    nsxSubnet2,
-			expectedDHCP: false,
-			obj:          subnetPortCR,
+			wantErr:   false,
+			nsxSubnet: nsxSubnet2,
+			obj:       subnetPortCR,
 		},
 		{
 			name: "RestorePod",
@@ -346,9 +342,8 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 				})
 				return patches
 			},
-			wantErr:      false,
-			nsxSubnet:    nsxSubnet2,
-			expectedDHCP: false,
+			wantErr:   false,
+			nsxSubnet: nsxSubnet2,
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod-1",
@@ -485,11 +480,10 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 			if patches != nil {
 				defer patches.Reset()
 			}
-			_, enableDHCP, err := service.CreateOrUpdateSubnetPort(tt.obj, tt.nsxSubnet, "", nil, false, tt.restore)
+			_, err := service.CreateOrUpdateSubnetPort(tt.obj, tt.nsxSubnet, "", nil, false, tt.restore, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreateOrUpdateSubnetPort() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			assert.Equal(t, tt.expectedDHCP, enableDHCP)
 			err = service.CleanupBeforeVPCDeletion(context.TODO())
 			assert.Nil(t, err)
 		})
@@ -1160,11 +1154,13 @@ func TestSubnetPortService_ListSubnetPortByStsUid(t *testing.T) {
 func TestSubnetPortService_AllocateAndReleasePortFromSubnet(t *testing.T) {
 	subnetPath := "subnet-path-1"
 	subnetId := "subnet-id-1"
+	// 1. Test standard IPv4 execution track
 	subnet1 := &model.VpcSubnet{
 		Ipv4SubnetSize: common.Int64(16),
 		IpAddresses:    []string{"10.0.0.1/28"},
 		Path:           &subnetPath,
 		Id:             &subnetId,
+		IpAddressType:  common.String(model.VpcSubnet_IP_ADDRESS_TYPE_IPV4),
 		SubnetDhcpConfig: &model.SubnetDhcpConfig{
 			Mode: common.String("DHCP_RELAY"),
 		},
@@ -1172,12 +1168,21 @@ func TestSubnetPortService_AllocateAndReleasePortFromSubnet(t *testing.T) {
 	subnetPortService := createSubnetPortService(t)
 	// Reset Subnet totalIP without SubnetPort does not influence the port count info
 	subnetPortService.ResetSubnetTotalIP(subnetPath)
-	ok, err := subnetPortService.AllocatePortFromSubnet(subnet1, false)
+
+	ok, err := subnetPortService.AllocatePortFromSubnet(subnet1, false, v1alpha1.IPAddressTypeIPv4)
 	assert.True(t, ok)
 	require.NoError(t, err)
+
+	// Verify counter adjustments via internal Store check
+	if obj, existed := subnetPortService.SubnetPortStore.PortCountInfo.Load(subnetPath); existed {
+		info := obj.(*CountInfo)
+		assert.Equal(t, 1, info.dirtyCount)
+		assert.Equal(t, 0, info.dirtyCountIPv6)
+	}
+
 	empty := subnetPortService.IsEmptySubnet(subnetPath)
 	assert.False(t, empty)
-	subnetPortService.ReleasePortInSubnet(subnetPath)
+	subnetPortService.ReleasePortInSubnet(subnetPath, v1alpha1.IPAddressTypeIPv4)
 	empty = subnetPortService.IsEmptySubnet(subnetPath)
 	assert.True(t, empty)
 
@@ -1185,9 +1190,34 @@ func TestSubnetPortService_AllocateAndReleasePortFromSubnet(t *testing.T) {
 	subnetPortService.updateExhaustedSubnet(subnetPath)
 	// Reset Subnet totalIP does not change other port count info
 	subnetPortService.ResetSubnetTotalIP(subnetPath)
-	ok, err = subnetPortService.AllocatePortFromSubnet(subnet1, false)
+	ok, err = subnetPortService.AllocatePortFromSubnet(subnet1, false, v1alpha1.IPAddressTypeIPv4)
 	assert.False(t, ok)
 	assert.Nil(t, err)
+
+	// 2. Test Dual-Stack Stack counter alignment
+	subnetPortService.SubnetPortStore.PortCountInfo.Delete(subnetPath) // Clear previous tracking context
+	dualStackSubnet := &model.VpcSubnet{
+		Path:          &subnetPath,
+		Id:            &subnetId,
+		IpAddressType: common.String(model.VpcSubnet_IP_ADDRESS_TYPE_IPV4_IPV6),
+		SubnetDhcpConfig: &model.SubnetDhcpConfig{
+			Mode: common.String("DHCP_RELAY"),
+		},
+		SubnetDhcpv6Config: &model.SubnetDhcpv6Config{
+			Mode: common.String("DHCP_RELAY"),
+		},
+		Ipv4SubnetSize: common.Int64(16),
+	}
+
+	ok, err = subnetPortService.AllocatePortFromSubnet(dualStackSubnet, false, v1alpha1.IPAddressTypeIPv4IPv6)
+	assert.True(t, ok)
+	require.NoError(t, err)
+
+	if obj, existed := subnetPortService.SubnetPortStore.PortCountInfo.Load(subnetPath); existed {
+		info := obj.(*CountInfo)
+		assert.Equal(t, 1, info.dirtyCount)
+		assert.Equal(t, 1, info.dirtyCountIPv6)
+	}
 }
 
 func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
@@ -1198,173 +1228,266 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 		IpAddresses:    []string{"10.0.0.1/28"},
 		Path:           &subnetPath,
 		Id:             &subnetId,
+		IpAddressType:  common.String(model.VpcSubnet_IP_ADDRESS_TYPE_IPV4),
 		AdvancedConfig: &model.SubnetAdvancedConfig{
-			StaticIpAllocation: &model.StaticIpAllocation{
-				Enabled: common.Bool(true)}},
-		SubnetDhcpConfig: &model.SubnetDhcpConfig{
-			Mode: common.String("DHCP_DEACTIVATED"),
+			StaticIpAllocation: &model.StaticIpAllocation{Enabled: common.Bool(true)},
 		},
+		SubnetDhcpConfig: &model.SubnetDhcpConfig{Mode: common.String("DHCP_DEACTIVATED")},
 	}
+
+	staticIPv6Subnet := &model.VpcSubnet{
+		Path:          &subnetPath,
+		Id:            &subnetId,
+		IpAddressType: common.String(model.VpcSubnet_IP_ADDRESS_TYPE_IPV6),
+		AdvancedConfig: &model.SubnetAdvancedConfig{
+			StaticIpAllocation: &model.StaticIpAllocation{Enabled: common.Bool(true)},
+		},
+		SubnetDhcpv6Config: &model.SubnetDhcpv6Config{Mode: common.String("DHCP_DEACTIVATED")},
+	}
+
+	dualStackStaticSubnet := &model.VpcSubnet{
+		Ipv4SubnetSize: common.Int64(16),
+		IpAddresses:    []string{"10.0.0.1/28"},
+		Path:           &subnetPath,
+		Id:             &subnetId,
+		IpAddressType:  common.String(model.VpcSubnet_IP_ADDRESS_TYPE_IPV4_IPV6),
+		AdvancedConfig: &model.SubnetAdvancedConfig{
+			StaticIpAllocation: &model.StaticIpAllocation{Enabled: common.Bool(true)},
+		},
+		SubnetDhcpConfig:   &model.SubnetDhcpConfig{Mode: common.String("DHCP_DEACTIVATED")},
+		SubnetDhcpv6Config: &model.SubnetDhcpv6Config{Mode: common.String("DHCP_DEACTIVATED")},
+	}
+
 	staticSubnetWithStaticIPAllocationDisabled := &model.VpcSubnet{
 		Ipv4SubnetSize: common.Int64(16),
 		IpAddresses:    []string{"10.0.0.1/28"},
 		Path:           &subnetPath,
 		Id:             &subnetId,
 		AdvancedConfig: &model.SubnetAdvancedConfig{
-			StaticIpAllocation: &model.StaticIpAllocation{
-				Enabled: common.Bool(false)}},
-		SubnetDhcpConfig: &model.SubnetDhcpConfig{
-			Mode: common.String("DHCP_DEACTIVATED"),
+			StaticIpAllocation: &model.StaticIpAllocation{Enabled: common.Bool(false)},
 		},
+		SubnetDhcpConfig: &model.SubnetDhcpConfig{Mode: common.String("DHCP_DEACTIVATED")},
 	}
+
 	dhcpServerSubnet := &model.VpcSubnet{
-		Ipv4SubnetSize: common.Int64(16),
-		IpAddresses:    []string{"10.0.0.1/28"},
-		Path:           &subnetPath,
-		Id:             &subnetId,
-		SubnetDhcpConfig: &model.SubnetDhcpConfig{
-			Mode: common.String("DHCP_SERVER"),
-		},
+		Ipv4SubnetSize:   common.Int64(16),
+		IpAddresses:      []string{"10.0.0.1/28"},
+		Path:             &subnetPath,
+		Id:               &subnetId,
+		SubnetDhcpConfig: &model.SubnetDhcpConfig{Mode: common.String("DHCP_SERVER")},
 	}
+
 	dhcpRelaySubnet := &model.VpcSubnet{
-		Ipv4SubnetSize: common.Int64(16),
-		IpAddresses:    []string{"10.0.0.1/28"},
-		Path:           &subnetPath,
-		Id:             &subnetId,
-		SubnetDhcpConfig: &model.SubnetDhcpConfig{
-			Mode: common.String("DHCP_RELAY"),
-		},
+		Ipv4SubnetSize:   common.Int64(16),
+		IpAddresses:      []string{"10.0.0.1/28"},
+		Path:             &subnetPath,
+		Id:               &subnetId,
+		SubnetDhcpConfig: &model.SubnetDhcpConfig{Mode: common.String("DHCP_RELAY")},
 	}
+
 	dhcpRelaySubnet1 := &model.VpcSubnet{
-		Ipv4SubnetSize: common.Int64(16),
-		IpAddresses:    []string{"10.0.0.1/30"},
-		Path:           &subnetPath,
-		Id:             &subnetId,
-		SubnetDhcpConfig: &model.SubnetDhcpConfig{
-			Mode: common.String("DHCP_RELAY"),
-		},
+		Ipv4SubnetSize:   common.Int64(16),
+		IpAddresses:      []string{"10.0.0.1/30"},
+		Path:             &subnetPath,
+		Id:               &subnetId,
+		SubnetDhcpConfig: &model.SubnetDhcpConfig{Mode: common.String("DHCP_RELAY")},
 	}
+
 	tests := []struct {
-		name          string
-		subnet        *model.VpcSubnet
-		sharedSubnet  bool
-		prepareFunc   func(service *SubnetPortService) *gomonkey.Patches
-		expectedValue bool
-		expectedErr   string
+		name            string
+		subnet          *model.VpcSubnet
+		sharedSubnet    bool
+		interfaceIPType v1alpha1.IPAddressType // Added to test struct
+		prepareFunc     func(service *SubnetPortService) *gomonkey.Patches
+		expectedValue   bool
+		expectedErr     string
 	}{
 		{
-			name:   "Failed to get subnet static ip pool",
-			subnet: staticSubnet,
+			name:            "Failed to get subnet static ip pool",
+			subnet:          staticSubnet,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(c *fakeIPPoolClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error) {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
 					return model.IpAddressPool{}, fmt.Errorf("mock static error")
 				})
-				return patches
 			},
 			expectedValue: false,
 			expectedErr:   "mock static error",
 		},
 		{
-			name:   "Failed to get subnet dhcp server config stats",
-			subnet: dhcpServerSubnet,
+			name:            "Failed to get subnet dhcp server config stats",
+			subnet:          dhcpServerSubnet,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.DhcpServerConfigStatsClient), "Get", func(c *fakeStatsClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, cursorParam *string, enforcementPointPathParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.DhcpServerStatistics, error) {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.DhcpServerConfigStatsClient), "Get", func(_ *fakeStatsClient, _, _, _, _ string, _ *string, _ *string, _ *bool, _ *string, _ *int64, _ *bool, _ *string) (model.DhcpServerStatistics, error) {
 					return model.DhcpServerStatistics{}, fmt.Errorf("mock dhcp error")
 				})
-				return patches
 			},
 			expectedValue: false,
 			expectedErr:   "mock dhcp error",
 		},
 		{
-			name:   "Allocate SubnetPort from static Subnet failed",
-			subnet: staticSubnet,
+			name:            "Allocate SubnetPort from static Subnet failed",
+			subnet:          staticSubnet,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(c *fakeIPPoolClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error) {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
 					return model.IpAddressPool{
 						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(0)},
 					}, nil
 				})
-				return patches
 			},
 			expectedValue: false,
 		},
 		{
-			name:   "Allocate SubnetPort from dhcp server Subnet failed",
-			subnet: dhcpServerSubnet,
+			name:            "Allocate SubnetPort from dhcp server Subnet failed",
+			subnet:          dhcpServerSubnet,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.DhcpServerConfigStatsClient), "Get", func(c *fakeStatsClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, cursorParam *string, enforcementPointPathParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.DhcpServerStatistics, error) {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.DhcpServerConfigStatsClient), "Get", func(_ *fakeStatsClient, _, _, _, _ string, _ *string, _ *string, _ *bool, _ *string, _ *int64, _ *bool, _ *string) (model.DhcpServerStatistics, error) {
 					return model.DhcpServerStatistics{
 						IpPoolStats: []model.DhcpIpPoolUsage{{PoolSize: common.Int64(0)}},
 					}, nil
 				})
-				return patches
 			},
 			expectedValue: false,
 		},
 		{
-			name:   "Allocate SubnetPort from dhcp relay Subnet failed",
-			subnet: dhcpRelaySubnet1,
+			name:            "Allocate SubnetPort from dhcp relay Subnet failed",
+			subnet:          dhcpRelaySubnet1,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				return nil
 			},
 			expectedValue: false,
 		},
 		{
-			name:   "Allocate SubnetPort from static subnet with staticIpAllocation disabled failed",
-			subnet: staticSubnetWithStaticIPAllocationDisabled,
+			name:            "Allocate SubnetPort from static subnet with staticIpAllocation disabled failed",
+			subnet:          staticSubnetWithStaticIPAllocationDisabled,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				return nil
 			},
 			expectedValue: true,
 		},
 		{
-			name:   "Allocate SubnetPort from static Subnet",
-			subnet: staticSubnet,
+			name:            "Allocate SubnetPort from static Subnet",
+			subnet:          staticSubnet,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(c *fakeIPPoolClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error) {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
 					return model.IpAddressPool{
 						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(10)},
 					}, nil
 				})
-				return patches
 			},
 			expectedValue: true,
 		},
 		{
-			name:   "Allocate SubnetPort from static shared Subnet failed",
-			subnet: staticSubnet,
+			name:            "Allocate SubnetPort from static shared Subnet failed",
+			subnet:          staticSubnet,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(c *fakeIPPoolClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error) {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
 					return model.IpAddressPool{
 						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(10), RequestedIpAllocations: common.Int64(10)},
 					}, nil
 				})
-				return patches
 			},
 			expectedValue: false,
 			sharedSubnet:  true,
 		},
 		{
-			name:   "Allocate SubnetPort from dhcp server Subnet",
-			subnet: dhcpServerSubnet,
+			name:            "Allocate SubnetPort from dhcp server Subnet",
+			subnet:          dhcpServerSubnet,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.DhcpServerConfigStatsClient), "Get", func(c *fakeStatsClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, cursorParam *string, enforcementPointPathParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.DhcpServerStatistics, error) {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.DhcpServerConfigStatsClient), "Get", func(_ *fakeStatsClient, _, _, _, _ string, _ *string, _ *string, _ *bool, _ *string, _ *int64, _ *bool, _ *string) (model.DhcpServerStatistics, error) {
 					return model.DhcpServerStatistics{
 						IpPoolStats: []model.DhcpIpPoolUsage{{PoolSize: common.Int64(10)}},
 					}, nil
 				})
-				return patches
 			},
 			expectedValue: true,
 		},
 		{
-			name:   "Allocate SubnetPort from dhcp relay Subnet",
-			subnet: dhcpRelaySubnet,
+			name:            "Allocate SubnetPort from dhcp relay Subnet",
+			subnet:          dhcpRelaySubnet,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				return nil
 			},
 			expectedValue: true,
+		},
+		{
+			name:            "Failed to get static-ipv6-default pool",
+			subnet:          staticIPv6Subnet,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv6,
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, poolId string) (model.IpAddressPool, error) {
+					if poolId == "static-ipv6-default" {
+						return model.IpAddressPool{}, fmt.Errorf("mock ipv6 static pool error")
+					}
+					return model.IpAddressPool{}, nil
+				})
+			},
+			expectedValue: false,
+			expectedErr:   "mock ipv6 static pool error",
+		},
+		{
+			name:            "Allocate SubnetPort from static IPv6 Subnet successful",
+			subnet:          staticIPv6Subnet,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv6,
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, poolId string) (model.IpAddressPool, error) {
+					if poolId == "static-ipv6-default" {
+						return model.IpAddressPool{
+							PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(20)},
+						}, nil
+					}
+					return model.IpAddressPool{}, nil
+				})
+			},
+			expectedValue: true,
+		},
+		{
+			name:            "Allocate Dual-Stack SubnetPort failed due to IPv4 starvation",
+			subnet:          dualStackStaticSubnet,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4IPv6,
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, poolId string) (model.IpAddressPool, error) {
+					if poolId == "static-ipv4-default" {
+						return model.IpAddressPool{
+							PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(0)},
+						}, nil
+					}
+					return model.IpAddressPool{
+						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(100)},
+					}, nil
+				})
+			},
+			expectedValue: false,
+		},
+		{
+			name:            "Allocate Dual-Stack SubnetPort failed due to IPv6 starvation",
+			subnet:          dualStackStaticSubnet,
+			interfaceIPType: v1alpha1.IPAddressTypeIPv4IPv6,
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, poolId string) (model.IpAddressPool, error) {
+					if poolId == "static-ipv4-default" {
+						return model.IpAddressPool{
+							PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(10)},
+						}, nil
+					}
+					if poolId == "static-ipv6-default" {
+						return model.IpAddressPool{
+							PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(0)},
+						}, nil
+					}
+					return model.IpAddressPool{}, nil
+				})
+			},
+			expectedValue: false,
 		},
 	}
 
@@ -1375,23 +1498,26 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			if patches != nil {
 				defer patches.Reset()
 			}
-			canAllocate, err := subnetPortService.AllocatePortFromSubnet(tt.subnet, tt.sharedSubnet)
+
+			canAllocate, err := subnetPortService.AllocatePortFromSubnet(tt.subnet, tt.sharedSubnet, tt.interfaceIPType)
 			assert.Equal(t, tt.expectedValue, canAllocate)
 			if tt.expectedErr != "" {
+				assert.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {
 				assert.Nil(t, err)
 			}
+
 			if tt.expectedValue {
-				canAllocate, err = subnetPortService.AllocatePortFromSubnet(tt.subnet, tt.sharedSubnet)
+				canAllocate, err = subnetPortService.AllocatePortFromSubnet(tt.subnet, tt.sharedSubnet, tt.interfaceIPType)
 				assert.Equal(t, tt.expectedValue, canAllocate)
 				if tt.expectedErr != "" {
+					assert.NotNil(t, err)
 					assert.Contains(t, err.Error(), tt.expectedErr)
 				} else {
 					assert.Nil(t, err)
 				}
 			}
-
 		})
 	}
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -473,6 +473,9 @@ func NSXSubnetDHCPEnabled(nsxSubnet *model.VpcSubnet) bool {
 	return nsxSubnet.SubnetDhcpConfig != nil && nsxSubnet.SubnetDhcpConfig.Mode != nil && *nsxSubnet.SubnetDhcpConfig.Mode != nsxutil.ParseDHCPMode(v1alpha1.DHCPConfigModeDeactivated)
 }
 
+func NSXSubnetDHCPv6Enabled(nsxSubnet *model.VpcSubnet) bool {
+	return nsxSubnet.SubnetDhcpv6Config != nil && nsxSubnet.SubnetDhcpv6Config.Mode != nil && *nsxSubnet.SubnetDhcpv6Config.Mode != nsxutil.ParseDHCPMode(string(v1alpha1.DHCPv6ConfigModeDeactivated))
+}
 func NSXSubnetStaticIPAllocationEnabled(nsxSubnet *model.VpcSubnet) bool {
 	if nsxSubnet.AdvancedConfig == nil || nsxSubnet.AdvancedConfig.StaticIpAllocation == nil || nsxSubnet.AdvancedConfig.StaticIpAllocation.Enabled == nil || !*nsxSubnet.AdvancedConfig.StaticIpAllocation.Enabled {
 		return false


### PR DESCRIPTION
This PR focuses on happy path for IPv6/Dual Stack in SubnetPort
It contains the following changes
- Support multiple status.networkInterfaceConfig.ipAddresses and spec.addressBindings in SubnetPort
- Support StaticIPAllocationType in SubnetPort
- Support AllocatePortFromSubnet for IPv6 and dual stack

Testing done:
Tested regression case for Pod/VM with IPv4
Tested SubnetPort/VM creation in dual stack testbed