### PR TITLE
Update ProjectDnsRecord and ProjectDnsZone references to DnsRecord and DnsZone

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/vmware/govmomi v0.53.1
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.8.0
 	github.com/vmware/vsphere-automation-sdk-go/runtime v0.8.0
-	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260517061842-508c01aec2fc
-	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20260506074423-13747423203f
+	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.0.0-20260614145640-9b3a306dd40d
+	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20260614145640-9b3a306dd40d
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.50.0

--- a/go.sum
+++ b/go.sum
@@ -226,10 +226,10 @@ github.com/vmware/vsphere-automation-sdk-go/lib v0.8.0 h1:u1SXOTM6D4Ygb3jeidj2Rd
 github.com/vmware/vsphere-automation-sdk-go/lib v0.8.0/go.mod h1:8d5JTwjpM/Z03n/IZb0fwmXkJNWvWwuLXBqoakqYio4=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.8.0 h1:KnDIX9LY0nru7iMQTg0sy9vChhyorPo5OdASM2MaAcI=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.8.0/go.mod h1:DzLetYAmw1+vj7bqElRWEpuy40WYE/woL3alsymYa/c=
-github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260517061842-508c01aec2fc h1:eiMYaZj7fQimyNjQkIsjtbr12RKIC5Dl+6uhtPZVtdo=
-github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260517061842-508c01aec2fc/go.mod h1:C3JVOHRVLrGBQ8kTWAiGYlRz5UQC5qAcTdt3tvA+5P0=
-github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20260506074423-13747423203f h1:dzC9XLdl0fdqZB/K97m/NMY9o/voA2Qa4shHRnK900Q=
-github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20260506074423-13747423203f/go.mod h1:fDH7JI080OD5t6TGwjJx3mMX/g6W7t6Radlome6hze8=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.0.0-20260614145640-9b3a306dd40d h1:0e8+fVUGeGVw3bVZuF16zRfyI3jmS9PPEUaPPbuL0fs=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.0.0-20260614145640-9b3a306dd40d/go.mod h1:C3JVOHRVLrGBQ8kTWAiGYlRz5UQC5qAcTdt3tvA+5P0=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20260614145640-9b3a306dd40d h1:vuLe5Bqk7AucZdV6C1MgaZSPTt/4diiID56RkefLhrs=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20260614145640-9b3a306dd40d/go.mod h1:fDH7JI080OD5t6TGwjJx3mMX/g6W7t6Radlome6hze8=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 h1:S2dVYn90KE98chqDkyE9Z4N61UnQd+KOfgp5Iu53llk=

--- a/pkg/mock/dnsrecordsclient/client.go
+++ b/pkg/mock/dnsrecordsclient/client.go
@@ -49,10 +49,10 @@ func (mr *MockDnsRecordsClientMockRecorder) Delete(arg0, arg1, arg2 interface{})
 }
 
 // Get mocks base method.
