### PR TITLE
Correct logic for label selector matchExpressions

### DIFF
--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -1279,6 +1279,7 @@ func (service *SecurityPolicyService) updateExpressionsMatchLabels(matchLabels m
 //   - {key: k1, operator: NotIn, values: [a1, a2, a3]}
 //   - {key: k1, operator: NotIn, values: [a2, a3, a4]}
 //     => {key: k1, operator: NotIn, values: [a1, a2, a3, a4]}
+//
 // For In operator, it merges values by taking the intersection:
 // e.g.
 //   - {key: k1, operator: In, values: [a1, a2, a3]}

--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -1271,13 +1271,19 @@ func (service *SecurityPolicyService) updateExpressionsMatchLabels(matchLabels m
 	}
 }
 
-// NSX understand the multiple values w.r.t a key in a joined string manner
-// this function iterates over input matchExpressions LabelSelectorRequirement
-// with same operator and Key, and merges them into one and values to a joined string
+// NSX understand the multiple values w.r.t a key in a joined string manner.
+// This function iterates over input matchExpressions LabelSelectorRequirement
+// with same operator and Key, and merges them into one.
+// For NotIn operator, it merges values by taking the union:
 // e.g.
 //   - {key: k1, operator: NotIn, values: [a1, a2, a3]}
 //   - {key: k1, operator: NotIn, values: [a2, a3, a4]}
 //     => {key: k1, operator: NotIn, values: [a1, a2, a3, a4]}
