### PR TITLE
fix: return validation error correctly for nested NamespaceSelector

### DIFF
--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -1739,12 +1739,14 @@ func (service *SecurityPolicyService) updatePeerExpressions(obj *v1alpha1.Securi
 			// Validate expressions for POD/VM Selectors
 			mergedMatchExpressions = service.mergeSelectorMatchExpression(*matchExpressions)
 			opInValueCount, err = service.validateSelectorOpIn(*mergedMatchExpressions, matchLabels)
+			if err != nil {
+				return 0, 0, err
+			}
 
 			nsMergedMatchExpressions := service.mergeSelectorMatchExpression(*nsMatchExpressions)
 			nsOpInValCount, opErr := service.validateSelectorOpIn(*nsMergedMatchExpressions, nsMatchLabels)
-
-			if err != nil || opErr != nil {
-				return 0, 0, err
+			if opErr != nil {
+				return 0, 0, opErr
 			}
 
 			if opInValueCount > 0 && nsOpInValCount > 0 {

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -2357,3 +2357,54 @@ func appendRuleIDAndHashTags(baseTags []model.Tag, ruleHash, ruleID string) []mo
 			},
 		}...)
 }
+
+func Test_updatePeerExpressions_NamespaceSelector_OpIn_Limit(t *testing.T) {
+	s := &SecurityPolicyService{
+		Service: common.Service{
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{
+					Cluster:          "k8scl-one",
+					EnableVPCNetwork: false,
+				},
+			},
+		},
+	}
+	s.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(&s.Service), "GetNamespaceUID",
+		func(s *common.Service, ns string) types.UID {
+			return types.UID("ns-uid")
+		})
+	defer patches.Reset()
+
+	sp := &v1alpha1.SecurityPolicy{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-sp",
+			Namespace: "test-ns",
+			UID:       "sp-uid",
+		},
+	}
+
+	peer := &v1alpha1.SecurityPolicyPeer{
+		PodSelector: &v1.LabelSelector{
+			MatchLabels: map[string]string{"app": "test"},
+		},
+		NamespaceSelector: &v1.LabelSelector{
+			MatchExpressions: []v1.LabelSelectorRequirement{
+				{
+					Key:      "name",
+					Operator: v1.LabelSelectorOpIn,
+					Values:   []string{"ns1", "ns2", "ns3", "ns4", "ns5", "ns6"},
+				},
+			},
+		},
+	}
+
+	group := &model.Group{
+		Expression: []*data.StructValue{},
+	}
+
+	_, _, err := s.updatePeerExpressions(sp, peer, group, 0, false)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "count of values list for operator 'In' expressions")
+	assert.Contains(t, err.Error(), "exceed limit of 5")
+}


### PR DESCRIPTION
When validating the `In` operator for a nested NamespaceSelector, the error `opErr` was swallowed if the PodSelector validation `err` was nil. This caused the expression building to abort silently, resulting in an incomplete NSX Group criterion (e.g. missing namespace and pod labels) that incorrectly allowed all pods.

This commit fixes the error handling to return `opErr` when it is not nil.

Testing done:
1. In the problematic testbed, apply the network policy with the selector:
```
    - namespaceSelector:
        matchExpressions:
        - key: name
          operator: In
          values:
          - ns1
          - ns2
          - ns3
          - ns4
          - ns5
          - ns6
```
then no error on the networkpolicy.
2. Applying the patch to the testbed, then observe the error annotation:
```
Annotations:  nsx-op/error: NETWORK_POLICY_VALIDATION_FAILED
```
And the error in NSX Operator log:
```
2026-06-05T09:14:58.315915769Z stdout F ESC[90m2026-06-05 09:14:58.000ESC[0m ESC[91mERRORESC[0m ESC[33mcontroller.go:438ESC[0m ESC[1mReconciler errorESC[0m ESC[36merror=ESC[0mESC[31mESC[1m"count of values list for operator 'In' expressions 6 exceed limit of 5"ESC[0mESC[0m NetworkPolicy={"name":"test-np","namespace":"svc-cci-ns-8atj1"} controller=networkpolicy controllerGroup=networking.k8s.io controllerKind=NetworkPolicy name=test-np namespace=svc-cci-ns-8atj1 reconcileID=85387d9b-da76-4ac6-b479-55f4f4d12e51
```