### PR TITLE
Fix node TN ID lookup failure due to FQDN case sensitivity

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,6 +135,8 @@ type NsxConfig struct {
 	VpcWcpEnhance *bool `ini:"vpc_wcp_enhance"`
 	// RestoreVif controls whether SubnetPort vif should be restored during restore mode.
 	RestoreVif *bool `ini:"restore_vif"`
+	// TnIdCheckInterval is the interval in seconds to check TN ID for node.
+	TnIdCheckInterval int `ini:"tn_id_check_interval"`
 }
 
 type K8sConfig struct {
@@ -269,6 +271,7 @@ func NewNSXOpertorConfig() *NSXOperatorConfig {
 		&NsxConfig{
 			InventoryBatchPeriod: 5,
 			InventoryBatchSize:   50,
+			TnIdCheckInterval:    300,
 		},
 		&K8sConfig{},
 		&VCConfig{},

--- a/pkg/nsx/services/node/node.go
+++ b/pkg/nsx/services/node/node.go
@@ -2,7 +2,8 @@ package node
 
 import (
 	"fmt"
-	"sync"
+	"strings"
+	"time"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"k8s.io/client-go/tools/cache"
@@ -21,15 +22,10 @@ var (
 type NodeService struct {
 	servicecommon.Service
 	NodeStore *NodeStore
+	stopChan  chan struct{}
 }
 
 func InitializeNode(service servicecommon.Service) (*NodeService, error) {
-	wg := sync.WaitGroup{}
-	wgDone := make(chan bool)
-	fatalErrors := make(chan error)
-
-	wg.Add(1)
-
 	nodeService := &NodeService{
 		Service: service,
 		NodeStore: &NodeStore{
@@ -43,79 +39,124 @@ func InitializeNode(service servicecommon.Service) (*NodeService, error) {
 				BindingType: model.HostTransportNodeBindingType(),
 			},
 		},
+		stopChan: make(chan struct{}),
 	}
-	// TODO: confirm whether we can remove the following initialization because node doesn't have the cluster tag so it's a dry run
-	go nodeService.InitializeResourceStore(&wg, fatalErrors, ResourceTypeNode, nil, nodeService.NodeStore)
 
-	go func() {
-		wg.Wait()
-		close(wgDone)
-	}()
-
-	select {
-	case <-wgDone:
-		break
-	case err := <-fatalErrors:
-		return nodeService, err
-	}
+	nodeService.startPeriodicSync()
 
 	return nodeService, nil
-
 }
 
-func (service *NodeService) GetNodeByName(nodeName string) []*model.HostTransportNode {
-	return service.NodeStore.GetByIndex(servicecommon.IndexKeyNodeName, nodeName)
+func (service *NodeService) startPeriodicSync() {
+	checkInterval := time.Duration(service.NSXClient.NsxConfig.TnIdCheckInterval) * time.Second
+	if checkInterval <= 0 {
+		checkInterval = 5 * time.Minute
+	}
+	ticker := time.NewTicker(checkInterval)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				if err := service.syncAllNodes(); err != nil {
+					log.Error(err, "Failed to periodically sync nodes from NSX")
+				}
+			case <-service.stopChan:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
 }
 
-func (service *NodeService) SyncNodeStore(nodeName string, deleted bool) error {
-	nodes := service.NodeStore.GetByIndex(servicecommon.IndexKeyNodeName, nodeName)
-	if len(nodes) > 1 {
-		return fmt.Errorf("multiple nodes found for node name %s", nodeName)
-	}
-	// TODO: confirm whether we need to resync the node info from NSX
-	if len(nodes) == 1 {
-		log.Info("node alreay cached", "node.Fqdn", nodes[0].NodeDeploymentInfo.Fqdn, "node.UniqueId", *nodes[0].UniqueId)
-		// updatedNode, err := service.NSXClient.HostTransPortNodesClient.Get("default", "default", nodes[0].Id)
-		// if err != nil {
-		// 	return fmt.Errorf("failed to get HostTransPortNode for node %s: %s", nodeName, err)
-		// }
-		// node.NodeStore.Apply(updatedNode)
-	}
+func (service *NodeService) syncAllNodes() error {
+	log.Info("Periodically syncing nodes from NSX")
 	nodeResults, err := service.NSXClient.HostTransPortNodesClient.List("default", "default", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		return fmt.Errorf("failed to list HostTransportNodes: %s", err)
 	}
-	if deleted {
-		nodes := service.NodeStore.GetByIndex(servicecommon.IndexKeyNodeName, nodeName)
-		if len(nodes) == 0 {
-			log.Info("skip deleting node in store because the node is not in store", "nodeName", nodeName)
-			return nil
-		}
-		for _, node := range nodes {
-			node.MarkedForDelete = servicecommon.Bool(true)
-			service.NodeStore.Apply(node)
+
+	keys := service.NodeStore.ListIndexFuncValues(servicecommon.IndexKeyNodeName)
+
+	nsxNodeMap := make(map[string]*model.HostTransportNode)
+	for i := range nodeResults.Results {
+		node := nodeResults.Results[i]
+		if node.NodeDeploymentInfo != nil && node.NodeDeploymentInfo.Fqdn != nil {
+			nsxNodeMap[strings.ToLower(*node.NodeDeploymentInfo.Fqdn)] = &node
 		}
 	}
-	synced := false
-	for _, node := range nodeResults.Results {
-		node := node
-		if *node.NodeDeploymentInfo.Fqdn == nodeName {
-			if deleted {
-				// Retry until the NSX HostTransportNode is deleted.
-				return fmt.Errorf("node %s had beed deleted but HostTransportNodes still exists", nodeName)
+
+	for key := range keys {
+		if nsxNode, ok := nsxNodeMap[key]; ok {
+			// Node exists in NSX, update local store
+			if err := service.NodeStore.Apply(nsxNode); err != nil {
+				log.Error(err, "failed to apply node to store", "nodeName", key)
 			}
-			err = service.NodeStore.Apply(&node)
-			if err != nil {
-				return fmt.Errorf("failed to sync node %s: %s", nodeName, err)
+		} else {
+			// Node is in local store but no longer in NSX, mark for delete and remove
+			log.Info("Node found in local store but missing in NSX, deleting from store", "nodeName", key)
+			nodes := service.NodeStore.GetByIndex(servicecommon.IndexKeyNodeName, key)
+			for _, node := range nodes {
+				node.MarkedForDelete = servicecommon.Bool(true)
+				if err := service.NodeStore.Apply(node); err != nil {
+					log.Error(err, "failed to delete node from store", "nodeName", key)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (service *NodeService) GetNodeByName(nodeName string) []*model.HostTransportNode {
+	return service.NodeStore.GetByIndex(servicecommon.IndexKeyNodeName, strings.ToLower(nodeName))
+}
+
+func (service *NodeService) SyncNodeStore(nodeName string, deleted bool) error {
+	nodeNameLower := strings.ToLower(nodeName)
+
+	if deleted {
+		log.Info("Deleting node from store", "nodeName", nodeName)
+		nodes := service.NodeStore.GetByIndex(servicecommon.IndexKeyNodeName, nodeNameLower)
+		for _, node := range nodes {
+			node.MarkedForDelete = servicecommon.Bool(true)
+			if err := service.NodeStore.Apply(node); err != nil {
+				return fmt.Errorf("failed to delete node %s from store: %s", nodeName, err)
+			}
+		}
+		return nil
+	}
+
+	nodes := service.NodeStore.GetByIndex(servicecommon.IndexKeyNodeName, nodeNameLower)
+	if len(nodes) > 1 {
+		return fmt.Errorf("multiple nodes found for node name %s in store", nodeName)
+	}
+	if len(nodes) == 1 {
+		log.Debug("Node already cached, skipping NSX query in event handler", "nodeName", nodeName)
+		return nil
+	}
+
+	log.Info("Node cache missed, querying from NSX", "nodeName", nodeName)
+	nodeResults, err := service.NSXClient.HostTransPortNodesClient.List("default", "default", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	err = nsxutil.TransNSXApiError(err)
+	if err != nil {
+		return fmt.Errorf("failed to list HostTransportNodes: %s", err)
+	}
+
+	synced := false
+	for i := range nodeResults.Results {
+		node := nodeResults.Results[i]
+		if node.NodeDeploymentInfo != nil && node.NodeDeploymentInfo.Fqdn != nil && strings.EqualFold(*node.NodeDeploymentInfo.Fqdn, nodeName) {
+			if err := service.NodeStore.Apply(&node); err != nil {
+				return fmt.Errorf("failed to apply node %s to store: %s", nodeName, err)
 			}
 			synced = true
+			log.Info("Successfully synced node from NSX", "nodeName", nodeName)
 			break
 		}
 	}
-	if !synced && !deleted {
-		// Retry until the NSX HostTransportNode is available.
-		return fmt.Errorf("node %s not found yet in NSX side", nodeName)
+
+	if !synced {
+		return fmt.Errorf("node %s not found in NSX", nodeName)
 	}
 	return nil
 }

--- a/pkg/nsx/services/node/node_test.go
+++ b/pkg/nsx/services/node/node_test.go
@@ -1,14 +1,10 @@
 package node
 
 import (
-	"reflect"
-	"sync"
+	"strings"
 	"testing"
 
-	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcement_points"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"k8s.io/client-go/tools/cache"
@@ -57,6 +53,9 @@ func createMockNodeService() *NodeService {
 					CoeConfig: &config.CoeConfig{
 						Cluster: "k8scl-one:test",
 					},
+					NsxConfig: &config.NsxConfig{
+						TnIdCheckInterval: 300,
+					},
 				},
 			},
 		},
@@ -76,26 +75,6 @@ func createMockNodeService() *NodeService {
 
 func TestInitializeNode(t *testing.T) {
 	mockService := createMockNodeService()
-
-	var tc *bindings.TypeConverter
-	patches := gomonkey.ApplyMethod(reflect.TypeOf(tc), "ConvertToGolang",
-		func(_ *bindings.TypeConverter, d data.DataValue, b bindings.BindingType) (interface{}, []error) {
-			mId, mTag, mScope := "11111", "11111", "11111"
-			m := model.HostTransportNode{
-				Id:   &mId,
-				Tags: []model.Tag{{Tag: &mTag, Scope: &mScope}},
-			}
-			var j interface{} = m
-			return j, nil
-		})
-	defer patches.Reset()
-
-	patch := gomonkey.ApplyMethod(reflect.TypeOf(&mockService.Service), "InitializeResourceStore", func(_ *servicecommon.Service, wg *sync.WaitGroup,
-		fatalErrors chan error, resourceTypeValue string, tags []model.Tag, store servicecommon.Store,
-	) {
-		wg.Done()
-	})
-	defer patch.Reset()
 
 	nodeService, err := InitializeNode(mockService.Service)
 	assert.NoError(t, err)
@@ -119,18 +98,24 @@ func TestNodeService_GetNodeByName(t *testing.T) {
 	nodes := service.GetNodeByName(nodeName)
 	assert.Len(t, nodes, 1)
 	assert.Equal(t, nodeName, *nodes[0].NodeDeploymentInfo.Fqdn)
+
+	// Test case-insensitive
+	nodesUpper := service.GetNodeByName("TEST-NODE")
+	assert.Len(t, nodesUpper, 1)
+	assert.Equal(t, nodeName, *nodesUpper[0].NodeDeploymentInfo.Fqdn)
 }
 
 func TestNodeService_SyncNodeStore(t *testing.T) {
 	logf.SetLogger(logger.ZapCustomLogger(false, 0).Logger)
 	service := createMockNodeService()
 	nodeName := "test-node"
+
 	// Test case: Node not found
 	err := service.SyncNodeStore("non-existent-node", false)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "node non-existent-node not found yet in NSX side")
+	assert.Contains(t, err.Error(), "node non-existent-node not found in NSX")
 
-	err = service.SyncNodeStore(nodeName, false)
+	err = service.SyncNodeStore("TEST-NODE", false)
 	assert.NoError(t, err)
 
 	nodes := service.GetNodeByName(nodeName)
@@ -139,9 +124,52 @@ func TestNodeService_SyncNodeStore(t *testing.T) {
 
 	// Test case: Node deletion
 	err = service.SyncNodeStore(nodeName, true)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 
-	nodes = service.GetNodeByName(nodeName)
+	nodes = service.NodeStore.GetByIndex(servicecommon.IndexKeyNodeName, strings.ToLower(nodeName))
+	assert.Len(t, nodes, 0)
+}
+
+func TestNodeService_SyncAllNodes(t *testing.T) {
+	logf.SetLogger(logger.ZapCustomLogger(false, 0).Logger)
+	service := createMockNodeService()
+	nodeName := "test-node"
+
+	// First, add a node to the store (simulating K8s Node Add event)
+	err := service.SyncNodeStore(nodeName, false)
+	assert.NoError(t, err)
+
+	// Now run syncAllNodes
+	err = service.syncAllNodes()
+	assert.NoError(t, err)
+
+	nodes := service.GetNodeByName(nodeName)
+	assert.Len(t, nodes, 1)
+	assert.Equal(t, nodeName, *nodes[0].NodeDeploymentInfo.Fqdn)
+
+	// Test case: Node deleted from NSX side
+	// Add a dummy node to local store that doesn't exist in the mocked NSX List response
+	dummyNodeName := "dummy-node"
+	dummyNodeId := "dummy-id"
+	dummyNode := &model.HostTransportNode{
+		UniqueId: &dummyNodeId,
+		NodeDeploymentInfo: &model.FabricHostNode{
+			Fqdn: &dummyNodeName,
+		},
+	}
+	err = service.NodeStore.Add(dummyNode)
+	assert.NoError(t, err)
+
+	// Verify dummy node is in store
+	nodes = service.GetNodeByName(dummyNodeName)
+	assert.Len(t, nodes, 1)
+
+	// Run syncAllNodes, it should detect dummy-node is missing in NSX and delete it from local store
+	err = service.syncAllNodes()
+	assert.NoError(t, err)
+
+	// Verify dummy node is deleted
+	nodes = service.GetNodeByName(dummyNodeName)
 	assert.Len(t, nodes, 0)
 }
 

--- a/pkg/nsx/services/node/store.go
+++ b/pkg/nsx/services/node/store.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
@@ -65,7 +66,10 @@ func keyFunc(obj interface{}) (string, error) {
 func nodeIndexByNodeName(obj interface{}) ([]string, error) {
 	switch o := obj.(type) {
 	case *model.HostTransportNode:
-		return []string{*o.NodeDeploymentInfo.Fqdn}, nil
+		if o.NodeDeploymentInfo != nil && o.NodeDeploymentInfo.Fqdn != nil {
+			return []string{strings.ToLower(*o.NodeDeploymentInfo.Fqdn)}, nil
+		}
+		return nil, nil
 	default:
 		return nil, errors.New("nodeIndexByNodeName doesn't support unknown type")
 	}

--- a/pkg/nsx/services/node/store_test.go
+++ b/pkg/nsx/services/node/store_test.go
@@ -22,6 +22,20 @@ func Test_KeyFunc(t *testing.T) {
 	})
 }
 
+func Test_nodeIndexByNodeName(t *testing.T) {
+	nodeName := "Test-Node.Local"
+	node := model.HostTransportNode{
+		NodeDeploymentInfo: &model.FabricHostNode{
+			Fqdn: &nodeName,
+		},
+	}
+	t.Run("case_insensitive_fqdn", func(t *testing.T) {
+		got, err := nodeIndexByNodeName(&node)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"test-node.local"}, got)
+	})
+}
+
 func TestSubnetStore_Apply(t *testing.T) {
 	resourceStore := common.ResourceStore{
 		Indexer: cache.NewIndexer(


### PR DESCRIPTION
Fix node TN ID lookup failure due to FQDN case sensitivity and optimize sync strategy

When the ESX host FQDN in NSX contains uppercase letters (e.g., Host-A.domain.local),
nsx-operator failed to match it with the Kubernetes node name which is typically lowercase,
resulting in "Failed to get Node ID for Pod" errors and pods stuck in ProviderFailed state.

This commit fixes the issue and optimizes the synchronization strategy by:
1. Making the NodeStore index key case-insensitive by converting FQDNs to lowercase.
2. Implementing a background goroutine that periodically performs a full `List` of NSX
   HostTransportNodes to keep the local cache fresh. The interval is configurable via
   `tn_id_check_interval` in `ncp.ini` (default 5 minutes).
3. Preventing store pollution by ensuring the background sync only updates nodes that
   are already known to Kubernetes (i.e., existing keys in the local NodeStore).
4. Removing the `InitializeResourceStore` logic for nodes on startup. This was a dry run
   that always returned 0 results (since HostTransportNodes lack cluster tags), resulting
   in an unnecessary NSX Search API call.

The refactored workflow:
1. Background Periodic Sync Workflow
```
+-----------------------------------------------------------------------------------------+
| NodeService.startPeriodicSync()                                                         |
|                                                                                         |
|  1. Ticker triggers every `tn_id_check_interval` (default 5 mins)                       |
|          |                                                                              |
|          v                                                                              |
|  2. Trigger full query: NSXClient.HostTransPortNodesClient.List()                       |
|          |                                                                              |
|          v                                                                              |
|    +-------------+                                                                      |
|    | NSX Manager |                                                                      |
|    +-------------+                                                                      |
|          |                                                                              |
|          | 3. Return all HostTransportNodes list                                        |
|          v                                                                              |
|  4. Build `nsxNodeMap` from results (Key: lowercase FQDN, Value: Node)                  |
|          |                                                                              |
|          v                                                                              |
|  5. Get all keys currently in local NodeStore (Nodes known to K8s)                      |
|          |                                                                              |
|          v                                                                              |
|  6. Iterate over local keys:                                                            |
|     For each `key`:                                                                     |
|       If `nsxNodeMap` has `key`:                                                        |
|           NodeStore.Apply(nsxNode)  <-- Update local cache with fresh NSX data          |
|       Else:                                                                             |
|           NodeStore.Delete(key)     <-- Node deleted in NSX, remove from local cache    |
|                                                                                         |
|  7. Sleep until next tick                                                               |
+-----------------------------------------------------------------------------------------+
```
2. Node Add Workflow (Triggered by K8s Node Event)
```
+----------------+
| K8s API Server |
+----------------+
        |
        | 1. Node Event (Add / Update)
        v
+----------------+
| NodeController |
+----------------+
        |
        | 2. Reconcile(nodeName)
        |    Calls SyncNodeStore(nodeName, deleted=false)
        v
+-----------------------------------------------------------------------------------------+
| NodeService.SyncNodeStore                                                               |
|                                                                                         |
|  3. Convert to lowercase: nodeNameLower = strings.ToLower(nodeName)                     |
|                                                                                         |
|  4. Query local cache: NodeStore.GetByIndex(IndexKeyNodeName, nodeNameLower)            |
|          |                                                                              |
|    +-----+-----+                                                                        |
|    |           |                                                                        |
| [Cache Hit] [Cache Miss]                                                                |
|    |           |                                                                        |
|    v           v                                                                        |
| [Return]    5. NSXClient.HostTransPortNodesClient.List()                                |
|                |                                                                        |
|                v                                                                        |
|             6. Iterate list & case-insensitive match (EqualFold)                        |
|                |                                                                        |
|             7. Write matched node to NodeStore                                          |
|                |                                                                        |
|                v                                                                        |
|             8. Return nil (Success)                                                     |
+-----------------------------------------------------------------------------------------+
```

Testing done:
1. update the node fqdn to upper case, then check the NSX Operator can reconcile the pod in the node
2. remove one node, the NSX Operator can delete the node from store.
3. add the node back, the NSX Operator can add the node to the store.