### PR TITLE
Skip ipBlock when resolving named ports in egress rules

### DIFF
--- a/pkg/nsx/services/securitypolicy/expand.go
+++ b/pkg/nsx/services/securitypolicy/expand.go
@@ -320,6 +320,9 @@ func (service *SecurityPolicyService) getPodSelectors(obj *v1alpha1.SecurityPoli
 		outPeers := getRuleDestinationPeers(rule)
 		if len(outPeers) > 0 {
 			for _, target := range outPeers {
+				if target.PodSelector == nil && target.NamespaceSelector == nil {
+					continue
+				}
 				var namespaceSelectors []client.ListOptions // ResolveNamespace may return multiple namespaces
 				var labelSelector client.ListOptions
 				var namespaceSelector client.ListOptions

--- a/pkg/nsx/services/securitypolicy/expand_test.go
+++ b/pkg/nsx/services/securitypolicy/expand_test.go
@@ -191,6 +191,21 @@ func TestSecurityPolicyService_getPodSelectors(t *testing.T) {
 			},
 		},
 	}
+	rule4 := v1alpha1.SecurityPolicyRule{
+		Action:    &allowAction,
+		Direction: &directionOut,
+		Name:      "rule-with-ipblock",
+		AppliedTo: []v1alpha1.SecurityPolicyTarget{},
+		Destinations: []v1alpha1.SecurityPolicyPeer{
+			{
+				IPBlocks: []v1alpha1.IPBlock{
+					{
+						CIDR: "40.200.123.123/32",
+					},
+				},
+			},
+		},
+	}
 	type fields struct {
 		Client                     client.Client
 		NSXClient                  *nsx.Client
@@ -237,17 +252,21 @@ func TestSecurityPolicyService_getPodSelectors(t *testing.T) {
 		args    args
 		want    client.ListOptions
 		wantErr assert.ErrorAssertionFunc
+		wantLen int
 	}{
-		{"1", fields{}, args{&sp, &rule}, client.ListOptions{LabelSelector: labelSelector, Namespace: "ns1"}, nil},
-		{"2", fields{}, args{&sp1, &rule2}, client.ListOptions{LabelSelector: labelSelector2, Namespace: "ns1"}, nil},
-		{"3", fields{}, args{&sp1, &rule3}, client.ListOptions{LabelSelector: labelSelector, Namespace: "ns1"}, nil},
+		{"1", fields{}, args{&sp, &rule}, client.ListOptions{LabelSelector: labelSelector, Namespace: "ns1"}, nil, 1},
+		{"2", fields{}, args{&sp1, &rule2}, client.ListOptions{LabelSelector: labelSelector2, Namespace: "ns1"}, nil, 1},
+		{"3", fields{}, args{&sp1, &rule3}, client.ListOptions{LabelSelector: labelSelector, Namespace: "ns1"}, nil, 2},
+		{"4", fields{}, args{&sp1, &rule4}, client.ListOptions{}, nil, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			service := &SecurityPolicyService{}
 			got, _ := service.getPodSelectors(tt.args.obj, tt.args.rule)
-			assert.Equal(t, true, len(got) > 0, "getPodSelector(%v, %v) should return 1 selector", tt.args.obj, tt.args.rule)
-			assert.Equalf(t, tt.want, got[0], "getPodSelector(%v, %v)", tt.args.obj, tt.args.rule)
+			assert.Equal(t, tt.wantLen, len(got), "getPodSelector(%v, %v) should return %d selector", tt.args.obj, tt.args.rule, tt.wantLen)
+			if tt.wantLen > 0 {
+				assert.Equalf(t, tt.want, got[0], "getPodSelector(%v, %v)", tt.args.obj, tt.args.rule)
+			}
 		})
 	}
 }


### PR DESCRIPTION
When a NetworkPolicy egress rule contains both an ipBlock and a named port,
the NSX Operator incorrectly resolved the ipBlock destination as all pods
in the current namespace. This resulted in DFW rules that incorrectly
allowed traffic to the pod's own IP instead of the intended external IPs.

This commit fixes the issue by explicitly skipping peers that have neither
a PodSelector nor a NamespaceSelector (such as ipBlock) when collecting
pod selectors for named port resolution in the OUT direction.

