### PR TITLE
Support distributed vxlan connection

### DIFF
--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -40,15 +40,16 @@ const (
 )
 
 var (
-	log                           = logger.Log
-	ResourceTypeVPC               = common.ResourceTypeVpc
-	NewConverter                  = common.NewConverter
-	globalLbProvider              = NoneLB
-	lbProviderMutex               = &sync.Mutex{}
-	MarkedForDelete               = true
-	EnforceRevisionCheckParam     = false
-	TypeGatewayConnection         = "gateway-connections"
-	TypeDistributedVlanConnection = "distributed-vlan-connections"
+	log                            = logger.Log
+	ResourceTypeVPC                = common.ResourceTypeVpc
+	NewConverter                   = common.NewConverter
+	globalLbProvider               = NoneLB
+	lbProviderMutex                = &sync.Mutex{}
+	MarkedForDelete                = true
+	EnforceRevisionCheckParam      = false
+	TypeGatewayConnection          = "gateway-connections"
+	TypeDistributedVlanConnection  = "distributed-vlan-connections"
+	TypeDistributedVXlanConnection = "distributed-vxlan-connections"
 )
 
 type VPCService struct {
@@ -821,6 +822,7 @@ func (s *VPCService) checkVpcAttachmentRealization(createdAttachment *model.VpcA
 func (s *VPCService) GetConnectionTypeFromConnectionPath(connectionPath string) (string, error) {
 	/* examples of connection_path:
 	   /infra/distributed-vlan-connections/gateway-101
+	   /infra/distributed-vxlan-connections/dvxlan-101
 	   /infra/gateway-connections/tenant-1
 	*/
 	parts := strings.Split(connectionPath, "/")
@@ -954,7 +956,7 @@ func (s *VPCService) ValidateConnectionStatus(nc *v1alpha1.VPCNetworkConfigurati
 		case TypeGatewayConnection:
 			status.GatewayConnectionReady = true
 			status.GatewayConnectionReason = ""
-		case TypeDistributedVlanConnection:
+		case TypeDistributedVlanConnection, TypeDistributedVXlanConnection:
 			status.ServiceClusterReady = true
 			status.ServiceClusterReason = ""
 		}

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -853,6 +853,48 @@ func TestValidateConnectionStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "ServiceClusterReadyWithVXlanConnection",
+			expectedStatus: &common.VPCConnectionStatus{
+				GatewayConnectionReady:  false,
+				GatewayConnectionReason: common.ReasonGatewayConnectionNotSet,
+				ServiceClusterReady:     true,
+			},
+			vpcNetworkConfig: v1alpha1.VPCNetworkConfiguration{
+				Spec: v1alpha1.VPCNetworkConfigurationSpec{
+					NSXProject: "/orgs/default/projects/project-quality",
+				},
+			},
+			prepareFunc: func(_ *testing.T, service *VPCService) (patches *gomonkey.Patches) {
+				patches = gomonkey.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VPCConnectivityProfilesClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{
+						model.VpcConnectivityProfile{
+							ServiceGateway: &model.VpcServiceGatewayConfig{
+								Enable:           common.Bool(true),
+								EdgeClusterPaths: []string{"/service-cluster-path"},
+							},
+							TransitGatewayPath: common.String("/transit-gateway"),
+						},
+						nil,
+					},
+					Times: 1,
+				}})
+				patches.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.TransitGatewayAttachmentClient), "List", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{
+						model.TransitGatewayAttachmentListResult{
+							Results: []model.TransitGatewayAttachment{
+								{
+									ConnectionPath: common.String("/infra/distributed-vxlan-connections/dvxlan-103"),
+								},
+							},
+						},
+						nil,
+					},
+					Times: 1,
+				}})
+				return patches
+			},
+		},
+		{
 			name: "GatewayConnectionReady",
 			expectedStatus: &common.VPCConnectionStatus{
 				GatewayConnectionReady: true,


### PR DESCRIPTION
Connection distributed-vxlan-connections shall be considered as DTGW ready

Testing done:
Observed lb snat ip can be updated for VPC on transit gateway with distributed-vxlan-connections connection

```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: NetworkInfo
metadata:
  creationTimestamp: "2026-06-08T11:00:06Z"
  generation: 3
  name: eorg-2-tgw-1-vpc-1-region1-ns-1-ptx5d
  namespace: eorg-2-tgw-1-vpc-1-region1-ns-1-ptx5d
  resourceVersion: "2193200"
  uid: e86c9175-a5e6-4463-8102-1f148a7811dd
vpcs:
- defaultSNATIP: 40.138.0.112
  loadBalancerBackendIPs:
  - 100.64.32.3
  loadBalancerIPAddresses: 100.64.32.3
  name: eorg-2-tgw-1-vpc-1-region1
  networkStack: FullStackVPC
  privateIPs:
  - 172.20.0.0/16
```

Observed ServiceClusterReady can be ready when using VPC Connectivity Profile with distributed-vxlan-connections

```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: VPCNetworkConfiguration
metadata:
  creationTimestamp: "2026-06-10T04:28:01Z"
  generation: 1
  name: system
  resourceVersion: "22296"
  uid: 5f2896ee-05dc-457c-b8d0-b7e776f42329
spec:
  defaultIPv6PrefixLength: 64
  defaultSubnetSize: 8
  nsxProject: /orgs/default/projects/default
  privateIPs:
  - 172.30.0.0/16
  vpcConnectivityProfile: /orgs/default/projects/default/vpc-connectivity-profiles/vxlantgw-VpcConnectivityProfile-UJsRjFWj0Z
status:
  conditions:
  - reason: GatewayConnectionNotSet
    status: "False"
    type: GatewayConnectionReady
  - lastTransitionTime: "2026-06-10T05:15:20Z"
    status: "True"
    type: ServiceClusterReady
  - lastTransitionTime: "2026-06-10T04:29:34Z"
    status: "True"
    type: ExternalIPBlocksConfigured
  - lastTransitionTime: "2026-06-10T04:29:34Z"
    status: "True"
    type: AutoSnatEnabled
  vpcs:
  - name: kube-system_9rjdc
    nsxLoadBalancerPath: /orgs/default/projects/default/vpcs/kube-system_9rjdc/vpc-lbs/default
    vpcPath: /orgs/default/projects/default/vpcs/kube-system_9rjdc
```