### PR TITLE
Expose LBCapability condition on system VPCNetworkConfiguration for VNA+IPv6

### DIFF
--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -141,6 +141,7 @@ _Appears in:_
 | `ServiceClusterReady` |  |
 | `AutoSnatEnabled` |  |
 | `ExternalIPBlocksConfigured` |  |
+| `LBCapability` |  |
 | `DeletionFailed` |  |
 | `UpdateFailed` |  |
 

--- a/pkg/apis/vpc/v1alpha1/condition_types.go
+++ b/pkg/apis/vpc/v1alpha1/condition_types.go
@@ -14,6 +14,7 @@ const (
 	ServiceClusterReady        ConditionType = "ServiceClusterReady"
 	AutoSnatEnabled            ConditionType = "AutoSnatEnabled"
 	ExternalIPBlocksConfigured ConditionType = "ExternalIPBlocksConfigured"
+	LBCapability               ConditionType = "LBCapability"
 	DeleteFailure              ConditionType = "DeletionFailed"
 	UpdateFailure              ConditionType = "UpdateFailed"
 )

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -463,9 +463,9 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// LBCapability=False is informational only — namespace readiness is not blocked.
 	if ncName == commonservice.SystemVPCNetworkConfigurationName {
 		ipFamily := r.Service.NSXConfig.K8sConfig.GetIPAddressType()
-		lbCapable := !(networkStack == v1alpha1.VLANBackedVPC &&
-			lbProvider == vpc.NSXLB &&
-			util.IPAddressTypeIncludesIPv6(ipFamily))
+		lbCapable := networkStack != v1alpha1.VLANBackedVPC ||
+			lbProvider != vpc.NSXLB ||
+			!util.IPAddressTypeIncludesIPv6(ipFamily)
 		// When LBCapability is False, read NSX LBS realization alarms (best-effort) so
 		// manual testing can observe what NSX actually reports. The hardcoded reason string
 		// is always used for machine-readability; the NSX alarm goes into the message field.

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -329,15 +329,22 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		log.Error(err, "Failed to get LB Provider")
 		return common.ResultRequeue, nil
 	}
-	// For non-pre-created system VPC, set LBCapability before VPC creation.
+	// Set LBCapability before VPC creation for the system VPC.
 	// CreateOrUpdateVPC fails in VNA + NSX-LB + IPv6/DualStack, so without this early
 	// check the condition would never be reported when VPC creation errors out.