TestDone:


1. Create Pod:
```
cat pod.yaml 
apiVersion: v1
kind: Pod
metadata:
  name: db-pod
  namespace: egress-named-port-ipblock-np-ns
  labels:
    app: db
spec:
  containers:
  - name: db-container
    image: "netfvt-docker-local.packages.vcfd.broadcom.net/humanux/http_https_echo:latest"
    ports:
    - containerPort: 6001
      name: http
      protocol: TCP
    - containerPort: 7001
      name: db
      protocol: UDP
```
2. Create NetworkPolicy
```
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: test-np-egress-ipblock
  namespace: egress-named-port-ipblock-np-ns
spec:
  podSelector:
    matchLabels:
      app: db
  policyTypes:
  - Egress
  egress:
  - ports:
    - port: 6000
      protocol: TCP
    - port: http
      protocol: TCP
    to:
    - ipBlock:
        cidr: 40.200.123.123/32
```
3. Check Rules in NSX:

security-policies:
```
curl -k -u "${NSX_USER}:${NSX_PASS}"   -X GET   -H "Content-Type: application/json"   "${NSX_MANAGER}/policy/api/v1/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies"
{
  "results" : [ {
    "category" : "Application",
    "logging_enabled" : false,
    "resource_type" : "SecurityPolicy",
    "id" : "test-np-egress-ipblock-allow_1d4el",
    "display_name" : "test-np-egress-ipblock",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "6b11585d-9e43-42b2-bc87-9adfbb565b39"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace",
      "tag" : "egress-named-port-ipblock-np-ns"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "f5bb39e7-f910-4018-a308-251a1e8ed90b"
    }, {
      "scope" : "nsx-op/network_policy_name",
      "tag" : "test-np-egress-ipblock"
    }, {
      "scope" : "nsx-op/network_policy_uid",
      "tag" : "c107d941-a035-4a5a-9835-4742b774af32_allow"
    } ],
    "path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-allow_1d4el",
    "relative_path" : "test-np-egress-ipblock-allow_1d4el",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0",
    "remote_path" : "",
    "unique_id" : "4f7373d8-0668-4407-87ea-c99e05ebadc5",
    "realization_id" : "4f7373d8-0668-4407-87ea-c99e05ebadc5",
    "owner_id" : "5062b9e8-e133-44cf-82d7-301e13f59ed4",
    "marked_for_delete" : false,
    "overridden" : false,
    "sequence_number" : 2010,
    "internal_sequence_number" : 66002010,
    "stateful" : true,
    "tcp_strict" : true,
    "locked" : false,
    "lock_modified_time" : 0,
    "scope" : [ "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/groups/test-np-egress-ipblock-allow-scope_1d4el" ],
    "is_default" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_system_owned" : false,
    "_create_time" : 1782214901198,
    "_create_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_last_modified_time" : 1782214901198,
    "_last_modified_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_revision" : 0
  }, {
    "category" : "Application",
    "logging_enabled" : false,
    "resource_type" : "SecurityPolicy",
    "id" : "test-np-egress-ipblock-isolation_1d4el",
    "display_name" : "test-np-egress-ipblock",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "6b11585d-9e43-42b2-bc87-9adfbb565b39"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace",
      "tag" : "egress-named-port-ipblock-np-ns"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "f5bb39e7-f910-4018-a308-251a1e8ed90b"
    }, {
      "scope" : "nsx-op/network_policy_name",
      "tag" : "test-np-egress-ipblock"
    }, {
      "scope" : "nsx-op/network_policy_uid",
      "tag" : "c107d941-a035-4a5a-9835-4742b774af32_isolation"
    } ],
    "path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-isolation_1d4el",
    "relative_path" : "test-np-egress-ipblock-isolation_1d4el",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0",
    "remote_path" : "",
    "unique_id" : "6c92a3de-211b-47d3-99d7-767326dc808a",
    "realization_id" : "6c92a3de-211b-47d3-99d7-767326dc808a",
    "owner_id" : "5062b9e8-e133-44cf-82d7-301e13f59ed4",
    "marked_for_delete" : false,
    "overridden" : false,
    "sequence_number" : 2090,
    "internal_sequence_number" : 66002090,
    "stateful" : true,
    "tcp_strict" : true,
    "locked" : false,
    "lock_modified_time" : 0,
    "scope" : [ "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/groups/test-np-egress-ipblock-isolation-scope_1d4el" ],
    "is_default" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_system_owned" : false,
    "_create_time" : 1782214902509,
    "_create_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_last_modified_time" : 1782214902509,
    "_last_modified_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_revision" : 0
  } ],
  "result_count" : 2,
  "sort_by" : "internal_sequence_number",
  "sort_ascending" : true
}
```

