### PR TITLE
Use TLS1.3 for webhook and nsx-eas container port

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"os"
@@ -225,6 +226,11 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			hookServer = webhook.NewServer(webhook.Options{
 				Port:    config.WebhookServerPort,
 				CertDir: config.WebhookCertDir,
+				TLSOpts: []func(*tls.Config){
+					func(cfg *tls.Config) {
+						cfg.MinVersion = tls.VersionTLS13
+					},
+				},
 			})
 			if err := mgr.Add(hookServer); err != nil {
 				log.Error(err, "Failed to add hook server")

--- a/pkg/eas/server/server.go
+++ b/pkg/eas/server/server.go
@@ -129,6 +129,7 @@ func (s *EASServer) buildGenericAPIServer() (*genericapiserver.GenericAPIServer,
 	}
 	servingOpts.ServerCert.CertKey.CertFile = certFile
 	servingOpts.ServerCert.CertKey.KeyFile = keyFile
+	servingOpts.MinTLSVersion = "VersionTLS13"
 
 	// ── Delegated authentication ─────────────────────────────────────────────
 	// SkipInClusterLookup=true prevents the generic apiserver from starting a


### PR DESCRIPTION
Per security requirement, TLS1.2 is not acceptable, use TLS1.3 cryto for 9881 port for webhook and 9553 for nsx-eas.

Testing Done:
using script to verify 9553 and 9981 port with script
```
# Ports to test
set ports {9981 9553}
set versions {tls1_3 tls1_2}

foreach port $ports {
    foreach version $versions {
        puts "\n=== Testing Port $port with $version ===\n"
        send "openssl s_client -connect $pod_ip:$port -$version < /dev/null\r"
        expect "# "
        set output $expect_out(buffer)
        
        if {[string match "*Verify return code: 21*" $output] || [string match "*Verify return code: 18*" $output] || [string match "*BEGIN CERTIFICATE*" $output]} {
            puts "\nRESULT: PASSED (Connection established)\n"
        } elseif {[string match "*alert protocol version*" $output] || [string match "*alert number 70*" $output]} {
            puts "\nRESULT: FAILED (Rejected due to protocol version - expected for TLS 1.2)\n"
        } else {
            puts "\nRESULT: UNKNOWN\n"
            puts "$output"
        }
    }
}

send "exit\r"
expect eof
EOF
```
Here are the automated test results I just ran on your live environment:

test result as follow:
```
Getting pod IP...
Pod IP: 172.26.0.2
========================================
Testing Port 9981 with tls1_3
========================================
RESULT: PASSED (Connection established)
========================================
Testing Port 9981 with tls1_2
========================================
RESULT: FAILED (Rejected due to protocol version - expected for TLS 1.2)
========================================
Testing Port 9553 with tls1_3
========================================
RESULT: PASSED (Connection established)
========================================
Testing Port 9553 with tls1_2
========================================
RESULT: FAILED (Rejected due to protocol version - expected for TLS 1.2)
```

