### PR TITLE
Add nsx operator coverage image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ IMG ?= controller:latest
 ENVTEST_K8S_VERSION = 1.22
 LDFLAGS            :=
 GOFLAGS            :=
+COVERAGE	       ?= false
 BINDIR             ?= $(CURDIR)/bin
 GO_FILES           := $(shell find . -type d -name '.cache' -prune -o -type f -name '*.go' -print)
 
@@ -93,7 +94,11 @@ test: manifests generate fmt vet envtest .coverage ## Run tests with clean outpu
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
 	@mkdir -p $(BINDIR)
+ifeq ($(COVERAGE), true)
+	GOOS=linux go build -o $(BINDIR)/manager -covermode atomic $(GOFLAGS) -ldflags '$(LDFLAGS)' cmd/main.go
+else
 	GOOS=linux go build -o $(BINDIR)/manager $(GOFLAGS) -ldflags '$(LDFLAGS)' cmd/main.go
+endif
 
 .PHONY: build-clean
 build-clean: generate fmt vet ## Build clean binary.

--- a/build/image/photon-coverage/Dockerfile
+++ b/build/image/photon-coverage/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.25.7 as golang-build
+
+WORKDIR /source
+
+COPY . /source
+RUN CGO_ENABLED=0 go build -o manager -covermode atomic cmd/main.go
+RUN CGO_ENABLED=0 go build -o clean -covermode atomic cmd_clean/main.go
+
+FROM photon
+
+RUN tdnf -y install shadow && \
+    useradd -s /bin/bash nsx-operator
+
+COPY --from=golang-build /source/manager /usr/local/bin/
+COPY --from=golang-build /source/clean /usr/local/bin/
+
+USER nsx-operator
+
+ENTRYPOINT ["/usr/local/bin/manager"]


### PR DESCRIPTION
Testing done:

QE verified coverage code can be collected with the coverage image.