Rules:

```
curl -k -u "${NSX_USER}:${NSX_PASS}"   -X GET   -H "Content-Type: application/json"   "${NSX_MANAGER}/policy/api/v1/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-allow_1d4el"
{
  "category" : "Application",
  "rules" : [ {
    "action" : "ALLOW",
    "resource_type" : "Rule",
    "id" : "test-np-egress-ipblock-allow-3dce0d25_1d4el_6000",
    "display_name" : "TCP.6000_TCP.http.TCP.6000_egress_allow",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "6b11585d-9e43-42b2-bc87-9adfbb565b39"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace",
      "tag" : "egress-named-port-ipblock-np-ns"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "f5bb39e7-f910-4018-a308-251a1e8ed90b"
    }, {
      "scope" : "nsx-op/network_policy_name",
      "tag" : "test-np-egress-ipblock"
    }, {
      "scope" : "nsx-op/network_policy_uid",
      "tag" : "c107d941-a035-4a5a-9835-4742b774af32_allow"
    }, {
      "scope" : "nsx-op/rule_hash",
      "tag" : "3dce0d25"
    }, {
      "scope" : "nsx-op/rule_id",
      "tag" : "test-np-egress-ipblock-allow-3dce0d25_1d4el"
    } ],
    "path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-allow_1d4el/rules/test-np-egress-ipblock-allow-3dce0d25_1d4el_6000",
    "relative_path" : "test-np-egress-ipblock-allow-3dce0d25_1d4el_6000",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-allow_1d4el",
    "remote_path" : "",
    "unique_id" : "00000000-0000-0000-0000-000000002031",
    "realization_id" : "00000000-0000-0000-0000-000000002031",
    "owner_id" : "5062b9e8-e133-44cf-82d7-301e13f59ed4",
    "marked_for_delete" : false,
    "overridden" : false,
    "rule_id" : 2031,
    "sequence_number" : 0,
    "sources_excluded" : false,
    "destinations_excluded" : false,
    "source_groups" : [ "ANY" ],
    "destination_groups" : [ "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/groups/test-np-egress-ipblock-allow-3dce0d25-dst_1d4el" ],
    "services" : [ "ANY" ],
    "service_entries" : [ {
      "l4_protocol" : "TCP",
      "source_ports" : [ ],
      "destination_ports" : [ "6000" ],
      "resource_type" : "L4PortSetServiceEntry",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    } ],
    "profiles" : [ "ANY" ],
    "logged" : false,
    "scope" : [ "ANY" ],
    "disabled" : false,
    "direction" : "OUT",
    "ip_protocol" : "IPV4_IPV6",
    "is_default" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_system_owned" : false,
    "_create_time" : 1782214901211,
    "_create_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_last_modified_time" : 1782214901211,
    "_last_modified_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_revision" : 0
  }, {
    "action" : "ALLOW",
    "resource_type" : "Rule",
    "id" : "test-np-egress-ipblock-allow-3dce0d25_1d4el_6001",
    "display_name" : "TCP.6000_TCP.http.TCP.6001_egress_allow",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "6b11585d-9e43-42b2-bc87-9adfbb565b39"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace",
      "tag" : "egress-named-port-ipblock-np-ns"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "f5bb39e7-f910-4018-a308-251a1e8ed90b"
    }, {
      "scope" : "nsx-op/network_policy_name",
      "tag" : "test-np-egress-ipblock"
    }, {
      "scope" : "nsx-op/network_policy_uid",
      "tag" : "c107d941-a035-4a5a-9835-4742b774af32_allow"
    }, {
      "scope" : "nsx-op/rule_hash",
      "tag" : "3dce0d25"
    }, {
      "scope" : "nsx-op/rule_id",
      "tag" : "test-np-egress-ipblock-allow-3dce0d25_1d4el"
    } ],
    "path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-allow_1d4el/rules/test-np-egress-ipblock-allow-3dce0d25_1d4el_6001",
    "relative_path" : "test-np-egress-ipblock-allow-3dce0d25_1d4el_6001",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-allow_1d4el",
    "remote_path" : "",
    "unique_id" : "00000000-0000-0000-0000-000000002032",
    "realization_id" : "00000000-0000-0000-0000-000000002032",
    "owner_id" : "5062b9e8-e133-44cf-82d7-301e13f59ed4",
    "marked_for_delete" : false,
    "overridden" : false,
    "rule_id" : 2032,
    "sequence_number" : 0,
    "sources_excluded" : false,
    "destinations_excluded" : false,
    "source_groups" : [ "ANY" ],
    "destination_groups" : [ "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/groups/test-np-egress-ipblock-allow-3dce0d25_1d4el_6001_ipset" ],
    "services" : [ "ANY" ],
    "service_entries" : [ {
      "l4_protocol" : "TCP",
      "source_ports" : [ ],
      "destination_ports" : [ "6001" ],
      "resource_type" : "L4PortSetServiceEntry",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    } ],
    "profiles" : [ "ANY" ],
    "logged" : false,
    "scope" : [ "ANY" ],
    "disabled" : false,
    "direction" : "OUT",
    "ip_protocol" : "IPV4_IPV6",
    "is_default" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_system_owned" : false,
    "_create_time" : 1782214901225,
    "_create_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_last_modified_time" : 1782214901225,
    "_last_modified_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_revision" : 0
  } ],
  "logging_enabled" : false,
  "resource_type" : "SecurityPolicy",
  "id" : "test-np-egress-ipblock-allow_1d4el",
  "display_name" : "test-np-egress-ipblock",
  "tags" : [ {
    "scope" : "nsx-op/cluster",
    "tag" : "6b11585d-9e43-42b2-bc87-9adfbb565b39"
  }, {
    "scope" : "nsx-op/version",
    "tag" : "1.0.0"
  }, {
    "scope" : "nsx-op/namespace",
    "tag" : "egress-named-port-ipblock-np-ns"
  }, {
    "scope" : "nsx-op/namespace_uid",
    "tag" : "f5bb39e7-f910-4018-a308-251a1e8ed90b"
  }, {
    "scope" : "nsx-op/network_policy_name",
    "tag" : "test-np-egress-ipblock"
  }, {
    "scope" : "nsx-op/network_policy_uid",
    "tag" : "c107d941-a035-4a5a-9835-4742b774af32_allow"
  } ],
  "path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-allow_1d4el",
  "relative_path" : "test-np-egress-ipblock-allow_1d4el",
  "parent_path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0",
  "remote_path" : "",
  "unique_id" : "4f7373d8-0668-4407-87ea-c99e05ebadc5",
  "realization_id" : "4f7373d8-0668-4407-87ea-c99e05ebadc5",
  "owner_id" : "5062b9e8-e133-44cf-82d7-301e13f59ed4",
  "marked_for_delete" : false,
  "overridden" : false,
  "sequence_number" : 2010,
  "internal_sequence_number" : 66002010,
  "stateful" : true,
  "tcp_strict" : true,
  "locked" : false,
  "lock_modified_time" : 0,
  "scope" : [ "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/groups/test-np-egress-ipblock-allow-scope_1d4el" ],
  "rule_count" : 2,
  "is_default" : false,
  "_protection" : "REQUIRE_OVERRIDE",
  "_system_owned" : false,
  "_create_time" : 1782214901198,
  "_create_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
  "_last_modified_time" : 1782214901198,
  "_last_modified_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
  "_revision" : 0
}
```