+// For In operator, it merges values by taking the intersection:
+// e.g.
+//   - {key: k1, operator: In, values: [a1, a2, a3]}
+//   - {key: k1, operator: In, values: [a2, a3, a4]}
+//     => {key: k1, operator: In, values: [a2, a3]}
 func (service *SecurityPolicyService) mergeSelectorMatchExpression(matchExpressions []v1.LabelSelectorRequirement) *[]v1.LabelSelectorRequirement {
 	mergedMatchExpressions := make([]v1.LabelSelectorRequirement, 0)
 	var mergedSelector v1.LabelSelectorRequirement
@@ -1320,7 +1326,7 @@ func (service *SecurityPolicyService) mergeSelectorMatchExpression(matchExpressi
 
 // Todo, refactor code when NSX support 'In' LabelSelector.
 // Given NSX currently doesn't support 'In' LabelSelector, to keep design simple,
-// only allow just one 'In' LabelSelector in matchExpressions with at most of five values in it.
+// only allow just one 'In' LabelSelector in matchExpressions with same key and totally maximum five values.
 func (service *SecurityPolicyService) validateSelectorOpIn(matchExpressions []v1.LabelSelectorRequirement, matchLabels map[string]string) (int, error) {
 	mexprInOpCount := 0
 	mexprInValueCount := 0
@@ -1346,10 +1352,10 @@ func (service *SecurityPolicyService) validateSelectorOpIn(matchExpressions []v1
 		}
 	}
 	if mexprInOpCount > MaxMatchExpressionInOp {
-		errorMsg = fmt.Sprintf("count of operator 'In' expressions %d exceed limit of %d",
+		errorMsg = fmt.Sprintf("count of operator 'In' expressions %d with the same key exceed maximum limit of %d",
 			mexprInOpCount, MaxMatchExpressionIn)
 	} else if mexprInValueCount > MaxMatchExpressionInValues {
-		errorMsg = fmt.Sprintf("count of values list for operator 'In' expressions %d exceed limit of %d",
+		errorMsg = fmt.Sprintf("count of values list for operator 'In' expressions %d  with the same key exceed maximum limit of %d",
 			mexprInValueCount, MaxMatchExpressionInValues)
 	}
 

--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -1278,20 +1278,6 @@ func (service *SecurityPolicyService) updateExpressionsMatchLabels(matchLabels m
 //   - {key: k1, operator: NotIn, values: [a1, a2, a3]}
 //   - {key: k1, operator: NotIn, values: [a2, a3, a4]}
 //     => {key: k1, operator: NotIn, values: [a1, a2, a3, a4]}
-func intersectStr(a, b []string) []string {
-	set := make(map[string]bool)
-	for _, v := range a {
-		set[v] = true
-	}
-	var res []string
-	for _, v := range b {
-		if set[v] {
-			res = append(res, v)
-		}
-	}
-	return util.RemoveDuplicateStr(res)
-}
-
 func (service *SecurityPolicyService) mergeSelectorMatchExpression(matchExpressions []v1.LabelSelectorRequirement) *[]v1.LabelSelectorRequirement {
 	mergedMatchExpressions := make([]v1.LabelSelectorRequirement, 0)
 	var mergedSelector v1.LabelSelectorRequirement
@@ -1308,7 +1294,7 @@ func (service *SecurityPolicyService) mergeSelectorMatchExpression(matchExpressi
 			labelSelectorMap[d.Operator][d.Key] = d.Values
 		} else {
 			if d.Operator == v1.LabelSelectorOpIn {
-				labelSelectorMap[d.Operator][d.Key] = intersectStr(labelSelectorMap[d.Operator][d.Key], d.Values)
+				labelSelectorMap[d.Operator][d.Key] = util.IntersectStr(labelSelectorMap[d.Operator][d.Key], d.Values)
 			} else {
 				labelSelectorMap[d.Operator][d.Key] = append(
 					labelSelectorMap[d.Operator][d.Key],

--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -1278,6 +1278,20 @@ func (service *SecurityPolicyService) updateExpressionsMatchLabels(matchLabels m
 //   - {key: k1, operator: NotIn, values: [a1, a2, a3]}
 //   - {key: k1, operator: NotIn, values: [a2, a3, a4]}
 //     => {key: k1, operator: NotIn, values: [a1, a2, a3, a4]}
+func intersectStr(a, b []string) []string {
+	set := make(map[string]bool)
+	for _, v := range a {
+		set[v] = true
+	}
+	var res []string
+	for _, v := range b {
+		if set[v] {
+			res = append(res, v)
+		}
+	}
+	return util.RemoveDuplicateStr(res)
+}
+
 func (service *SecurityPolicyService) mergeSelectorMatchExpression(matchExpressions []v1.LabelSelectorRequirement) *[]v1.LabelSelectorRequirement {
 	mergedMatchExpressions := make([]v1.LabelSelectorRequirement, 0)
 	var mergedSelector v1.LabelSelectorRequirement
@@ -1289,14 +1303,20 @@ func (service *SecurityPolicyService) mergeSelectorMatchExpression(matchExpressi
 			labelSelectorMap[d.Operator] = map[string][]string{}
 		}
 		_, exists = labelSelectorMap[d.Operator][d.Key]
-		labelSelectorMap[d.Operator][d.Key] = append(
-			labelSelectorMap[d.Operator][d.Key],
-			d.Values...)
 
-		if exists {
-			labelSelectorMap[d.Operator][d.Key] = util.RemoveDuplicateStr(
-				labelSelectorMap[d.Operator][d.Key],
-			)
+		if !exists {
+			labelSelectorMap[d.Operator][d.Key] = d.Values
+		} else {
+			if d.Operator == v1.LabelSelectorOpIn {
+				labelSelectorMap[d.Operator][d.Key] = intersectStr(labelSelectorMap[d.Operator][d.Key], d.Values)
+			} else {
+				labelSelectorMap[d.Operator][d.Key] = append(
+					labelSelectorMap[d.Operator][d.Key],
+					d.Values...)
+				labelSelectorMap[d.Operator][d.Key] = util.RemoveDuplicateStr(
+					labelSelectorMap[d.Operator][d.Key],
+				)
+			}
 		}
 	}
 
@@ -1320,17 +1340,23 @@ func (service *SecurityPolicyService) validateSelectorOpIn(matchExpressions []v1
 	mexprInValueCount := 0
 	var err error
 	errorMsg := ""
-	exists := false
-	var opInIndex int
 
-	for i, expr := range matchExpressions {
+	for _, expr := range matchExpressions {
 		if expr.Operator == v1.LabelSelectorOpIn {
-			_, exists = matchLabels[expr.Key]
-			if exists {
-				opInIndex = i
-			}
 			mexprInOpCount++
 			mexprInValueCount += len(expr.Values)
+
+			if _, exists := matchLabels[expr.Key]; exists {
+				// matchLabels can only be duplicated with matchExpressions operator 'In' expression
+				// Since only operator 'In' is equivalent to key-value condition
+				for _, value := range expr.Values {
+					if matchLabels[expr.Key] == value {
+						errorMsg = fmt.Sprintf("duplicate expression - %s:%s specified in both matchLabels and matchExpressions operator 'In'",
+							expr.Key, value)
+						break
+					}
+				}
+			}
 		}
 	}
 	if mexprInOpCount > MaxMatchExpressionInOp {
@@ -1339,16 +1365,6 @@ func (service *SecurityPolicyService) validateSelectorOpIn(matchExpressions []v1
 	} else if mexprInValueCount > MaxMatchExpressionInValues {
 		errorMsg = fmt.Sprintf("count of values list for operator 'In' expressions %d exceed limit of %d",
 			mexprInValueCount, MaxMatchExpressionInValues)
-	} else if exists {
-		// matchLabels can only be duplicated with matchExpressions operator 'In' expression
-		// Since only operator 'In' is equivalent to key-value condition
-		for _, value := range matchExpressions[opInIndex].Values {
-			if matchLabels[matchExpressions[opInIndex].Key] == value {
-				errorMsg = fmt.Sprintf("duplicate expression - %s:%s specified in both matchLabels and matchExpressions operator 'In'",
-					matchExpressions[opInIndex].Key, value)
-				break
-			}
-		}
 	}
 
 	if len(errorMsg) != 0 {
@@ -1764,7 +1780,7 @@ func (service *SecurityPolicyService) updatePeerExpressions(obj *v1alpha1.Securi
 
 			// NamespaceSelector AND with PodSelector or VMSelector expressions to produce final expressions
 			err = service.updateMixedExpressionsMatchExpression(*nsMergedMatchExpressions, nsMatchLabels,
-				*matchExpressions, matchLabels, &group.Expression, clusterExpression, tagValueExpression, expressions)
+				*mergedMatchExpressions, matchLabels, &group.Expression, clusterExpression, tagValueExpression, expressions)
 			if err != nil {
 				return 0, 0, err
 			}

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -2514,5 +2514,5 @@ func Test_updatePeerExpressions_NamespaceSelector_OpIn_Limit(t *testing.T) {
 	_, _, err := s.updatePeerExpressions(sp, peer, group, 0, false)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "count of values list for operator 'In' expressions")
-	assert.Contains(t, err.Error(), "exceed limit of 5")
+	assert.Contains(t, err.Error(), "exceed maximum limit of 5")
 }

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -719,7 +719,8 @@ func Test_MergeSelectorMatchExpression(t *testing.T) {
 	assert.Equal(t, 1, len(*mergedMatchExpressions))
 	assert.Equal(t, v1.LabelSelectorOpIn, (*mergedMatchExpressions)[0].Operator)
 	assert.Equal(t, "k1", (*mergedMatchExpressions)[0].Key)
-	assert.Equal(t, 3, len((*mergedMatchExpressions)[0].Values))
+	assert.Equal(t, 1, len((*mergedMatchExpressions)[0].Values))
+	assert.Equal(t, "a2", (*mergedMatchExpressions)[0].Values[0])
 
 	// Case: the same key with different operator will not merge
 	matchExpressions = []v1.LabelSelectorRequirement{

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -20,6 +20,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	t1v1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/legacy/v1alpha1"
@@ -150,6 +151,12 @@ func RemoveDuplicateStr(strSlice []string) []string {
 	}
 
 	return resultStr
+}
+
+func IntersectStr(a, b []string) []string {
+	setA := sets.New(a...)
+	setB := sets.New(b...)
+	return sets.List(setA.Intersection(setB))
 }
 
 func ToUpper(obj interface{}) string {

--- a/test/e2e/manifest/testNetworkPolicy/np_multiple_in.yaml
+++ b/test/e2e/manifest/testNetworkPolicy/np_multiple_in.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-np-multiple-in
+spec:
+  ingress:
+  - ports:
+    - port: 80
+    from:
+    - podSelector:
+        matchExpressions:
+          - key: tier
+            operator: In
+            values: ["frontend", "backend"]
+          - key: tier
+            operator: In
+            values: ["backend", "db"]
+  podSelector:
+    matchLabels:
+      nptcp1: tcp1
+  policyTypes:
+  - Ingress

--- a/test/e2e/manifest/testNetworkPolicy/np_multiple_in_pods.yaml
+++ b/test/e2e/manifest/testNetworkPolicy/np_multiple_in_pods.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+  labels:
+    tier: frontend
+spec:
+  restartPolicy: Never
+  containers:
+  - name: frontend
+    image: "netfvt-docker-local.packages.vcfd.broadcom.net/humanux/http_https_echo:latest"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: backend
+  labels:
+    tier: backend
+spec:
+  restartPolicy: Never
+  containers:
+    - name: backend
+      image: "netfvt-docker-local.packages.vcfd.broadcom.net/humanux/http_https_echo:latest"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: db
+  labels:
+    tier: db
+spec:
+  restartPolicy: Never
+  containers:
+    - name: db
+      image: "netfvt-docker-local.packages.vcfd.broadcom.net/humanux/http_https_echo:latest"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: target-pod
+  labels:
+    nptcp1: tcp1
+spec:
+  restartPolicy: Never
+  containers:
+    - name: target-pod
+      image: "netfvt-docker-local.packages.vcfd.broadcom.net/humanux/http_https_echo:latest"

--- a/test/e2e/nsx_security_policy_test.go
+++ b/test/e2e/nsx_security_policy_test.go
@@ -51,6 +51,7 @@ func TestSecurityPolicy(t *testing.T) {
 		RunSubtest(t, "testSecurityPolicyVPCToFieldEgress", func(t *testing.T) { testSecurityPolicyVPCToFieldEgress(t) })
 		RunSubtest(t, "testSecurityPolicyNamedPortWithoutPod", func(t *testing.T) { testSecurityPolicyNamedPortWithoutPod(t) })
 		RunSubtest(t, "testSecurityPolicyNamedPorWithPod", func(t *testing.T) { testSecurityPolicyNamedPorWithPod(t) })
+		RunSubtest(t, "testNetworkPolicyMultipleIn", func(t *testing.T) { testNetworkPolicyMultipleIn(t) })
 	})
 
 	// IPv6-only tests: run only when cluster has IPv6 Pod CIDR configured.
@@ -508,4 +509,74 @@ func assureSecurityPolicyReady(t *testing.T, ns, spName string) {
 		return false, nil
 	})
 	require.NoError(t, err)
+}
+
+// testNetworkPolicyMultipleIn verifies that multiple In expressions on the same key are properly intersected.
+func testNetworkPolicyMultipleIn(t *testing.T) {
+	deadlineCtx, deadlineCancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer deadlineCancel()
+
+	ns := NsSecurityPolicy
+	npName := "test-np-multiple-in"
+
+	// Create pods
+	podPath, _ := filepath.Abs("./manifest/testNetworkPolicy/np_multiple_in_pods.yaml")
+	require.NoError(t, applyYAML(podPath, ns))
+	defer deleteYAML(podPath, "")
+
+	frontend := "frontend"
+	backend := "backend"
+	db := "db"
+	target := "target-pod"
+
+	// Wait for pods
+	_, err := testData.podWaitForIPs(defaultTimeout, frontend, ns)
+	assert.NoError(t, err, "Error when waiting for IP for Pod %s", frontend)
+	_, err = testData.podWaitForIPs(defaultTimeout, backend, ns)
+	assert.NoError(t, err, "Error when waiting for IP for Pod %s", backend)
+	_, err = testData.podWaitForIPs(defaultTimeout, db, ns)
+	assert.NoError(t, err, "Error when waiting for IP for Pod %s", db)
+	iPs, err := testData.podWaitForIPs(defaultTimeout, target, ns)
+	assert.NoError(t, err, "Error when waiting for IP for Pod %s", target)
+
+	// Test traffic before policy
+	require.True(t, checkTrafficByCurl(ns, frontend, frontend, iPs.ipv4.String(), podPort, true), "Traffic should work before policy")
+	require.True(t, checkTrafficByCurl(ns, backend, backend, iPs.ipv4.String(), podPort, true), "Traffic should work before policy")
+	require.True(t, checkTrafficByCurl(ns, db, db, iPs.ipv4.String(), podPort, true), "Traffic should work before policy")
+
+	// Create NetworkPolicy
+	npPath, _ := filepath.Abs("./manifest/testNetworkPolicy/np_multiple_in.yaml")
+	require.NoError(t, applyYAML(npPath, ns))
+	defer deleteYAML(npPath, ns)
+
+	// Wait for NetworkPolicy -> SecurityPolicy to be created
+	assert.NoError(t, testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, npName, true))
+
+	// Test traffic after policy
+	// Only backend should be allowed because intersection of ["frontend", "backend"] and ["backend", "db"] is ["backend"]
+	require.True(t, checkTrafficByCurl(ns, frontend, frontend, iPs.ipv4.String(), podPort, false), "Traffic from frontend should be blocked")
+	require.True(t, checkTrafficByCurl(ns, backend, backend, iPs.ipv4.String(), podPort, true), "Traffic from backend should be allowed")
+	require.True(t, checkTrafficByCurl(ns, db, db, iPs.ipv4.String(), podPort, false), "Traffic from db should be blocked")
+
+	// Delete NetworkPolicy
+	_ = deleteYAML(npPath, ns)
+
+	err = wait.PollUntilContextTimeout(deadlineCtx, 1*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
+		_, err = testData.clientset.NetworkingV1().NetworkPolicies(ns).Get(ctx, npName, v1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	assert.NoError(t, testData.waitForResourceExistOrNot(ns, common.ResourceTypeSecurityPolicy, npName, false))
+
+	// Test traffic after delete
+	require.True(t, checkTrafficByCurl(ns, frontend, frontend, iPs.ipv4.String(), podPort, true), "Traffic from frontend should work after delete")
+	require.True(t, checkTrafficByCurl(ns, backend, backend, iPs.ipv4.String(), podPort, true), "Traffic from backend should work after delete")
+	require.True(t, checkTrafficByCurl(ns, db, db, iPs.ipv4.String(), podPort, true), "Traffic from db should work after delete")
 }


### PR DESCRIPTION
Fix translation and validation of multiple 'In' matchExpressions

This commit addresses multiple issues in how Kubernetes label selectors are 
translated to NSX-T group expressions and validated:

1. Correct evaluation of multiple 'In' operators: Kubernetes requires multiple 
   expressions in `matchExpressions` to be evaluated with a logical AND. 
   Previously, multiple 'In' expressions on the same key were merged using 
   a logical OR by simply appending the values. This adds an `intersectStr` 
   helper to correctly compute the intersection of values instead.

2. Fix MaxMatchExpressionInOp validation limit: Ensures validation checks 
   happen on the original, un-merged expressions so users cannot inadvertently 
   bypass the single 'In' operator limit.

3. Fix state overwrite during duplicate checking: In `validateSelectorOpIn`, 
   the loop checking for duplicates between `matchLabels` and `matchExpressions` 
   was overwriting loop variables (`exists` and `opInIndex`) on each iteration. 
   This caused only the last expression to be correctly validated. The loop 
   has been refactored to check all 'In' expressions directly.

4. Add E2E tests: Introduces a new test `testNetworkPolicyMultipleIn` and 
   accompanying manifests to verify that traffic is correctly restricted 
   when intersecting multiple 'In' expressions.

    Signed-off-by: Wenqi Qiu <wenqi.qiu@broadcom.com>

TestDone:

Before the patch:
```
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# kubectl exec -it db -n test-ns -- curl --connect-timeout 2 http://$TARGET_IP
{
  "request": {
    "path": "/",
    "headers": {
      "host": "10.246.0.67",
      "user-agent": "curl/7.67.0",
      "accept": "*/*"
    },
    "method": "GET",
    "body": "",
    "fresh": false,
    "hostname": "10.246.0.67",
    "ip": "10.246.0.68",
    "ips": [],
    "port": 80,
    "remoteport": 56656,
    "protocol": "http",
    "query": {},
    "subdomains": [],
    "xhr": false
  },
  "server": {
    "hostname": "backend",
    "network": {
      "lo": [
        {
          "address": "127.0.0.1",
          "netmask": "255.0.0.0",
          "family": "IPv4",
          "mac": "00:00:00:00:00:00",
          "internal": true,
          "cidr": "127.0.0.1/8"
        }
      ],
      "podvnic": [
        {
          "address": "10.246.0.67",
          "netmask": "255.255.255.224",
          "family": "IPv4",
          "mac": "04:50:56:00:dc:00",
          "internal": false,
          "cidr": "10.246.0.67/27"
        }
      ]
    }
  }
}root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# kubectl exec -it backend -n test-ns -- curl --connect-timeout 2 http://$TARGET_IP
{
  "request": {
    "path": "/",
    "headers": {
      "host": "10.246.0.67",
      "user-agent": "curl/7.67.0",
      "accept": "*/*"
    },
    "method": "GET",
    "body": "",
    "fresh": false,
    "hostname": "10.246.0.67",
    "ip": "10.246.0.67",
    "ips": [],
    "port": 80,
    "remoteport": 49466,
    "protocol": "http",
    "query": {},
    "subdomains": [],
    "xhr": false
  },
  "server": {
    "hostname": "backend",
    "network": {
      "lo": [
        {
          "address": "127.0.0.1",
          "netmask": "255.0.0.0",
          "family": "IPv4",
          "mac": "00:00:00:00:00:00",
          "internal": true,
          "cidr": "127.0.0.1/8"
        }
      ],
      "podvnic": [
        {
          "address": "10.246.0.67",
          "netmask": "255.255.255.224",
          "family": "IPv4",
          "mac": "04:50:56:00:dc:00",
          "internal": false,
          "cidr": "10.246.0.67/27"
        }
      ]
    }
  }
}root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# kubectl exec -it frontend -n test-ns  -- curl --connect-timeout 2 http://$TARGET_IP
{
  "request": {
    "path": "/",
    "headers": {
      "host": "10.246.0.67",
      "user-agent": "curl/7.67.0",
      "accept": "*/*"
    },
    "method": "GET",
    "body": "",
    "fresh": false,
    "hostname": "10.246.0.67",
    "ip": "10.246.0.66",
    "ips": [],
    "port": 80,
    "remoteport": 46992,
    "protocol": "http",
    "query": {},
    "subdomains": [],
    "xhr": false
  },
  "server": {
    "hostname": "backend",
    "network": {
      "lo": [
        {
          "address": "127.0.0.1",
          "netmask": "255.0.0.0",
          "family": "IPv4",
          "mac": "00:00:00:00:00:00",
          "internal": true,
          "cidr": "127.0.0.1/8"
        }
      ],
      "podvnic": [
        {
          "address": "10.246.0.67",
          "netmask": "255.255.255.224",
          "family": "IPv4",
          "mac": "04:50:56:00:dc:00",
          "internal": false,
          "cidr": "10.246.0.67/27"
        }
      ]
    }
  }
}root@42180818f9f602c97c03d42f1abc23f3 [ ~/bugs-or-and ]# 
```

Group details in NSX:

```
curl -k -u "${NSX_USER}:${NSX_PASS}"   -X GET   -H "Content-Type: application/json"   "${NSX_MANAGER}/policy/api/v1/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5"
{
  "expression" : [ {
    "expressions" : [ {
      "member_type" : "VpcSubnetPort",
      "key" : "Tag",
      "operator" : "EQUALS",
      "scope_operator" : "EQUALS",
      "value" : "nsx-op/cluster|6b11585d-9e43-42b2-bc87-9adfbb565b39",
      "resource_type" : "Condition",
      "id" : "2c53b0ab-839e-4bcd-ae9f-ef6be35d850e",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/condition-expressions/2c53b0ab-839e-4bcd-ae9f-ef6be35d850e",
      "relative_path" : "2c53b0ab-839e-4bcd-ae9f-ef6be35d850e",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "conjunction_operator" : "AND",
      "resource_type" : "ConjunctionOperator",
      "id" : "594c4d4b-9e46-452d-bb10-586e7547d602",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/conjunction-expressions/594c4d4b-9e46-452d-bb10-586e7547d602",
      "relative_path" : "594c4d4b-9e46-452d-bb10-586e7547d602",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "member_type" : "VpcSubnetPort",
      "key" : "Tag",
      "operator" : "EQUALS",
      "scope_operator" : "EQUALS",
      "value" : "nsx-op/namespace_uid|09151c86-e812-406e-b83c-bcae7a46e977",
      "resource_type" : "Condition",
      "id" : "8f1113c0-1d78-4e77-9c0b-327da27ada1d",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/condition-expressions/8f1113c0-1d78-4e77-9c0b-327da27ada1d",
      "relative_path" : "8f1113c0-1d78-4e77-9c0b-327da27ada1d",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "conjunction_operator" : "AND",
      "resource_type" : "ConjunctionOperator",
      "id" : "a4c416ea-f617-4cd9-88bb-9f1f477d481d",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/conjunction-expressions/a4c416ea-f617-4cd9-88bb-9f1f477d481d",
      "relative_path" : "a4c416ea-f617-4cd9-88bb-9f1f477d481d",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "member_type" : "VpcSubnetPort",
      "key" : "Tag",
      "operator" : "EQUALS",
      "scope_operator" : "EQUALS",
      "value" : "tier|frontend",
      "resource_type" : "Condition",
      "id" : "6b5ba238-80cc-4c61-bb92-a43abe43097e",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/condition-expressions/6b5ba238-80cc-4c61-bb92-a43abe43097e",
      "relative_path" : "6b5ba238-80cc-4c61-bb92-a43abe43097e",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    } ],
    "resource_type" : "NestedExpression",
    "id" : "e3a22b71-2eb8-441c-9c11-bf4e0811167b",
    "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/nested-expressions/e3a22b71-2eb8-441c-9c11-bf4e0811167b",
    "relative_path" : "e3a22b71-2eb8-441c-9c11-bf4e0811167b",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
    "remote_path" : "",
    "marked_for_delete" : false,
    "overridden" : false,
    "_protection" : "NOT_PROTECTED"
  }, {
    "conjunction_operator" : "OR",
    "resource_type" : "ConjunctionOperator",
    "id" : "2acd071c-6aa6-4e9d-b70e-93105065105d",
    "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/conjunction-expressions/2acd071c-6aa6-4e9d-b70e-93105065105d",
    "relative_path" : "2acd071c-6aa6-4e9d-b70e-93105065105d",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
    "remote_path" : "",
    "marked_for_delete" : false,
    "overridden" : false,
    "_protection" : "NOT_PROTECTED"
  }, {
    "expressions" : [ {
      "member_type" : "VpcSubnetPort",
      "key" : "Tag",
      "operator" : "EQUALS",
      "scope_operator" : "EQUALS",
      "value" : "nsx-op/cluster|6b11585d-9e43-42b2-bc87-9adfbb565b39",
      "resource_type" : "Condition",
      "id" : "dc234b33-2f46-43ce-b297-c34c413b62f3",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/condition-expressions/dc234b33-2f46-43ce-b297-c34c413b62f3",
      "relative_path" : "dc234b33-2f46-43ce-b297-c34c413b62f3",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "conjunction_operator" : "AND",
      "resource_type" : "ConjunctionOperator",
      "id" : "ac925211-f1c2-4b1f-9ec4-b963fd9ecb32",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/conjunction-expressions/ac925211-f1c2-4b1f-9ec4-b963fd9ecb32",
      "relative_path" : "ac925211-f1c2-4b1f-9ec4-b963fd9ecb32",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "member_type" : "VpcSubnetPort",
      "key" : "Tag",
      "operator" : "EQUALS",
      "scope_operator" : "EQUALS",
      "value" : "nsx-op/namespace_uid|09151c86-e812-406e-b83c-bcae7a46e977",
      "resource_type" : "Condition",
      "id" : "cb7a98ff-9d5c-4beb-a51c-aff234048ff5",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/condition-expressions/cb7a98ff-9d5c-4beb-a51c-aff234048ff5",
      "relative_path" : "cb7a98ff-9d5c-4beb-a51c-aff234048ff5",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "conjunction_operator" : "AND",
      "resource_type" : "ConjunctionOperator",
      "id" : "27e5bd67-e6ed-43cd-b3e5-5c0c9ecc3376",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/conjunction-expressions/27e5bd67-e6ed-43cd-b3e5-5c0c9ecc3376",
      "relative_path" : "27e5bd67-e6ed-43cd-b3e5-5c0c9ecc3376",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "member_type" : "VpcSubnetPort",
      "key" : "Tag",
      "operator" : "EQUALS",
      "scope_operator" : "EQUALS",
      "value" : "tier|backend",
      "resource_type" : "Condition",
      "id" : "8dbf897c-0c73-45a3-9824-db7161ca214d",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/condition-expressions/8dbf897c-0c73-45a3-9824-db7161ca214d",
      "relative_path" : "8dbf897c-0c73-45a3-9824-db7161ca214d",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    } ],
    "resource_type" : "NestedExpression",
    "id" : "806c0873-fe89-41f0-8242-83ea951ef74d",
    "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/nested-expressions/806c0873-fe89-41f0-8242-83ea951ef74d",
    "relative_path" : "806c0873-fe89-41f0-8242-83ea951ef74d",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
    "remote_path" : "",
    "marked_for_delete" : false,
    "overridden" : false,
    "_protection" : "NOT_PROTECTED"
  }, {
    "conjunction_operator" : "OR",
    "resource_type" : "ConjunctionOperator",
    "id" : "b4f2ebdb-f9b4-4d7b-ba26-2b084befa438",
    "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/conjunction-expressions/b4f2ebdb-f9b4-4d7b-ba26-2b084befa438",
    "relative_path" : "b4f2ebdb-f9b4-4d7b-ba26-2b084befa438",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
    "remote_path" : "",
    "marked_for_delete" : false,
    "overridden" : false,
    "_protection" : "NOT_PROTECTED"
  }, {
    "expressions" : [ {
      "member_type" : "VpcSubnetPort",
      "key" : "Tag",
      "operator" : "EQUALS",
      "scope_operator" : "EQUALS",
      "value" : "nsx-op/cluster|6b11585d-9e43-42b2-bc87-9adfbb565b39",
      "resource_type" : "Condition",
      "id" : "e9fe8678-a09a-4282-83d3-148b842580a9",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/condition-expressions/e9fe8678-a09a-4282-83d3-148b842580a9",
      "relative_path" : "e9fe8678-a09a-4282-83d3-148b842580a9",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "conjunction_operator" : "AND",
      "resource_type" : "ConjunctionOperator",
      "id" : "19c3d9aa-e647-44f4-940b-c4dd7871656d",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/conjunction-expressions/19c3d9aa-e647-44f4-940b-c4dd7871656d",
      "relative_path" : "19c3d9aa-e647-44f4-940b-c4dd7871656d",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "member_type" : "VpcSubnetPort",
      "key" : "Tag",
      "operator" : "EQUALS",
      "scope_operator" : "EQUALS",
      "value" : "nsx-op/namespace_uid|09151c86-e812-406e-b83c-bcae7a46e977",
      "resource_type" : "Condition",
      "id" : "971d35c9-019c-4d03-aaf6-8b75b59c1623",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/condition-expressions/971d35c9-019c-4d03-aaf6-8b75b59c1623",
      "relative_path" : "971d35c9-019c-4d03-aaf6-8b75b59c1623",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "conjunction_operator" : "AND",
      "resource_type" : "ConjunctionOperator",
      "id" : "80c7142a-42b1-439b-99a1-e53a2b46b1ec",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/conjunction-expressions/80c7142a-42b1-439b-99a1-e53a2b46b1ec",
      "relative_path" : "80c7142a-42b1-439b-99a1-e53a2b46b1ec",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "member_type" : "VpcSubnetPort",
      "key" : "Tag",
      "operator" : "EQUALS",
      "scope_operator" : "EQUALS",
      "value" : "tier|db",
      "resource_type" : "Condition",
      "id" : "ec02d8fa-745f-475e-9718-02eb346ecd35",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/condition-expressions/ec02d8fa-745f-475e-9718-02eb346ecd35",
      "relative_path" : "ec02d8fa-745f-475e-9718-02eb346ecd35",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    } ],
    "resource_type" : "NestedExpression",
    "id" : "0ebba973-7e31-4ab6-9168-182fc2a87b35",
    "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5/nested-expressions/0ebba973-7e31-4ab6-9168-182fc2a87b35",
    "relative_path" : "0ebba973-7e31-4ab6-9168-182fc2a87b35",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
    "remote_path" : "",
    "marked_for_delete" : false,
    "overridden" : false,
    "_protection" : "NOT_PROTECTED"
  } ],
  "extended_expression" : [ ],
  "reference" : false,
  "resource_type" : "Group",
  "id" : "test-np-multiple-in-allow-2b716384-src_1hnx5",
  "display_name" : "test-np-multiple-in_2b716384_src",
  "tags" : [ {
    "scope" : "nsx-op/group_type",
    "tag" : "source"
  }, {
    "scope" : "nsx-op/rule_id",
    "tag" : "test-np-multiple-in-allow-2b716384_1hnx5"
  }, {
    "scope" : "nsx-op/selector_hash",
    "tag" : "f02826b31e0679b1c3b6c4c2412133e115ace28c"
  }, {
    "scope" : "nsx-op/cluster",
    "tag" : "6b11585d-9e43-42b2-bc87-9adfbb565b39"
  }, {
    "scope" : "nsx-op/version",
    "tag" : "1.0.0"
  }, {
    "scope" : "nsx-op/namespace",
    "tag" : "test-ns"
  }, {
    "scope" : "nsx-op/namespace_uid",
    "tag" : "09151c86-e812-406e-b83c-bcae7a46e977"
  }, {
    "scope" : "nsx-op/network_policy_name",
    "tag" : "test-np-multiple-in"
  }, {
    "scope" : "nsx-op/network_policy_uid",
    "tag" : "c33cc273-5aca-4755-941e-250366f42c44_allow"
  }, {
    "scope" : "nsx-op/nsx_share_created_for",
    "tag" : "notShared"
  } ],
  "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr/groups/test-np-multiple-in-allow-2b716384-src_1hnx5",
  "relative_path" : "test-np-multiple-in-allow-2b716384-src_1hnx5",
  "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_lk9kr",
  "remote_path" : "",
  "unique_id" : "a6c633e7-aaa1-4cde-967d-a6cda91e701b",
  "realization_id" : "a6c633e7-aaa1-4cde-967d-a6cda91e701b",
  "owner_id" : "5062b9e8-e133-44cf-82d7-301e13f59ed4",
  "marked_for_delete" : false,
  "overridden" : false,
  "_protection" : "REQUIRE_OVERRIDE",
  "_system_owned" : false,
  "_create_time" : 1782311293346,
  "_create_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
  "_last_modified_time" : 1782311293346,
  "_last_modified_user" : "wcp-cluster-user-6b11585d-9e43-42b2-bc87-9adfbb565b39-0a9f80fb-45c0-4f66-9ed1-b2d7465c15e7",
  "_revision" : 0
}
```


After Patch:

<img width="1760" height="1378" alt="74943ad2-eb93-4317-9dbc-b51df1b63ca6" src="https://github.com/user-attachments/assets/15cdca70-9305-4104-9117-1c883289fb60" />


```
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# k get networkpolicy -n test-ns -oyaml
apiVersion: v1
items:
- apiVersion: networking.k8s.io/v1
  kind: NetworkPolicy
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"test-np-multiple-in","namespace":"test-ns"},"spec":{"ingress":[{"from":[{"podSelector":{"matchExpressions":[{"key":"tier","operator":"In","values":["frontend","backend"]},{"key":"tier","operator":"In","values":["backend","db"]}]}}],"ports":[{"port":80}]}],"podSelector":{"matchLabels":{"nptcp1":"tcp1"}},"policyTypes":["Ingress"]}}
    creationTimestamp: "2026-06-30T09:12:49Z"
    generation: 1
    name: test-np-multiple-in
    namespace: test-ns
    resourceVersion: "439589"
    uid: 19d50000-c4e2-4863-baff-8816b064e7ce
  spec:
    ingress:
    - from:
      - podSelector:
          matchExpressions:
          - key: tier
            operator: In
            values:
            - frontend
            - backend
          - key: tier
            operator: In
            values:
            - backend
            - db
      ports:
      - port: 80
        protocol: TCP
    podSelector:
      matchLabels:
        nptcp1: tcp1
    policyTypes:
    - Ingress
kind: List
metadata:
  resourceVersion: ""
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# kubectl exec -it db -n test-ns -- curl --connect-timeout 2 http://$TARGET_IP
curl: (28) Connection timed out after 2001 milliseconds
command terminated with exit code 28
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# kubectl exec -it frontend -n test-ns -- curl --connect-timeout 2 http://$TARGET_IP
curl: (28) Connection timed out after 2001 milliseconds
command terminated with exit code 28
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# kubectl exec -it backend -n test-ns -- curl --connect-timeout 2 http://$TARGET_IP
{
  "request": {
    "path": "/",
    "headers": {
      "host": "10.246.0.35",
      "user-agent": "curl/7.67.0",
      "accept": "*/*"
    },
    "method": "GET",
    "body": "",
    "fresh": false,
    "hostname": "10.246.0.35",
    "ip": "10.246.0.37",
    "ips": [],
    "port": 80,
    "remoteport": 43146,
    "protocol": "http",
    "query": {},
    "subdomains": [],
    "xhr": false
  },
  "server": {
    "hostname": "target-pod",
    "network": {
      "lo": [
        {
          "address": "127.0.0.1",
          "netmask": "255.0.0.0",
          "family": "IPv4",
          "mac": "00:00:00:00:00:00",
          "internal": true,
          "cidr": "127.0.0.1/8"
        }
      ],
      "podvnic": [
        {
          "address": "10.246.0.35",
          "netmask": "255.255.255.224",
          "family": "IPv4",
          "mac": "04:50:56:00:00:00",
          "internal": false,
          "cidr": "10.246.0.35/27"
        }
      ]
    }
  }
}root@422c72f507918f80fe61efcdc8407eb3 [ ~ ]# 
```

Group Details in NSX：

```
curl -k -u "${NSX_USER}:${NSX_PASS}"   -X GET   -H "Content-Type: application/json"   "${NSX_MANAGER}/policy/api/v1/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj"
{
  "expression" : [ {
    "expressions" : [ {
      "member_type" : "VpcSubnetPort",
      "key" : "Tag",
      "operator" : "EQUALS",
      "scope_operator" : "EQUALS",
      "value" : "nsx-op/cluster|9995e6cf-e8fa-4970-b9a1-30edb607a709",
      "resource_type" : "Condition",
      "id" : "854cfc38-a1c0-4452-b25b-633e7f62e5ae",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj/condition-expressions/854cfc38-a1c0-4452-b25b-633e7f62e5ae",
      "relative_path" : "854cfc38-a1c0-4452-b25b-633e7f62e5ae",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "conjunction_operator" : "AND",
      "resource_type" : "ConjunctionOperator",
      "id" : "c35e602a-7264-45d5-9801-49e5f58295c4",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj/conjunction-expressions/c35e602a-7264-45d5-9801-49e5f58295c4",
      "relative_path" : "c35e602a-7264-45d5-9801-49e5f58295c4",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "member_type" : "VpcSubnetPort",
      "key" : "Tag",
      "operator" : "EQUALS",
      "scope_operator" : "EQUALS",
      "value" : "nsx-op/namespace_uid|e573fed0-e7d1-4773-bd80-f28681ad5a59",
      "resource_type" : "Condition",
      "id" : "d6791e07-9d8d-436d-9c2b-d40e130dc144",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj/condition-expressions/d6791e07-9d8d-436d-9c2b-d40e130dc144",
      "relative_path" : "d6791e07-9d8d-436d-9c2b-d40e130dc144",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "conjunction_operator" : "AND",
      "resource_type" : "ConjunctionOperator",
      "id" : "2ca39ac8-937b-4efb-a2b9-cab81e6be5d2",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj/conjunction-expressions/2ca39ac8-937b-4efb-a2b9-cab81e6be5d2",
      "relative_path" : "2ca39ac8-937b-4efb-a2b9-cab81e6be5d2",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    }, {
      "member_type" : "VpcSubnetPort",
      "key" : "Tag",
      "operator" : "EQUALS",
      "scope_operator" : "EQUALS",
      "value" : "tier|backend",
      "resource_type" : "Condition",
      "id" : "2eeca6eb-745d-40d5-9f63-c3cc6f69b1bc",
      "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj/condition-expressions/2eeca6eb-745d-40d5-9f63-c3cc6f69b1bc",
      "relative_path" : "2eeca6eb-745d-40d5-9f63-c3cc6f69b1bc",
      "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj",
      "remote_path" : "",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    } ],
    "resource_type" : "NestedExpression",
    "id" : "e30119af-2318-45ca-b82e-ce2e9aaa65fb",
    "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj/nested-expressions/e30119af-2318-45ca-b82e-ce2e9aaa65fb",
    "relative_path" : "e30119af-2318-45ca-b82e-ce2e9aaa65fb",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj",
    "remote_path" : "",
    "marked_for_delete" : false,
    "overridden" : false,
    "_protection" : "NOT_PROTECTED"
  } ],
  "extended_expression" : [ ],
  "reference" : false,
  "resource_type" : "Group",
  "id" : "test-np-multiple-in-allow-2b716384-src_qtezj",
  "display_name" : "test-np-multiple-in_2b716384_src",
  "tags" : [ {
    "scope" : "nsx-op/group_type",
    "tag" : "source"
  }, {
    "scope" : "nsx-op/rule_id",
    "tag" : "test-np-multiple-in-allow-2b716384_qtezj"
  }, {
    "scope" : "nsx-op/selector_hash",
    "tag" : "f02826b31e0679b1c3b6c4c2412133e115ace28c"
  }, {
    "scope" : "nsx-op/cluster",
    "tag" : "9995e6cf-e8fa-4970-b9a1-30edb607a709"
  }, {
    "scope" : "nsx-op/version",
    "tag" : "1.0.0"
  }, {
    "scope" : "nsx-op/namespace",
    "tag" : "test-ns"
  }, {
    "scope" : "nsx-op/namespace_uid",
    "tag" : "e573fed0-e7d1-4773-bd80-f28681ad5a59"
  }, {
    "scope" : "nsx-op/network_policy_name",
    "tag" : "test-np-multiple-in"
  }, {
    "scope" : "nsx-op/network_policy_uid",
    "tag" : "19d50000-c4e2-4863-baff-8816b064e7ce_allow"
  }, {
    "scope" : "nsx-op/nsx_share_created_for",
    "tag" : "notShared"
  } ],
  "path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d/groups/test-np-multiple-in-allow-2b716384-src_qtezj",
  "relative_path" : "test-np-multiple-in-allow-2b716384-src_qtezj",
  "parent_path" : "/orgs/default/projects/project-quality/vpcs/test-ns_9e31d",
  "remote_path" : "",
  "unique_id" : "c71be21f-ea00-4648-88ab-6d0e881f1741",
  "realization_id" : "c71be21f-ea00-4648-88ab-6d0e881f1741",
  "owner_id" : "7de74739-f9fa-442d-b3d2-8bc33b171db9",
  "marked_for_delete" : false,
  "overridden" : false,
  "_system_owned" : false,
  "_protection" : "REQUIRE_OVERRIDE",
  "_create_time" : 1782810791371,
  "_create_user" : "wcp-cluster-user-9995e6cf-e8fa-4970-b9a1-30edb607a709-b3816e2f-166a-43e6-9a3e-013de621c9af",
  "_last_modified_time" : 1782810791371,
  "_last_modified_user" : "wcp-cluster-user-9995e6cf-e8fa-4970-b9a1-30edb607a709-b3816e2f-166a-43e6-9a3e-013de621c9af",
  "_revision" : 0
}%                                                       
```

https://10.191.159.144/job/nsx_operator/2397/