-	if ncName == commonservice.SystemVPCNetworkConfigurationName && !vpc.IsPreCreatedVPC(nc) && len(nc.Spec.VPCConnectivityProfile) > 0 {
-		if earlyProfile, profileErr := r.Service.GetVpcConnectivityProfile(nc, nc.Spec.VPCConnectivityProfile); profileErr == nil {
+	if ncName == commonservice.SystemVPCNetworkConfigurationName && len(nc.Spec.VPCConnectivityProfile) > 0 {
+		earlyProfile, profileErr := r.Service.GetVpcConnectivityProfile(nc, nc.Spec.VPCConnectivityProfile)
+		if profileErr != nil {
+			log.Error(profileErr, "Requeue NetworkInfo CR because failed to get VPC connectivity profile for LBCapability check", "req", req)
+			if !retryWithSystemVPC {
+				retryWithSystemVPC = true
+				systemNSCondition = nsMsgVPCConnProfileNotReady.getNSNetworkCondition()
+			}
+		} else {
 			ipFamily := r.Service.NSXConfig.K8sConfig.GetIPAddressType()
 			isVNA, vnaErr := vpc.IsVNAMode(earlyProfile)
 			if vnaErr != nil {
-				log.Info("Requeue NetworkInfo CR because VPC connectivity profile EdgeClusterPaths are not available", "req", req)
+				log.Info("Requeue NetworkInfo CR because VPC connectivity profile ServiceGateway/EdgeClusterPaths not available", "req", req)
 				if !retryWithSystemVPC {
 					retryWithSystemVPC = true
 					systemNSCondition = nsMsgVPCConnProfileNotReady.getNSNetworkCondition()
@@ -476,26 +483,6 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCCreateUpdateError.getNSNetworkCondition(err))
 				return common.ResultNormal, err
 			}
-		}
-	}
-
-	// Set LBCapability condition on the system VPC config.
-	// Condition is False when VNA (all ServiceGateway.EdgeClusterPaths are VNA clusters) +
-	// NSX-LB + IPv6/DualStack, True otherwise.
-	// LBCapability=False is informational only — namespace readiness is not blocked.
-	if ncName == commonservice.SystemVPCNetworkConfigurationName {
-		ipFamily := r.Service.NSXConfig.K8sConfig.GetIPAddressType()
-		isVNA, err := vpc.IsVNAMode(vpcConnectivityProfile)
-		if err != nil {
-			// EdgeClusterPaths not yet populated — can't determine LBCapability; retry.
-			log.Info("Requeue NetworkInfo CR because VPC connectivity profile EdgeClusterPaths are not available", "req", req)
-			if !retryWithSystemVPC {
-				retryWithSystemVPC = true
-				systemNSCondition = nsMsgVPCConnProfileNotReady.getNSNetworkCondition()
-			}
-		} else {
-			lbCapable := !isVNA || lbProvider != vpc.NSXLB || !util.IPAddressTypeIncludesIPv6(ipFamily)
-			setVPCNetworkConfigurationStatusWithLBCapability(ctx, r.Client, systemVpcNetCfg, lbCapable)
 		}
 	}
 

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -74,6 +74,7 @@ var (
 	nsMsgVPCGetExtIPBlockError    = newNsUnreadyMessage("Error happened to get external IP blocks: %v", NSReasonVPCNotReady)
 	nsMsgVPCNoExternalIPBlock     = newNsUnreadyMessage("System VPC has no external IP blocks", NSReasonVPCNotReady)
 	nsMsgVPCAutoSNATDisabled      = newNsUnreadyMessage("SNAT is not enabled in System VPC", NSReasonVPCSnatNotReady)
+	nsMsgVPCConnProfileNotReady   = newNsUnreadyMessage("VPC connectivity profile EdgeClusterPaths are not available", NSReasonVPCNetConfigNotReady)
 	nsMsgVPCDefaultSNATIPGetError = newNsUnreadyMessage("Default SNAT IP is not allocated in VPC: %v", NSReasonVPCSnatNotReady)
 	nsMsgVPCIsReady               = newNsUnreadyMessage("", "")
 	nsMsgVPCDNSZonesSyncError     = newNsUnreadyMessage("Failed to sync permitted DNS zones from NSX: %v", NSReasonVPCNotReady)
@@ -328,6 +329,26 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		log.Error(err, "Failed to get LB Provider")
 		return common.ResultRequeue, nil
 	}
+	// For non-pre-created system VPC, set LBCapability before VPC creation.
+	// CreateOrUpdateVPC fails in VNA + NSX-LB + IPv6/DualStack, so without this early
+	// check the condition would never be reported when VPC creation errors out.
+	if ncName == commonservice.SystemVPCNetworkConfigurationName && !vpc.IsPreCreatedVPC(nc) && len(nc.Spec.VPCConnectivityProfile) > 0 {
+		if earlyProfile, profileErr := r.Service.GetVpcConnectivityProfile(nc, nc.Spec.VPCConnectivityProfile); profileErr == nil {
+			ipFamily := r.Service.NSXConfig.K8sConfig.GetIPAddressType()
+			isVNA, vnaErr := vpc.IsVNAMode(earlyProfile)
+			if vnaErr != nil {
+				log.Info("Requeue NetworkInfo CR because VPC connectivity profile EdgeClusterPaths are not available", "req", req)
+				if !retryWithSystemVPC {
+					retryWithSystemVPC = true
+					systemNSCondition = nsMsgVPCConnProfileNotReady.getNSNetworkCondition()
+				}
+			} else {
+				lbCapable := !isVNA || lbProvider != vpc.NSXLB || !util.IPAddressTypeIncludesIPv6(ipFamily)
+				setVPCNetworkConfigurationStatusWithLBCapability(ctx, r.Client, systemVpcNetCfg, lbCapable)
+			}
+		}
+	}
+
 	createdVpc, err := r.Service.CreateOrUpdateVPC(ctx, networkInfoCR, nc, lbProvider, serviceClusterReady, r.restoreMode)
 	if err != nil {
 		r.StatusUpdater.UpdateFail(ctx, networkInfoCR, err, "Failed to create or update VPC", setNetworkInfoVPCStatusWithError, nil)
@@ -464,10 +485,18 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// LBCapability=False is informational only — namespace readiness is not blocked.
 	if ncName == commonservice.SystemVPCNetworkConfigurationName {
 		ipFamily := r.Service.NSXConfig.K8sConfig.GetIPAddressType()
-		lbCapable := !vpc.IsVNAMode(vpcConnectivityProfile) ||
-			lbProvider != vpc.NSXLB ||
-			!util.IPAddressTypeIncludesIPv6(ipFamily)
-		setVPCNetworkConfigurationStatusWithLBCapability(ctx, r.Client, systemVpcNetCfg, lbCapable)
+		isVNA, err := vpc.IsVNAMode(vpcConnectivityProfile)
+		if err != nil {
+			// EdgeClusterPaths not yet populated — can't determine LBCapability; retry.
+			log.Info("Requeue NetworkInfo CR because VPC connectivity profile EdgeClusterPaths are not available", "req", req)
+			if !retryWithSystemVPC {
+				retryWithSystemVPC = true
+				systemNSCondition = nsMsgVPCConnProfileNotReady.getNSNetworkCondition()
+			}
+		} else {
+			lbCapable := !isVNA || lbProvider != vpc.NSXLB || !util.IPAddressTypeIncludesIPv6(ipFamily)
+			setVPCNetworkConfigurationStatusWithLBCapability(ctx, r.Client, systemVpcNetCfg, lbCapable)
+		}
 	}
 
 	// if lb VPC enabled, read avi subnet path and cidr

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -458,6 +458,27 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
+	// Set LBCapability condition on the system VPC config.
+	// Condition is False when VNA (VLANBackedVPC) + NSX-LB + IPv6/DualStack, True otherwise.
+	// LBCapability=False is informational only — namespace readiness is not blocked.
+	if ncName == commonservice.SystemVPCNetworkConfigurationName {
+		ipFamily := r.Service.NSXConfig.K8sConfig.GetIPAddressType()
+		lbCapable := !(networkStack == v1alpha1.VLANBackedVPC &&
+			lbProvider == vpc.NSXLB &&
+			util.IPAddressTypeIncludesIPv6(ipFamily))
+		// When LBCapability is False, read NSX LBS realization alarms (best-effort) so
+		// manual testing can observe what NSX actually reports. The hardcoded reason string
+		// is always used for machine-readability; the NSX alarm goes into the message field.
+		var nsxAlarmMsg string
+		if !lbCapable && len(nsxLBSPath) > 0 {
+			nsxAlarmMsg = r.Service.GetLBSRealizationAlarmMessages(nsxLBSPath)
+			if nsxAlarmMsg != "" {
+				log.Info("NSX LBS realization alarms for LBCapability=False", "lbsPath", nsxLBSPath, "alarms", nsxAlarmMsg)
+			}
+		}
+		setVPCNetworkConfigurationStatusWithLBCapability(ctx, r.Client, systemVpcNetCfg, lbCapable, nsxAlarmMsg)
+	}
+
 	// if lb VPC enabled, read avi subnet path and cidr
 	// nsx bug, if set LoadBalancerVpcEndpoint.Enabled to false, when read this VPC back,
 	// LoadBalancerVpcEndpoint.Enabled will become a nil pointer.

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -459,24 +459,15 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// Set LBCapability condition on the system VPC config.
-	// Condition is False when VNA (VLANBackedVPC) + NSX-LB + IPv6/DualStack, True otherwise.
+	// Condition is False when VNA (all ServiceGateway.EdgeClusterPaths are VNA clusters) +
+	// NSX-LB + IPv6/DualStack, True otherwise.
 	// LBCapability=False is informational only — namespace readiness is not blocked.
 	if ncName == commonservice.SystemVPCNetworkConfigurationName {
 		ipFamily := r.Service.NSXConfig.K8sConfig.GetIPAddressType()
-		lbCapable := networkStack != v1alpha1.VLANBackedVPC ||
+		lbCapable := !vpc.IsVNAMode(vpcConnectivityProfile) ||
 			lbProvider != vpc.NSXLB ||
 			!util.IPAddressTypeIncludesIPv6(ipFamily)
-		// When LBCapability is False, read NSX LBS realization alarms (best-effort) so
-		// manual testing can observe what NSX actually reports. The hardcoded reason string
-		// is always used for machine-readability; the NSX alarm goes into the message field.
-		var nsxAlarmMsg string
-		if !lbCapable && len(nsxLBSPath) > 0 {
-			nsxAlarmMsg = r.Service.GetLBSRealizationAlarmMessages(nsxLBSPath)
-			if nsxAlarmMsg != "" {
-				log.Info("NSX LBS realization alarms for LBCapability=False", "lbsPath", nsxLBSPath, "alarms", nsxAlarmMsg)
-			}
-		}
-		setVPCNetworkConfigurationStatusWithLBCapability(ctx, r.Client, systemVpcNetCfg, lbCapable, nsxAlarmMsg)
+		setVPCNetworkConfigurationStatusWithLBCapability(ctx, r.Client, systemVpcNetCfg, lbCapable)
 	}
 
 	// if lb VPC enabled, read avi subnet path and cidr

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -332,8 +332,10 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Set LBCapability before VPC creation for the system VPC.
 	// CreateOrUpdateVPC fails in VNA + NSX-LB + IPv6/DualStack, so without this early
 	// check the condition would never be reported when VPC creation errors out.
+	var earlyProfile *model.VpcConnectivityProfile
 	if ncName == commonservice.SystemVPCNetworkConfigurationName && len(nc.Spec.VPCConnectivityProfile) > 0 {
-		earlyProfile, profileErr := r.Service.GetVpcConnectivityProfile(nc, nc.Spec.VPCConnectivityProfile)
+		var profileErr error
+		earlyProfile, profileErr = r.Service.GetVpcConnectivityProfile(nc, nc.Spec.VPCConnectivityProfile)
 		if profileErr != nil {
 			log.Error(profileErr, "Requeue NetworkInfo CR because failed to get VPC connectivity profile for LBCapability check", "req", req)
 			if !retryWithSystemVPC {
@@ -403,11 +405,17 @@ func (r *NetworkInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	var vpcConnectivityProfile *model.VpcConnectivityProfile
 	// Only process vpcConnectivityProfile-dependent logic if path exists
 	if len(vpcConnectivityProfilePath) > 0 {
-		vpcConnectivityProfile, err = r.Service.GetVpcConnectivityProfile(nc, vpcConnectivityProfilePath)
-		if err != nil {
-			r.StatusUpdater.UpdateFail(ctx, networkInfoCR, err, "Failed to get VPC connectivity profile", setNetworkInfoVPCStatusWithError, nil)
-			setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCGetExtIPBlockError.getNSNetworkCondition(err))
-			return common.ResultRequeueAfter10sec, err
+		if earlyProfile != nil && vpcConnectivityProfilePath == nc.Spec.VPCConnectivityProfile {
+			// Reuse the profile already fetched for the early LBCapability check
+			// instead of issuing a duplicate GetVpcConnectivityProfile call to NSX.
+			vpcConnectivityProfile = earlyProfile
+		} else {
+			vpcConnectivityProfile, err = r.Service.GetVpcConnectivityProfile(nc, vpcConnectivityProfilePath)
+			if err != nil {
+				r.StatusUpdater.UpdateFail(ctx, networkInfoCR, err, "Failed to get VPC connectivity profile", setNetworkInfoVPCStatusWithError, nil)
+				setNSNetworkReadyCondition(ctx, r.Client, req.Namespace, nsMsgVPCGetExtIPBlockError.getNSNetworkCondition(err))
+				return common.ResultRequeueAfter10sec, err
+			}
 		}
 
 		// Check external IP blocks on system VPC network config.

--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -239,7 +239,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				})
 				patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{model.VpcConnectivityProfile{ExternalIpBlocks: []string{"fake-ip-block"}}, nil},
-					Times:  1,
+					Times:  2,
 				}})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetLBProvider", func(_ *vpc.VPCService) (vpc.LBProvider, error) {
 					return vpc.NSXLB, nil
@@ -314,7 +314,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				})
 				patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{model.VpcConnectivityProfile{ExternalIpBlocks: []string{"fake-ip-block"}}, nil},
-					Times:  1,
+					Times:  2,
 				}})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetLBProvider", func(_ *vpc.VPCService) (vpc.LBProvider, error) {
 					return vpc.NSXLB, nil
