### PR TITLE
Use TLS1.3 for webhook container port

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"os"
@@ -218,6 +219,11 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			hookServer = webhook.NewServer(webhook.Options{
 				Port:    config.WebhookServerPort,
 				CertDir: config.WebhookCertDir,
+				TLSOpts: []func(*tls.Config){
+					func(cfg *tls.Config) {
+						cfg.MinVersion = tls.VersionTLS13
+					},
+				},
 			})
 			if err := mgr.Add(hookServer); err != nil {
 				log.Error(err, "Failed to add hook server")


### PR DESCRIPTION
Per security requirement, TLS1.2 is not acceptable, use TLS1.3 cryto for 9881 port for webhook.