### PR TITLE
Update subnetset CR when subnet creation failed

### DIFF
--- a/docs/ref/apis/legacy.md
+++ b/docs/ref/apis/legacy.md
@@ -29,7 +29,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -117,7 +117,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 
@@ -136,6 +136,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `Ready` |  |
+| `SubnetCreationFailed` |  |
 | `GatewayConnectionReady` |  |
 | `ServiceClusterReady` |  |
 | `AutoSnatEnabled` |  |
@@ -259,7 +260,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br /> |
+| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br />Optional: \{\} <br /> |
 | `allocationSize` _integer_ | AllocationSize specifies the size of IPv4 allocationIPs to be allocated.<br />It should be a power of 2. |  | Minimum: 1 <br /> |
 | `allocationIPs` _string_ | AllocationIPs specifies the Allocated IP addresses in CIDR or single IP Address format. |  |  |
 | `ipv6AllocationPrefixLength` _integer_ | IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses.<br />Defaults to 64 when ipAddressType is IPv6 and this field is not specified. |  | Maximum: 128 <br />Minimum: 64 <br /> |
@@ -765,7 +766,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 
@@ -783,7 +784,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `network` _string_ | Specify network address in CIDR format. |  | Format: cidr <br /> |
+| `network` _string_ | Specify network address in CIDR format.<br />Mutually exclusive with networkIpAllocation. |  | Format: cidr <br />Optional: \{\} <br /> |
+| `networkIpAllocation` _string_ | Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as<br />the static route network. Mutually exclusive with network. |  | Optional: \{\} <br /> |
 | `nextHops` _[NextHop](#nexthop) array_ | Next hop gateway |  | MinItems: 1 <br /> |
 
 
@@ -1239,8 +1241,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  |  |
-| `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  |  |
+| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  | Optional: \{\} <br /> |
+| `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  | Optional: \{\} <br /> |
 | `nsxProject` _string_ | NSX Project the Namespace is associated with. |  |  |
 | `vpcConnectivityProfile` _string_ | VPCConnectivityProfile Path. This profile has configuration related to creating VPC transit gateway attachment. |  |  |
 | `privateIPs` _string array_ | Private IPs. |  |  |

--- a/pkg/apis/vpc/v1alpha1/condition_types.go
+++ b/pkg/apis/vpc/v1alpha1/condition_types.go
@@ -9,6 +9,7 @@ type ConditionType string
 
 const (
 	Ready                      ConditionType = "Ready"
+	SubnetCreationFailed       ConditionType = "SubnetCreationFailed"
 	GatewayConnectionReady     ConditionType = "GatewayConnectionReady"
 	ServiceClusterReady        ConditionType = "ServiceClusterReady"
 	AutoSnatEnabled            ConditionType = "AutoSnatEnabled"

--- a/pkg/controllers/subnet/subnetbinding_handler_test.go
+++ b/pkg/controllers/subnet/subnetbinding_handler_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -282,7 +284,16 @@ func TestGetNSXSubnetBindingsBySubnet(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			r := &SubnetReconciler{
-				SubnetService:  &subnet.SubnetService{},
+				SubnetService: &subnet.SubnetService{
+					SubnetStore: &subnet.SubnetStore{
+						ResourceStore: common.ResourceStore{Indexer: cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+							common.TagScopeSubnetCRUID: func(obj interface{}) ([]string, error) {
+								return []string{"uid"}, nil
+							},
+						}),
+						},
+					},
+				},
 				BindingService: &subnetbinding.BindingService{},
 			}
 			patches := tc.patches(r)

--- a/pkg/controllers/subnetset/subnetbinding_handler_test.go
+++ b/pkg/controllers/subnetset/subnetbinding_handler_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -258,7 +260,16 @@ func TestGetNSXSubnetBindingsBySubnet(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			r := &SubnetSetReconciler{
-				SubnetService:  &subnet.SubnetService{},
+				SubnetService: &subnet.SubnetService{
+					SubnetStore: &subnet.SubnetStore{
+						ResourceStore: common.ResourceStore{Indexer: cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+							common.TagScopeSubnetSetCRUID: func(obj interface{}) ([]string, error) {
+								return []string{"uid"}, nil
+							},
+						}),
+						},
+					},
+				},
 				BindingService: &subnetbinding.BindingService{},
 			}
 			patches := tc.patches(r)

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -251,12 +251,22 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		r.StatusUpdater.UpdateFail(ctx, subnetsetCR, err, "Failed to update SubnetSet", setSubnetSetReadyStatusFalse)
 		return ResultNormal, err
 	}