@@ -517,13 +517,14 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					Values: gomonkey.Params{model.VpcConnectivityProfile{
 						ExternalIpBlocks: []string{"fake-ip-block"},
 						ServiceGateway: &model.VpcServiceGatewayConfig{
-							Enable: servicecommon.Bool(true),
+							Enable:           servicecommon.Bool(true),
+							EdgeClusterPaths: []string{"fake-edge-cluster-path"},
 							NatConfig: &model.VpcNatConfig{
 								EnableDefaultSnat: servicecommon.Bool(true),
 							},
 						},
 					}, nil},
-					Times: 1,
+					Times: 2,
 				}})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetDefaultNSXLBSPathByVPC", func(_ *vpc.VPCService, _ string) string {
 					return "lbs-path"
@@ -610,7 +611,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 						ExternalIpBlocks: []string{"fake-ip-block"},
 						ServiceGateway:   nil,
 					}, nil},
-					Times: 1,
+					Times: 2,
 				}})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetDefaultNSXLBSPathByVPC", func(_ *vpc.VPCService, _ string) string {
 					return "lbs-path"
@@ -692,7 +693,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 						ExternalIpBlocks: []string{"fake-ip-block"},
 						ServiceGateway:   nil,
 					}, nil},
-					Times: 1,
+					Times: 2,
 				}})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetDefaultNSXLBSPathByVPC", func(_ *vpc.VPCService, _ string) string {
 					return "lbs-path"
@@ -1209,7 +1210,7 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 							EdgeClusterPaths: []string{"fake-edge-cluster-path"},
 						},
 					}, nil},
-					Times: 1,
+					Times: 2,
 				}})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetDefaultNSXLBSPathByVPC", func(_ *vpc.VPCService, _ string) string {
 					return "lbs-path"
@@ -1396,6 +1397,68 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 			want:    common.ResultRequeueAfter10sec,
 			wantErr: true,
 		},
+		{
+			name: "LBCapabilitySetBeforeVPCCreationFailure",
+			prepareFunc: func(t *testing.T, r *NetworkInfoReconciler, ctx context.Context) (patches *gomonkey.Patches) {
+				assert.NoError(t, r.Client.Create(ctx, &v1alpha1.NetworkInfo{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: requestArgs.req.Namespace,
+						Name:      requestArgs.req.Name,
+					},
+				}))
+				assert.NoError(t, r.Client.Create(ctx, &v1alpha1.VPCNetworkConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: "system"},
+					Status: v1alpha1.VPCNetworkConfigurationStatus{
+						Conditions: []v1alpha1.Condition{
+							{Type: v1alpha1.GatewayConnectionReady, Status: corev1.ConditionTrue},
+							{Type: v1alpha1.ServiceClusterReady, Status: corev1.ConditionTrue},
+						},
+					},
+				}))
+				r.Service.NSXConfig.K8sConfig.IPFamily = "IPv6"
+				patches = gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "GetNetworkconfigNameFromNS", func(_ *vpc.VPCService, _ context.Context, _ string) (string, error) {
+					return servicecommon.SystemVPCNetworkConfigurationName, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetVPCNetworkConfig", func(_ *vpc.VPCService, _ string) (*v1alpha1.VPCNetworkConfiguration, bool, error) {
+					return &v1alpha1.VPCNetworkConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: servicecommon.SystemVPCNetworkConfigurationName},
+						Spec: v1alpha1.VPCNetworkConfigurationSpec{
+							VPCConnectivityProfile: "/orgs/default/projects/nsx_operator_e2e_test/vpc-connectivity-profiles/default",
+							NSXProject:             "/orgs/default/projects/project-quality",
+						},
+					}, true, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetLBProvider", func(_ *vpc.VPCService) (vpc.LBProvider, error) {
+					return vpc.NSXLB, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetVpcConnectivityProfile", func(_ *vpc.VPCService, _ *v1alpha1.VPCNetworkConfiguration, _ string) (*model.VpcConnectivityProfile, error) {
+					return &model.VpcConnectivityProfile{
+						ServiceGateway: &model.VpcServiceGatewayConfig{
+							EdgeClusterPaths: []string{
+								"/infra/sites/default/enforcement-points/default/virtual-network-appliance-clusters/vnac-1",
+							},
+						},
+					}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateVPC", func(_ *vpc.VPCService, _ context.Context, _ *v1alpha1.NetworkInfo, _ *v1alpha1.VPCNetworkConfiguration, _ vpc.LBProvider, _ bool, _ bool) (*model.Vpc, error) {
+					return nil, fmt.Errorf("VPC LBS creation failed: VNA mode does not support IPv6 LB")
+				})
+				lbCapabilitySet := false
+				patches.ApplyFunc(setVPCNetworkConfigurationStatusWithLBCapability, func(_ context.Context, _ client.Client, _ *v1alpha1.VPCNetworkConfiguration, lbCapable bool) {
+					assert.False(t, lbCapable, "LBCapability must be False for VNA+NSX-LB+IPv6")
+					lbCapabilitySet = true
+				})
+				patches.ApplyFunc(setNSNetworkReadyCondition, func(_ context.Context, _ client.Client, _ string, _ *corev1.NamespaceCondition) {})
+				patches.ApplyFunc((*common.StatusUpdater).UpdateFail, func(_ *common.StatusUpdater, _ context.Context, _ client.Object, _ error, _ string, _ common.UpdateFailStatusFn, _ ...interface{}) {})
+				t.Cleanup(func() {
+					assert.True(t, lbCapabilitySet, "setVPCNetworkConfigurationStatusWithLBCapability must be called before CreateOrUpdateVPC fails")
+				})
+				return patches
+			},
+			args:    requestArgs,
+			want:    common.ResultRequeueAfter10sec,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1497,7 +1560,7 @@ func TestNetworkInfoReconciler_Reconcile_ExternalIPBlockInSystemVPC(t *testing.T
 
 			patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
 				Values: gomonkey.Params{model.VpcConnectivityProfile{ServiceGateway: nil}, nil},
-				Times:  1,
+				Times:  2,
 			}})
 
 			patches.ApplyFunc(setVPCNetworkConfigurationStatusWithNoExternalIPBlock, func(_ context.Context, _ client.Client, _ *v1alpha1.VPCNetworkConfiguration, _ bool) {

--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -1449,7 +1449,8 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					lbCapabilitySet = true
 				})
 				patches.ApplyFunc(setNSNetworkReadyCondition, func(_ context.Context, _ client.Client, _ string, _ *corev1.NamespaceCondition) {})
