### PR TITLE
Resolve incorrect port range when start port is zero or omitted

### DIFF
--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -538,7 +538,7 @@ func buildRuleServiceEntries(port v1alpha1.SecurityPolicyPort) *data.StructValue
 	// For the named port case, the caller should
 	// convert to a new SecurityPolicyPort using the correct port number.
 	var zeroPort intstr.IntOrString
-	if port.Port != zeroPort {
+	if port.Port != zeroPort || port.EndPort != 0 {
 		if port.EndPort == 0 || port.EndPort == port.Port.IntValue() {
 			portRange = port.Port.String()
 		} else {

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -1730,6 +1730,51 @@ func Test_buildRuleServiceEntries(t *testing.T) {
 				)
 			}(),
 		},
+		{
+			name: "zero port with endPort",
+			port: v1alpha1.SecurityPolicyPort{
+				Port:     intstr.FromInt(0),
+				EndPort:  6000,
+				Protocol: "TCP",
+			},
+			expected: func() *data.StructValue {
+				destinationPorts := data.NewListValue()
+				destinationPorts.Add(data.NewStringValue("0-6000"))
+				return data.NewStructValue(
+					"",
+					map[string]data.DataValue{
+						"source_ports":      data.NewListValue(),
+						"destination_ports": destinationPorts,
+						"l4_protocol":       data.NewStringValue("TCP"),
+						"resource_type":     data.NewStringValue("L4PortSetServiceEntry"),
+						"marked_for_delete": data.NewBooleanValue(false),
+						"overridden":        data.NewBooleanValue(false),
+					},
+				)
+			}(),
+		},
+		{
+			name: "omitted port with endPort",
+			port: v1alpha1.SecurityPolicyPort{
+				EndPort:  6000,
+				Protocol: "TCP",
+			},
+			expected: func() *data.StructValue {
+				destinationPorts := data.NewListValue()
+				destinationPorts.Add(data.NewStringValue("0-6000"))
+				return data.NewStructValue(
+					"",
+					map[string]data.DataValue{
+						"source_ports":      data.NewListValue(),
+						"destination_ports": destinationPorts,
+						"l4_protocol":       data.NewStringValue("TCP"),
+						"resource_type":     data.NewStringValue("L4PortSetServiceEntry"),
+						"marked_for_delete": data.NewBooleanValue(false),
+						"overridden":        data.NewBooleanValue(false),
+					},
+				)
+			}(),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When creating a SecurityPolicy with an `endPort` but without a `port` field (or with `port` set to `0`), the controller incorrectly generated an empty `destination_ports` list in the NSX service entry. This caused NSX to interpret the rule as matching all destination ports (ANY) instead of the specified range (e.g., 0-6000).
The root cause was that `buildRuleServiceEntries` only checked if `port.Port != zeroPort`. When `port.Port` was `0` or omitted, this condition evaluated to `false`, skipping the port range generation logic entirely.
Fix this by expanding the condition to `port.Port != zeroPort || port.EndPort != 0`.
This ensures that the port range is correctly built when `endPort` is specified, even if the starting `port` is zero or omitted. Also added corresponding unit test cases to verify the fix.

Test Done:
1. create the security policy:
  apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SecurityPolicy
metadata:
  name: test-sp
spec:
  appliedTo:
  - vmSelector:
      matchLabels:
        sptcp1: tcp1
  rules:
  - action: allow
    direction: in
    sources:
    - podSelector:
        matchLabels:
          nptcp1: tcp1
    - vmSelector:
        matchLabels:
          sptcp1: tcp1
    ports:
      - protocol: TCP
        endPort: 6000
        
2. check the rules:
GET /orgs/default/projects/project-quality/vpcs/qe_ptu6p/security-policies/test-sp_ncvw3/rules
    "source_groups" : [ "/orgs/default/projects/project-quality/vpcs/qe_ptu6p/groups/test-sp-110407bc-src_ncvw3" ],
    "destination_groups" : [ "ANY" ],
    "services" : [ "ANY" ],
    "service_entries" : [ {
      "l4_protocol" : "TCP",
      "source_ports" : [ ],
      "destination_ports" : **[ "0-6000" ]**,
      "resource_type" : "L4PortSetServiceEntry",
      "marked_for_delete" : false,
      "overridden" : false,        