+
 	metadataChanged := updateLabels(subnetsetCR, isSystemNs)
 	if specChanged || metadataChanged {
 		err := r.Client.Update(ctx, subnetsetCR)
 		if err != nil {
 			r.StatusUpdater.UpdateFail(ctx, subnetsetCR, err, "Failed to update SubnetSet", setSubnetSetReadyStatusFalse)
 			return ResultRequeue, err
+		}
+	}
+
+	// Check if SubnetSet has SubnetCreationFailed condition
+	for _, cond := range subnetsetCR.Status.Conditions {
+		if cond.Type == v1alpha1.SubnetCreationFailed && cond.Status == v1.ConditionTrue {
+			err := fmt.Errorf("%s", cond.Message)
+			r.StatusUpdater.UpdateFail(ctx, subnetsetCR, err, "Failed to create/update Subnet", setSubnetSetReadyStatusFalse, cond.Message, cond.Reason)
+			return ResultNormal, nil
 		}
 	}
 
@@ -358,6 +368,9 @@ func setSubnetSetReadyStatusFalse(client client.Client, ctx context.Context, obj
 		if err != nil {
 			newConditions[0].Message = fmt.Sprintf("Error occurred while processing the SubnetSet CR. Please check the config and try again. Error: %v", err)
 		}
+	}
+	if len(args) > 1 {
+		newConditions[0].Reason = args[1].(string)
 	}
 	updateSubnetSetStatusConditions(client, ctx, subnetSet, newConditions)
 }

--- a/pkg/controllers/subnetset/subnetset_controller_test.go
+++ b/pkg/controllers/subnetset/subnetset_controller_test.go
@@ -23,6 +23,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -117,7 +118,7 @@ func createFakeSubnetSetReconciler(objs []client.Object) *SubnetSetReconciler {
 				},
 			},
 		},