-				patches.ApplyFunc((*common.StatusUpdater).UpdateFail, func(_ *common.StatusUpdater, _ context.Context, _ client.Object, _ error, _ string, _ common.UpdateFailStatusFn, _ ...interface{}) {})
+				patches.ApplyFunc((*common.StatusUpdater).UpdateFail, func(_ *common.StatusUpdater, _ context.Context, _ client.Object, _ error, _ string, _ common.UpdateFailStatusFn, _ ...interface{}) {
+				})
 				t.Cleanup(func() {
 					assert.True(t, lbCapabilitySet, "setVPCNetworkConfigurationStatusWithLBCapability must be called before CreateOrUpdateVPC fails")
 				})

--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -238,8 +238,13 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					return false, nil
 				})
 				patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
-					Values: gomonkey.Params{model.VpcConnectivityProfile{ExternalIpBlocks: []string{"fake-ip-block"}}, nil},
-					Times:  2,
+					Values: gomonkey.Params{model.VpcConnectivityProfile{
+						ExternalIpBlocks: []string{"fake-ip-block"},
+						ServiceGateway: &model.VpcServiceGatewayConfig{
+							EdgeClusterPaths: []string{"fake-edge-cluster-path"},
+						},
+					}, nil},
+					Times: 2,
 				}})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetLBProvider", func(_ *vpc.VPCService) (vpc.LBProvider, error) {
 					return vpc.NSXLB, nil
@@ -313,8 +318,13 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 					return false, nil
 				})
 				patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
-					Values: gomonkey.Params{model.VpcConnectivityProfile{ExternalIpBlocks: []string{"fake-ip-block"}}, nil},
-					Times:  2,
+					Values: gomonkey.Params{model.VpcConnectivityProfile{
+						ExternalIpBlocks: []string{"fake-ip-block"},
+						ServiceGateway: &model.VpcServiceGatewayConfig{
+							EdgeClusterPaths: []string{"fake-edge-cluster-path"},
+						},
+					}, nil},
+					Times: 2,
 				}})
 				patches.ApplyMethod(reflect.TypeOf(r.Service), "GetLBProvider", func(_ *vpc.VPCService) (vpc.LBProvider, error) {
 					return vpc.NSXLB, nil
@@ -609,7 +619,9 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{model.VpcConnectivityProfile{
 						ExternalIpBlocks: []string{"fake-ip-block"},
-						ServiceGateway:   nil,
+						ServiceGateway: &model.VpcServiceGatewayConfig{
+							EdgeClusterPaths: []string{"fake-edge-cluster-path"},
+						},
 					}, nil},
 					Times: 2,
 				}})
@@ -691,7 +703,9 @@ func TestNetworkInfoReconciler_Reconcile(t *testing.T) {
 				patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
 					Values: gomonkey.Params{model.VpcConnectivityProfile{
 						ExternalIpBlocks: []string{"fake-ip-block"},
-						ServiceGateway:   nil,
+						ServiceGateway: &model.VpcServiceGatewayConfig{
+							EdgeClusterPaths: []string{"fake-edge-cluster-path"},
+						},
 					}, nil},
 					Times: 2,
 				}})
