### PR TITLE
Fix dangling ContainerApplicationIds in ContainerApplicationInstance when Service is deleted

### DIFF
--- a/pkg/mock/realizedentitiesclient/client.go
+++ b/pkg/mock/realizedentitiesclient/client.go
@@ -7,8 +7,8 @@ package mocks
 import (
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
 	model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockRealizedEntitiesClient is a mock of RealizedEntitiesClient interface.

--- a/pkg/nsx/services/inventory/build_test.go
+++ b/pkg/nsx/services/inventory/build_test.go
@@ -784,6 +784,41 @@ func TestApplyServiceIDUpdates(t *testing.T) {
 	assert.Equal(t, instance.ExternalId, inventoryService.requestBuffer[0].ContainerObject["external_id"])
 }
 
+func TestRemoveDeletedServiceIDFromApplicationInstances(t *testing.T) {
+	inventoryService, _ := createService(t)
+
+	staleInstance1 := &containerinventory.ContainerApplicationInstance{
+		ExternalId:              "stale-pod-uid-1",
+		ContainerApplicationIds: []string{"service-uid-789", "service-uid-999"},
+	}
+
+	staleInstance2 := &containerinventory.ContainerApplicationInstance{
+		ExternalId:              "stale-pod-uid-2",
+		ContainerApplicationIds: []string{"service-uid-789"},
+	}
+
+	normalInstance := &containerinventory.ContainerApplicationInstance{
+		ExternalId:              "normal-pod-uid",
+		ContainerApplicationIds: []string{"service-uid-999"},
+	}
+
+	inventoryService.ApplicationInstanceStore.Add(staleInstance1)
+	inventoryService.ApplicationInstanceStore.Add(staleInstance2)
+	inventoryService.ApplicationInstanceStore.Add(normalInstance)
+
+	inventoryService.removeDeletedServiceIDFromApplicationInstances("service-uid-789")
+
+	updatedInstance1 := inventoryService.ApplicationInstanceStore.GetByKey("stale-pod-uid-1").(*containerinventory.ContainerApplicationInstance)
+	assert.NotContains(t, updatedInstance1.ContainerApplicationIds, "service-uid-789")
+	assert.Contains(t, updatedInstance1.ContainerApplicationIds, "service-uid-999")
+
+	updatedInstance2 := inventoryService.ApplicationInstanceStore.GetByKey("stale-pod-uid-2").(*containerinventory.ContainerApplicationInstance)
+	assert.NotContains(t, updatedInstance2.ContainerApplicationIds, "service-uid-789")
+
+	updatedInstance3 := inventoryService.ApplicationInstanceStore.GetByKey("normal-pod-uid").(*containerinventory.ContainerApplicationInstance)
+	assert.Contains(t, updatedInstance3.ContainerApplicationIds, "service-uid-999")
+}
+
 func TestUpdateServiceIDsForApplicationInstance(t *testing.T) {
 	inventoryService, k8sClient := createService(t)
 

--- a/pkg/nsx/services/inventory/builder.go
+++ b/pkg/nsx/services/inventory/builder.go
@@ -517,6 +517,18 @@ func (s *InventoryService) removeStaleServiceIDsFromApplicationInstances(podUIDs
 	return false
 }
 
+func (s *InventoryService) removeDeletedServiceIDFromApplicationInstances(serviceUID string) {
+	allInstances := s.ApplicationInstanceStore.List()
+	for _, instObj := range allInstances {
+		inst := instObj.(*containerinventory.ContainerApplicationInstance)
+		if !util.Contains(inst.ContainerApplicationIds, serviceUID) {
+			continue
+		}
+		newIds := util.FilterOut(inst.ContainerApplicationIds, serviceUID)
+		s.applyServiceIDUpdates(inst, newIds)
+	}
+}
+
 func (s *InventoryService) BuildNode(node *corev1.Node) (retry bool) {
 	log.Trace("Building Node", "Node", node.Name)
 	retry = false

--- a/pkg/nsx/services/inventory/service.go
+++ b/pkg/nsx/services/inventory/service.go
@@ -49,6 +49,7 @@ func (s *InventoryService) SyncContainerApplication(name, namespace string, key 
 	externalId := key.ExternalId
 	if apierrors.IsNotFound(err) ||
 		((err == nil) && (string(service.UID) != externalId)) {
+		s.removeDeletedServiceIDFromApplicationInstances(externalId)
 		err = s.DeleteResource(externalId, ContainerApplication)
 		if err != nil {
 			log.Error(err, "Delete ContainerApplication Resource error", "key", key)
@@ -74,6 +75,7 @@ func (s *InventoryService) CleanStaleInventoryApplication() error {
 		if project == nil {
 			log.Info("Cannot find ContainerProject by id, so clean up stale ContainerApplication", "Project Id",
 				inventoryApplication.ContainerProjectId, "Application name", inventoryApplication.DisplayName, "External Id", inventoryApplication.ExternalId)
+			s.removeDeletedServiceIDFromApplicationInstances(inventoryApplication.ExternalId)
 			err := s.DeleteResource(inventoryApplication.ExternalId, ContainerApplication)
 			if err != nil {
 				log.Error(err, "Clean stale InventoryApplication", "External Id", inventoryApplication.ExternalId)
@@ -81,6 +83,7 @@ func (s *InventoryService) CleanStaleInventoryApplication() error {
 			}
 		} else if s.isApplicationDeleted(project.(*containerinventory.ContainerProject).DisplayName, inventoryApplication.DisplayName, inventoryApplication.ExternalId) {
 			log.Info("Clean stale inventoryApplication", "Name", inventoryApplication.DisplayName, "External Id", inventoryApplication.ExternalId)
+			s.removeDeletedServiceIDFromApplicationInstances(inventoryApplication.ExternalId)
 			err := s.DeleteResource(inventoryApplication.ExternalId, ContainerApplication)
 			if err != nil {
 				log.Error(err, "Clean stale InventoryApplication", "External Id", inventoryApplication.ExternalId)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -236,7 +236,7 @@ func Contains(s []string, str string) bool {
 }
 
 func FilterOut(s []string, strToRemove string) []string {
-	var result []string
+	result := make([]string, 0)
 	for _, element := range s {
 		if element != strToRemove {
 			result = append(result, element)

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -809,6 +809,24 @@ func (data *TestData) waitForResourceExist(namespace string, resourceType string
 	return err
 }
 
+func (data *TestData) waitForContainerApplicationInstanceToContainAppId(podName string, appId string, shouldContain bool) error {
+	return wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, defaultTimeout, false, func(ctx context.Context) (bool, error) {
+		queryParam := fmt.Sprintf("resource_type:ContainerApplicationInstance AND display_name:*%s* AND container_application_ids:*%s*", podName, appId)
+		var cursor *string
+		var pageSize int64 = 500
+		response, err := data.nsxClient.QueryClient.List(queryParam, cursor, nil, &pageSize, nil, nil)
+		if err != nil {
+			return false, err
+		}
+
+		exist := len(response.Results) > 0
+		if exist != shouldContain {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
 func (data *TestData) waitForResourceExistOrNot(namespace string, resourceType string, resourceName string, shouldExist bool) error {
 	return data.waitForResourceExist(namespace, resourceType, "display_name", resourceName, shouldExist)
 }

--- a/test/e2e/nsx_inventory_test.go
+++ b/test/e2e/nsx_inventory_test.go
@@ -119,7 +119,7 @@ func testPodServiceDeletionInventoryUpdate(t *testing.T) {
 
 	// Create a pod
 	podName := fmt.Sprintf("test-pod-svc-%s", getRandomString())
-	pod, err := testData.createPod(ns, podName, containerName, podImage, corev1.ProtocolTCP, 80)
+	_, err := testData.createPod(ns, podName, containerName, podImage, corev1.ProtocolTCP, 80)
 	if err != nil {
 		t.Fatalf("Failed to create pod: %v", err)
 	}

--- a/test/e2e/nsx_inventory_test.go
+++ b/test/e2e/nsx_inventory_test.go
@@ -35,6 +35,10 @@ func TestInventorySync(t *testing.T) {
 			StartParallel(t)
 			testPodSync(t)
 		})
+		RunSubtest(t, "testPodServiceDeletionInventoryUpdate", func(t *testing.T) {
+			StartParallel(t)
+			testPodServiceDeletionInventoryUpdate(t)
+		})
 		RunSubtest(t, "testServiceSync", func(t *testing.T) {
 			StartParallel(t)
 			testServiceSync(t)
@@ -103,6 +107,73 @@ func testPodSync(t *testing.T) {
 	// Wait for the pod to be removed from the NSX inventory
 	err = testData.waitForResourceExistOrNot(ns, "ContainerApplicationInstance", podName, false)
 	assert.NoError(t, err, "Pod was not removed from NSX inventory")
+}
+
+// testPodServiceDeletionInventoryUpdate tests that a deleted Kubernetes service is removed from the pod's ContainerApplicationInstance
+func testPodServiceDeletionInventoryUpdate(t *testing.T) {
+	_, deadlineCancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer deadlineCancel()
+
+	// Use the pre-created namespace
+	ns := NsInventorySync
+
+	// Create a pod
+	podName := fmt.Sprintf("test-pod-svc-%s", getRandomString())
+	pod, err := testData.createPod(ns, podName, containerName, podImage, corev1.ProtocolTCP, 80)
+	if err != nil {
+		t.Fatalf("Failed to create pod: %v", err)
+	}
+
+	// Wait for the pod to be ready
+	_, err = testData.podWaitFor(resourceReadyTime, podName, ns, func(pod *corev1.Pod) (bool, error) {
+		return pod.Status.Phase == corev1.PodRunning, nil
+	})
+	if err != nil {
+		t.Fatalf("Pod did not become ready: %v", err)
+	}
+
+	// Wait for the pod to be synced to the NSX inventory as a ContainerApplicationInstance
+	err = testData.waitForResourceExistOrNot(ns, "ContainerApplicationInstance", podName, true)
+	assert.NoError(t, err, "Pod was not synced to NSX inventory as ContainerApplicationInstance")
+
+	// Create a service selecting the pod
+	serviceName := fmt.Sprintf("test-service-%s", getRandomString())
+	port := int32(80)
+	targetPort := int32(80)
+	selector := map[string]string{"app": podName}
+
+	service, err := testData.createService(ns, serviceName, port, targetPort, corev1.ProtocolTCP, selector, corev1.ServiceTypeClusterIP)
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+
+	// Wait for the service to be synced to the NSX inventory as a ContainerApplication
+	err = testData.waitForResourceExistOrNot(ns, "ContainerApplication", serviceName, true)
+	assert.NoError(t, err, "Service was not synced to NSX inventory as ContainerApplication")
+
+	// Wait for the pod's ContainerApplicationInstance to contain the service's UID
+	err = testData.waitForContainerApplicationInstanceToContainAppId(podName, string(service.UID), true)
+	assert.NoError(t, err, "Pod's ContainerApplicationInstance did not contain the service's UID")
+
+	// Delete the service
+	err = testData.clientset.CoreV1().Services(ns).Delete(context.TODO(), serviceName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Failed to delete service: %v", err)
+	}
+
+	// Wait for the service to be removed from the NSX inventory
+	err = testData.waitForResourceExistOrNot(ns, "ContainerApplication", serviceName, false)
+	assert.NoError(t, err, "Service was not removed from NSX inventory")
+
+	// Wait for the pod's ContainerApplicationInstance to NOT contain the service's UID
+	err = testData.waitForContainerApplicationInstanceToContainAppId(podName, string(service.UID), false)
+	assert.NoError(t, err, "Pod's ContainerApplicationInstance still contained the service's UID after service deletion")
+
+	// Clean up pod
+	err = testData.clientset.CoreV1().Pods(ns).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Failed to delete pod: %v", err)
+	}
 }
 
 // testServiceSync tests that a Kubernetes service is synced to the NSX inventory as a ContainerApplication


### PR DESCRIPTION
When a Service is deleted, nsx-operator only deleted the ContainerApplication
resource, but failed to update the associated ContainerApplicationInstance
(Pod) resources to remove the Service UID. This caused a dangling reference
in the inventory.

This commit introduces a cleanup step that strips the deleted Service UID
from all associated Pod instances and updates the NSX inventory properly.

Testing done:
```
1. Only apply the e2e case commit "e2e: add test for stale service UID in ContainerApplicationInstance", the e2e run failed:
2026-06-11 05:40:54,227 INFO util [util.py:49]: === NAME  TestInventorySync/ParallelTests/testPodServiceDeletionInventoryUpdate
2026-06-11 05:40:54,227 INFO util [util.py:49]:     nsx_inventory_test.go:170:
2026-06-11 05:40:54,227 INFO util [util.py:49]:         	Error Trace:	/root/nsx-operator/test/e2e/nsx_inventory_test.go:170
2026-06-11 05:40:54,227 INFO util [util.py:49]:         	            				/root/nsx-operator/test/e2e/nsx_inventory_test.go:40
2026-06-11 05:40:54,227 INFO util [util.py:49]:         	            				/root/nsx-operator/test/e2e/main_test.go:91
2026-06-11 05:40:54,227 INFO util [util.py:49]:         	Error:      	Received unexpected error:
2026-06-11 05:40:54,227 INFO util [util.py:49]:         	            	context deadline exceeded
2026-06-11 05:40:54,227 INFO util [util.py:49]:         	Test:       	TestInventorySync/ParallelTests/testPodServiceDeletionInventoryUpdate
2026-06-11 05:40:54,227 INFO util [util.py:49]:         	Messages:   	Pod's ContainerApplicationInstance still contained the service's UID after service deletion
2. Additionally apply the fix commit "Fix dangling ContainerApplicationIds in ContainerApplicationInstance when Service is deleted", the e2e case testPodServiceDeletionInventoryUpdate passed.
```