4. After patch:

security-policies in NSX:
```
curl -k -u "${NSX_USER}:${NSX_PASS}"   -X GET   -H "Content-Type: application/json"   "${NSX_MANAGER}/policy/api/v1/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies"
{
  "results" : [ {
    "category" : "Application",
    "logging_enabled" : false,
    "resource_type" : "SecurityPolicy",
    "id" : "test-np-egress-ipblock-allow_f2vp6",
    "display_name" : "test-np-egress-ipblock",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "6b11585d-9e43-42b2-bc87-9adfbb565b39"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace",
      "tag" : "egress-named-port-ipblock-np-ns"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "f5bb39e7-f910-4018-a308-251a1e8ed90b"
    }, {
      "scope" : "nsx-op/network_policy_name",
      "tag" : "test-np-egress-ipblock"
    }, {
      "scope" : "nsx-op/network_policy_uid",
      "tag" : "97d491c4-1a5f-4589-a442-824defc8c2c6_allow"
    } ],
    "path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-allow_f2vp6",
    "relative_path" : "test-np-egress-ipblock-allow_f2vp6",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0",
    "remote_path" : "",
    "unique_id" : "53359750-784c-4c06-bf02-c06a78c8b49f",
    "realization_id" : "53359750-784c-4c06-bf02-c06a78c8b49f",
    "owner_id" : "5062b9e8-e133-44cf-82d7-301e13f59ed4",
    "marked_for_delete" : false,
    "overridden" : false,
    "sequence_number" : 2010,
    "internal_sequence_number" : 66002010,
    "stateful" : true,
    "tcp_strict" : true,
    "locked" : false,
    "lock_modified_time" : 0,
    "scope" : [ "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/groups/test-np-egress-ipblock-allow-scope_f2vp6" ],
    "is_default" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_system_owned" : false,
    "_create_time" : 1782213963958,
    "_create_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_last_modified_time" : 1782213963958,
    "_last_modified_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_revision" : 0
  }, {
    "category" : "Application",
    "logging_enabled" : false,
    "resource_type" : "SecurityPolicy",
    "id" : "test-np-egress-ipblock-isolation_f2vp6",
    "display_name" : "test-np-egress-ipblock",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "6b11585d-9e43-42b2-bc87-9adfbb565b39"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace",
      "tag" : "egress-named-port-ipblock-np-ns"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "f5bb39e7-f910-4018-a308-251a1e8ed90b"
    }, {
      "scope" : "nsx-op/network_policy_name",
      "tag" : "test-np-egress-ipblock"
    }, {
      "scope" : "nsx-op/network_policy_uid",
      "tag" : "97d491c4-1a5f-4589-a442-824defc8c2c6_isolation"
    } ],
    "path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-isolation_f2vp6",
    "relative_path" : "test-np-egress-ipblock-isolation_f2vp6",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0",
    "remote_path" : "",
    "unique_id" : "8e82c162-c301-4020-93cf-1e6c638c0ede",
    "realization_id" : "8e82c162-c301-4020-93cf-1e6c638c0ede",
    "owner_id" : "5062b9e8-e133-44cf-82d7-301e13f59ed4",
    "marked_for_delete" : false,
    "overridden" : false,
    "sequence_number" : 2090,
    "internal_sequence_number" : 66002090,
    "stateful" : true,
    "tcp_strict" : true,
    "locked" : false,
    "lock_modified_time" : 0,
    "scope" : [ "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/groups/test-np-egress-ipblock-isolation-scope_f2vp6" ],
    "is_default" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_system_owned" : false,
    "_create_time" : 1782213966364,
    "_create_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_last_modified_time" : 1782213966364,
    "_last_modified_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_revision" : 0
  } ],
  "result_count" : 2,
  "sort_by" : "internal_sequence_number",
  "sort_ascending" : true
}
```