-func (m *MockDnsRecordsClient) Get(arg0, arg1, arg2 string) (model.ProjectDnsRecord, error) {
+func (m *MockDnsRecordsClient) Get(arg0, arg1, arg2 string) (model.DnsRecord, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
-	ret0, _ := ret[0].(model.ProjectDnsRecord)
+	ret0, _ := ret[0].(model.DnsRecord)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -64,10 +64,10 @@ func (mr *MockDnsRecordsClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *g
 }
 
 // List mocks base method.
-func (m *MockDnsRecordsClient) List(arg0, arg1 string, arg2 *string, arg3 *bool, arg4 *string, arg5 *int64, arg6 *bool, arg7, arg8 *string) (model.ProjectDnsRecordListResult, error) {
+func (m *MockDnsRecordsClient) List(arg0, arg1 string, arg2 *string, arg3 *bool, arg4 *string, arg5 *int64, arg6 *bool, arg7, arg8 *string) (model.DnsRecordListResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
-	ret0, _ := ret[0].(model.ProjectDnsRecordListResult)
+	ret0, _ := ret[0].(model.DnsRecordListResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -79,7 +79,7 @@ func (mr *MockDnsRecordsClientMockRecorder) List(arg0, arg1, arg2, arg3, arg4, a
 }
 
 // Patch mocks base method.
-func (m *MockDnsRecordsClient) Patch(arg0, arg1, arg2 string, arg3 model.ProjectDnsRecord) error {
+func (m *MockDnsRecordsClient) Patch(arg0, arg1, arg2 string, arg3 model.DnsRecord) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Patch", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -93,10 +93,10 @@ func (mr *MockDnsRecordsClientMockRecorder) Patch(arg0, arg1, arg2, arg3 interfa
 }
 
 // Update mocks base method.
-func (m *MockDnsRecordsClient) Update(arg0, arg1, arg2 string, arg3 model.ProjectDnsRecord) (model.ProjectDnsRecord, error) {
+func (m *MockDnsRecordsClient) Update(arg0, arg1, arg2 string, arg3 model.DnsRecord) (model.DnsRecord, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(model.ProjectDnsRecord)
+	ret0, _ := ret[0].(model.DnsRecord)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/mock/dnszonesclient/client.go
+++ b/pkg/mock/dnszonesclient/client.go
@@ -49,10 +49,10 @@ func (mr *MockZonesClientMockRecorder) Delete(arg0, arg1, arg2, arg3 interface{}
 }
 
 // Get mocks base method.
-func (m *MockZonesClient) Get(arg0, arg1, arg2, arg3 string) (model.ProjectDnsZone, error) {
+func (m *MockZonesClient) Get(arg0, arg1, arg2, arg3 string) (model.DnsZone, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(model.ProjectDnsZone)
+	ret0, _ := ret[0].(model.DnsZone)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -64,10 +64,10 @@ func (mr *MockZonesClientMockRecorder) Get(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // List mocks base method.
-func (m *MockZonesClient) List(arg0, arg1, arg2 string, arg3 *string, arg4 *bool, arg5 *string, arg6 *int64, arg7 *bool, arg8 *string) (model.ProjectDnsZoneListResult, error) {
+func (m *MockZonesClient) List(arg0, arg1, arg2 string, arg3 *string, arg4 *bool, arg5 *string, arg6 *int64, arg7 *bool, arg8 *string) (model.DnsZoneListResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
-	ret0, _ := ret[0].(model.ProjectDnsZoneListResult)
+	ret0, _ := ret[0].(model.DnsZoneListResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -79,7 +79,7 @@ func (mr *MockZonesClientMockRecorder) List(arg0, arg1, arg2, arg3, arg4, arg5, 
 }
 
 // Patch mocks base method.
-func (m *MockZonesClient) Patch(arg0, arg1, arg2, arg3 string, arg4 model.ProjectDnsZone) error {
+func (m *MockZonesClient) Patch(arg0, arg1, arg2, arg3 string, arg4 model.DnsZone) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Patch", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -93,10 +93,10 @@ func (mr *MockZonesClientMockRecorder) Patch(arg0, arg1, arg2, arg3, arg4 interf
 }
 
 // Update mocks base method.
-func (m *MockZonesClient) Update(arg0, arg1, arg2, arg3 string, arg4 model.ProjectDnsZone) (model.ProjectDnsZone, error) {
+func (m *MockZonesClient) Update(arg0, arg1, arg2, arg3 string, arg4 model.DnsZone) (model.DnsZone, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(model.ProjectDnsZone)
+	ret0, _ := ret[0].(model.DnsZone)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -130,7 +130,7 @@ type Client struct {
 	StaticIPReservationsClient        subnets.StaticIpReservationsClient
 	NsxApiClient                      *nsxt.APIClient
 	VifsClient                        fabric.VifsClient
-	ProjectDnsZoneClient              dns_services.ZonesClient
+	DnsZoneClient                     dns_services.ZonesClient
 	DnsRecordsClient                  projects.DnsRecordsClient
 
 	NSXChecker    NSXHealthChecker
@@ -254,7 +254,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 
 	nsxApiClient, _ := CreateNsxtApiClient(cf, cluster.client)
 	vifsClient := fabric.NewVifsClient(connector)
-	projectDnsZoneClient := dns_services.NewZonesClient(connector)
+	dnsZoneClient := dns_services.NewZonesClient(connector)
 	dnsRecordsClient := projects.NewDnsRecordsClient(connector)
 
 	nsxChecker := &NSXHealthChecker{
@@ -327,7 +327,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 		LbMonitorProfilesClient:           lbMonitorProfilesClient,
 		NsxApiClient:                      nsxApiClient,
 		VifsClient:                        vifsClient,
-		ProjectDnsZoneClient:              projectDnsZoneClient,
+		DnsZoneClient:                     dnsZoneClient,
 		DnsRecordsClient:                  dnsRecordsClient,
 	}
 	nsxClient.Cluster.SetOnNodeVersionChanged(func(oldVer, newVer string) {

--- a/pkg/nsx/services/common/policy_tree.go
+++ b/pkg/nsx/services/common/policy_tree.go
@@ -24,7 +24,7 @@ type GetId[T any] func(obj T) *string
 
 func getNSXResourcePath[T any](obj T) *string {
 	switch v := any(obj).(type) {
-	case *model.ProjectDnsRecord:
+	case *model.DnsRecord:
 		return v.Path
 	case *model.VpcIpAddressAllocation:
 		return v.Path
@@ -70,7 +70,7 @@ func getNSXResourcePath[T any](obj T) *string {
 
 func getNSXResourceId[T any](obj T) *string {
 	switch v := any(obj).(type) {
-	case *model.ProjectDnsRecord:
+	case *model.DnsRecord:
 		return v.Id
 	case *model.VpcIpAddressAllocation:
 		return v.Id
@@ -116,7 +116,7 @@ func getNSXResourceId[T any](obj T) *string {
 
 func getNSXResourceName[T any](obj T) *string {
 	switch v := any(obj).(type) {
-	case *model.ProjectDnsRecord:
+	case *model.DnsRecord:
 		return v.DisplayName
 	case *model.VpcIpAddressAllocation:
 		return v.DisplayName
@@ -162,8 +162,8 @@ func getNSXResourceName[T any](obj T) *string {
 
 func leafWrapper[T any](obj T) (*data.StructValue, error) {
 	switch v := any(obj).(type) {
-	case *model.ProjectDnsRecord:
-		return WrapProjectDnsRecord(v)
+	case *model.DnsRecord:
+		return WrapDnsRecord(v)
 	case *model.VpcIpAddressAllocation:
 		return WrapVpcIpAddressAllocation(v)
 	case *model.VpcSubnet:
@@ -278,7 +278,7 @@ var (
 	PolicyResourceInfraLBPool                                                                          = PolicyResourceType{ModelKey: ResourceTypeLBPool, PathKey: "lb-pools"}
 	PolicyResourceInfraLBVirtualServer                                                                 = PolicyResourceType{ModelKey: ResourceTypeLBVirtualServer, PathKey: "lb-virtual-servers"}
 	PolicyResourceVpcIPAddressAllocation                                                               = PolicyResourceType{ModelKey: ResourceTypeIPAddressAllocation, PathKey: "ip-address-allocations"}
-	PolicyResourceProjectDnsRecord                                                                     = PolicyResourceType{ModelKey: ResourceTypeProjectDnsRecord, PathKey: PathSegmentProjectDnsRecords}
+	PolicyResourceDnsRecord                                                                            = PolicyResourceType{ModelKey: ResourceTypeDnsRecord, PathKey: PathSegmentDnsRecords}
 	PolicyResourceDomain                                                                               = PolicyResourceType{ModelKey: ResourceTypeDomain, PathKey: "domains"}
 	PolicyResourceShare                                                                                = PolicyResourceType{ModelKey: ResourceTypeShare, PathKey: "shares"}
 	PolicyResourceSharedResource                                                                       = PolicyResourceType{ModelKey: ResourceTypeSharedResource, PathKey: "resources"}
@@ -311,9 +311,9 @@ var (
 	PolicyPathInfraDomain                       PolicyResourcePath[*model.Domain]                      = []PolicyResourceType{PolicyResourceInfra, PolicyResourceDomain}
 	PolicyPathVpcSubnetDynamicIPReservation     PolicyResourcePath[*model.DynamicIpAddressReservation] = []PolicyResourceType{PolicyResourceOrg, PolicyResourceProject, PolicyResourceVpc, PolicyResourceVpcSubnet, PolicyResourceVpcDynamicIPReservation}
 	PolicyPathVpcSubnetStaticIPReservation      PolicyResourcePath[*model.StaticIpAddressReservation]  = []PolicyResourceType{PolicyResourceOrg, PolicyResourceProject, PolicyResourceVpc, PolicyResourceVpcSubnet, PolicyResourceVpcStaticIPReservation}
-	// PolicyPathProjectDnsRecord is the OrgRoot hierarchy for *model.ProjectDnsRecord under a project.
+	// PolicyPathDnsRecord is the OrgRoot hierarchy for *model.DnsRecord under a project.
 	// Path pattern: /orgs/{org}/projects/{project}/dns-records/{record-id}.
-	PolicyPathProjectDnsRecord PolicyResourcePath[*model.ProjectDnsRecord] = []PolicyResourceType{PolicyResourceOrg, PolicyResourceProject, PolicyResourceProjectDnsRecord}
+	PolicyPathDnsRecord PolicyResourcePath[*model.DnsRecord] = []PolicyResourceType{PolicyResourceOrg, PolicyResourceProject, PolicyResourceDnsRecord}
 )
 
 type hNodeKey struct {

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -172,9 +172,9 @@ const (
 	GatewayInterfaceId = "gateway-interface"
 	VPCKey             = "/orgs/%s/projects/%s/vpcs/%s"
 
-	// PathSegmentProjectDnsRecords is the NSX Policy URL path segment for project-scoped DNS records
-	// (full path: /orgs/{org}/projects/{project}/dns-records/{id}). Must match PolicyResourceProjectDnsRecord.PathKey.
-	PathSegmentProjectDnsRecords = "dns-records"
+	// PathSegmentDnsRecords is the NSX Policy URL path segment for project-scoped DNS records
+	// (full path: /orgs/{org}/projects/{project}/dns-records/{id}). Must match PolicyResourceDnsRecord.PathKey.
+	PathSegmentDnsRecords = "dns-records"
 )
 
 var (
@@ -216,7 +216,7 @@ var (
 	ResourceTypeChildSubnetConnectionBindingMap  = "ChildSubnetConnectionBindingMap"
 	ResourceTypeChildVpcAttachment               = "ChildVpcAttachment"
 	ResourceTypeChildVpcIPAddressAllocation      = "ChildVpcIpAddressAllocation"
-	ResourceTypeChildProjectDnsRecord            = "ChildProjectDnsRecord"
+	ResourceTypeChildDnsRecord                   = "ChildDnsRecord"
 	ResourceTypeChildVpcSubnet                   = "ChildVpcSubnet"
 	ResourceTypeChildVpcSubnetPort               = "ChildVpcSubnetPort"
 	ResourceTypeChildDynamicIpAddressReservation = "ChildDynamicIpAddressReservation"
@@ -235,7 +235,7 @@ var (
 	ResourceTypeSubnetConnectionBindingMap       = "SubnetConnectionBindingMap"
 	ResourceTypeDynamicIpAddressReservation      = "DynamicIpAddressReservation"
 	ResourceTypeStaticIpAddressReservation       = "StaticIpAddressReservation"
-	ResourceTypeProjectDnsRecord                 = "ProjectDnsRecord"
+	ResourceTypeDnsRecord                        = "DnsRecord"
 
 	// ResourceTypeClusterControlPlane is used by NSXServiceAccountController
 	ResourceTypeClusterControlPlane = "clustercontrolplane"

--- a/pkg/nsx/services/common/wrap.go
+++ b/pkg/nsx/services/common/wrap.go
@@ -85,19 +85,19 @@ func (service *Service) WrapAttachment(attachment *model.VpcAttachment) ([]*data
 	return []*data.StructValue{dataValue.(*data.StructValue)}, nil
 }
 
-func WrapProjectDnsRecord(rec *model.ProjectDnsRecord) (*data.StructValue, error) {
+func WrapDnsRecord(rec *model.DnsRecord) (*data.StructValue, error) {
 	if rec == nil {
-		return nil, fmt.Errorf("nil ProjectDnsRecord")
+		return nil, fmt.Errorf("nil DnsRecord")
 	}
 	// Fqdn may be server-populated / read-only on PATCH; send payload without it (operator may set it on in-memory copies for indexing).
 	send := *rec
 	send.Fqdn = nil
-	send.ResourceType = &ResourceTypeProjectDnsRecord
-	child := model.ChildProjectDnsRecord{
-		Id:               send.Id,
-		MarkedForDelete:  send.MarkedForDelete,
-		ResourceType:     ResourceTypeChildProjectDnsRecord,
-		ProjectDnsRecord: &send,
+	send.ResourceType = &ResourceTypeDnsRecord
+	child := model.ChildDnsRecord{
+		Id:              send.Id,
+		MarkedForDelete: send.MarkedForDelete,
+		ResourceType:    ResourceTypeChildDnsRecord,
+		DnsRecord:       &send,
 	}
 	dataValue, errors := NewConverter().ConvertToVapi(child, child.GetType__())
 	if len(errors) > 0 {

--- a/pkg/nsx/services/dns/builder.go
+++ b/pkg/nsx/services/dns/builder.go
@@ -16,8 +16,8 @@ const (
 	DefaultRecordTtL = 300
 )
 
-// BuildProjectDnsRecord builds one *model.ProjectDnsRecord for row using batchOwner or row.effectiveOwner.
-func (s *DNSRecordService) BuildProjectDnsRecord(batchOwner *ResourceRef, row EndpointRow) *model.ProjectDnsRecord {
+// BuildDnsRecord builds one *model.DnsRecord for row using batchOwner or row.effectiveOwner.
+func (s *DNSRecordService) BuildDnsRecord(batchOwner *ResourceRef, row EndpointRow) *model.DnsRecord {
 	owner := batchOwner
 	if row.effectiveOwner != nil {
 		owner = row.effectiveOwner
@@ -39,13 +39,13 @@ func (s *DNSRecordService) tagsForOwner(owner *ResourceRef) []model.Tag {
 	return tags
 }
 
-// getRecordIDAndPathAndType returns the desired ProjectDnsRecord's Id, Path, and RecordType
+// getRecordIDAndPathAndType returns the desired DnsRecord's Id, Path, and RecordType
 func getRecordIDAndPathAndType(recordName, endpointRecordType, zonePath string) (string, string, string) {
 	nsxRecordType := getNSXDnsRecordType(endpointRecordType)
 	recID := strings.ReplaceAll(recordName, ".", "_")
-	// Ignore the errors returned in `parseProjectDNSZonePath`, as it was validated in previous steps when
+	// Ignore the errors returned in `parseDnsZonePath`, as it was validated in previous steps when
 	// preparing the DNS zone maps in the service.
-	orgID, projectID, _, zoneID, _ := parseProjectDNSZonePath(zonePath)
+	orgID, projectID, _, zoneID, _ := parseDnsZonePath(zonePath)
 	recID = recID + "_" + zoneID
 	if strings.TrimSpace(nsxRecordType) != "" {
 		recID = recID + "_" + strings.ToLower(strings.TrimSpace(nsxRecordType))
@@ -54,7 +54,7 @@ func getRecordIDAndPathAndType(recordName, endpointRecordType, zonePath string) 
 	return recID, recordPath, nsxRecordType
 }
 
-func (r *EndpointRow) buildDNSRecord(basicTags []model.Tag) *model.ProjectDnsRecord {
+func (r *EndpointRow) buildDNSRecord(basicTags []model.Tag) *model.DnsRecord {
 	// Append the tags according to the Endpoint labels, e.g., the parent gateway settings for a Route.
 	tags := r.appendRowOwnershipTags(basicTags)
 	recID, path, rt := getRecordIDAndPathAndType(r.nsxRecordName, r.RecordType, r.zonePath)
@@ -63,7 +63,7 @@ func (r *EndpointRow) buildDNSRecord(basicTags []model.Tag) *model.ProjectDnsRec
 		ttl = int64(r.Endpoint.RecordTTL)
 	}
 	display := r.nsxRecordName
-	rec := &model.ProjectDnsRecord{
+	rec := &model.DnsRecord{
 		Id:           common.String(recID),
 		Path:         common.String(path),
 		RecordName:   common.String(r.nsxRecordName),
@@ -73,7 +73,7 @@ func (r *EndpointRow) buildDNSRecord(basicTags []model.Tag) *model.ProjectDnsRec
 		RecordValues: append([]string(nil), r.Targets...),
 		ZonePath:     common.String(r.zonePath),
 		Ttl:          common.Int64(ttl),
-		// Mirror logical FQDN for store indexing / conflict detection; stripped before Policy PATCH (see WrapProjectDnsRecord).
+		// Mirror logical FQDN for store indexing / conflict detection; stripped before Policy PATCH (see WrapDnsRecord).
 		Fqdn: common.String(strings.ToLower(r.Endpoint.DNSName)),
 	}
 	return rec
@@ -82,18 +82,18 @@ func (r *EndpointRow) buildDNSRecord(basicTags []model.Tag) *model.ProjectDnsRec
 func getNSXDnsRecordType(recType string) string {
 	switch recType {
 	case extdns.RecordTypeAAAA:
-		return model.ProjectDnsRecord_RECORD_TYPE_AAAA
+		return model.DnsRecord_RECORD_TYPE_AAAA
 	case extdns.RecordTypeCNAME:
-		return model.ProjectDnsRecord_RECORD_TYPE_CNAME
+		return model.DnsRecord_RECORD_TYPE_CNAME
 	case extdns.RecordTypeNS:
-		return model.ProjectDnsRecord_RECORD_TYPE_NS
+		return model.DnsRecord_RECORD_TYPE_NS
 	case extdns.RecordTypePTR:
-		return model.ProjectDnsRecord_RECORD_TYPE_PTR
+		return model.DnsRecord_RECORD_TYPE_PTR
 	case extdns.RecordTypeA:
-		return model.ProjectDnsRecord_RECORD_TYPE_A
+		return model.DnsRecord_RECORD_TYPE_A
 	default:
 		log.Info("Unknown record type is detected, using type A instead", "type", recType)
-		return model.ProjectDnsRecord_RECORD_TYPE_A
+		return model.DnsRecord_RECORD_TYPE_A
 	}
 }
 
@@ -113,7 +113,7 @@ func modelTag(scope, value string) model.Tag {
 	return model.Tag{Scope: common.String(scope), Tag: common.String(value)}
 }
 
-func mergeDNSRecordForUpdate(desired, existing *model.ProjectDnsRecord) *model.ProjectDnsRecord {
+func mergeDNSRecordForUpdate(desired, existing *model.DnsRecord) *model.DnsRecord {
 	out := *desired
 	out.Id = existing.Id
 	out.DisplayName = existing.DisplayName

--- a/pkg/nsx/services/dns/cleanup.go
+++ b/pkg/nsx/services/dns/cleanup.go
@@ -11,13 +11,13 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
-// CleanupInfraResources deletes all cached ProjectDnsRecord objects on NSX (Hierarchy / OrgRoot patch) and removes them from the local store.
+// CleanupInfraResources deletes all cached DnsRecord objects on NSX (Hierarchy / OrgRoot patch) and removes them from the local store.
 func (s *DNSRecordService) CleanupInfraResources(ctx context.Context) error {
 	objs := s.DNSRecordStore.ListDNSRecords()
 	if len(objs) == 0 {
 		return nil
 	}
-	toDelete := make([]*model.ProjectDnsRecord, 0, len(objs))
+	toDelete := make([]*model.DnsRecord, 0, len(objs))
 	for _, rec := range objs {
 		if rec == nil {
 			continue
@@ -26,8 +26,8 @@ func (s *DNSRecordService) CleanupInfraResources(ctx context.Context) error {
 		cp.MarkedForDelete = common.Bool(true)
 		toDelete = append(toDelete, &cp)
 	}
-	log.Info("Cleaning up ProjectDnsRecord resources on NSX", "count", len(toDelete))
-	return s.ProjectDnsRecordBuilder.PagingUpdateResources(ctx, toDelete, common.DefaultHAPIChildrenCount, s.NSXClient, func(deletedObjs []*model.ProjectDnsRecord) {
+	log.Info("Cleaning up DnsRecord resources on NSX", "count", len(toDelete))
+	return s.DnsRecordBuilder.PagingUpdateResources(ctx, toDelete, common.DefaultHAPIChildrenCount, s.NSXClient, func(deletedObjs []*model.DnsRecord) {
 		s.DNSRecordStore.DeleteMultipleObjects(deletedObjs)
 	})
 }

--- a/pkg/nsx/services/dns/compare.go
+++ b/pkg/nsx/services/dns/compare.go
@@ -13,14 +13,14 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
-// dnsRecordComparable adapts model.ProjectDnsRecord for common.CompareResource(s) (see ipaddressallocation/compare.go).
-type dnsRecordComparable model.ProjectDnsRecord
+// dnsRecordComparable adapts model.DnsRecord for common.CompareResource(s) (see ipaddressallocation/compare.go).
+type dnsRecordComparable model.DnsRecord
 
 func (d *dnsRecordComparable) Key() string {
 	if d == nil {
 		return ""
 	}
-	rec := (*model.ProjectDnsRecord)(d)
+	rec := (*model.DnsRecord)(d)
 	if rec.Path == nil {
 		return ""
 	}
@@ -31,8 +31,8 @@ func (d *dnsRecordComparable) Value() data.DataValue {
 	if d == nil {
 		return nil
 	}
-	rec := (*model.ProjectDnsRecord)(d)
-	s := &model.ProjectDnsRecord{
+	rec := (*model.DnsRecord)(d)
+	s := &model.DnsRecord{
 		RecordName:   rec.RecordName,
 		RecordType:   rec.RecordType,
 		ZonePath:     rec.ZonePath,
@@ -72,7 +72,7 @@ func sortedNormalizedTagsForCompare(tags []model.Tag) []model.Tag {
 	return out
 }
 
-func comparableToProjectDnsRecord(c common.Comparable) *model.ProjectDnsRecord {
+func comparableToDnsRecord(c common.Comparable) *model.DnsRecord {
 	if c == nil {
 		return nil
 	}
@@ -80,13 +80,13 @@ func comparableToProjectDnsRecord(c common.Comparable) *model.ProjectDnsRecord {
 	if !ok {
 		return nil
 	}
-	out := model.ProjectDnsRecord(*dc)
+	out := model.DnsRecord(*dc)
 	return &out
 }
 
 // compareRecords returns (toUpsert, toRemove) for reconcile; caller marks toRemove copies deleted.
-func compareRecords(desired, existing []*model.ProjectDnsRecord) (toUpsert []*model.ProjectDnsRecord, toRemove []*model.ProjectDnsRecord) {
-	existingByPath := make(map[string]*model.ProjectDnsRecord)
+func compareRecords(desired, existing []*model.DnsRecord) (toUpsert []*model.DnsRecord, toRemove []*model.DnsRecord) {
+	existingByPath := make(map[string]*model.DnsRecord)
 	existingComp := make([]common.Comparable, 0, len(existing))
 	for _, e := range existing {
 		if e == nil || e.Path == nil {
@@ -108,9 +108,9 @@ func compareRecords(desired, existing []*model.ProjectDnsRecord) (toUpsert []*mo
 
 	changed, stale := common.CompareResources(existingComp, desiredComp)
 
-	toUpsert = make([]*model.ProjectDnsRecord, 0, len(changed))
+	toUpsert = make([]*model.DnsRecord, 0, len(changed))
 	for _, ch := range changed {
-		d := comparableToProjectDnsRecord(ch)
+		d := comparableToDnsRecord(ch)
 		if d == nil || d.Path == nil {
 			continue
 		}
@@ -121,9 +121,9 @@ func compareRecords(desired, existing []*model.ProjectDnsRecord) (toUpsert []*mo
 		}
 	}
 
-	toRemove = make([]*model.ProjectDnsRecord, 0, len(stale))
+	toRemove = make([]*model.DnsRecord, 0, len(stale))
 	for _, st := range stale {
-		if rec := comparableToProjectDnsRecord(st); rec != nil {
+		if rec := comparableToDnsRecord(st); rec != nil {
 			toRemove = append(toRemove, rec)
 		}
 	}

--- a/pkg/nsx/services/dns/compare_contributing_test.go
+++ b/pkg/nsx/services/dns/compare_contributing_test.go
@@ -28,8 +28,8 @@ func TestDNSRecordComparable_Key_table(t *testing.T) {
 		want string
 	}{
 		{"nil receiver", nil, ""},
-		{"nil Path field", (*dnsRecordComparable)(&model.ProjectDnsRecord{}), ""},
-		{"valid path", (*dnsRecordComparable)(&model.ProjectDnsRecord{Path: &path}), path},
+		{"nil Path field", (*dnsRecordComparable)(&model.DnsRecord{}), ""},
+		{"valid path", (*dnsRecordComparable)(&model.DnsRecord{Path: &path}), path},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -55,12 +55,12 @@ func TestSortedNormalizedTagsForCompare_nilFields(t *testing.T) {
 	require.Nil(t, got[0].Scope)
 }
 
-func TestComparableToProjectDnsRecord_table(t *testing.T) {
+func TestComparableToDnsRecord_table(t *testing.T) {
 	t.Run("nil interface returns nil", func(t *testing.T) {
-		require.Nil(t, comparableToProjectDnsRecord(nil))
+		require.Nil(t, comparableToDnsRecord(nil))
 	})
 	t.Run("wrong type returns nil", func(t *testing.T) {
-		require.Nil(t, comparableToProjectDnsRecord(&wrongComparable{}))
+		require.Nil(t, comparableToDnsRecord(&wrongComparable{}))
 	})
 }
 
@@ -77,7 +77,7 @@ func TestResourceRefFromDNSRecord_table(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		rec      *model.ProjectDnsRecord
+		rec      *model.DnsRecord
 		wantOk   bool
 		wantKind string
 		wantNS   string
@@ -90,12 +90,12 @@ func TestResourceRefFromDNSRecord_table(t *testing.T) {
 		},
 		{
 			name:   "no owner tags",
-			rec:    &model.ProjectDnsRecord{Tags: []model.Tag{}},
+			rec:    &model.DnsRecord{Tags: []model.Tag{}},
 			wantOk: false,
 		},
 		{
 			name: "missing name tag",
-			rec: &model.ProjectDnsRecord{Tags: []model.Tag{
+			rec: &model.DnsRecord{Tags: []model.Tag{
 				modelTag(servicecommon.TagScopeDNSRecordFor, servicecommon.TagValueDNSRecordForService),
 				modelTag(servicecommon.TagScopeDNSRecordOwnerNamespace, "ns"),
 				// TagScopeDNSRecordOwnerName is missing
@@ -104,7 +104,7 @@ func TestResourceRefFromDNSRecord_table(t *testing.T) {
 		},
 		{
 			name: "unknown dns_for kind",
-			rec: &model.ProjectDnsRecord{Tags: []model.Tag{
+			rec: &model.DnsRecord{Tags: []model.Tag{
 				modelTag(servicecommon.TagScopeDNSRecordFor, "custom_unknown_kind"),
 				modelTag(servicecommon.TagScopeDNSRecordOwnerNamespace, "ns"),
 				modelTag(servicecommon.TagScopeDNSRecordOwnerName, "svc"),
@@ -113,7 +113,7 @@ func TestResourceRefFromDNSRecord_table(t *testing.T) {
 		},
 		{
 			name:     "valid Service record",
-			rec:      &model.ProjectDnsRecord{Tags: validTags(ResourceKindService, "ns1", "svcA")},
+			rec:      &model.DnsRecord{Tags: validTags(ResourceKindService, "ns1", "svcA")},
 			wantOk:   true,
 			wantKind: ResourceKindService,
 			wantNS:   "ns1",
@@ -121,7 +121,7 @@ func TestResourceRefFromDNSRecord_table(t *testing.T) {
 		},
 		{
 			name:     "valid HTTPRoute record",
-			rec:      &model.ProjectDnsRecord{Tags: validTags(ResourceKindHTTPRoute, "app", "route1")},
+			rec:      &model.DnsRecord{Tags: validTags(ResourceKindHTTPRoute, "app", "route1")},
 			wantOk:   true,
 			wantKind: ResourceKindHTTPRoute,
 			wantNS:   "app",
@@ -147,17 +147,17 @@ func TestResourceRefFromDNSRecord_table(t *testing.T) {
 func TestPrimaryOwnerNNIndexKeyFromRecord_table(t *testing.T) {
 	tests := []struct {
 		name    string
-		rec     *model.ProjectDnsRecord
+		rec     *model.DnsRecord
 		wantKey string
 	}{
 		{
 			name:    "record with no owner tags returns empty",
-			rec:     &model.ProjectDnsRecord{Tags: []model.Tag{}},
+			rec:     &model.DnsRecord{Tags: []model.Tag{}},
 			wantKey: "",
 		},
 		{
 			name: "record with valid owner tags returns index key",
-			rec: &model.ProjectDnsRecord{Tags: []model.Tag{
+			rec: &model.DnsRecord{Tags: []model.Tag{
 				modelTag(servicecommon.TagScopeDNSRecordFor, servicecommon.TagValueDNSRecordForService),
 				modelTag(servicecommon.TagScopeDNSRecordOwnerNamespace, "ns"),
 				modelTag(servicecommon.TagScopeDNSRecordOwnerName, "svc"),
@@ -166,7 +166,7 @@ func TestPrimaryOwnerNNIndexKeyFromRecord_table(t *testing.T) {
 		},
 		{
 			name: "HTTPRoute owner returns correct key",
-			rec: &model.ProjectDnsRecord{Tags: []model.Tag{
+			rec: &model.DnsRecord{Tags: []model.Tag{
 				modelTag(servicecommon.TagScopeDNSRecordFor, servicecommon.TagValueDNSRecordForHTTPRoute),
 				modelTag(servicecommon.TagScopeDNSRecordOwnerNamespace, "app"),
 				modelTag(servicecommon.TagScopeDNSRecordOwnerName, "route1"),

--- a/pkg/nsx/services/dns/contributing.go
+++ b/pkg/nsx/services/dns/contributing.go
@@ -17,11 +17,11 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
-func parseContributingOwnersFromRecord(rec *model.ProjectDnsRecord) []string {
+func parseContributingOwnersFromRecord(rec *model.DnsRecord) []string {
 	return parseContributingOwnersTag(decompressContributingTags(rec))
 }
 
-func decompressContributingTags(rec *model.ProjectDnsRecord) string {
+func decompressContributingTags(rec *model.DnsRecord) string {
 	encodedContributingKeys := firstTagValue(rec.Tags, common.TagScopeDNSRecordContributingOwners)
 	if encodedContributingKeys == "" {
 		return ""
@@ -71,7 +71,7 @@ func mergeContributingOwnerKeys(existing string, add string, primaryNNKey string
 	return formatContributingOwnersTag(seen.UnsortedList())
 }
 
-func resourceRefFromDNSRecord(rec *model.ProjectDnsRecord) (*ResourceRef, bool) {
+func resourceRefFromDNSRecord(rec *model.DnsRecord) (*ResourceRef, bool) {
 	if rec == nil {
 		return nil, false
 	}
@@ -111,7 +111,7 @@ func ownerNNIndexKeyForResourceRef(owner *ResourceRef) string {
 	return dnsRecordOwnerKey(createdFor, dnsRecordOwnerNamespacedNameKey(owner.GetNamespace(), owner.GetName()))
 }
 
-func primaryOwnerNNIndexKeyFromRecord(rec *model.ProjectDnsRecord) string {
+func primaryOwnerNNIndexKeyFromRecord(rec *model.DnsRecord) string {
 	return getDNSRecordOwnerNamespacedName(rec)
 }
 

--- a/pkg/nsx/services/dns/initialize.go
+++ b/pkg/nsx/services/dns/initialize.go
@@ -15,16 +15,16 @@ import (
 
 // InitializeDNSRecordService constructs a DNSRecordService and hydrates DNSRecordStore from NSX Policy search.
 func InitializeDNSRecordService(commonService common.Service, vpcService common.VPCServiceProvider) (*DNSRecordService, error) {
-	builder, err := common.PolicyPathProjectDnsRecord.NewPolicyTreeBuilder()
+	builder, err := common.PolicyPathDnsRecord.NewPolicyTreeBuilder()
 	if err != nil {
 		return nil, fmt.Errorf("creating DNS record tree builder: %w", err)
 	}
 	s := &DNSRecordService{
-		Service:                 commonService,
-		DNSRecordStore:          BuildDNSRecordStore(),
-		VPCService:              vpcService,
-		DNSZoneMap:              newDNSZoneCache(),
-		ProjectDnsRecordBuilder: builder,
+		Service:          commonService,
+		DNSRecordStore:   BuildDNSRecordStore(),
+		VPCService:       vpcService,
+		DNSZoneMap:       newDNSZoneCache(),
+		DnsRecordBuilder: builder,
 	}
 
 	cluster := commonService.NSXConfig.CoeConfig.Cluster
@@ -35,7 +35,7 @@ func InitializeDNSRecordService(commonService common.Service, vpcService common.
 	fatalErrors := make(chan error, 1)
 
 	wg.Add(1)
-	go commonService.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypeProjectDnsRecord, tags, s.DNSRecordStore)
+	go commonService.InitializeResourceStore(&wg, fatalErrors, common.ResourceTypeDnsRecord, tags, s.DNSRecordStore)
 
 	go func() {
 		wg.Wait()

--- a/pkg/nsx/services/dns/recordservice.go
+++ b/pkg/nsx/services/dns/recordservice.go
@@ -29,7 +29,7 @@ var (
 )
 
 // NSX Policy path: /orgs/{org}/projects/{project}/dns-records/{record-id}
-var projectDNSRecordPathRe = regexp.MustCompile(`^/orgs/([^/]+)/projects/([^/]+)/dns-records/([^/]+)$`)
+var dnsRecordPathRe = regexp.MustCompile(`^/orgs/([^/]+)/projects/([^/]+)/dns-records/([^/]+)$`)
 
 // dnsZoneCache is a thread-safe zone path → DNS domain name cache.
 type dnsZoneCache struct {
@@ -66,10 +66,10 @@ func (c *dnsZoneCache) set(key, value string) {
 // DNSRecordService reconciles DNS rows against NSX (store + future HAPI); optional VPCService and DNSZoneMap for zone validation.
 type DNSRecordService struct {
 	common.Service
-	VPCService              common.VPCServiceProvider
-	DNSRecordStore          *RecordStore
-	DNSZoneMap              *dnsZoneCache
-	ProjectDnsRecordBuilder *common.PolicyTreeBuilder[*model.ProjectDnsRecord]
+	VPCService       common.VPCServiceProvider
+	DNSRecordStore   *RecordStore
+	DNSZoneMap       *dnsZoneCache
+	DnsRecordBuilder *common.PolicyTreeBuilder[*model.DnsRecord]
 }
 
 // CreateOrUpdateRecords upserts batch rows into the store and NSX placeholder. Returns (storeMutated, err).
@@ -81,7 +81,7 @@ func (s *DNSRecordService) CreateOrUpdateRecords(ctx context.Context, batch *Agg
 	if len(toUpsert) == 0 && len(toRemove) == 0 {
 		return false, nil
 	}
-	toApply, syncErr := s.syncProjectDnsRecordsInNSX(ctx, toUpsert, toRemove)
+	toApply, syncErr := s.syncDnsRecordsInNSX(ctx, toUpsert, toRemove)
 	// Apply whichever records were successfully processed to keep the local store in sync even on
 	// partial realization failures; this prevents re-sending already-realized records next reconcile.
 	if len(toApply) > 0 {
@@ -92,52 +92,52 @@ func (s *DNSRecordService) CreateOrUpdateRecords(ctx context.Context, batch *Agg
 	return len(toApply) > 0, syncErr
 }
 
-// syncProjectDnsRecordsInNSX sends upserts then deletes via OrgRoot hierarchy patch. For each upsert it checks
+// syncDnsRecordsInNSX sends upserts then deletes via OrgRoot hierarchy patch. For each upsert it checks
 // realization on the patched record path (like Subnet), then GETs the record from NSX for the store; on realization
 // failure it deletes the record via Policy API.
-func (s *DNSRecordService) syncProjectDnsRecordsInNSX(ctx context.Context, toUpsert, toRemove []*model.ProjectDnsRecord) ([]*model.ProjectDnsRecord, error) {
-	removeOps := make([]*model.ProjectDnsRecord, 0, len(toRemove))
+func (s *DNSRecordService) syncDnsRecordsInNSX(ctx context.Context, toUpsert, toRemove []*model.DnsRecord) ([]*model.DnsRecord, error) {
+	removeOps := make([]*model.DnsRecord, 0, len(toRemove))
 	for _, rec := range toRemove {
 		cp := *rec
 		cp.MarkedForDelete = common.Bool(true)
 		removeOps = append(removeOps, &cp)
 	}
 
-	batch := append(append([]*model.ProjectDnsRecord(nil), toUpsert...), removeOps...)
+	batch := append(append([]*model.DnsRecord(nil), toUpsert...), removeOps...)
 
 	if len(batch) == 0 {
 		return nil, nil
 	}
-	log.Info("Patching ProjectDnsRecord batch on NSX", "upsert", len(toUpsert), "remove", len(toRemove))
-	if err := s.ProjectDnsRecordBuilder.PagingUpdateResources(ctx, batch, common.DefaultHAPIChildrenCount, s.NSXClient, nil); err != nil {
+	log.Info("Patching DnsRecord batch on NSX", "upsert", len(toUpsert), "remove", len(toRemove))
+	if err := s.DnsRecordBuilder.PagingUpdateResources(ctx, batch, common.DefaultHAPIChildrenCount, s.NSXClient, nil); err != nil {
 		return nil, err
 	}
 	if len(toUpsert) == 0 {
 		return removeOps, nil
 	}
-	refreshed := make([]*model.ProjectDnsRecord, 0, len(toUpsert))
+	refreshed := make([]*model.DnsRecord, 0, len(toUpsert))
 	var realizeErrs []error
 	for _, rec := range toUpsert {
-		orgID, projectID, recordID, perr := parseProjectDNSRecordPolicyPath(*rec.Path)
+		orgID, projectID, recordID, perr := parseDnsRecordPolicyPath(*rec.Path)
 		if perr != nil {
-			log.Error(perr, "Failed to parse ProjectDnsRecord path, skipping record", "path", *rec.Path)
+			log.Error(perr, "Failed to parse DnsRecord path, skipping record", "path", *rec.Path)
 			realizeErrs = append(realizeErrs, perr)
 			continue
 		}
 		live, gerr := s.NSXClient.DnsRecordsClient.Get(orgID, projectID, recordID)
 		gerr = nsxutil.TransNSXApiError(gerr)
 		if gerr != nil {
-			log.Error(gerr, "Failed to get realized ProjectDnsRecord from NSX", "Id", recordID)
+			log.Error(gerr, "Failed to get realized DnsRecord from NSX", "Id", recordID)
 			realizeErrs = append(realizeErrs, fmt.Errorf("failed to get record %s from NSX after realization: %w", recordID, gerr))
 			continue
 		}
-		log.Debug("ProjectDnsRecord realized and refreshed", "Id", recordID)
+		log.Debug("DnsRecord realized and refreshed", "Id", recordID)
 		lc := live
 		refreshed = append(refreshed, &lc)
 	}
-	toApply := append(append([]*model.ProjectDnsRecord(nil), refreshed...), removeOps...)
+	toApply := append(append([]*model.DnsRecord(nil), refreshed...), removeOps...)
 	if len(realizeErrs) > 0 {
-		log.Error(errors.Join(realizeErrs...), "Some ProjectDnsRecords failed realization",
+		log.Error(errors.Join(realizeErrs...), "Some DnsRecords failed realization",
 			"failed", len(realizeErrs), "succeeded", len(refreshed))
 		return toApply, errors.Join(realizeErrs...)
 	}
@@ -193,7 +193,7 @@ func (s *DNSRecordService) validateEndpointRowConflict(zonePath string, ep *extd
 //   - primary owner, no contributors → mark for delete
 //   - primary owner, has contributors → promote first contributor, append promoted record to toUpdate
 //   - contributing owner → drop key from contributing tag, append updated record to toUpdate
-func (s *DNSRecordService) classifyOwnerRemoval(rec *model.ProjectDnsRecord, deletedOwnerKey string, toDelete, toUpdate *[]*model.ProjectDnsRecord) error {
+func (s *DNSRecordService) classifyOwnerRemoval(rec *model.DnsRecord, deletedOwnerKey string, toDelete, toUpdate *[]*model.DnsRecord) error {
 	contribs := parseContributingOwnersFromRecord(rec) // already sorted
 	if getDNSRecordOwnerNamespacedName(rec) == deletedOwnerKey {
 		if len(contribs) == 0 {
@@ -219,7 +219,7 @@ func (s *DNSRecordService) classifyOwnerRemoval(rec *model.ProjectDnsRecord, del
 //   - desired rows: build the target record, compare with store, enqueue update if changed.
 //   - stale rows: records once owned by batch.Owner that are no longer in the desired set
 //     are either deleted (sole owner) or re-tagged (promote/remove-contributor).
-func (s *DNSRecordService) applyDNSUpsertRows(batch *AggregatedDNSEndpoints) ([]*model.ProjectDnsRecord, []*model.ProjectDnsRecord, error) {
+func (s *DNSRecordService) applyDNSUpsertRows(batch *AggregatedDNSEndpoints) ([]*model.DnsRecord, []*model.DnsRecord, error) {
 	if batch.Owner == nil {
 		if len(batch.Rows) > 0 {
 			return nil, nil, fmt.Errorf("aggregated DNS batch has rows but Owner is nil")
@@ -229,9 +229,9 @@ func (s *DNSRecordService) applyDNSUpsertRows(batch *AggregatedDNSEndpoints) ([]
 	log.Debug("Computing DNS record diff", "kind", batch.Owner.Kind,
 		"namespace", batch.Owner.GetNamespace(), "name", batch.Owner.GetName(), "rows", len(batch.Rows))
 
-	desiredRecs := make([]*model.ProjectDnsRecord, 0, len(batch.Rows))
+	desiredRecs := make([]*model.DnsRecord, 0, len(batch.Rows))
 	for _, row := range batch.Rows {
-		if rec := s.BuildProjectDnsRecord(batch.Owner, row); rec != nil {
+		if rec := s.BuildDnsRecord(batch.Owner, row); rec != nil {
 			desiredRecs = append(desiredRecs, rec)
 		}
 	}
@@ -243,7 +243,7 @@ func (s *DNSRecordService) applyDNSUpsertRows(batch *AggregatedDNSEndpoints) ([]
 	// compareRecords: new/content-changed records go to toUpsert; stale go to staleRecs.
 	toUpsert, staleRecs := compareRecords(desiredRecs, ownedRecs)
 
-	var toRemove []*model.ProjectDnsRecord
+	var toRemove []*model.DnsRecord
 	for _, rec := range staleRecs {
 		if err := s.classifyOwnerRemoval(rec, ownerNNKey, &toRemove, &toUpsert); err != nil {
 			return nil, nil, err
@@ -253,7 +253,7 @@ func (s *DNSRecordService) applyDNSUpsertRows(batch *AggregatedDNSEndpoints) ([]
 	return toUpsert, toRemove, nil
 }
 
-func (s *DNSRecordService) collectRecordsByOwner(ownerKind, ownerNamespace, ownerName string) (string, []*model.ProjectDnsRecord) {
+func (s *DNSRecordService) collectRecordsByOwner(ownerKind, ownerNamespace, ownerName string) (string, []*model.DnsRecord) {
 	createdFor := resourceKindToCreatedFor(ownerKind)
 	if createdFor == "" {
 		return "", nil
@@ -277,7 +277,7 @@ func (s *DNSRecordService) DeleteRecordByOwnerNN(ctx context.Context, kind, name
 	if !cacheChanged {
 		return false, nil
 	}
-	toApply, syncErr := s.syncProjectDnsRecordsInNSX(ctx, toUpdate, toDelete)
+	toApply, syncErr := s.syncDnsRecordsInNSX(ctx, toUpdate, toDelete)
 	if len(toApply) > 0 {
 		if applyErr := s.DNSRecordStore.Apply(toApply); applyErr != nil {
 			return false, applyErr
@@ -286,7 +286,7 @@ func (s *DNSRecordService) DeleteRecordByOwnerNN(ctx context.Context, kind, name
 	return len(toApply) > 0, syncErr
 }
 
-func (s *DNSRecordService) calculateRecordsForDeletion(kind, namespace, name string) (toUpdate []*model.ProjectDnsRecord, toDelete []*model.ProjectDnsRecord, err error) {
+func (s *DNSRecordService) calculateRecordsForDeletion(kind, namespace, name string) (toUpdate []*model.DnsRecord, toDelete []*model.DnsRecord, err error) {
 	deletedNNKey, all := s.collectRecordsByOwner(kind, namespace, name)
 	if deletedNNKey == "" || len(all) == 0 {
 		log.Debug("No owned DNS records found, skipping delete", "kind", kind, "namespace", namespace, "name", name)
@@ -302,12 +302,12 @@ func (s *DNSRecordService) calculateRecordsForDeletion(kind, namespace, name str
 	return toUpdate, toDelete, nil
 }
 
-func gatewayIndexTagFromRecord(rec *model.ProjectDnsRecord) string {
+func gatewayIndexTagFromRecord(rec *model.DnsRecord) string {
 	return firstTagValue(rec.Tags, common.TagScopeDNSRecordGatewayIndexList)
 }
 
 // recordAfterPrimaryDeletePromotion returns the updated record when the primary owner is removed but contributors remain.
-func (s *DNSRecordService) recordAfterPrimaryDeletePromotion(rec *model.ProjectDnsRecord, sortedContribNNKeys []string) (*model.ProjectDnsRecord, error) {
+func (s *DNSRecordService) recordAfterPrimaryDeletePromotion(rec *model.DnsRecord, sortedContribNNKeys []string) (*model.DnsRecord, error) {
 	promotedNN := sortedContribNNKeys[0]
 	remaining := append([]string(nil), sortedContribNNKeys[1:]...)
 	createdFor, ns, name, ok := parseOwnerNNIndexKey(promotedNN)
@@ -326,7 +326,7 @@ func (s *DNSRecordService) recordAfterPrimaryDeletePromotion(rec *model.ProjectD
 }
 
 // recordAfterContributingRemoval removes deletedNNKey from the contributing tag; returns (updatedRecord, changed).
-func recordAfterContributingRemoval(rec *model.ProjectDnsRecord, deletedNNKey string) (*model.ProjectDnsRecord, bool) {
+func recordAfterContributingRemoval(rec *model.DnsRecord, deletedNNKey string) (*model.DnsRecord, bool) {
 	keys := parseContributingOwnersFromRecord(rec)
 	if !slices.Contains(keys, deletedNNKey) {
 		return nil, false
@@ -338,8 +338,8 @@ func recordAfterContributingRemoval(rec *model.ProjectDnsRecord, deletedNNKey st
 	return &out, true
 }
 
-func dedupeRecordsByPath(recs []*model.ProjectDnsRecord) []*model.ProjectDnsRecord {
-	seen := make(map[string]*model.ProjectDnsRecord)
+func dedupeRecordsByPath(recs []*model.DnsRecord) []*model.DnsRecord {
+	seen := make(map[string]*model.DnsRecord)
 	for _, r := range recs {
 		if r == nil || r.Path == nil {
 			continue
@@ -350,7 +350,7 @@ func dedupeRecordsByPath(recs []*model.ProjectDnsRecord) []*model.ProjectDnsReco
 		}
 		seen[p] = r
 	}
-	out := make([]*model.ProjectDnsRecord, 0, len(seen))
+	out := make([]*model.DnsRecord, 0, len(seen))
 	for _, r := range seen {
 		out = append(out, r)
 	}
@@ -380,29 +380,29 @@ func getCluster(s *DNSRecordService) string {
 	return s.NSXConfig.Cluster
 }
 
-// parseProjectDNSRecordPolicyPath splits a Policy ProjectDnsRecord path into org, project, and record id.
-func parseProjectDNSRecordPolicyPath(path string) (orgID, projectID, recordID string, err error) {
+// parseDnsRecordPolicyPath splits a Policy DnsRecord path into org, project, and record id.
+func parseDnsRecordPolicyPath(path string) (orgID, projectID, recordID string, err error) {
 	p := strings.TrimSpace(path)
 	if p == "" {
-		return "", "", "", fmt.Errorf("empty ProjectDnsRecord path")
+		return "", "", "", fmt.Errorf("empty DnsRecord path")
 	}
-	matches := projectDNSRecordPathRe.FindStringSubmatch(p)
+	matches := dnsRecordPathRe.FindStringSubmatch(p)
 	if len(matches) != 4 {
-		return "", "", "", fmt.Errorf("invalid ProjectDnsRecord path %q: expected /orgs/{org}/projects/{project}/dns-records/{record-id}", path)
+		return "", "", "", fmt.Errorf("invalid DnsRecord path %q: expected /orgs/{org}/projects/{project}/dns-records/{record-id}", path)
 	}
 	orgID, projectID, recordID = matches[1], matches[2], matches[3]
 	if strings.TrimSpace(recordID) == "" {
-		return "", "", "", fmt.Errorf("empty record id in ProjectDnsRecord path %q", path)
+		return "", "", "", fmt.Errorf("empty record id in DnsRecord path %q", path)
 	}
 	return orgID, projectID, recordID, nil
 }
 
-func (s *DNSRecordService) deleteProjectDnsRecordOnNSX(live *model.ProjectDnsRecord) error {
-	orgID, projectID, recordID, err := parseProjectDNSRecordPolicyPath(*live.Path)
+func (s *DNSRecordService) deleteDnsRecordOnNSX(live *model.DnsRecord) error {
+	orgID, projectID, recordID, err := parseDnsRecordPolicyPath(*live.Path)
 	if err != nil {
 		return err
 	}
-	log.Info("Deleting ProjectDnsRecord from NSX", "Id", recordID)
+	log.Info("Deleting DnsRecord from NSX", "Id", recordID)
 	err = s.NSXClient.DnsRecordsClient.Delete(orgID, projectID, recordID)
 	return nsxutil.TransNSXApiError(err)
 }

--- a/pkg/nsx/services/dns/recordservice_test.go
+++ b/pkg/nsx/services/dns/recordservice_test.go
@@ -36,7 +36,7 @@ import (
 
 var _ servicecommon.VPCServiceProvider = (*pkgmock.MockVPCServiceProvider)(nil)
 
-// Policy DNS zone paths must match projectDNSZonePathRe in zones.go:
+// Policy DNS zone paths must match dnsZonePathRe in zones.go:
 const (
 	testDNSZonePathT      = "/orgs/org1/projects/proj1/dns-services/ds1/zones/zone-t"
 	testDNSZonePathGw     = "/orgs/org1/projects/proj1/dns-services/ds1/zones/zone-gw"
@@ -79,7 +79,7 @@ func testDNSZoneMapForVPCFixture() map[string]string {
 // is hermetic: no package-level state is shared between test cases.
 type testDNSSvc struct {
 	*DNSRecordService
-	bodies map[string]*model.ProjectDnsRecord
+	bodies map[string]*model.DnsRecord
 }
 
 // registerBodiesForBatch pre-populates the mock Get registry with the records that
@@ -90,7 +90,7 @@ func registerBodiesForBatch(t *testing.T, env *testDNSSvc, batch *AggregatedDNSE
 		return
 	}
 	for _, row := range batch.Rows {
-		rec := env.BuildProjectDnsRecord(batch.Owner, row)
+		rec := env.BuildDnsRecord(batch.Owner, row)
 		if rec == nil || rec.Id == nil {
 			continue
 		}
@@ -104,7 +104,7 @@ func recordStoreKey(zonePath, recordName, recordType string) string {
 	return path
 }
 
-func newTestNSXClient(t *testing.T, bodies map[string]*model.ProjectDnsRecord) *nsx.Client {
+func newTestNSXClient(t *testing.T, bodies map[string]*model.DnsRecord) *nsx.Client {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
@@ -120,7 +120,7 @@ func newTestNSXClient(t *testing.T, bodies map[string]*model.ProjectDnsRecord) *
 
 	dnsRec := dnsrecmocks.NewMockDnsRecordsClient(ctrl)
 	dnsRec.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(orgID, projectID, recordID string) (model.ProjectDnsRecord, error) {
+		func(orgID, projectID, recordID string) (model.DnsRecord, error) {
 			p := fmt.Sprintf("/orgs/%s/projects/%s/%s/%s", orgID, projectID, DNSRecordPathSegment, recordID)
 			if d := bodies[recordID]; d != nil {
 				out := *d
@@ -129,7 +129,7 @@ func newTestNSXClient(t *testing.T, bodies map[string]*model.ProjectDnsRecord) *
 				return out, nil
 			}
 			rid := recordID
-			return model.ProjectDnsRecord{Id: &rid, Path: &p}, nil
+			return model.DnsRecord{Id: &rid, Path: &p}, nil
 		}).AnyTimes()
 	dnsRec.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
@@ -142,9 +142,9 @@ func newTestNSXClient(t *testing.T, bodies map[string]*model.ProjectDnsRecord) *
 
 func newTestDNSRecordService(t *testing.T, store *RecordStore) *testDNSSvc {
 	t.Helper()
-	bodies := make(map[string]*model.ProjectDnsRecord)
+	bodies := make(map[string]*model.DnsRecord)
 	fc := fake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).Build()
-	builder, err := servicecommon.PolicyPathProjectDnsRecord.NewPolicyTreeBuilder()
+	builder, err := servicecommon.PolicyPathDnsRecord.NewPolicyTreeBuilder()
 	require.NoError(t, err)
 	svc := &DNSRecordService{
 		Service: servicecommon.Service{
@@ -152,8 +152,8 @@ func newTestDNSRecordService(t *testing.T, store *RecordStore) *testDNSSvc {
 			NSXConfig: &config.NSXOperatorConfig{CoeConfig: &config.CoeConfig{Cluster: "unit-test"}},
 			NSXClient: newTestNSXClient(t, bodies),
 		},
-		DNSRecordStore:          store,
-		ProjectDnsRecordBuilder: builder,
+		DNSRecordStore:   store,
+		DnsRecordBuilder: builder,
 	}
 	return &testDNSSvc{DNSRecordService: svc, bodies: bodies}
 }
@@ -363,7 +363,7 @@ func TestDNSRecordService_deletesAndQueries_table(t *testing.T) {
 				ep := extdns.NewEndpoint("gw.example.com", extdns.RecordTypeA, "10.0.0.1")
 				ep.WithLabel(EndpointLabelParentGateway, "app/gw1")
 				row := EndpointRow{Endpoint: ep, zonePath: z, nsxRecordName: "gw.example.com"}
-				require.NotNil(t, env.BuildProjectDnsRecord(owner, row))
+				require.NotNil(t, env.BuildDnsRecord(owner, row))
 				requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(owner, []EndpointRow{row}))
 				key := recordStoreKey(row.zonePath, row.nsxRecordName, row.Endpoint.RecordType)
 				require.NotNil(t, env.DNSRecordStore.GetByKey(key))
@@ -382,7 +382,7 @@ func TestDNSRecordService_deletesAndQueries_table(t *testing.T) {
 				epG := extdns.NewEndpoint("gw.example.com", extdns.RecordTypeA, "10.0.0.1")
 				epG.WithLabel(EndpointLabelParentGateway, "app/gw1")
 				rowG := EndpointRow{Endpoint: epG, zonePath: z, nsxRecordName: "gw.example.com"}
-				require.NotNil(t, env.BuildProjectDnsRecord(gwOwner, rowG))
+				require.NotNil(t, env.BuildDnsRecord(gwOwner, rowG))
 				requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(gwOwner, []EndpointRow{rowG}))
 				hrEp := extdns.NewEndpoint("r.example.com", extdns.RecordTypeA, "10.0.0.2")
 				hrEp.WithLabel(EndpointLabelParentGateway, "app/gw1")
@@ -391,7 +391,7 @@ func TestDNSRecordService_deletesAndQueries_table(t *testing.T) {
 					Kind:   ResourceKindHTTPRoute,
 					Object: &metav1.ObjectMeta{Namespace: "app", Name: "hr1", UID: types.UID("u-hr")},
 				}
-				require.NotNil(t, env.BuildProjectDnsRecord(hrOwner, *hrRow))
+				require.NotNil(t, env.BuildDnsRecord(hrOwner, *hrRow))
 				requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(hrOwner, []EndpointRow{*hrRow}))
 				requireNoErrDeleteDNS(ctx, t, env, ResourceKindGateway, "app", "gw1")
 				require.Nil(t, env.DNSRecordStore.GetByKey(recordStoreKey(rowG.zonePath, rowG.nsxRecordName, rowG.Endpoint.RecordType)))
@@ -409,7 +409,7 @@ func TestDNSRecordService_deletesAndQueries_table(t *testing.T) {
 					Kind:   ResourceKindHTTPRoute,
 					Object: &metav1.ObjectMeta{Namespace: ns, Name: "hr1", UID: types.UID("uid-hr1")},
 				}
-				require.NotNil(t, env.BuildProjectDnsRecord(hrOwner, *row))
+				require.NotNil(t, env.BuildDnsRecord(hrOwner, *row))
 				requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(hrOwner, []EndpointRow{*row}))
 				require.True(t, env.ListReferredGatewayNN().Has(types.NamespacedName{Namespace: "demo", Name: "gw1"}))
 				groups := env.ListRecordOwnerResource()
@@ -427,9 +427,9 @@ func TestDNSRecordService_deletesAndQueries_table(t *testing.T) {
 }
 
 // dnsRecordStructValue converts rec to a *data.StructValue for use in mock SearchResponse.Results.
-func dnsRecordStructValue(t *testing.T, rec model.ProjectDnsRecord) *data.StructValue {
+func dnsRecordStructValue(t *testing.T, rec model.DnsRecord) *data.StructValue {
 	t.Helper()
-	dv, errs := servicecommon.NewConverter().ConvertToVapi(rec, model.ProjectDnsRecordBindingType())
+	dv, errs := servicecommon.NewConverter().ConvertToVapi(rec, model.DnsRecordBindingType())
 	require.Empty(t, errs, "ConvertToVapi failed")
 	sv, ok := dv.(*data.StructValue)
 	require.True(t, ok, "expected *data.StructValue from ConvertToVapi")
@@ -442,7 +442,7 @@ func TestInitializeDNSRecordService_table(t *testing.T) {
 	vpcM := &pkgmock.MockVPCServiceProvider{}
 
 	// A minimal record whose ZonePath falls into testDNSZonePathT.
-	recWithZone := model.ProjectDnsRecord{
+	recWithZone := model.DnsRecord{
 		Id:       servicecommon.String("rec-warmup"),
 		Path:     servicecommon.String("/orgs/org1/projects/proj1/dns-records/rec-warmup"),
 		ZonePath: servicecommon.String(testDNSZonePathT),
@@ -471,14 +471,14 @@ func TestInitializeDNSRecordService_table(t *testing.T) {
 				rc := int64(0)
 				qc.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(model.SearchResponse{Results: nil, Cursor: nil, ResultCount: &rc}, nil).Times(1)
-				// ProjectDnsZoneClient.Get must NOT be called: no records, no warm-up.
+				// DnsZoneClient.Get must NOT be called: no records, no warm-up.
 				zc := dnszonemocks.NewMockZonesClient(ctrl)
-				return &nsx.Client{QueryClient: qc, ProjectDnsZoneClient: zc, NsxConfig: cfg}
+				return &nsx.Client{QueryClient: qc, DnsZoneClient: zc, NsxConfig: cfg}
 			},
 			checkSvc: func(t *testing.T, svc *DNSRecordService) {
 				require.NotNil(t, svc.DNSRecordStore)
 				require.NotNil(t, svc.VPCService)
-				require.NotNil(t, svc.ProjectDnsRecordBuilder)
+				require.NotNil(t, svc.DnsRecordBuilder)
 				require.NotNil(t, svc.DNSZoneMap)
 				_, found := svc.DNSZoneMap.get(testDNSZonePathT)
 				require.False(t, found, "zone map must be empty when store is empty")
@@ -494,8 +494,8 @@ func TestInitializeDNSRecordService_table(t *testing.T) {
 					Return(model.SearchResponse{Results: []*data.StructValue{sv}, Cursor: nil, ResultCount: &rc}, nil).Times(1)
 				domain := "example.com"
 				zc := dnszonemocks.NewMockZonesClient(ctrl)
-				zc.EXPECT().Get("org1", "proj1", "ds1", "zone-t").Return(model.ProjectDnsZone{DnsDomainName: &domain}, nil).Times(1)
-				return &nsx.Client{QueryClient: qc, ProjectDnsZoneClient: zc, NsxConfig: cfg}
+				zc.EXPECT().Get("org1", "proj1", "ds1", "zone-t").Return(model.DnsZone{DnsDomainName: &domain}, nil).Times(1)
+				return &nsx.Client{QueryClient: qc, DnsZoneClient: zc, NsxConfig: cfg}
 			},
 			checkSvc: func(t *testing.T, svc *DNSRecordService) {
 				got, found := svc.DNSZoneMap.get(testDNSZonePathT)
@@ -512,8 +512,8 @@ func TestInitializeDNSRecordService_table(t *testing.T) {
 				qc.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(model.SearchResponse{Results: []*data.StructValue{sv}, Cursor: nil, ResultCount: &rc}, nil).Times(1)
 				zc := dnszonemocks.NewMockZonesClient(ctrl)
-				zc.EXPECT().Get("org1", "proj1", "ds1", "zone-t").Return(model.ProjectDnsZone{}, errors.New("nsx zone unavailable")).Times(1)
-				return &nsx.Client{QueryClient: qc, ProjectDnsZoneClient: zc, NsxConfig: cfg}
+				zc.EXPECT().Get("org1", "proj1", "ds1", "zone-t").Return(model.DnsZone{}, errors.New("nsx zone unavailable")).Times(1)
+				return &nsx.Client{QueryClient: qc, DnsZoneClient: zc, NsxConfig: cfg}
 			},
 			checkSvc: func(t *testing.T, svc *DNSRecordService) {
 				_, found := svc.DNSZoneMap.get(testDNSZonePathT)
@@ -529,8 +529,8 @@ func TestInitializeDNSRecordService_table(t *testing.T) {
 				qc.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(model.SearchResponse{Results: []*data.StructValue{sv}, Cursor: nil, ResultCount: &rc}, nil).Times(1)
 				zc := dnszonemocks.NewMockZonesClient(ctrl)
-				zc.EXPECT().Get("org1", "proj1", "ds1", "zone-t").Return(model.ProjectDnsZone{DnsDomainName: nil}, nil).Times(1)
-				return &nsx.Client{QueryClient: qc, ProjectDnsZoneClient: zc, NsxConfig: cfg}
+				zc.EXPECT().Get("org1", "proj1", "ds1", "zone-t").Return(model.DnsZone{DnsDomainName: nil}, nil).Times(1)
+				return &nsx.Client{QueryClient: qc, DnsZoneClient: zc, NsxConfig: cfg}
 			},
 			checkSvc: func(t *testing.T, svc *DNSRecordService) {
 				_, found := svc.DNSZoneMap.get(testDNSZonePathT)
@@ -540,7 +540,7 @@ func TestInitializeDNSRecordService_table(t *testing.T) {
 		{
 			name: "warmup_dedup_same_zone_path_get_once",
 			setupMock: func(t *testing.T, ctrl *gomock.Controller) *nsx.Client {
-				rec2 := model.ProjectDnsRecord{
+				rec2 := model.DnsRecord{
 					Id:       servicecommon.String("rec-warmup-2"),
 					Path:     servicecommon.String("/orgs/org1/projects/proj1/dns-records/rec-warmup-2"),
 					ZonePath: servicecommon.String(testDNSZonePathT),
@@ -554,8 +554,8 @@ func TestInitializeDNSRecordService_table(t *testing.T) {
 				domain := "example.com"
 				// Even though two records share the same zone path, Get must be called exactly once.
 				zc := dnszonemocks.NewMockZonesClient(ctrl)
-				zc.EXPECT().Get("org1", "proj1", "ds1", "zone-t").Return(model.ProjectDnsZone{DnsDomainName: &domain}, nil).Times(1)
-				return &nsx.Client{QueryClient: qc, ProjectDnsZoneClient: zc, NsxConfig: cfg}
+				zc.EXPECT().Get("org1", "proj1", "ds1", "zone-t").Return(model.DnsZone{DnsDomainName: &domain}, nil).Times(1)
+				return &nsx.Client{QueryClient: qc, DnsZoneClient: zc, NsxConfig: cfg}
 			},
 			checkSvc: func(t *testing.T, svc *DNSRecordService) {
 				got, found := svc.DNSZoneMap.get(testDNSZonePathT)
@@ -599,7 +599,7 @@ func TestCreateOrUpdateRecords_ownerScoped_mergeUpdatesTargets(t *testing.T) {
 	recordName := "x.example.com"
 	ep0 := extdns.NewEndpoint("x.example.com", extdns.RecordTypeA, "10.0.0.1")
 	ep0.WithLabel(EndpointLabelParentGateway, "ns/gw")
-	require.NotNil(t, env.BuildProjectDnsRecord(owner, EndpointRow{Endpoint: ep0, zonePath: z, nsxRecordName: recordName}))
+	require.NotNil(t, env.BuildDnsRecord(owner, EndpointRow{Endpoint: ep0, zonePath: z, nsxRecordName: recordName}))
 	for _, targets := range [][]string{{"10.0.0.1"}, {"10.0.0.2"}} {
 		ep := extdns.NewEndpoint("x.example.com", extdns.RecordTypeA, targets...)
 		ep.WithLabel(EndpointLabelParentGateway, "ns/gw")
@@ -622,14 +622,14 @@ func Test_CreateOrUpdateRecords_Service_DeleteByOwnerNN(t *testing.T) {
 	ep := extdns.NewEndpoint("x.example.com", extdns.RecordTypeA, "10.0.0.1")
 	ep.WithLabel(EndpointLabelParentGateway, "ns1/lbsvc")
 	row := EndpointRow{Endpoint: ep, zonePath: z, nsxRecordName: "x.example.com"}
-	require.NotNil(t, env.BuildProjectDnsRecord(owner, row))
+	require.NotNil(t, env.BuildDnsRecord(owner, row))
 	requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(owner, []EndpointRow{row}))
 	require.Len(t, env.DNSRecordStore.GetByOwnerResourceNamespacedName(ResourceKindService, "ns1", "lbsvc"), 1)
 	requireNoErrDeleteDNS(ctx, t, env, ResourceKindService, "ns1", "lbsvc")
 	assert.Empty(t, env.DNSRecordStore.GetByOwnerResourceNamespacedName(ResourceKindService, "ns1", "lbsvc"))
 }
 
-func TestParseProjectDNSRecordPolicyPath_table(t *testing.T) {
+func TestParseDnsRecordPolicyPath_table(t *testing.T) {
 	tests := []struct {
 		name    string
 		path    string
@@ -648,17 +648,17 @@ func TestParseProjectDNSRecordPolicyPath_table(t *testing.T) {
 		{
 			name:   "missing_segment",
 			path:   "/orgs/acme/projects/p1/projects/rec-a",
-			errSub: "invalid ProjectDnsRecord path",
+			errSub: "invalid DnsRecord path",
 		},
 		{
 			name:   "empty_path",
 			path:   "",
-			errSub: "empty ProjectDnsRecord path",
+			errSub: "empty DnsRecord path",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			org, prj, id, err := parseProjectDNSRecordPolicyPath(tt.path)
+			org, prj, id, err := parseDnsRecordPolicyPath(tt.path)
 			if tt.errSub != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errSub)
@@ -674,16 +674,16 @@ func TestParseProjectDNSRecordPolicyPath_table(t *testing.T) {
 
 func TestDedupeRecordsByPath(t *testing.T) {
 	p := "/orgs/o/projects/p/dns-records/a"
-	a := &model.ProjectDnsRecord{Path: servicecommon.String(p), Id: servicecommon.String("a")}
-	b := &model.ProjectDnsRecord{Path: servicecommon.String(p), Id: servicecommon.String("b")}
-	out := dedupeRecordsByPath([]*model.ProjectDnsRecord{a, b})
+	a := &model.DnsRecord{Path: servicecommon.String(p), Id: servicecommon.String("a")}
+	b := &model.DnsRecord{Path: servicecommon.String(p), Id: servicecommon.String("b")}
+	out := dedupeRecordsByPath([]*model.DnsRecord{a, b})
 	require.Len(t, out, 1)
 }
 
-func TestDeleteProjectDnsRecordOnNSX(t *testing.T) {
+func TestDeleteDnsRecordOnNSX(t *testing.T) {
 	env := newTestDNSRecordService(t, BuildDNSRecordStore())
 	p := "/orgs/org1/projects/proj1/dns-records/rec1"
-	err := env.deleteProjectDnsRecordOnNSX(&model.ProjectDnsRecord{Path: &p})
+	err := env.deleteDnsRecordOnNSX(&model.DnsRecord{Path: &p})
 	require.NoError(t, err)
 }
 
@@ -778,13 +778,13 @@ func TestGetNSXDnsRecordType_table(t *testing.T) {
 		input string
 		want  string
 	}{
-		{extdns.RecordTypeA, model.ProjectDnsRecord_RECORD_TYPE_A},
-		{extdns.RecordTypeAAAA, model.ProjectDnsRecord_RECORD_TYPE_AAAA},
-		{extdns.RecordTypeCNAME, model.ProjectDnsRecord_RECORD_TYPE_CNAME},
-		{extdns.RecordTypeNS, model.ProjectDnsRecord_RECORD_TYPE_NS},
-		{extdns.RecordTypePTR, model.ProjectDnsRecord_RECORD_TYPE_PTR},
-		{"UNKNOWN", model.ProjectDnsRecord_RECORD_TYPE_A},
-		{"", model.ProjectDnsRecord_RECORD_TYPE_A},
+		{extdns.RecordTypeA, model.DnsRecord_RECORD_TYPE_A},
+		{extdns.RecordTypeAAAA, model.DnsRecord_RECORD_TYPE_AAAA},
+		{extdns.RecordTypeCNAME, model.DnsRecord_RECORD_TYPE_CNAME},
+		{extdns.RecordTypeNS, model.DnsRecord_RECORD_TYPE_NS},
+		{extdns.RecordTypePTR, model.DnsRecord_RECORD_TYPE_PTR},
+		{"UNKNOWN", model.DnsRecord_RECORD_TYPE_A},
+		{"", model.DnsRecord_RECORD_TYPE_A},
 	}
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
@@ -855,8 +855,8 @@ func TestSortedNormalizedTagsForCompare_table(t *testing.T) {
 }
 
 func TestRecordAfterPrimaryDeletePromotion_table(t *testing.T) {
-	makeOwnerRec := func(kind, ns, name, path string) *model.ProjectDnsRecord {
-		return &model.ProjectDnsRecord{
+	makeOwnerRec := func(kind, ns, name, path string) *model.DnsRecord {
+		return &model.DnsRecord{
 			Path: servicecommon.String(path),
 			Tags: []model.Tag{
 				modelTag(servicecommon.TagScopeDNSRecordFor, resourceKindToCreatedFor(kind)),
@@ -874,8 +874,8 @@ func TestRecordAfterPrimaryDeletePromotion_table(t *testing.T) {
 	tests := []struct {
 		name           string
 		sortedContribs []string
-		rec            *model.ProjectDnsRecord
-		storeRecords   []*model.ProjectDnsRecord
+		rec            *model.DnsRecord
+		storeRecords   []*model.DnsRecord
 		wantErr        bool
 		wantOwnerName  string
 		wantGateway    string
@@ -884,39 +884,39 @@ func TestRecordAfterPrimaryDeletePromotion_table(t *testing.T) {
 		{
 			name:           "invalid contrib key format returns error",
 			sortedContribs: []string{"badformat"},
-			rec:            &model.ProjectDnsRecord{},
+			rec:            &model.DnsRecord{},
 			wantErr:        true,
 		},
 		{
 			name:           "unknown kind in contrib key returns error",
 			sortedContribs: []string{"unknown_kind/ns/name"},
-			rec:            &model.ProjectDnsRecord{},
+			rec:            &model.DnsRecord{},
 			wantErr:        true,
 		},
 		{
 			name:           "sole contributor promoted, no remaining contribs",
 			sortedContribs: []string{keyA},
-			rec:            &model.ProjectDnsRecord{Path: sharedPath},
-			storeRecords:   []*model.ProjectDnsRecord{storeRecA},
+			rec:            &model.DnsRecord{Path: sharedPath},
+			storeRecords:   []*model.DnsRecord{storeRecA},
 			wantOwnerName:  "a",
 			wantContribs:   nil,
 		},
 		{
 			name:           "first of two contributors promoted, second remains",
 			sortedContribs: []string{keyA, keyB},
-			rec:            &model.ProjectDnsRecord{Path: sharedPath},
-			storeRecords:   []*model.ProjectDnsRecord{storeRecA},
+			rec:            &model.DnsRecord{Path: sharedPath},
+			storeRecords:   []*model.DnsRecord{storeRecA},
 			wantOwnerName:  "a",
 			wantContribs:   []string{keyB},
 		},
 		{
 			name:           "gateway tag from original record is preserved",
 			sortedContribs: []string{keyA},
-			rec: &model.ProjectDnsRecord{
+			rec: &model.DnsRecord{
 				Path: sharedPath,
 				Tags: []model.Tag{modelTag(servicecommon.TagScopeDNSRecordGatewayIndexList, "ns/gw1")},
 			},
-			storeRecords:  []*model.ProjectDnsRecord{storeRecA},
+			storeRecords:  []*model.DnsRecord{storeRecA},
 			wantOwnerName: "a",
 			wantGateway:   "ns/gw1",
 			wantContribs:  nil,
@@ -951,7 +951,7 @@ func TestClassifyOwnerRemoval_table(t *testing.T) {
 	keyA := dnsRecordOwnerKey(servicecommon.TagValueDNSRecordForHTTPRoute, dnsRecordOwnerNamespacedNameKey("ns", "a"))
 	keyB := dnsRecordOwnerKey(servicecommon.TagValueDNSRecordForHTTPRoute, dnsRecordOwnerNamespacedNameKey("ns", "b"))
 
-	makeRec := func(ownerKey string, contribs []string, path string) *model.ProjectDnsRecord {
+	makeRec := func(ownerKey string, contribs []string, path string) *model.DnsRecord {
 		createdFor, ns, name, _ := parseOwnerNNIndexKey(ownerKey)
 		tags := []model.Tag{
 			modelTag(servicecommon.TagScopeDNSRecordFor, createdFor),
@@ -961,11 +961,11 @@ func TestClassifyOwnerRemoval_table(t *testing.T) {
 		if len(contribs) > 0 {
 			tags = append(tags, modelTag(servicecommon.TagScopeDNSRecordContributingOwners, formatContributingOwnersTag(contribs)))
 		}
-		return &model.ProjectDnsRecord{Path: servicecommon.String(path), Tags: tags}
+		return &model.DnsRecord{Path: servicecommon.String(path), Tags: tags}
 	}
 
 	// Store record for the promoted owner (needed when primary is deleted with contribs)
-	storeRecA := &model.ProjectDnsRecord{
+	storeRecA := &model.DnsRecord{
 		Path: servicecommon.String("/orgs/org1/projects/proj1/dns-records/for_a"),
 		Tags: []model.Tag{
 			modelTag(servicecommon.TagScopeDNSRecordFor, servicecommon.TagValueDNSRecordForHTTPRoute),
@@ -976,9 +976,9 @@ func TestClassifyOwnerRemoval_table(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		rec           *model.ProjectDnsRecord
+		rec           *model.DnsRecord
 		deletedKey    string
-		storeRecords  []*model.ProjectDnsRecord
+		storeRecords  []*model.DnsRecord
 		wantDeleteLen int
 		wantUpdateLen int
 		wantMarked    bool
@@ -995,7 +995,7 @@ func TestClassifyOwnerRemoval_table(t *testing.T) {
 			name:          "primary owner, has contribs: first contrib promoted",
 			rec:           makeRec(keyB, []string{keyA}, "/orgs/org1/projects/proj1/dns-records/shared"),
 			deletedKey:    keyB,
-			storeRecords:  []*model.ProjectDnsRecord{storeRecA},
+			storeRecords:  []*model.DnsRecord{storeRecA},
 			wantUpdateLen: 1,
 			wantContribs:  nil,
 		},
@@ -1021,7 +1021,7 @@ func TestClassifyOwnerRemoval_table(t *testing.T) {
 			}
 			env := newTestDNSRecordService(t, store)
 
-			var toDelete, toUpdate []*model.ProjectDnsRecord
+			var toDelete, toUpdate []*model.DnsRecord
 			err := env.classifyOwnerRemoval(tc.rec, tc.deletedKey, &toDelete, &toUpdate)
 			require.NoError(t, err)
 			require.Len(t, toDelete, tc.wantDeleteLen)
@@ -1041,31 +1041,31 @@ func TestCompareRecords_toUpsertAndRemove(t *testing.T) {
 	z := testDNSZonePathZ
 	id1 := "id1"
 	id2 := "id2"
-	d1 := &model.ProjectDnsRecord{
+	d1 := &model.DnsRecord{
 		Id:           &id1,
 		Path:         servicecommon.String("/orgs/o/projects/p/dns-records/" + id1),
 		RecordName:   servicecommon.String("n1"),
-		RecordType:   servicecommon.String(model.ProjectDnsRecord_RECORD_TYPE_A),
+		RecordType:   servicecommon.String(model.DnsRecord_RECORD_TYPE_A),
 		ZonePath:     &z,
 		RecordValues: []string{"1.1.1.1"},
 	}
-	e1 := &model.ProjectDnsRecord{
+	e1 := &model.DnsRecord{
 		Id:           &id1,
 		Path:         servicecommon.String("/orgs/o/projects/p/dns-records/" + id1),
 		RecordName:   servicecommon.String("n1"),
-		RecordType:   servicecommon.String(model.ProjectDnsRecord_RECORD_TYPE_A),
+		RecordType:   servicecommon.String(model.DnsRecord_RECORD_TYPE_A),
 		ZonePath:     &z,
 		RecordValues: []string{"9.9.9.9"},
 	}
-	stale := &model.ProjectDnsRecord{
+	stale := &model.DnsRecord{
 		Id:           &id2,
 		Path:         servicecommon.String("/orgs/o/projects/p/dns-records/" + id2),
 		RecordName:   servicecommon.String("n2"),
-		RecordType:   servicecommon.String(model.ProjectDnsRecord_RECORD_TYPE_A),
+		RecordType:   servicecommon.String(model.DnsRecord_RECORD_TYPE_A),
 		ZonePath:     &z,
 		RecordValues: []string{"2.2.2.2"},
 	}
-	up, rm := compareRecords([]*model.ProjectDnsRecord{d1}, []*model.ProjectDnsRecord{e1, stale})
+	up, rm := compareRecords([]*model.DnsRecord{d1}, []*model.DnsRecord{e1, stale})
 	require.Len(t, rm, 1)
 	require.Equal(t, id2, *rm[0].Id)
 	require.Len(t, up, 1)
@@ -1084,7 +1084,7 @@ func TestCleanupInfraResources(t *testing.T) {
 	ep := extdns.NewEndpoint("cl.example.com", extdns.RecordTypeA, "192.0.2.1")
 	ep.WithLabel(EndpointLabelParentGateway, "ns/gw")
 	row := EndpointRow{Endpoint: ep, zonePath: z, nsxRecordName: "cl.example.com"}
-	require.NotNil(t, env.BuildProjectDnsRecord(owner, row))
+	require.NotNil(t, env.BuildDnsRecord(owner, row))
 	requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(owner, []EndpointRow{row}))
 	require.NotEmpty(t, store.ListDNSRecords())
 
@@ -1101,12 +1101,12 @@ func TestValidateEndpointRowConflict_table(t *testing.T) {
 	ownerB := &ResourceRef{Kind: ResourceKindService, Object: &metav1.ObjectMeta{Namespace: "ns", Name: "svcB"}}
 	epA := extdns.NewEndpoint(fqdn, extdns.RecordTypeA, "10.0.0.1")
 
-	makeStoreRec := func(owner *ResourceRef, path string, values []string) *model.ProjectDnsRecord {
+	makeStoreRec := func(owner *ResourceRef, path string, values []string) *model.DnsRecord {
 		createdFor := resourceKindToCreatedFor(owner.Kind)
-		return &model.ProjectDnsRecord{
+		return &model.DnsRecord{
 			Path:         servicecommon.String(path),
 			ZonePath:     servicecommon.String(zonePath),
-			RecordType:   servicecommon.String(model.ProjectDnsRecord_RECORD_TYPE_A),
+			RecordType:   servicecommon.String(model.DnsRecord_RECORD_TYPE_A),
 			RecordName:   servicecommon.String("svc"),
 			Fqdn:         servicecommon.String(fqdn),
 			RecordValues: values,
@@ -1120,7 +1120,7 @@ func TestValidateEndpointRowConflict_table(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		storeRecs  []*model.ProjectDnsRecord
+		storeRecs  []*model.DnsRecord
 		owner      *ResourceRef
 		wantErr    bool
 		errSub     string
@@ -1132,28 +1132,28 @@ func TestValidateEndpointRowConflict_table(t *testing.T) {
 		},
 		{
 			name:      "own record in store: returns row directly",
-			storeRecs: []*model.ProjectDnsRecord{makeStoreRec(ownerA, "/orgs/org1/projects/proj1/dns-records/r-svcA", []string{"10.0.0.1"})},
+			storeRecs: []*model.DnsRecord{makeStoreRec(ownerA, "/orgs/org1/projects/proj1/dns-records/r-svcA", []string{"10.0.0.1"})},
 			owner:     ownerA,
 		},
 		{
 			name:      "FQDN conflict: different target values for different owner",
-			storeRecs: []*model.ProjectDnsRecord{makeStoreRec(ownerB, "/orgs/org1/projects/proj1/dns-records/r-svcB", []string{"10.0.0.99"})},
+			storeRecs: []*model.DnsRecord{makeStoreRec(ownerB, "/orgs/org1/projects/proj1/dns-records/r-svcB", []string{"10.0.0.99"})},
 			owner:     ownerA,
 			wantErr:   true,
 			errSub:    "configured with different values",
 		},
 		{
 			name:       "adoption: same values from different owner",
-			storeRecs:  []*model.ProjectDnsRecord{makeStoreRec(ownerB, "/orgs/org1/projects/proj1/dns-records/r-svcB", []string{"10.0.0.1"})},
+			storeRecs:  []*model.DnsRecord{makeStoreRec(ownerB, "/orgs/org1/projects/proj1/dns-records/r-svcB", []string{"10.0.0.1"})},
 			owner:      ownerA,
 			wantShared: true,
 		},
 		{
 			name: "adoption fails: same values but incomplete owner metadata",
-			storeRecs: []*model.ProjectDnsRecord{{
+			storeRecs: []*model.DnsRecord{{
 				Path:         servicecommon.String("/orgs/org1/projects/proj1/dns-records/r-noowner"),
 				ZonePath:     servicecommon.String(zonePath),
-				RecordType:   servicecommon.String(model.ProjectDnsRecord_RECORD_TYPE_A),
+				RecordType:   servicecommon.String(model.DnsRecord_RECORD_TYPE_A),
 				RecordName:   servicecommon.String("svc"),
 				Fqdn:         servicecommon.String(fqdn),
 				RecordValues: []string{"10.0.0.1"},
@@ -1232,7 +1232,7 @@ func TestApplyDNSUpsertRows_unsupportedOwnerKind(t *testing.T) {
 		{Endpoint: ep, zonePath: testDNSZonePathT, nsxRecordName: "a"},
 	})
 	// collectRecordsByOwner returns ("", nil) for unknown kind, so ownerNNKey="" → toUpsert is non-empty
-	// but syncProjectDnsRecordsInNSX will be called. The important thing is no panic.
+	// but syncDnsRecordsInNSX will be called. The important thing is no panic.
 	_, _, err := env.applyDNSUpsertRows(batch)
 	require.NoError(t, err)
 }
@@ -1242,7 +1242,7 @@ func TestSyncDNSZonesByVpcNetworkConfig_table(t *testing.T) {
 	t.Cleanup(func() { ctrl.Finish() })
 	zc := dnszonemocks.NewMockZonesClient(ctrl)
 
-	builder, err := servicecommon.PolicyPathProjectDnsRecord.NewPolicyTreeBuilder()
+	builder, err := servicecommon.PolicyPathDnsRecord.NewPolicyTreeBuilder()
 	require.NoError(t, err)
 	cfg := &config.NSXOperatorConfig{CoeConfig: &config.CoeConfig{Cluster: "unit-test"}}
 	svc := &DNSRecordService{
@@ -1250,12 +1250,12 @@ func TestSyncDNSZonesByVpcNetworkConfig_table(t *testing.T) {
 			Client:    fake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).Build(),
 			NSXConfig: cfg,
 			NSXClient: &nsx.Client{
-				NsxConfig:            cfg,
-				ProjectDnsZoneClient: zc,
+				NsxConfig:     cfg,
+				DnsZoneClient: zc,
 			},
 		},
-		DNSZoneMap:              newDNSZoneCache(),
-		ProjectDnsRecordBuilder: builder,
+		DNSZoneMap:       newDNSZoneCache(),
+		DnsRecordBuilder: builder,
 	}
 
 	// No error returns when VPCNetworkConfiguration does not set DNS zones.
@@ -1265,7 +1265,7 @@ func TestSyncDNSZonesByVpcNetworkConfig_table(t *testing.T) {
 
 	domain := "fetched.example"
 	zp := testDNSZonePathZ
-	zc.EXPECT().Get("org1", "proj1", "ds1", "zone-z").Return(model.ProjectDnsZone{
+	zc.EXPECT().Get("org1", "proj1", "ds1", "zone-z").Return(model.DnsZone{
 		DnsDomainName: &domain,
 	}, nil).Times(1)
 

--- a/pkg/nsx/services/dns/store.go
+++ b/pkg/nsx/services/dns/store.go
@@ -23,7 +23,7 @@ type RecordStore struct {
 
 func dnsRecordKeyFunc(obj interface{}) (string, error) {
 	switch v := obj.(type) {
-	case *model.ProjectDnsRecord:
+	case *model.DnsRecord:
 		if v.Path != nil {
 			return *v.Path, nil
 		}
@@ -44,13 +44,13 @@ func filterTagBy(v []model.Tag, tagScope string) []string {
 }
 
 // dnsRecordCreatedForValue returns the dns_for tag value on rec, or "".
-func dnsRecordCreatedForValue(rec *model.ProjectDnsRecord) string {
+func dnsRecordCreatedForValue(rec *model.DnsRecord) string {
 	return firstTagValue(rec.Tags, common.TagScopeDNSRecordFor)
 }
 
 func indexDNSRecordByOwnerTypeNN(obj interface{}) ([]string, error) {
 	switch v := obj.(type) {
-	case *model.ProjectDnsRecord:
+	case *model.DnsRecord:
 		ownerKey := getDNSRecordOwnerNamespacedName(v)
 		if ownerKey == "" {
 			return []string{}, nil
@@ -62,7 +62,7 @@ func indexDNSRecordByOwnerTypeNN(obj interface{}) ([]string, error) {
 }
 
 // ownerCreatedForAndNNFromDNSRecord returns (dns_for, owner ns, owner name, ok) from rec tags.
-func ownerCreatedForAndNNFromDNSRecord(record *model.ProjectDnsRecord) (createdFor, ns, name string, ok bool) {
+func ownerCreatedForAndNNFromDNSRecord(record *model.DnsRecord) (createdFor, ns, name string, ok bool) {
 	createdFor = dnsRecordCreatedForValue(record)
 	if createdFor == "" {
 		return "", "", "", false
@@ -99,7 +99,7 @@ func (s *RecordStore) GroupRecordsByResourceKind() map[string]sets.Set[types.Nam
 }
 
 // getDNSRecordOwnerNamespacedName returns owner index key "createdFor/ns/name", or "" if tags incomplete.
-func getDNSRecordOwnerNamespacedName(record *model.ProjectDnsRecord) string {
+func getDNSRecordOwnerNamespacedName(record *model.DnsRecord) string {
 	createdFor, ns, name, ok := ownerCreatedForAndNNFromDNSRecord(record)
 	if !ok {
 		return ""
@@ -116,7 +116,7 @@ func firstTagValue(tags []model.Tag, scope string) string {
 }
 
 // gatewayIndexKeysFromDNSRecord returns parent-gateway label keys for Route rows (comma-separated in tag).
-func gatewayIndexKeysFromDNSRecord(v *model.ProjectDnsRecord) []string {
+func gatewayIndexKeysFromDNSRecord(v *model.DnsRecord) []string {
 	raw := gatewayIndexTagFromRecord(v)
 	if raw == "" {
 		return nil
@@ -146,7 +146,7 @@ func dnsRecordZonePathRecordNameIndexKey(zonePath, recordNameLower, recordType s
 	return zp + "|" + rn + "|" + rt
 }
 
-func dnsRecordRecordNameLower(rec *model.ProjectDnsRecord) string {
+func dnsRecordRecordNameLower(rec *model.DnsRecord) string {
 	if rec == nil || rec.RecordName == nil {
 		return ""
 	}
@@ -155,7 +155,7 @@ func dnsRecordRecordNameLower(rec *model.ProjectDnsRecord) string {
 
 func indexDNSRecordByZonePathRecordName(obj interface{}) ([]string, error) {
 	switch v := obj.(type) {
-	case *model.ProjectDnsRecord:
+	case *model.DnsRecord:
 		dnsZone := v.ZonePath
 		if dnsZone == nil || *dnsZone == "" {
 			return []string{}, nil // no zone path; skip this index. This is for security purpose, should not happen in the runtime.
@@ -177,7 +177,7 @@ func indexDNSRecordByZonePathRecordName(obj interface{}) ([]string, error) {
 
 func indexDNSRecordByGatewayNamespacedName(obj interface{}) ([]string, error) {
 	switch v := obj.(type) {
-	case *model.ProjectDnsRecord:
+	case *model.DnsRecord:
 		createdFor := firstTagValue(v.Tags, common.TagScopeDNSRecordFor)
 		if createdFor == "" {
 			return []string{}, nil // record has no dns_for tag; not indexed by gateway
@@ -217,7 +217,7 @@ const (
 )
 
 func (s *RecordStore) Apply(i interface{}) error {
-	records := i.([]*model.ProjectDnsRecord)
+	records := i.([]*model.DnsRecord)
 	for _, rec := range records {
 		if rec.MarkedForDelete != nil && *rec.MarkedForDelete {
 			if err := s.Delete(rec); err != nil {
@@ -233,20 +233,20 @@ func (s *RecordStore) Apply(i interface{}) error {
 	return nil
 }
 
-func (s *RecordStore) GetByKey(key string) *model.ProjectDnsRecord {
+func (s *RecordStore) GetByKey(key string) *model.DnsRecord {
 	obj := s.ResourceStore.GetByKey(key)
-	r, ok := obj.(*model.ProjectDnsRecord)
+	r, ok := obj.(*model.DnsRecord)
 	if !ok {
 		return nil
 	}
 	return r
 }
 
-func (s *RecordStore) GetByIndex(index string, value string) []*model.ProjectDnsRecord {
+func (s *RecordStore) GetByIndex(index string, value string) []*model.DnsRecord {
 	objs := s.ResourceStore.GetByIndex(index, value)
-	out := make([]*model.ProjectDnsRecord, 0, len(objs))
+	out := make([]*model.DnsRecord, 0, len(objs))
 	for _, o := range objs {
-		out = append(out, o.(*model.ProjectDnsRecord))
+		out = append(out, o.(*model.DnsRecord))
 	}
 	return out
 }
@@ -288,7 +288,7 @@ func resourceKindToCreatedFor(kind string) string {
 }
 
 // DeleteMultipleObjects removes records from the in-memory store (used after NSX deletion succeeds).
-func (s *RecordStore) DeleteMultipleObjects(records []*model.ProjectDnsRecord) {
+func (s *RecordStore) DeleteMultipleObjects(records []*model.DnsRecord) {
 	for _, rec := range records {
 		if rec == nil {
 			continue
@@ -300,7 +300,7 @@ func (s *RecordStore) DeleteMultipleObjects(records []*model.ProjectDnsRecord) {
 }
 
 // GetByOwnerResourceNamespacedName returns all DNS records whose primary owner matches kind/namespace/name.
-func (s *RecordStore) GetByOwnerResourceNamespacedName(kind, namespace, name string) []*model.ProjectDnsRecord {
+func (s *RecordStore) GetByOwnerResourceNamespacedName(kind, namespace, name string) []*model.DnsRecord {
 	createdFor := resourceKindToCreatedFor(kind)
 	if createdFor == "" {
 		return nil
@@ -321,11 +321,11 @@ func (s *RecordStore) ListZonePaths() sets.Set[string] {
 	return result
 }
 
-func (s *RecordStore) ListDNSRecords() []*model.ProjectDnsRecord {
+func (s *RecordStore) ListDNSRecords() []*model.DnsRecord {
 	objs := s.List()
-	out := make([]*model.ProjectDnsRecord, 0, len(objs))
+	out := make([]*model.DnsRecord, 0, len(objs))
 	for _, o := range objs {
-		if r, ok := o.(*model.ProjectDnsRecord); ok && r != nil {
+		if r, ok := o.(*model.DnsRecord); ok && r != nil {
 			out = append(out, r)
 		}
 	}
@@ -334,13 +334,13 @@ func (s *RecordStore) ListDNSRecords() []*model.ProjectDnsRecord {
 
 // ListRecordsReferencingContributingOwner returns rows whose contributing-owners tag contains contribNNKey.
 // It uses the contributingOwner index for O(1) lookup instead of a full table scan.
-func (s *RecordStore) ListRecordsReferencingContributingOwner(contribNNKey string) []*model.ProjectDnsRecord {
+func (s *RecordStore) ListRecordsReferencingContributingOwner(contribNNKey string) []*model.DnsRecord {
 	return s.GetByIndex(indexKeyDNSRecordContributingOwner, contribNNKey)
 }
 
 func indexDNSRecordByZonePath(obj interface{}) ([]string, error) {
 	switch v := obj.(type) {
-	case *model.ProjectDnsRecord:
+	case *model.DnsRecord:
 		if v.ZonePath == nil || *v.ZonePath == "" {
 			return []string{}, nil
 		}
@@ -354,7 +354,7 @@ func indexDNSRecordByZonePath(obj interface{}) ([]string, error) {
 // tag into one index entry per contributing-owner key, enabling O(1) reverse lookup.
 func indexDNSRecordByContributingOwner(obj interface{}) ([]string, error) {
 	switch v := obj.(type) {
-	case *model.ProjectDnsRecord:
+	case *model.DnsRecord:
 		keys := parseContributingOwnersFromRecord(v)
 		if len(keys) == 0 {
 			return []string{}, nil
@@ -376,7 +376,7 @@ func BuildDNSRecordStore() *RecordStore {
 				indexKeyDNSRecordZonePath:           indexDNSRecordByZonePath,
 				indexKeyDNSRecordContributingOwner:  indexDNSRecordByContributingOwner,
 			}),
-			BindingType: model.ProjectDnsRecordBindingType(),
+			BindingType: model.DnsRecordBindingType(),
 		},
 	}
 }

--- a/pkg/nsx/services/dns/store_test.go
+++ b/pkg/nsx/services/dns/store_test.go
@@ -22,12 +22,12 @@ func TestDNSRecordKeyFunc_table(t *testing.T) {
 	}{
 		{
 			name: "valid path",
-			obj:  &model.ProjectDnsRecord{Path: &path},
+			obj:  &model.DnsRecord{Path: &path},
 			want: path,
 		},
 		{
 			name:    "nil path returns error",
-			obj:     &model.ProjectDnsRecord{},
+			obj:     &model.DnsRecord{},
 			wantErr: true,
 		},
 		{
@@ -69,16 +69,16 @@ func TestResourceKindToCreatedFor_table(t *testing.T) {
 	}
 }
 
-func TestDNSRecordFQDNLower_table(t *testing.T) {
+func TestDNSRecordRecordNameLower_table(t *testing.T) {
 	fqdn := "A.EXAMPLE.COM"
 	tests := []struct {
 		name string
-		rec  *model.ProjectDnsRecord
+		rec  *model.DnsRecord
 		want string
 	}{
 		{"nil record", nil, ""},
-		{"nil fqdn field", &model.ProjectDnsRecord{}, ""},
-		{"valid fqdn lowercased", &model.ProjectDnsRecord{RecordName: &fqdn}, "a.example.com"},
+		{"nil fqdn field", &model.DnsRecord{}, ""},
+		{"valid fqdn lowercased", &model.DnsRecord{RecordName: &fqdn}, "a.example.com"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -90,17 +90,17 @@ func TestDNSRecordFQDNLower_table(t *testing.T) {
 func TestDeleteMultipleObjects_table(t *testing.T) {
 	t.Run("nil records skipped without panic", func(t *testing.T) {
 		store := BuildDNSRecordStore()
-		store.DeleteMultipleObjects([]*model.ProjectDnsRecord{nil, nil})
+		store.DeleteMultipleObjects([]*model.DnsRecord{nil, nil})
 	})
 
 	t.Run("valid record removed from store", func(t *testing.T) {
 		store := BuildDNSRecordStore()
 		path := "/orgs/o/projects/p/dns-records/r1"
-		rec := &model.ProjectDnsRecord{Path: servicecommon.String(path)}
+		rec := &model.DnsRecord{Path: servicecommon.String(path)}
 		require.NoError(t, store.Add(rec))
 		require.NotNil(t, store.GetByKey(path))
 
-		store.DeleteMultipleObjects([]*model.ProjectDnsRecord{nil, rec})
+		store.DeleteMultipleObjects([]*model.DnsRecord{nil, rec})
 		require.Nil(t, store.GetByKey(path))
 	})
 }
@@ -108,14 +108,14 @@ func TestDeleteMultipleObjects_table(t *testing.T) {
 func TestApply_addAndDeleteBranches(t *testing.T) {
 	store := BuildDNSRecordStore()
 	path := "/orgs/o/projects/p/dns-records/r2"
-	rec := &model.ProjectDnsRecord{Path: servicecommon.String(path)}
+	rec := &model.DnsRecord{Path: servicecommon.String(path)}
 
-	require.NoError(t, store.Apply([]*model.ProjectDnsRecord{rec}))
+	require.NoError(t, store.Apply([]*model.DnsRecord{rec}))
 	require.NotNil(t, store.GetByKey(path))
 
 	cp := *rec
 	cp.MarkedForDelete = servicecommon.Bool(true)
-	require.NoError(t, store.Apply([]*model.ProjectDnsRecord{&cp}))
+	require.NoError(t, store.Apply([]*model.DnsRecord{&cp}))
 	require.Nil(t, store.GetByKey(path))
 }
 
@@ -141,32 +141,32 @@ func TestIndexFunctions_unsupported_type(t *testing.T) {
 }
 
 func TestIndexDNSRecordByZonePathFQDN_earlyReturn_table(t *testing.T) {
-	rt := model.ProjectDnsRecord_RECORD_TYPE_A
+	rt := model.DnsRecord_RECORD_TYPE_A
 	fqdn := "a.example.com"
 	zp := "/z1"
 	tests := []struct {
 		name    string
-		rec     *model.ProjectDnsRecord
+		rec     *model.DnsRecord
 		wantLen int
 	}{
 		{
 			name:    "nil ZonePath returns empty",
-			rec:     &model.ProjectDnsRecord{RecordType: &rt, RecordName: &fqdn},
+			rec:     &model.DnsRecord{RecordType: &rt, RecordName: &fqdn},
 			wantLen: 0,
 		},
 		{
 			name:    "nil RecordType returns empty",
-			rec:     &model.ProjectDnsRecord{ZonePath: &zp, RecordName: &fqdn},
+			rec:     &model.DnsRecord{ZonePath: &zp, RecordName: &fqdn},
 			wantLen: 0,
 		},
 		{
 			name:    "empty fqdn returns empty",
-			rec:     &model.ProjectDnsRecord{ZonePath: &zp, RecordType: &rt},
+			rec:     &model.DnsRecord{ZonePath: &zp, RecordType: &rt},
 			wantLen: 0,
 		},
 		{
 			name:    "valid record returns one index key",
-			rec:     &model.ProjectDnsRecord{ZonePath: &zp, RecordType: &rt, RecordName: &fqdn},
+			rec:     &model.DnsRecord{ZonePath: &zp, RecordType: &rt, RecordName: &fqdn},
 			wantLen: 1,
 		},
 	}

--- a/pkg/nsx/services/dns/types.go
+++ b/pkg/nsx/services/dns/types.go
@@ -20,8 +20,8 @@ const (
 	ResourceKindGRPCRoute = "GRPCRoute"
 	ResourceKindTLSRoute  = "TLSRoute"
 	ResourceKindService   = "Service"
-	// DNSRecordPathSegment is the NSX Policy path segment for project-scoped ProjectDnsRecord (same as common.PathSegmentProjectDnsRecords).
-	DNSRecordPathSegment = common.PathSegmentProjectDnsRecords
+	// DNSRecordPathSegment is the NSX Policy path segment for project-scoped DnsRecord (same as common.PathSegmentDnsRecords).
+	DNSRecordPathSegment = common.PathSegmentDnsRecords
 )
 
 // EndpointLabelParentGateway is the ExternalDNS Endpoint label for parent Gateway ns/name (comma-separated if merged).

--- a/pkg/nsx/services/dns/zones.go
+++ b/pkg/nsx/services/dns/zones.go
@@ -17,15 +17,15 @@ import (
 )
 
 // NSX Policy path: /orgs/{org}/projects/{project}/dns-services/{dnsService}/zones/{zoneId}
-var projectDNSZonePathRe = regexp.MustCompile(`^/orgs/([^/]+)/projects/([^/]+)/dns-services/([^/]+)/zones/([^/]+)$`)
+var dnsZonePathRe = regexp.MustCompile(`^/orgs/([^/]+)/projects/([^/]+)/dns-services/([^/]+)/zones/([^/]+)$`)
 
-// parseProjectDNSZonePath splits a Policy zone path into org, project, DNS service, and zone ID.
-func parseProjectDNSZonePath(zonePath string) (orgID, projectID, dnsServiceID, zoneID string, err error) {
+// parseDnsZonePath splits a Policy zone path into org, project, DNS service, and zone ID.
+func parseDnsZonePath(zonePath string) (orgID, projectID, dnsServiceID, zoneID string, err error) {
 	p := strings.TrimSpace(zonePath)
 	if p == "" {
 		return "", "", "", "", fmt.Errorf("empty DNS zone path")
 	}
-	matches := projectDNSZonePathRe.FindStringSubmatch(p)
+	matches := dnsZonePathRe.FindStringSubmatch(p)
 	if len(matches) != 5 {
 		return "", "", "", "", fmt.Errorf("invalid DNS zone path %q: expected /orgs/{org}/projects/{project}/dns-services/{dns-service}/zones/{zone}", zonePath)
 	}
@@ -154,12 +154,12 @@ func (s *DNSRecordService) SyncDNSZonesByVpcNetworkConfig(vpcConfig *v1alpha1.VP
 	return dnsZoneDomainMapping, nil
 }
 
-func (s *DNSRecordService) getDNSZoneFromNSX(zonePath string) (*model.ProjectDnsZone, error) {
-	orgID, projectID, dnsServiceID, zoneID, err := parseProjectDNSZonePath(zonePath)
+func (s *DNSRecordService) getDNSZoneFromNSX(zonePath string) (*model.DnsZone, error) {
+	orgID, projectID, dnsServiceID, zoneID, err := parseDnsZonePath(zonePath)
 	if err != nil {
 		return nil, err
 	}
-	z, err := s.NSXClient.ProjectDnsZoneClient.Get(orgID, projectID, dnsServiceID, zoneID)
+	z, err := s.NSXClient.DnsZoneClient.Get(orgID, projectID, dnsServiceID, zoneID)
 	if err != nil {
 		return nil, nsxutil.TransNSXApiError(err)
 	}

--- a/pkg/nsx/services/dns/zones_test.go
+++ b/pkg/nsx/services/dns/zones_test.go
@@ -104,7 +104,7 @@ func TestZonePathForHostnameFromMap_table(t *testing.T) {
 	}
 }
 
-func TestParseProjectDNSZonePath_table(t *testing.T) {
+func TestParseDnsZonePath_table(t *testing.T) {
 	tests := []struct {
 		name       string
 		path       string
@@ -130,7 +130,7 @@ func TestParseProjectDNSZonePath_table(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			org, proj, dnsSvc, zone, err := parseProjectDNSZonePath(tc.path)
+			org, proj, dnsSvc, zone, err := parseDnsZonePath(tc.path)
 			if tc.wantErr {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
NSX modified its API from ProjectDnsRecord -> DnsRecord and ProjectDnsZone -> DnsZone. This commit updates the internal references, NSX API clients, and mock clients to match the new API model while preserving the public interface of the pkg/nsx/services/dns package.

The changes involve:
- Updating URL path segments and policy resource types.
- Switching ProjectDnsZoneClient to DnsZoneClient in nsx.Client.
- Adapting the internal recordservice synchronization and path parsing methods accordingly.
- Refactoring the comparable struct and wrapper functions in the pkg/nsx/services/common package.
- Aligning and passing all unit tests for the updated structures.

Test Done:
1. Prepare a NSX DNS zone
```
root@wd008124-vdnet-nsxmanager-ob-25437122-1-dev-nsxvpc-19225:~# curl -k -u $cred https://10.192.2.27/policy/api/v1/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1
{
  "dns_domain_name" : "example.com",
  "ttl" : 300,
  "resource_type" : "DnsZone",
  "id" : "zone1",
  "display_name" : "zone1",
  "path" : "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
  "relative_path" : "zone1",
  "parent_path" : "/orgs/default/projects/project-quality/dns-services/default-dns-service",
  "remote_path" : "",
  "unique_id" : "32687d09-b814-498f-8344-74ae6f8027ba",
  "realization_id" : "32687d09-b814-498f-8344-74ae6f8027ba",
  "owner_id" : "8edf6436-b500-4dc5-a7f4-37376e6e3b39",
  "marked_for_delete" : false,
  "overridden" : false,
  "_system_owned" : false,
  "_protection" : "NOT_PROTECTED",
  "_create_time" : 1782097014310,
  "_create_user" : "admin",
  "_last_modified_time" : 1782097014310,
  "_last_modified_user" : "admin",
  "_revision" : 0
}
```
2. Create a vSphere Namespace with an existing NSX DNS zone
```
dcli> com vmware vcenter namespaces instances createv2 --namespace test1 --supervisor e55714b2-724d-4f3e-b626-8c334bd9d2bc --network-spec-network-provider NSX_VPC --network-spec-vpc-network-dns-zones
 "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1"
 
dcli> com vmware vcenter namespaces instances getv2 --namespace test1
content_libraries:
creator: 
edges: 
....
network_spec:
   vpc_network:
      dns_zones:
         - /orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1
      default_IPv6_prefix_length: 
      vpc_config:
         private_cidrs:
            - address: 172.26.0.0
              prefix: 16

      shared_subnets: 
      vpc: /orgs/default/projects/project-quality/vpcs/test1_oq2jy
      default_subnet_size: 32
      auto_created: True
   network_provider: NSX_VPC
supervisor: e55714b2-724d-4f3e-b626-8c334bd9d2bc
```
3. Check VpcNetworkConfiguration is updated correctly
```
root@421b7cd5e1fb8baf62542fc7ab391f41 [ ~ ]# kubectl get vpcnetworkconfigurations
NAME                                                    VPCPATH
default                                                 
svc-cci-ns-85bxw-9c68b6aa-f454-4e49-b9fc-2541d32f5a69   /orgs/default/projects/project-quality/vpcs/vmware-system-supervisor-services-vpc_j6edg
svc-tkg-m1hbh-dbf850be-6f3b-44a4-b9a4-ba3726996d25      /orgs/default/projects/project-quality/vpcs/vmware-system-supervisor-services-vpc_j6edg
svc-velero-xq0b2-85e6f997-da1a-4607-8dec-6f9982cfd444   /orgs/default/projects/project-quality/vpcs/vmware-system-supervisor-services-vpc_j6edg
system                                                  /orgs/default/projects/project-quality/vpcs/kube-system_eguhh
test1-37e0650a-1d7b-42a9-b6e4-c9bc7f090481              /orgs/default/projects/project-quality/vpcs/test1_oq2jy
tn1-1e309d10-2529-4531-bfcf-250edb5f85a1                /orgs/default/projects/project-quality/vpcs/tn1_onxba
vmware-system-supervisor-services                       /orgs/default/projects/project-quality/vpcs/vmware-system-supervisor-services-vpc_j6edg
root@421b7cd5e1fb8baf62542fc7ab391f41 [ ~ ]# kubectl get vpcnetworkconfigurations test1-37e0650a-1d7b-42a9-b6e4-c9bc7f090481 -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: VPCNetworkConfiguration
metadata:
  creationTimestamp: "2026-06-22T06:48:56Z"
  generation: 1
  name: test1-37e0650a-1d7b-42a9-b6e4-c9bc7f090481
  resourceVersion: "6696320"
  uid: e3c19ff0-4f79-466d-9e5a-335400698746
spec:
  defaultIPv6PrefixLength: 64
  defaultSubnetSize: 32
  dnsZones:
  - /orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1
  nsxProject: /orgs/default/projects/project-quality
  privateIPs:
  - 172.26.0.0/16
  vpcConnectivityProfile: /orgs/default/projects/project-quality/vpc-connectivity-profiles/default--8edf6436-b500-4dc5-a7f4-37376e6e3b39
status:
  vpcs:
  - name: test1_oq2jy
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/test1_oq2jy/vpc-lbs/default
    vpcPath: /orgs/default/projects/project-quality/vpcs/test1_oq2jy
```
4. Check NetworkInfo is updated correctly
```
root@421b7cd5e1fb8baf62542fc7ab391f41 [ ~ ]# kubectl get networkinfo -n test1 test1 -oyaml
allowedDNSDomains:
- example.com
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: NetworkInfo
metadata:
  creationTimestamp: "2026-06-22T06:48:56Z"
  generation: 2
  name: test1
  namespace: test1
  resourceVersion: "6696321"
  uid: 75817ca0-74ac-47c0-86ab-1fc691bc2130
vpcs:
- defaultSNATIP: 192.168.0.7
  loadBalancerBackendIPs:
  - 100.64.0.7
  loadBalancerIPAddresses: 100.64.0.7
  name: test1_oq2jy
  networkStack: FullStackVPC
  privateIPs:
  - 172.26.0.0/16
```
5. Verify the DNS record API. Rebase this change on top of https://github.com/vmware-tanzu/nsx-operator/pull/1426 . Then annotate the service and check status.
```
root@421b7cd5e1fb8baf62542fc7ab391f41 [ ~ ]# kubectl get svc -n test1
NAME      TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
httpbin   LoadBalancer   172.24.165.36   192.168.0.8   80:32215/TCP   28m
root@421b7cd5e1fb8baf62542fc7ab391f41 [ ~ ]# kubectl -n test1 annotate svc httpbin nsx.vmware.com/hostname="my-svc.example.com" --overwrite
service/httpbin annotated
root@421b7cd5e1fb8baf62542fc7ab391f41 [ ~ ]# kubectl get svc -n httpbin -n test1 httpbin -oyaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"labels":{"app":"httpbin","service":"httpbin"},"name":"httpbin","namespace":"test1"},"spec":{"ports":[{"name":"http","port":80,"targetPort":8080}],"selector":{"app":"httpbin"},"type":"LoadBalancer"}}
    nsx.vmware.com/hostname: my-svc.example.com
  creationTimestamp: "2026-06-22T07:35:59Z"
  finalizers:
  - netoperator.vmware.com/service
  labels:
    app: httpbin
    service: httpbin
    service.route.lbapi.run.tanzu.vmware.com/gateway-name: httpbin
    service.route.lbapi.run.tanzu.vmware.com/gateway-namespace: test1
    service.route.lbapi.run.tanzu.vmware.com/type: direct
  name: httpbin
  namespace: test1
  resourceVersion: "6743298"
  uid: 5edbdbca-b748-43b2-9cf5-c4fa44f10edc
spec:
  allocateLoadBalancerNodePorts: true
  clusterIP: 172.24.165.36
  clusterIPs:
  - 172.24.165.36
  externalTrafficPolicy: Cluster
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  ipFamilyPolicy: SingleStack
  ports:
  - name: http
    nodePort: 32215
    port: 80
    protocol: TCP
    targetPort: 8080
  selector:
    app: httpbin
  sessionAffinity: None
  type: LoadBalancer
status:
  conditions:
  - lastTransitionTime: "2026-06-22T08:04:50Z"
    message: ""
    reason: DNSRecordConfigured
    status: "True"
    type: Ready
  loadBalancer:
    ingress:
    - ip: 192.168.0.8
      ipMode: Proxy

// Check NSX DNS records
root@wd008124-vdnet-nsxmanager-ob-25437122-1-dev-nsxvpc-19225:~# curl -k -u $cred https://10.192.2.27/policy/api/v1/orgs/default/projects/project-quality/dns-records
{
  "results" : [ {
    "zone_path" : "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
    "record_name" : "my-svc",
    "record_type" : "A",
    "record_values" : [ "192.168.0.8" ],
    "ttl" : 300,
    "resource_type" : "DnsRecord",
    "id" : "my-svc_zone1_a",
    "display_name" : "my-svc",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "e55714b2-724d-4f3e-b626-8c334bd9d2bc"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "2e78bd33-7ca3-46d6-afff-1f7578e31979"
    }, {
      "scope" : "nsx-op/dns_for",
      "tag" : "service"
    }, {
      "scope" : "nsx-op/dns_owner_namespace",
      "tag" : "test1"
    }, {
      "scope" : "nsx-op/dns_owner_name",
      "tag" : "httpbin"
    } ],
    "path" : "/orgs/default/projects/project-quality/dns-records/my-svc_zone1_a",
    "relative_path" : "my-svc_zone1_a",
    "parent_path" : "/orgs/default/projects/project-quality",
    "remote_path" : "",
    "unique_id" : "95e6f13a-2265-48e1-b7cf-41be482d83a9",
    "realization_id" : "95e6f13a-2265-48e1-b7cf-41be482d83a9",
    "owner_id" : "8edf6436-b500-4dc5-a7f4-37376e6e3b39",
    "marked_for_delete" : false,
    "overridden" : false,
    "_system_owned" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_create_time" : 1782115490269,
    "_create_user" : "wcp-cluster-user-e55714b2-724d-4f3e-b626-8c334bd9d2bc-828b3628-47d1-4312-bee9-9b762b8a90e4",
    "_last_modified_time" : 1782115490269,
    "_last_modified_user" : "wcp-cluster-user-e55714b2-724d-4f3e-b626-8c334bd9d2bc-828b3628-47d1-4312-bee9-9b762b8a90e4",
    "_revision" : 0
  } ],
  "result_count" : 1,
  "sort_by" : "display_name",
  "sort_ascending" : true
}
```
6. Verify the permitted DNS zone (/orgs/default/projects/p1/dns-services/default-dns-service/zones/p1-default-zone) in the vSphere Namespace is under a different project, then DNS records are created in the same NSX project as the permitted DNS zone
```
# Update vSphere Namespace's permitted DNS zone and check VpcNetworkConfiguration
root@421b7cd5e1fb8baf62542fc7ab391f41 [ ~ ]# kubectl get vpcnetworkconfigurations test1-37e0650a-1d7b-42a9-b6e4-c9bc7f090481 -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: VPCNetworkConfiguration
metadata:
  creationTimestamp: "2026-06-22T06:48:56Z"
  generation: 2
  name: test1-37e0650a-1d7b-42a9-b6e4-c9bc7f090481
  resourceVersion: "6748688"
  uid: e3c19ff0-4f79-466d-9e5a-335400698746
spec:
  defaultIPv6PrefixLength: 64
  defaultSubnetSize: 32
  dnsZones:
  - /orgs/default/projects/p1/dns-services/default-dns-service/zones/p1-default-zone
  nsxProject: /orgs/default/projects/project-quality
  privateIPs:
  - 172.26.0.0/16
  vpcConnectivityProfile: /orgs/default/projects/project-quality/vpc-connectivity-profiles/default--8edf6436-b500-4dc5-a7f4-37376e6e3b39
status:
  vpcs:
  - name: test1_oq2jy
    nsxLoadBalancerPath: /orgs/default/projects/project-quality/vpcs/test1_oq2jy/vpc-lbs/default
    vpcPath: /orgs/default/projects/project-quality/vpcs/test1_oq2jy
 
// Check NetworkInfo updates
root@421b7cd5e1fb8baf62542fc7ab391f41 [ ~ ]# kubectl get networkinfo -n test1 test1 -oyaml
allowedDNSDomains:
- p1-default.com
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: NetworkInfo
metadata:
  creationTimestamp: "2026-06-22T06:48:56Z"
  generation: 3
  name: test1
  namespace: test1
  resourceVersion: "6748695"
  uid: 75817ca0-74ac-47c0-86ab-1fc691bc2130
vpcs:
- defaultSNATIP: 192.168.0.7
  loadBalancerBackendIPs:
  - 100.64.0.7
  loadBalancerIPAddresses: 100.64.0.7
  name: test1_oq2jy
  networkStack: FullStackVPC
  privateIPs:
  - 172.26.0.0/16

// Annotate LB Service using the updated DNS zone's domain name
root@421b7cd5e1fb8baf62542fc7ab391f41 [ ~ ]# kubectl -n test1 annotate svc httpbin nsx.vmware.com/hostname="my-svc.p1-default.com" --overwrite
service/httpbin annotated

// Check the Service's conditions
root@421b7cd5e1fb8baf62542fc7ab391f41 [ ~ ]# kubectl get svc -n httpbin -n test1 httpbin -oyaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"labels":{"app":"httpbin","service":"httpbin"},"name":"httpbin","namespace":"test1"},"spec":{"ports":[{"name":"http","port":80,"targetPort":8080}],"selector":{"app":"httpbin"},"type":"LoadBalancer"}}
    nsx.vmware.com/hostname: my-svc.p1-default.com
  creationTimestamp: "2026-06-22T07:35:59Z"
  finalizers:
  - netoperator.vmware.com/service
  labels:
    app: httpbin
    service: httpbin
    service.route.lbapi.run.tanzu.vmware.com/gateway-name: httpbin
    service.route.lbapi.run.tanzu.vmware.com/gateway-namespace: test1
    service.route.lbapi.run.tanzu.vmware.com/type: direct
  name: httpbin
  namespace: test1
  resourceVersion: "6749970"
  uid: 5edbdbca-b748-43b2-9cf5-c4fa44f10edc
spec:
  allocateLoadBalancerNodePorts: true
  clusterIP: 172.24.165.36
  clusterIPs:
  - 172.24.165.36
  externalTrafficPolicy: Cluster
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  ipFamilyPolicy: SingleStack
  ports:
  - name: http
    nodePort: 32215
    port: 80
    protocol: TCP
    targetPort: 8080
  selector:
    app: httpbin
  sessionAffinity: None
  type: LoadBalancer
status:
  conditions:
  - lastTransitionTime: "2026-06-22T08:15:36Z"
    message: ""
    reason: DNSRecordConfigured
    status: "True"
    type: Ready
  loadBalancer:
    ingress:
    - ip: 192.168.0.8
      ipMode: Proxy

// Check DNS record is created under project  "/orgs/default/projects/p1"
root@wd008124-vdnet-nsxmanager-ob-25437122-1-dev-nsxvpc-19225:~# curl -k -u $cred https://10.192.2.27/policy/api/v1/orgs/default/projects/p1/dns-records
{
  "results" : [ {
    "zone_path" : "/orgs/default/projects/p1/dns-services/default-dns-service/zones/p1-default-zone",
    "record_name" : "my-svc",
    "record_type" : "A",
    "record_values" : [ "192.168.0.8" ],
    "ttl" : 300,
    "resource_type" : "DnsRecord",
    "id" : "my-svc_p1-default-zone_a",
    "display_name" : "my-svc",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "e55714b2-724d-4f3e-b626-8c334bd9d2bc"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "2e78bd33-7ca3-46d6-afff-1f7578e31979"
    }, {
      "scope" : "nsx-op/dns_for",
      "tag" : "service"
    }, {
      "scope" : "nsx-op/dns_owner_namespace",
      "tag" : "test1"
    }, {
      "scope" : "nsx-op/dns_owner_name",
      "tag" : "httpbin"
    } ],
    "path" : "/orgs/default/projects/p1/dns-records/my-svc_p1-default-zone_a",
    "relative_path" : "my-svc_p1-default-zone_a",
    "parent_path" : "/orgs/default/projects/p1",
    "remote_path" : "",
    "unique_id" : "3b3b611d-4843-4c92-b179-a1445627cc2a",
    "realization_id" : "3b3b611d-4843-4c92-b179-a1445627cc2a",
    "owner_id" : "8edf6436-b500-4dc5-a7f4-37376e6e3b39",
    "marked_for_delete" : false,
    "overridden" : false,
    "_system_owned" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_create_time" : 1782116136089,
    "_create_user" : "wcp-cluster-user-e55714b2-724d-4f3e-b626-8c334bd9d2bc-828b3628-47d1-4312-bee9-9b762b8a90e4",
    "_last_modified_time" : 1782116136089,
    "_last_modified_user" : "wcp-cluster-user-e55714b2-724d-4f3e-b626-8c334bd9d2bc-828b3628-47d1-4312-bee9-9b762b8a90e4",
    "_revision" : 0
  } ],
  "result_count" : 1,
  "sort_by" : "display_name",
  "sort_ascending" : true
}
```