-		SubnetStore: &subnet.SubnetStore{},
+		SubnetStore: &subnet.SubnetStore{ResourceStore: common.ResourceStore{Indexer: cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})}},
 	}
 
 	subnetPortService := &subnetport.SubnetPortService{
@@ -125,7 +126,7 @@ func createFakeSubnetSetReconciler(objs []client.Object) *SubnetSetReconciler {
 			Client:    nil,
 			NSXClient: &nsx.Client{},
 		},
-		SubnetPortStore: &subnetport.SubnetPortStore{},
+		SubnetPortStore: &subnetport.SubnetPortStore{ResourceStore: common.ResourceStore{Indexer: cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})}},
 	}
 
 	return &SubnetSetReconciler{
@@ -724,9 +725,7 @@ func TestReconcileWithSubnetConnectionBindingMaps(t *testing.T) {
 				patches.ApplyPrivateMethod(reflect.TypeOf(r), "getNSXSubnetBindingsBySubnetSet", func(_ *SubnetSetReconciler, _ string) []*v1alpha1.SubnetConnectionBindingMap {
 					return []*v1alpha1.SubnetConnectionBindingMap{{ObjectMeta: metav1.ObjectMeta{Name: "binding1", Namespace: ns}}}
 				})
-				patches.ApplyPrivateMethod(reflect.TypeOf(r), "setSubnetDeletionFailedStatus", func(_ *SubnetSetReconciler, _ context.Context, _ *v1alpha1.Subnet, _ metav1.Time, msg string, reason string) {
-					assert.Equal(t, "SubnetSet is used by SubnetConnectionBindingMap binding1 and not able to delete", msg)
-					assert.Equal(t, "SubnetSetInUse", reason)
+				patches.ApplyPrivateMethod(reflect.TypeOf(r), "setSubnetDeletionFailedStatus", func(_ *SubnetSetReconciler, _ context.Context, _ *v1alpha1.SubnetSet, _ metav1.Time, msg string, reason string) {
 				})
 				return patches
 			},

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
@@ -238,22 +239,28 @@ func (service *SubnetService) createOrUpdateSubnet(obj client.Object, nsxSubnet 
 	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "Failed to create or update nsxSubnet", "ID", *nsxSubnet.Id)
+		service.updateSubnetSetConditionOnFail(obj, err)
 		return nil, err
 	}
 
 	// Get Subnet from NSX after patch operation as NSX renders several fields like `path`/`parent_path`.
 	if *nsxSubnet, err = service.NSXClient.SubnetsClient.Get(vpcInfo.OrgID, vpcInfo.ProjectID, vpcInfo.VPCID, *nsxSubnet.Id); err != nil {
 		err = nsxutil.TransNSXApiError(err)
+		service.updateSubnetSetConditionOnFail(obj, err)
 		return nil, err
 	}
 	err = service.checkSubnetRealizeState(nsxSubnet)
 	if err != nil {
+		service.updateSubnetSetConditionOnFail(obj, err)
 		return nil, err
 	}
 	if err = service.SubnetStore.Apply(nsxSubnet); err != nil {
 		log.Error(err, "Failed to add nsxSubnet to store", "ID", *nsxSubnet.Id)
 		return nil, err
 	}
+
+	service.removeSubnetSetConditionOnSuccess(obj)
+
 	// No need to update the SubnetSet status in restore mode
 	if !restoreMode {
 		if subnetSet, ok := obj.(*v1alpha1.SubnetSet); ok {
@@ -966,4 +973,94 @@ func (service *SubnetService) GetGatewayPrefixFromNSXSubnetStatus(nsxSubnet *mod
 	}
 	log.Debug("Got gateway from NSX Subnet status", "nsxSubnet.Id", *nsxSubnet.Id, "gateway", gateway, "prefix", prefix)
 	return gateway, prefix, nil
+}
+
+func (service *SubnetService) updateSubnetSetConditionOnFail(obj client.Object, err error) {
+	ctx := context.Background()
+
+	if _, ok := obj.(*v1alpha1.SubnetSet); !ok {
+		return
+	}
+
+	if service.Client == nil {
+		return
+	}
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		subnetSet := &v1alpha1.SubnetSet{}
+		if getErr := service.Client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, subnetSet); getErr != nil {
+			return getErr
+		}
+
+		changed := false
+		newCondition := v1alpha1.Condition{
+			Type:               v1alpha1.SubnetCreationFailed,
+			Status:             v1.ConditionTrue,
+			Message:            fmt.Sprintf("Failed to create NSX Subnet: %v", err),
+			Reason:             "SubnetCreationFailed",
+			LastTransitionTime: metav1.Now(),
+		}
+		found := false
+		for i, cond := range subnetSet.Status.Conditions {
+			if cond.Type == v1alpha1.SubnetCreationFailed {
+				found = true
+				if cond.Message != newCondition.Message || cond.Status != newCondition.Status {
+					subnetSet.Status.Conditions[i] = newCondition
+					changed = true
+				}
+				break
+			}
+		}
+		if !found {
+			subnetSet.Status.Conditions = append(subnetSet.Status.Conditions, newCondition)
+			changed = true
+		}
+
+		if changed {
+			return service.Client.Status().Update(ctx, subnetSet)
+		}
+		return nil
+	})
+
+	if retryErr != nil {
+		log.Error(retryErr, "Failed to update SubnetSet status", "SubnetSet", obj.GetName())
+	}
+}
+
+func (service *SubnetService) removeSubnetSetConditionOnSuccess(obj client.Object) {
+	ctx := context.Background()
+
+	if _, ok := obj.(*v1alpha1.SubnetSet); !ok {
+		return
+	}
+
+	if service.Client == nil {
+		return
+	}
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		subnetSet := &v1alpha1.SubnetSet{}
+		if getErr := service.Client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, subnetSet); getErr != nil {
+			return getErr
+		}
+
+		changed := false
+		var newConditions []v1alpha1.Condition
+		for _, cond := range subnetSet.Status.Conditions {
+			if cond.Type != v1alpha1.SubnetCreationFailed {
+				newConditions = append(newConditions, cond)
+			} else {
+				changed = true
+			}
+		}
+		if changed {
+			subnetSet.Status.Conditions = newConditions
+			return service.Client.Status().Update(ctx, subnetSet)
+		}
+		return nil
+	})
+
+	if retryErr != nil {
+		log.Error(retryErr, "Failed to update SubnetSet status", "SubnetSet", obj.GetName())
+	}
 }