@@ -1560,8 +1574,12 @@ func TestNetworkInfoReconciler_Reconcile_ExternalIPBlockInSystemVPC(t *testing.T
 			})
 
 			patches.ApplyMethodSeq(reflect.TypeOf(r.Service.Service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
-				Values: gomonkey.Params{model.VpcConnectivityProfile{ServiceGateway: nil}, nil},
-				Times:  2,
+				Values: gomonkey.Params{model.VpcConnectivityProfile{
+					ServiceGateway: &model.VpcServiceGatewayConfig{
+						EdgeClusterPaths: []string{"fake-edge-cluster-path"},
+					},
+				}, nil},
+				Times: 2,
 			}})
 
 			patches.ApplyFunc(setVPCNetworkConfigurationStatusWithNoExternalIPBlock, func(_ context.Context, _ client.Client, _ *v1alpha1.VPCNetworkConfiguration, _ bool) {

--- a/pkg/controllers/networkinfo/networkinfo_utils.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils.go
@@ -154,6 +154,31 @@ func setVPCNetworkConfigurationStatusWithSnatEnabled(ctx context.Context, client
 	}
 }
 
+// setVPCNetworkConfigurationStatusWithLBCapability sets the LBCapability condition on the
+// system VPCNetworkConfiguration. When lbCapable is false, reason is set to the spec-defined
+// constant and nsxAlarmMsg (if non-empty) is appended as the message field so manual testing
+// can observe the actual NSX alarm without changing the machine-readable reason string.
+func setVPCNetworkConfigurationStatusWithLBCapability(ctx context.Context, client client.Client, nc *v1alpha1.VPCNetworkConfiguration, lbCapable bool, nsxAlarmMsg string) {
+	newCondition := v1alpha1.Condition{
+		Type:               v1alpha1.LBCapability,
+		LastTransitionTime: metav1.Time{},
+	}
+	if lbCapable {
+		newCondition.Status = v1.ConditionTrue
+	} else {
+		newCondition.Status = v1.ConditionFalse
+		newCondition.Reason = common.ReasonIPv6LBNotSupportedOnVNA
+		newCondition.Message = nsxAlarmMsg
+	}
+	if mergeStatusCondition(&nc.Status.Conditions, &newCondition) {
+		if err := client.Status().Update(ctx, nc); err != nil {
+			log.Error(err, "Update VPCNetworkConfiguration LBCapability status failed", "VPCNetworkConfiguration", nc.Name)
+			return
+		}
+	}
+	log.Info("Updated VPCNetworkConfiguration LBCapability status", "VPCNetworkConfiguration", nc.Name, "lbCapable", lbCapable)
+}
+
 func setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx context.Context, client client.Client, nc *v1alpha1.VPCNetworkConfiguration, hasExternalIPs bool) {
 	newCondition := v1alpha1.Condition{
 		Type:               v1alpha1.ExternalIPBlocksConfigured,

--- a/pkg/controllers/networkinfo/networkinfo_utils.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils.go
@@ -155,10 +155,9 @@ func setVPCNetworkConfigurationStatusWithSnatEnabled(ctx context.Context, client
 }
 
 // setVPCNetworkConfigurationStatusWithLBCapability sets the LBCapability condition on the
-// system VPCNetworkConfiguration. When lbCapable is false, reason is set to the spec-defined
-// constant and nsxAlarmMsg (if non-empty) is appended as the message field so manual testing
-// can observe the actual NSX alarm without changing the machine-readable reason string.
-func setVPCNetworkConfigurationStatusWithLBCapability(ctx context.Context, client client.Client, nc *v1alpha1.VPCNetworkConfiguration, lbCapable bool, nsxAlarmMsg string) {
+// system VPCNetworkConfiguration. lbCapable is false when VNA + NSX-LB + IPv6/DualStack;
+// true otherwise.
+func setVPCNetworkConfigurationStatusWithLBCapability(ctx context.Context, client client.Client, nc *v1alpha1.VPCNetworkConfiguration, lbCapable bool) {
 	newCondition := v1alpha1.Condition{
 		Type:               v1alpha1.LBCapability,
 		LastTransitionTime: metav1.Time{},
@@ -168,7 +167,6 @@ func setVPCNetworkConfigurationStatusWithLBCapability(ctx context.Context, clien
 	} else {
 		newCondition.Status = v1.ConditionFalse
 		newCondition.Reason = common.ReasonIPv6LBNotSupportedOnVNA
-		newCondition.Message = nsxAlarmMsg
 	}
 	if mergeStatusCondition(&nc.Status.Conditions, &newCondition) {
 		if err := client.Status().Update(ctx, nc); err != nil {

--- a/pkg/controllers/networkinfo/networkinfo_utils.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils.go
@@ -175,8 +175,8 @@ func setVPCNetworkConfigurationStatusWithLBCapability(ctx context.Context, clien
 			log.Error(err, "Update VPCNetworkConfiguration LBCapability status failed", "VPCNetworkConfiguration", nc.Name)
 			return
 		}
+		log.Info("Updated VPCNetworkConfiguration LBCapability status", "VPCNetworkConfiguration", nc.Name, "lbCapable", lbCapable)
 	}
-	log.Info("Updated VPCNetworkConfiguration LBCapability status", "VPCNetworkConfiguration", nc.Name, "lbCapable", lbCapable)
 }
 
 func setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx context.Context, client client.Client, nc *v1alpha1.VPCNetworkConfiguration, hasExternalIPs bool) {

--- a/pkg/controllers/networkinfo/networkinfo_utils_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils_test.go
@@ -188,58 +188,38 @@ func TestSetVPCNetworkConfigurationStatusWithLBCapability(t *testing.T) {
 	tests := []struct {
 		name                    string
 		lbCapable               bool
-		nsxAlarmMsg             string
 		expectedConditionStatus corev1.ConditionStatus
 		expectedConditionReason string
-		expectedConditionMsg    string
 	}{
 		{
-			name:                    "VNA + NSXLB + IPv6 — LBCapability False, no NSX alarm",
+			name:                    "VNA + NSXLB + IPv6 — LBCapability False",
 			lbCapable:               false,
-			nsxAlarmMsg:             "",
 			expectedConditionStatus: corev1.ConditionFalse,
 			expectedConditionReason: common.ReasonIPv6LBNotSupportedOnVNA,
-			expectedConditionMsg:    "",
-		},
-		{
-			name:                    "VNA + NSXLB + IPv6 — LBCapability False, with NSX alarm",
-			lbCapable:               false,
-			nsxAlarmMsg:             "LBService IPv6 not supported on VLAN-backed VPC",
-			expectedConditionStatus: corev1.ConditionFalse,
-			expectedConditionReason: common.ReasonIPv6LBNotSupportedOnVNA,
-			expectedConditionMsg:    "LBService IPv6 not supported on VLAN-backed VPC",
 		},
 		{
 			name:                    "VNA + NSXLB + DualStack — LBCapability False",
 			lbCapable:               false,
-			nsxAlarmMsg:             "",
 			expectedConditionStatus: corev1.ConditionFalse,
 			expectedConditionReason: common.ReasonIPv6LBNotSupportedOnVNA,
-			expectedConditionMsg:    "",
 		},
 		{
 			name:                    "VNA + NSXLB + IPv4 — LBCapability True",
 			lbCapable:               true,
-			nsxAlarmMsg:             "",
 			expectedConditionStatus: corev1.ConditionTrue,
 			expectedConditionReason: "",
-			expectedConditionMsg:    "",
 		},
 		{
 			name:                    "VNA + AVI LB + IPv6 — LBCapability True",
 			lbCapable:               true,
-			nsxAlarmMsg:             "",
 			expectedConditionStatus: corev1.ConditionTrue,
 			expectedConditionReason: "",
-			expectedConditionMsg:    "",
 		},
 		{
 			name:                    "FullStack + NSXLB + IPv6 — LBCapability True",
 			lbCapable:               true,
-			nsxAlarmMsg:             "",
 			expectedConditionStatus: corev1.ConditionTrue,
 			expectedConditionReason: "",
-			expectedConditionMsg:    "",
 		},
 	}
 	for _, tt := range tests {
@@ -253,13 +233,12 @@ func TestSetVPCNetworkConfigurationStatusWithLBCapability(t *testing.T) {
 			}
 			assert.NoError(t, fakeClient.Create(ctx, nc))
 
-			setVPCNetworkConfigurationStatusWithLBCapability(ctx, fakeClient, nc, tt.lbCapable, tt.nsxAlarmMsg)
+			setVPCNetworkConfigurationStatusWithLBCapability(ctx, fakeClient, nc, tt.lbCapable)
 
 			assert.Equal(t, 1, len(nc.Status.Conditions))
 			assert.Equal(t, v1alpha1.LBCapability, nc.Status.Conditions[0].Type)
 			assert.Equal(t, tt.expectedConditionStatus, nc.Status.Conditions[0].Status)
 			assert.Equal(t, tt.expectedConditionReason, nc.Status.Conditions[0].Reason)
-			assert.Equal(t, tt.expectedConditionMsg, nc.Status.Conditions[0].Message)
 		})
 	}
 }

--- a/pkg/controllers/networkinfo/networkinfo_utils_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils_test.go
@@ -184,6 +184,86 @@ func TestSetVPCNetworkConfigurationStatusWithSnatEnabled(t *testing.T) {
 	}
 }
 
+func TestSetVPCNetworkConfigurationStatusWithLBCapability(t *testing.T) {
+	tests := []struct {
+		name                    string
+		lbCapable               bool
+		nsxAlarmMsg             string
+		expectedConditionStatus corev1.ConditionStatus
+		expectedConditionReason string
+		expectedConditionMsg    string
+	}{
+		{
+			name:                    "VNA + NSXLB + IPv6 — LBCapability False, no NSX alarm",
+			lbCapable:               false,
+			nsxAlarmMsg:             "",
+			expectedConditionStatus: corev1.ConditionFalse,
+			expectedConditionReason: common.ReasonIPv6LBNotSupportedOnVNA,
+			expectedConditionMsg:    "",
+		},
+		{
+			name:                    "VNA + NSXLB + IPv6 — LBCapability False, with NSX alarm",
+			lbCapable:               false,
+			nsxAlarmMsg:             "LBService IPv6 not supported on VLAN-backed VPC",
+			expectedConditionStatus: corev1.ConditionFalse,
+			expectedConditionReason: common.ReasonIPv6LBNotSupportedOnVNA,
+			expectedConditionMsg:    "LBService IPv6 not supported on VLAN-backed VPC",
+		},
+		{
+			name:                    "VNA + NSXLB + DualStack — LBCapability False",
+			lbCapable:               false,
+			nsxAlarmMsg:             "",
+			expectedConditionStatus: corev1.ConditionFalse,
+			expectedConditionReason: common.ReasonIPv6LBNotSupportedOnVNA,
+			expectedConditionMsg:    "",
+		},
+		{
+			name:                    "VNA + NSXLB + IPv4 — LBCapability True",
+			lbCapable:               true,
+			nsxAlarmMsg:             "",
+			expectedConditionStatus: corev1.ConditionTrue,
+			expectedConditionReason: "",
+			expectedConditionMsg:    "",
+		},
+		{
+			name:                    "VNA + AVI LB + IPv6 — LBCapability True",
+			lbCapable:               true,
+			nsxAlarmMsg:             "",
+			expectedConditionStatus: corev1.ConditionTrue,
+			expectedConditionReason: "",
+			expectedConditionMsg:    "",
+		},
+		{
+			name:                    "FullStack + NSXLB + IPv6 — LBCapability True",
+			lbCapable:               true,
+			nsxAlarmMsg:             "",
+			expectedConditionStatus: corev1.ConditionTrue,
+			expectedConditionReason: "",
+			expectedConditionMsg:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			scheme := clientgoscheme.Scheme
+			v1alpha1.AddToScheme(scheme)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&v1alpha1.VPCNetworkConfiguration{}).Build()
+			nc := &v1alpha1.VPCNetworkConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "ncName"},
+			}
+			assert.NoError(t, fakeClient.Create(ctx, nc))
+
+			setVPCNetworkConfigurationStatusWithLBCapability(ctx, fakeClient, nc, tt.lbCapable, tt.nsxAlarmMsg)
+
+			assert.Equal(t, 1, len(nc.Status.Conditions))
+			assert.Equal(t, v1alpha1.LBCapability, nc.Status.Conditions[0].Type)
+			assert.Equal(t, tt.expectedConditionStatus, nc.Status.Conditions[0].Status)
+			assert.Equal(t, tt.expectedConditionReason, nc.Status.Conditions[0].Reason)
+			assert.Equal(t, tt.expectedConditionMsg, nc.Status.Conditions[0].Message)
+		})
+	}
+}
+
 func TestGetConnectionStatusFromCR(t *testing.T) {
 	tests := []struct {
 		name                            string

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -249,6 +249,7 @@ var (
 	ReasonServiceClusterNotSet                       = "ServiceClusterNotSet"
 	ReasonNoExternalIPBlocksInVPCConnectivityProfile = "ExternalIPBlockMissingInProfile"
 	ReasonSNATNotSupportedInTEPLess                  = "SNAT not supported in TEP-less mode"
+	ReasonIPv6LBNotSupportedOnVNA                    = "IPv6 LB is not supported as VPCs are hosted on VNA"
 )
 
 type Service struct {

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1053,9 +1053,9 @@ func IsEnableAutoSNAT(vpcConnectivityProfile *model.VpcConnectivityProfile) bool
 
 // IsVNAMode reports whether all ServiceGateway.EdgeClusterPaths are VNA cluster paths
 // (/infra/sites/.../virtual-network-appliance-clusters/...).
-// Returns (false, nil) when profile or ServiceGateway is nil — not a VNA deployment.
-// Returns (false, error) when EdgeClusterPaths is empty — ServiceGateway exists but paths
-// are not yet populated; callers should not set LBCapability and should retry.
+// Returns (false, error) when profile or ServiceGateway is nil, or when EdgeClusterPaths
+// is empty — VNA mode cannot yet be determined; callers should not set LBCapability and
+// should retry.
 func IsVNAMode(profile *model.VpcConnectivityProfile) (bool, error) {
 	if profile == nil || profile.ServiceGateway == nil {
 		return false, fmt.Errorf("VPC connectivity profile or ServiceGateway is nil, cannot determine VNA mode")

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1051,6 +1051,25 @@ func IsEnableAutoSNAT(vpcConnectivityProfile *model.VpcConnectivityProfile) bool
 	return *vpcConnectivityProfile.ServiceGateway.NatConfig.EnableDefaultSnat
 }
 
+// IsVNAMode reports whether all ServiceGateway.EdgeClusterPaths are VNA cluster paths
+// (/infra/sites/.../virtual-network-appliance-clusters/...). Returns false when the
+// profile or its paths are absent — safe default, avoids false positives on LBCapability.
+func IsVNAMode(profile *model.VpcConnectivityProfile) bool {
+	if profile == nil || profile.ServiceGateway == nil {
+		return false
+	}
+	paths := profile.ServiceGateway.EdgeClusterPaths
+	if len(paths) == 0 {
+		return false
+	}
+	for _, p := range paths {
+		if !strings.Contains(p, "/virtual-network-appliance-clusters/") {
+			return false
+		}
+	}
+	return true
+}
+
 func (s *VPCService) GetLBProvider() (LBProvider, error) {
 	lbProviderMutex.Lock()
 	defer lbProviderMutex.Unlock()
@@ -1264,25 +1283,3 @@ func (s *VPCService) IsDefaultNSXProject(orgID, projectID string) (bool, error) 
 	return isDefault, nil
 }
 
-// GetLBSRealizationAlarmMessages reads the realization state of the given LBS policy path
-// and collects any alarm messages reported by NSX. Returns "" when no alarms are present
-// or when the realization state cannot be fetched (errors are logged, not propagated).
-// This is used for diagnostic logging when LBCapability is False, so callers can observe
-// what NSX actually reports rather than only seeing the hardcoded condition reason.
-func (s *VPCService) GetLBSRealizationAlarmMessages(lbsPath string) string {
-	results, err := s.NSXClient.RealizedEntitiesClient.List(lbsPath, nil)
-	err = nsxutil.TransNSXApiError(err)
-	if err != nil {
-		log.Error(err, "Failed to read LBS realization state for alarm messages", "LBSPath", lbsPath)
-		return ""
-	}
-	var msgs []string
-	for _, result := range results.Results {
-		for _, alarm := range result.Alarms {
-			if alarm.Message != nil {
-				msgs = append(msgs, *alarm.Message)
-			}
-		}
-	}
-	return strings.Join(msgs, "; ")
-}

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1263,3 +1263,26 @@ func (s *VPCService) IsDefaultNSXProject(orgID, projectID string) (bool, error) 
 	s.defaultProjectCache.Store(cacheKey, isDefault)
 	return isDefault, nil
 }
+
+// GetLBSRealizationAlarmMessages reads the realization state of the given LBS policy path
+// and collects any alarm messages reported by NSX. Returns "" when no alarms are present
+// or when the realization state cannot be fetched (errors are logged, not propagated).
+// This is used for diagnostic logging when LBCapability is False, so callers can observe
+// what NSX actually reports rather than only seeing the hardcoded condition reason.
+func (s *VPCService) GetLBSRealizationAlarmMessages(lbsPath string) string {
+	results, err := s.NSXClient.RealizedEntitiesClient.List(lbsPath, nil)
+	err = nsxutil.TransNSXApiError(err)
+	if err != nil {
+		log.Error(err, "Failed to read LBS realization state for alarm messages", "LBSPath", lbsPath)
+		return ""
+	}
+	var msgs []string
+	for _, result := range results.Results {
+		for _, alarm := range result.Alarms {
+			if alarm.Message != nil {
+				msgs = append(msgs, *alarm.Message)
+			}
+		}
+	}
+	return strings.Join(msgs, "; ")
+}

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1052,22 +1052,23 @@ func IsEnableAutoSNAT(vpcConnectivityProfile *model.VpcConnectivityProfile) bool
 }
 
 // IsVNAMode reports whether all ServiceGateway.EdgeClusterPaths are VNA cluster paths
-// (/infra/sites/.../virtual-network-appliance-clusters/...). Returns false when the
-// profile or its paths are absent — safe default, avoids false positives on LBCapability.
-func IsVNAMode(profile *model.VpcConnectivityProfile) bool {
+// (/infra/sites/.../virtual-network-appliance-clusters/...).
+// Returns (false, nil) when profile or ServiceGateway is nil — not a VNA deployment.
+// Returns (false, error) when EdgeClusterPaths is empty — ServiceGateway exists but paths
+// are not yet populated; callers should not set LBCapability and should retry.
+func IsVNAMode(profile *model.VpcConnectivityProfile) (bool, error) {
 	if profile == nil || profile.ServiceGateway == nil {
-		return false
+		return false, nil
 	}
-	paths := profile.ServiceGateway.EdgeClusterPaths
-	if len(paths) == 0 {
-		return false
+	if len(profile.ServiceGateway.EdgeClusterPaths) == 0 {
+		return false, fmt.Errorf("VPC connectivity profile has no EdgeClusterPaths, cannot determine VNA mode")
 	}
-	for _, p := range paths {
+	for _, p := range profile.ServiceGateway.EdgeClusterPaths {
 		if !strings.Contains(p, "/virtual-network-appliance-clusters/") {
-			return false
+			return false, nil
 		}
 	}
-	return true
+	return true, nil
 }
 
 func (s *VPCService) GetLBProvider() (LBProvider, error) {

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1058,7 +1058,7 @@ func IsEnableAutoSNAT(vpcConnectivityProfile *model.VpcConnectivityProfile) bool
 // are not yet populated; callers should not set LBCapability and should retry.
 func IsVNAMode(profile *model.VpcConnectivityProfile) (bool, error) {
 	if profile == nil || profile.ServiceGateway == nil {
-		return false, nil
+		return false, fmt.Errorf("VPC connectivity profile or ServiceGateway is nil, cannot determine VNA mode")
 	}
 	if len(profile.ServiceGateway.EdgeClusterPaths) == 0 {
 		return false, fmt.Errorf("VPC connectivity profile has no EdgeClusterPaths, cannot determine VNA mode")

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1282,4 +1282,3 @@ func (s *VPCService) IsDefaultNSXProject(orgID, projectID string) (bool, error) 
 	s.defaultProjectCache.Store(cacheKey, isDefault)
 	return isDefault, nil
 }
-

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -644,63 +644,79 @@ func TestIsEnableAutoSNAT(t *testing.T) {
 }
 
 func TestIsVNAMode(t *testing.T) {
-	// nil profile → false (safe default, no false positive on LBCapability=False)
-	assert.False(t, IsVNAMode(nil))
+	// nil profile → (false, nil): no profile means not VNA
+	isVNA, err := IsVNAMode(nil)
+	assert.NoError(t, err)
+	assert.False(t, isVNA)
 
-	// ServiceGateway nil → false
-	assert.False(t, IsVNAMode(&model.VpcConnectivityProfile{}))
+	// ServiceGateway nil → (false, nil): no service gateway means not VNA
+	isVNA, err = IsVNAMode(&model.VpcConnectivityProfile{})
+	assert.NoError(t, err)
+	assert.False(t, isVNA)
 
-	// ServiceGateway present but EdgeClusterPaths empty → false
-	assert.False(t, IsVNAMode(&model.VpcConnectivityProfile{
+	// EdgeClusterPaths empty → (false, error): profile exists but paths not populated, caller should retry
+	isVNA, err = IsVNAMode(&model.VpcConnectivityProfile{
 		ServiceGateway: &model.VpcServiceGatewayConfig{
 			EdgeClusterPaths: []string{},
 		},
-	}))
+	})
+	assert.Error(t, err)
+	assert.False(t, isVNA)
 
-	// regular edge cluster path → false
-	assert.False(t, IsVNAMode(&model.VpcConnectivityProfile{
+	// regular edge cluster path → (false, nil)
+	isVNA, err = IsVNAMode(&model.VpcConnectivityProfile{
 		ServiceGateway: &model.VpcServiceGatewayConfig{
 			EdgeClusterPaths: []string{
 				"/infra/sites/default/enforcement-points/default/edge-clusters/edge-cluster-1",
 			},
 		},
-	}))
+	})
+	assert.NoError(t, err)
+	assert.False(t, isVNA)
 
-	// service cluster path (distributed TGW) → false
-	assert.False(t, IsVNAMode(&model.VpcConnectivityProfile{
+	// service cluster path (distributed TGW) → (false, nil)
+	isVNA, err = IsVNAMode(&model.VpcConnectivityProfile{
 		ServiceGateway: &model.VpcServiceGatewayConfig{
 			EdgeClusterPaths: []string{"/infra/sites/default/enforcement-points/default/service-clusters/sc-1"},
 		},
-	}))
+	})
+	assert.NoError(t, err)
+	assert.False(t, isVNA)
 
-	// one VNA path, one regular path → false (not all VNA)
-	assert.False(t, IsVNAMode(&model.VpcConnectivityProfile{
+	// one VNA path, one regular path → (false, nil): not all VNA
+	isVNA, err = IsVNAMode(&model.VpcConnectivityProfile{
 		ServiceGateway: &model.VpcServiceGatewayConfig{
 			EdgeClusterPaths: []string{
 				"/infra/sites/default/enforcement-points/default/virtual-network-appliance-clusters/vnac-1",
 				"/infra/sites/default/enforcement-points/default/edge-clusters/edge-cluster-1",
 			},
 		},
-	}))
+	})
+	assert.NoError(t, err)
+	assert.False(t, isVNA)
 
-	// single VNA path → true
-	assert.True(t, IsVNAMode(&model.VpcConnectivityProfile{
+	// single VNA path → (true, nil)
+	isVNA, err = IsVNAMode(&model.VpcConnectivityProfile{
 		ServiceGateway: &model.VpcServiceGatewayConfig{
 			EdgeClusterPaths: []string{
 				"/infra/sites/default/enforcement-points/default/virtual-network-appliance-clusters/vnac-1",
 			},
 		},
-	}))
+	})
+	assert.NoError(t, err)
+	assert.True(t, isVNA)
 
-	// all paths are VNA → true
-	assert.True(t, IsVNAMode(&model.VpcConnectivityProfile{
+	// all paths are VNA → (true, nil)
+	isVNA, err = IsVNAMode(&model.VpcConnectivityProfile{
 		ServiceGateway: &model.VpcServiceGatewayConfig{
 			EdgeClusterPaths: []string{
 				"/infra/sites/site-a/enforcement-points/ep-1/virtual-network-appliance-clusters/vnac-01",
 				"/infra/sites/site-b/enforcement-points/ep-2/virtual-network-appliance-clusters/vnac-02",
 			},
 		},
-	}))
+	})
+	assert.NoError(t, err)
+	assert.True(t, isVNA)
 }
 
 func TestGetLbProvider(t *testing.T) {

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -643,6 +643,66 @@ func TestIsEnableAutoSNAT(t *testing.T) {
 	assert.True(t, IsEnableAutoSNAT(vpcConnProfile))
 }
 
+func TestIsVNAMode(t *testing.T) {
+	// nil profile → false (safe default, no false positive on LBCapability=False)
+	assert.False(t, IsVNAMode(nil))
+
+	// ServiceGateway nil → false
+	assert.False(t, IsVNAMode(&model.VpcConnectivityProfile{}))
+
+	// ServiceGateway present but EdgeClusterPaths empty → false
+	assert.False(t, IsVNAMode(&model.VpcConnectivityProfile{
+		ServiceGateway: &model.VpcServiceGatewayConfig{
+			EdgeClusterPaths: []string{},
+		},
+	}))
+
+	// regular edge cluster path → false
+	assert.False(t, IsVNAMode(&model.VpcConnectivityProfile{
+		ServiceGateway: &model.VpcServiceGatewayConfig{
+			EdgeClusterPaths: []string{
+				"/infra/sites/default/enforcement-points/default/edge-clusters/edge-cluster-1",
+			},
+		},
+	}))
+
+	// service cluster path (distributed TGW) → false
+	assert.False(t, IsVNAMode(&model.VpcConnectivityProfile{
+		ServiceGateway: &model.VpcServiceGatewayConfig{
+			EdgeClusterPaths: []string{"/infra/sites/default/enforcement-points/default/service-clusters/sc-1"},
+		},
+	}))
+
+	// one VNA path, one regular path → false (not all VNA)
+	assert.False(t, IsVNAMode(&model.VpcConnectivityProfile{
+		ServiceGateway: &model.VpcServiceGatewayConfig{
+			EdgeClusterPaths: []string{
+				"/infra/sites/default/enforcement-points/default/virtual-network-appliance-clusters/vnac-1",
+				"/infra/sites/default/enforcement-points/default/edge-clusters/edge-cluster-1",
+			},
+		},
+	}))
+
+	// single VNA path → true
+	assert.True(t, IsVNAMode(&model.VpcConnectivityProfile{
+		ServiceGateway: &model.VpcServiceGatewayConfig{
+			EdgeClusterPaths: []string{
+				"/infra/sites/default/enforcement-points/default/virtual-network-appliance-clusters/vnac-1",
+			},
+		},
+	}))
+
+	// all paths are VNA → true
+	assert.True(t, IsVNAMode(&model.VpcConnectivityProfile{
+		ServiceGateway: &model.VpcServiceGatewayConfig{
+			EdgeClusterPaths: []string{
+				"/infra/sites/site-a/enforcement-points/ep-1/virtual-network-appliance-clusters/vnac-01",
+				"/infra/sites/site-b/enforcement-points/ep-2/virtual-network-appliance-clusters/vnac-02",
+			},
+		},
+	}))
+}
+
 func TestGetLbProvider(t *testing.T) {
 	vpcService := &VPCService{
 		Service: common.Service{

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -644,14 +644,14 @@ func TestIsEnableAutoSNAT(t *testing.T) {
 }
 
 func TestIsVNAMode(t *testing.T) {
-	// nil profile → (false, nil): no profile means not VNA
+	// nil profile → (false, error): cannot determine VNA mode, caller should retry
 	isVNA, err := IsVNAMode(nil)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 	assert.False(t, isVNA)
 
-	// ServiceGateway nil → (false, nil): no service gateway means not VNA
+	// ServiceGateway nil → (false, error): cannot determine VNA mode, caller should retry
 	isVNA, err = IsVNAMode(&model.VpcConnectivityProfile{})
-	assert.NoError(t, err)
+	assert.Error(t, err)
 	assert.False(t, isVNA)
 
 	// EdgeClusterPaths empty → (false, error): profile exists but paths not populated, caller should retry


### PR DESCRIPTION
VNA (VLANBackedVPC) does not support L4 IPv6 Load Balancing when NSX-LB
is in use. NSX Operator now sets an LBCapability status condition on the
system VPCNetworkConfiguration so WCPSVC can observe this limitation
without probing NSX directly.


Setup: TEP-less (VNA) Supervisor with use_native_loadbalancer=True and ip_family=IPv6 or ip_family=DualStack in the nsx-operator config.

Verify condition is set:
```
kubectl get vpcnetworkconfiguration system -o jsonpath='{.status.conditions[?(@.type=="LBCapability")]}'
```

Expected:
```
{
  "lastTransitionTime": "...",
  "reason": "IPv6 LB is not supported as VPCs are hosted on VNA",
  "status": "False",
  "type": "LBCapability"
}
```
