### PR TITLE
SubnetPort Status CRD update for IPv6

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
@@ -70,8 +70,9 @@ spec:
               interfaceIPType:
                 description: |-
                   InterfaceIPType decides the address families of static IP allocation, when
-                  DHCP or SLAAC is not activated on the Subnet. It will be ignored when
-                  StaticIPAllocationType is set.
+                  DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType
+                  is set, IP families of InterfaceIPType should be a superset of
+                  StaticIPAllocationType.
                 enum:
                 - IPv4
                 - IPv6
@@ -82,8 +83,8 @@ spec:
                   StaticIPAllocationType explicitly requests static IP allocation of the
                   specified the address families. In a mixed-mode Subnet (where both DHCP
                   and static allocation are enabled), use this to define which families
-                  should be allocated from the static IP pools. This field is only valid
-                  when static allocation is enabled on the Subnet.
+                  should be allocated from the static IP pools. If not specified, this field
+                  will be back-filled based on InterfaceIPType and Subnet configuration.
                 enum:
                 - IPv4
                 - IPv6
@@ -146,6 +147,10 @@ spec:
                     description: DHCPDeactivatedOnSubnet indicates whether DHCP is
                       deactivated on the Subnet.
                     type: boolean
+                  dhcpv6DeactivatedOnSubnet:
+                    description: DHCPv6DeactivatedOnSubnet indicates whether DHCPv6
+                      is deactivated on the Subnet.
+                    type: boolean
                   ipAddresses:
                     items:
                       properties:
@@ -163,6 +168,10 @@ spec:
                   macAddress:
                     description: The MAC address.
                     type: string
+                  raDeactivated:
+                    description: RADeactivated indicates whether RAMode is deactivated
+                      on the VPC.
+                    type: boolean
                 type: object
             type: object
         type: object

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -421,6 +421,8 @@ _Appears in:_
 | `ipAddresses` _[NetworkInterfaceIPAddress](#networkinterfaceipaddress) array_ |  |  |  |
 | `macAddress` _string_ | The MAC address. |  |  |
 | `dhcpDeactivatedOnSubnet` _boolean_ | DHCPDeactivatedOnSubnet indicates whether DHCP is deactivated on the Subnet. |  |  |
+| `dhcpv6DeactivatedOnSubnet` _boolean_ | DHCPv6DeactivatedOnSubnet indicates whether DHCPv6 is deactivated on the Subnet. |  |  |
+| `raDeactivated` _boolean_ | RADeactivated indicates whether RAMode is deactivated on the VPC. |  |  |
 
 
 #### NetworkInterfaceIPAddress
@@ -1039,8 +1041,8 @@ _Appears in:_
 | `subnet` _string_ | Subnet defines the parent Subnet name of the SubnetPort. |  |  |
 | `subnetSet` _string_ | SubnetSet defines the parent SubnetSet name of the SubnetPort. |  |  |
 | `addressBindings` _[PortAddressBinding](#portaddressbinding) array_ | AddressBindings defines static address bindings used for the SubnetPort. |  |  |
-| `interfaceIPType` _[IPAddressType](#ipaddresstype)_ | InterfaceIPType decides the address families of static IP allocation, when<br />DHCP or SLAAC is not activated on the Subnet. It will be ignored when<br />StaticIPAllocationType is set. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
-| `staticIPAllocationType` _[StaticIPAllocationType](#staticipallocationtype)_ | StaticIPAllocationType explicitly requests static IP allocation of the<br />specified the address families. In a mixed-mode Subnet (where both DHCP<br />and static allocation are enabled), use this to define which families<br />should be allocated from the static IP pools. This field is only valid<br />when static allocation is enabled on the Subnet. |  | Enum: [IPv4 IPv6 IPv4IPv6 None] <br /> |
+| `interfaceIPType` _[IPAddressType](#ipaddresstype)_ | InterfaceIPType decides the address families of static IP allocation, when<br />DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType<br />is set, IP families of InterfaceIPType should be a superset of<br />StaticIPAllocationType. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
+| `staticIPAllocationType` _[StaticIPAllocationType](#staticipallocationtype)_ | StaticIPAllocationType explicitly requests static IP allocation of the<br />specified the address families. In a mixed-mode Subnet (where both DHCP<br />and static allocation are enabled), use this to define which families<br />should be allocated from the static IP pools. If not specified, this field<br />will be back-filled based on InterfaceIPType and Subnet configuration. |  | Enum: [IPv4 IPv6 IPv4IPv6 None] <br /> |
 
 
 #### SubnetPortStatus

--- a/pkg/apis/vpc/v1alpha1/subnetport_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetport_types.go
@@ -26,15 +26,16 @@ type SubnetPortSpec struct {
 	// AddressBindings defines static address bindings used for the SubnetPort.
 	AddressBindings []PortAddressBinding `json:"addressBindings,omitempty"`
 	// InterfaceIPType decides the address families of static IP allocation, when
-	// DHCP or SLAAC is not activated on the Subnet. It will be ignored when
-	// StaticIPAllocationType is set.
+	// DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType
+	// is set, IP families of InterfaceIPType should be a superset of
+	// StaticIPAllocationType.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
 	InterfaceIPType IPAddressType `json:"interfaceIPType,omitempty"`
 	// StaticIPAllocationType explicitly requests static IP allocation of the
 	// specified the address families. In a mixed-mode Subnet (where both DHCP
 	// and static allocation are enabled), use this to define which families
-	// should be allocated from the static IP pools. This field is only valid
-	// when static allocation is enabled on the Subnet.
+	// should be allocated from the static IP pools. If not specified, this field
+	// will be back-filled based on InterfaceIPType and Subnet configuration.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6;None
 	StaticIPAllocationType StaticIPAllocationType `json:"staticIPAllocationType,omitempty"`
 }
@@ -70,6 +71,10 @@ type NetworkInterfaceConfig struct {
 	MACAddress string `json:"macAddress,omitempty"`
 	// DHCPDeactivatedOnSubnet indicates whether DHCP is deactivated on the Subnet.
 	DHCPDeactivatedOnSubnet bool `json:"dhcpDeactivatedOnSubnet,omitempty"`
+	// DHCPv6DeactivatedOnSubnet indicates whether DHCPv6 is deactivated on the Subnet.
+	DHCPv6DeactivatedOnSubnet bool `json:"dhcpv6DeactivatedOnSubnet,omitempty"`
+	// RADeactivated indicates whether RAMode is deactivated on the VPC.
+	RADeactivated bool `json:"raDeactivated,omitempty"`
 }
 
 type NetworkInterfaceIPAddress struct {


### PR DESCRIPTION
Update the SubnetPort Status to show DHCPv6 and RA mode status.
Update some description for interfaceIPType and staticIPAllocationType for better understanding