### PR TITLE
Check the security policy error annotation before deleting it

### DIFF
--- a/pkg/controllers/securitypolicy/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller.go
@@ -92,6 +92,9 @@ func cleanSecurityPolicyErrorAnnotation(ctx context.Context, securityPolicy *v1a
 	if securityPolicy.Annotations == nil {
 		return
 	}
+	if _, exists := securityPolicy.Annotations[common.NSXOperatorError]; !exists {
+		return
+	}
 	delete(securityPolicy.Annotations, common.NSXOperatorError)
 
 	var updateErr error

--- a/pkg/controllers/securitypolicy/securitypolicy_controller_test.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller_test.go
@@ -235,7 +235,25 @@ func Test_cleanSecurityPolicyErrorAnnotation(t *testing.T) {
 	ctx := context.TODO()
 	info := ctrcommon.ErrorNoDFWLicense
 
-	// Define a SecurityPolicy with an annotation
+	// Test case 1: Annotations is nil, should not call Update
+	securityPolicyNilAnnotations := &v1alpha1.SecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: nil,
+		},
+	}
+	cleanSecurityPolicyErrorAnnotation(ctx, securityPolicyNilAnnotations, false, k8sClient)
+
+	// Test case 2: Annotations is not nil but does not contain NSXOperatorError, should not call Update
+	securityPolicyNoTargetAnnotation := &v1alpha1.SecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"other-annotation": "value",
+			},
+		},
+	}
+	cleanSecurityPolicyErrorAnnotation(ctx, securityPolicyNoTargetAnnotation, false, k8sClient)
+
+	// Test case 3: Define a SecurityPolicy with an annotation (isVPCEnabled = false)
 	securityPolicy := &v1alpha1.SecurityPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -251,7 +269,6 @@ func Test_cleanSecurityPolicyErrorAnnotation(t *testing.T) {
 		},
 	}
 
-	// Test case with isVPCEnabled = false
 	isVPCEnabled := false
 	k8sClient.EXPECT().Update(ctx, expectedSecurityPolicy).Return(nil).Times(1)
 	// Run the function
@@ -259,7 +276,7 @@ func Test_cleanSecurityPolicyErrorAnnotation(t *testing.T) {
 	// Assertions annotation removed
 	assert.NotContains(t, securityPolicy.Annotations, ctrcommon.NSXOperatorError)
 
-	// Test case with isVPCEnabled = true
+	// Test case 4: with isVPCEnabled = true
 	isVPCEnabled = true
 	k8sClient.EXPECT().
 		Update(ctx, gomock.AssignableToTypeOf(&crdv1alpha1.SecurityPolicy{})).

--- a/pkg/mock/realizedentitiesclient/client.go
+++ b/pkg/mock/realizedentitiesclient/client.go
@@ -7,8 +7,8 @@ package mocks
 import (
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
 	model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockRealizedEntitiesClient is a mock of RealizedEntitiesClient interface.


### PR DESCRIPTION
Check the security policy error annotation before deleting it

Test Done:
1. create a security policy
2. check the log if there is no log output like:
   Failed to clean SecurityPolicy annotation