Rules:


```
curl -k -u "${NSX_USER}:${NSX_PASS}"   -X GET   -H "Content-Type: application/json"   "${NSX_MANAGER}/policy/api/v1/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-allow_f2vp6" 
{
  "category" : "Application",
  "rules" : [ {
    "action" : "ALLOW",
    "resource_type" : "Rule",
    "id" : "test-np-egress-ipblock-allow-3dce0d25_f2vp6_6000",
    "display_name" : "TCP.6000_TCP.http.TCP.6000_egress_allow",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "6b11585d-9e43-42b2-bc87-9adfbb565b39"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace",
      "tag" : "egress-named-port-ipblock-np-ns"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "f5bb39e7-f910-4018-a308-251a1e8ed90b"
    }, {
      "scope" : "nsx-op/network_policy_name",
      "tag" : "test-np-egress-ipblock"
    }, {
      "scope" : "nsx-op/network_policy_uid",
      "tag" : "97d491c4-1a5f-4589-a442-824defc8c2c6_allow"
    }, {
      "scope" : "nsx-op/rule_hash",
      "tag" : "3dce0d25"
    }, {
      "scope" : "nsx-op/rule_id",
      "tag" : "test-np-egress-ipblock-allow-3dce0d25_f2vp6"
    } ],
    "path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-allow_f2vp6/rules/test-np-egress-ipblock-allow-3dce0d25_f2vp6_6000",
    "relative_path" : "test-np-egress-ipblock-allow-3dce0d25_f2vp6_6000",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-allow_f2vp6",
    "remote_path" : "",
    "unique_id" : "00000000-0000-0000-0000-000000002029",
    "realization_id" : "00000000-0000-0000-0000-000000002029",
    "owner_id" : "5062b9e8-e133-44cf-82d7-301e13f59ed4",
    "marked_for_delete" : false,
    "overridden" : false,
    "rule_id" : 2029,
    "sequence_number" : 0,
    "sources_excluded" : false,
    "destinations_excluded" : false,
    "source_groups" : [ "ANY" ],
    "destination_groups" : [ "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/groups/test-np-egress-ipblock-allow-3dce0d25-dst_f2vp6" ],
    "services" : [ "ANY" ],
    "service_entries" : [ {
      "l4_protocol" : "TCP",
      "source_ports" : [ ],
      "destination_ports" : [ "6000" ],
      "resource_type" : "L4PortSetServiceEntry",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    } ],
    "profiles" : [ "ANY" ],
    "logged" : false,
    "scope" : [ "ANY" ],
    "disabled" : false,
    "direction" : "OUT",
    "ip_protocol" : "IPV4_IPV6",
    "is_default" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_system_owned" : false,
    "_create_time" : 1782213963973,
    "_create_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_last_modified_time" : 1782213963973,
    "_last_modified_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
    "_revision" : 0
  } ],
  "logging_enabled" : false,
  "resource_type" : "SecurityPolicy",
  "id" : "test-np-egress-ipblock-allow_f2vp6",
  "display_name" : "test-np-egress-ipblock",
  "tags" : [ {
    "scope" : "nsx-op/cluster",
    "tag" : "6b11585d-9e43-42b2-bc87-9adfbb565b39"
  }, {
    "scope" : "nsx-op/version",
    "tag" : "1.0.0"
  }, {
    "scope" : "nsx-op/namespace",
    "tag" : "egress-named-port-ipblock-np-ns"
  }, {
    "scope" : "nsx-op/namespace_uid",
    "tag" : "f5bb39e7-f910-4018-a308-251a1e8ed90b"
  }, {
    "scope" : "nsx-op/network_policy_name",
    "tag" : "test-np-egress-ipblock"
  }, {
    "scope" : "nsx-op/network_policy_uid",
    "tag" : "97d491c4-1a5f-4589-a442-824defc8c2c6_allow"
  } ],
  "path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/security-policies/test-np-egress-ipblock-allow_f2vp6",
  "relative_path" : "test-np-egress-ipblock-allow_f2vp6",
  "parent_path" : "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0",
  "remote_path" : "",
  "unique_id" : "53359750-784c-4c06-bf02-c06a78c8b49f",
  "realization_id" : "53359750-784c-4c06-bf02-c06a78c8b49f",
  "owner_id" : "5062b9e8-e133-44cf-82d7-301e13f59ed4",
  "marked_for_delete" : false,
  "overridden" : false,
  "sequence_number" : 2010,
  "internal_sequence_number" : 66002010,
  "stateful" : true,
  "tcp_strict" : true,
  "locked" : false,
  "lock_modified_time" : 0,
  "scope" : [ "/orgs/default/projects/project-quality/vpcs/egress-named-port-ipblock-np-ns_iwwk0/groups/test-np-egress-ipblock-allow-scope_f2vp6" ],
  "rule_count" : 1,
  "is_default" : false,
  "_protection" : "REQUIRE_OVERRIDE",
  "_system_owned" : false,
  "_create_time" : 1782213963958,
  "_create_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
  "_last_modified_time" : 1782213963958,
  "_last_modified_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
  "_revision" : 0
}
```