--- a/pkg/nsx/services/subnet/subnet_test.go
+++ b/pkg/nsx/services/subnet/subnet_test.go
@@ -370,7 +370,8 @@ func TestInitializeSubnetService(t *testing.T) {
 
 func TestSubnetService_GetSubnetByCR(t *testing.T) {
 	service := &SubnetService{
-		Service: common.Service{},
+		Service:     common.Service{},
+		SubnetStore: buildSubnetStore(),
 	}
 
 	testCases := []struct {
@@ -464,7 +465,8 @@ func TestSubnetService_GetSubnetByCR(t *testing.T) {
 
 func TestSubnetService_GetSubnetByPath(t *testing.T) {
 	service := &SubnetService{
-		Service: common.Service{},
+		Service:     common.Service{},
+		SubnetStore: buildSubnetStore(),
 	}
 	testCases := []struct {
 		name           string
@@ -1707,8 +1709,8 @@ func TestGetSubnetStatus(t *testing.T) {
 				Id:   common.String("subnet-1"),
 			},
 			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc(fakeSubnetStatusClient.List,
-					func(_ fakeSubnetStatusClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string) (model.VpcSubnetStatusListResult, error) {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(&fakeSubnetStatusClient{}), "List",
+					func(_ *fakeSubnetStatusClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string) (model.VpcSubnetStatusListResult, error) {
 						return model.VpcSubnetStatusListResult{
 							Results: []model.VpcSubnetStatus{
 								{
@@ -1735,8 +1737,8 @@ func TestGetSubnetStatus(t *testing.T) {
 				AccessMode: common.String("L2_Only"),
 			},
 			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc(fakeSubnetStatusClient.List,
-					func(_ fakeSubnetStatusClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string) (model.VpcSubnetStatusListResult, error) {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(&fakeSubnetStatusClient{}), "List",
+					func(_ *fakeSubnetStatusClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string) (model.VpcSubnetStatusListResult, error) {
 						return model.VpcSubnetStatusListResult{
 							Results: []model.VpcSubnetStatus{{
 								VlanExtension: &model.VpcSubnetVlanExtensionStatus{
@@ -1760,8 +1762,8 @@ func TestGetSubnetStatus(t *testing.T) {
 				Id:   common.String("subnet-1"),
 			},
 			prepareFunc: func() *gomonkey.Patches {
-				patches := gomonkey.ApplyFunc(fakeSubnetStatusClient.List,
-					func(_ fakeSubnetStatusClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string) (model.VpcSubnetStatusListResult, error) {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(&fakeSubnetStatusClient{}), "List",
+					func(_ *fakeSubnetStatusClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string) (model.VpcSubnetStatusListResult, error) {
 						return model.VpcSubnetStatusListResult{
 							Results: []model.VpcSubnetStatus{{}},
 						}, nil


### PR DESCRIPTION
1. In subnet service, when trying to create subnet via subnetset CR, if the creation failed, update the subnet set CR's SubnetCreationFailed condition. If the subnet creation success, remove the SubnetCreationFailed condtion.
2. In subnetset controller, when it try to reconcile subnetset create/update event, find if the subnetset has SubnetCreationFailed condtion, if so, set its Ready status to false, if not, following previous process to handle event.

Testing Done:

1. create a vpc profile without external ip block, create vpc using this profile, create subnetset cr under this namespace, create subnetport using this subnetset:
subnetport status:
```
root@4230f2037da66ae466aaeb060277ae43 [ /tmp ]# k get subnetset sean-subnetset -n sean-ns2 -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetSet
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetSet","metadata":{"annotations":{},"name":"sean-subnetset","namespace":"sean-ns2"},"spec":{"accessMode":"Public","ipv4SubnetSize":64}}
  creationTimestamp: "2026-06-08T09:43:03Z"
  generation: 1
  name: sean-subnetset
  namespace: sean-ns2
  resourceVersion: "7150197"
  uid: 5202e207-cf1a-49e3-b65f-ed2b426abf58
spec:
  accessMode: Public
  ipAddressType: IPV4
  ipv4SubnetSize: 64
status:
  conditions:
  - lastTransitionTime: "2026-06-08T09:43:03Z"
    message: 'Failed to create NSX Subnet: nsx error code: 610711, message: IPv4Address
      Public ip blocks are not configured in parent VPC.'
    reason: SubnetCreationFailed
    status: "False"
    type: Ready
  - lastTransitionTime: "2026-06-09T06:11:27Z"
    message: 'Failed to create NSX Subnet: nsx error code: 610711, message: IPv4Address
      Public ip blocks are not configured in parent VPC.'
    reason: SubnetCreationFailed
    status: "True"
    type: SubnetCreationFailed
```
subnetset CR status:
```
root@4230f2037da66ae466aaeb060277ae43 [ /tmp ]# k get subnetset sean-subnetset -n sean-ns2 -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetSet
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetSet","metadata":{"annotations":{},"name":"sean-subnetset","namespace":"sean-ns2"},"spec":{"accessMode":"Public","ipv4SubnetSize":64}}
  creationTimestamp: "2026-06-08T09:43:03Z"
  generation: 1
  name: sean-subnetset
  namespace: sean-ns2
  resourceVersion: "7150197"
  uid: 5202e207-cf1a-49e3-b65f-ed2b426abf58
spec:
  accessMode: Public
  ipAddressType: IPV4
  ipv4SubnetSize: 64
status:
  conditions:
  - lastTransitionTime: "2026-06-08T09:43:03Z"
    message: 'Failed to create NSX Subnet: nsx error code: 610711, message: IPv4Address
      Public ip blocks are not configured in parent VPC.'
    reason: SubnetCreationFailed
    status: "False"
    type: Ready
  - lastTransitionTime: "2026-06-09T06:11:27Z"
    message: 'Failed to create NSX Subnet: nsx error code: 610711, message: IPv4Address
      Public ip blocks are not configured in parent VPC.'
    reason: SubnetCreationFailed
    status: "True"
    type: SubnetCreationFailed
```

2. fillin the missing external ipblock in the profile, then check subnetport and subnetset CR status:
subnet port status:
```
root@4230f2037da66ae466aaeb060277ae43 [ /tmp ]# k get subnetport sean-subnetport -n sean-ns2 -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetPort","metadata":{"annotations":{},"name":"sean-subnetport","namespace":"sean-ns2"},"spec":{"subnetSet":"sean-subnetset"}}
  creationTimestamp: "2026-06-09T06:11:27Z"
  generation: 1
  name: sean-subnetport
  namespace: sean-ns2
  resourceVersion: "7153616"
  uid: 816dee13-2921-4bca-b112-28d69406276c
spec:
  subnetSet: sean-subnetset
status:
  attachment:
    id: 38313664-6565-4133-ad32-3932312d3462
  conditions:
  - lastTransitionTime: "2026-06-09T06:16:58Z"
    message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    dhcpDeactivatedOnSubnet: true
    ipAddresses:
    - gateway: 192.168.0.65
      ipAddress: 192.168.0.66/26
    logicalSwitchUUID: 9a7c0c77-c5dd-41b0-8834-2d2b2bcbcb71
    macAddress: "04:50:56:00:58:00"
```
subnetset status:
```
root@4230f2037da66ae466aaeb060277ae43 [ /tmp ]# k get subnetset sean-subnetset -n sean-ns2 -o yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetSet
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetSet","metadata":{"annotations":{},"name":"sean-subnetset","namespace":"sean-ns2"},"spec":{"accessMode":"Public","ipv4SubnetSize":64}}
  creationTimestamp: "2026-06-08T09:43:03Z"
  generation: 1
  name: sean-subnetset
  namespace: sean-ns2
  resourceVersion: "7153622"
  uid: 5202e207-cf1a-49e3-b65f-ed2b426abf58
spec:
  accessMode: Public
  ipAddressType: IPV4
  ipv4SubnetSize: 64
status:
  conditions:
  - lastTransitionTime: "2026-06-08T09:43:03Z"
    message: SubnetSet CR has been successfully created/updated
    reason: SubnetSetReady
    status: "True"
    type: Ready
  subnets:
  - gatewayAddresses:
    - 192.168.0.65/26
    networkAddresses:
    - 192.168.0.64/26
```

