### PR TITLE
Avoid update status if no change

### DIFF
--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -708,3 +708,8 @@ func IntersectIPAddressTypes(types []v1alpha1.IPAddressType) (v1alpha1.IPAddress
 
 	return result, nil
 }
+
+// IsConditionSemanticEqual checks if two conditions are semantically equal.
+func IsConditionSemanticEqual(matchedCondition, newCondition *v1alpha1.Condition) bool {
+	return matchedCondition != nil && matchedCondition.Status == newCondition.Status && matchedCondition.Reason == newCondition.Reason && matchedCondition.Message == newCondition.Message
+}

--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_controller.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_controller.go
@@ -47,7 +47,7 @@ type IPAddressAllocationReconciler struct {
 
 func setReadyStatusFalse(client client.Client, ctx context.Context, obj client.Object, transitionTime metav1.Time, err error, _ ...interface{}) {
 	ipaddressallocation := obj.(*v1alpha1.IPAddressAllocation)
-	conditions := []v1alpha1.Condition{
+	newConditions := []v1alpha1.Condition{
 		{
 			Type:   v1alpha1.Ready,
 			Status: v1.ConditionFalse,
@@ -59,16 +59,12 @@ func setReadyStatusFalse(client client.Client, ctx context.Context, obj client.O
 			LastTransitionTime: transitionTime,
 		},
 	}
-	ipaddressallocation.Status.Conditions = conditions
-	e := client.Status().Update(ctx, ipaddressallocation)
-	if e != nil {
-		log.Error(e, "Unable to update IPAddressAllocation status", "IPAddressAllocation", ipaddressallocation)
-	}
+	updateIPAddressAllocationStatusConditions(client, ctx, ipaddressallocation, newConditions)
 }
 
 func setReadyStatusTrue(client client.Client, ctx context.Context, obj client.Object, transitionTime metav1.Time, _ ...interface{}) {
 	ipaddressallocation := obj.(*v1alpha1.IPAddressAllocation)
-	conditions := []v1alpha1.Condition{
+	newConditions := []v1alpha1.Condition{
 		{
 			Type:               v1alpha1.Ready,
 			Status:             v1.ConditionTrue,
@@ -77,11 +73,51 @@ func setReadyStatusTrue(client client.Client, ctx context.Context, obj client.Ob
 			LastTransitionTime: transitionTime,
 		},
 	}
-	ipaddressallocation.Status.Conditions = conditions
-	e := client.Status().Update(ctx, ipaddressallocation)
-	if e != nil {
-		log.Error(e, "Unable to update IPAddressAllocation status", "IPAddressAllocation", ipaddressallocation)
+	updateIPAddressAllocationStatusConditions(client, ctx, ipaddressallocation, newConditions)
+}
+
+func updateIPAddressAllocationStatusConditions(client client.Client, ctx context.Context, ipaddressallocation *v1alpha1.IPAddressAllocation, newConditions []v1alpha1.Condition) {
+	conditionsUpdated := false
+	for i := range newConditions {
+		if mergeIPAddressAllocationStatusCondition(ipaddressallocation, &newConditions[i]) {
+			conditionsUpdated = true
+		}
 	}
+	if conditionsUpdated {
+		if err := client.Status().Update(ctx, ipaddressallocation); err != nil {
+			log.Error(err, "Failed to update status", "Name", ipaddressallocation.Name, "Namespace", ipaddressallocation.Namespace)
+		} else {
+			log.Info("Updated IPAddressAllocation", "Name", ipaddressallocation.Name, "Namespace", ipaddressallocation.Namespace, "New Conditions", newConditions)
+		}
+	}
+}
+
+func mergeIPAddressAllocationStatusCondition(ipaddressallocation *v1alpha1.IPAddressAllocation, newCondition *v1alpha1.Condition) bool {
+	matchedCondition := getExistingConditionOfType(newCondition.Type, ipaddressallocation.Status.Conditions)
+
+	if common.IsConditionSemanticEqual(matchedCondition, newCondition) {
+		log.Trace("Conditions already match", "New Condition", newCondition, "Existing Condition", matchedCondition)
+		return false
+	}
+
+	if matchedCondition != nil {
+		matchedCondition.Reason = newCondition.Reason
+		matchedCondition.Message = newCondition.Message
+		matchedCondition.Status = newCondition.Status
+		matchedCondition.LastTransitionTime = newCondition.LastTransitionTime
+	} else {
+		ipaddressallocation.Status.Conditions = append(ipaddressallocation.Status.Conditions, *newCondition)
+	}
+	return true
+}
+
+func getExistingConditionOfType(conditionType v1alpha1.ConditionType, existingConditions []v1alpha1.Condition) *v1alpha1.Condition {
+	for i := range existingConditions {
+		if existingConditions[i].Type == conditionType {
+			return &existingConditions[i]
+		}
+	}
+	return nil
 }
 
 func (r *IPAddressAllocationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_controller_test.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_controller_test.go
@@ -68,6 +68,75 @@ func TestIPAddressAllocationController_setReadyStatusTrue(t *testing.T) {
 	}
 }
 
+func TestIPAddressAllocationController_updateIPAddressAllocationStatusConditions(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	ctx := context.TODO()
+
+	transitionTime := metav1.Now()
+
+	// Case 1: Matched condition found with no change
+	dummyIPAddressAllocation1 := &v1alpha1.IPAddressAllocation{
+		Status: v1alpha1.IPAddressAllocationStatus{
+			Conditions: []v1alpha1.Condition{
+				{
+					Type:               v1alpha1.Ready,
+					Status:             v1.ConditionTrue,
+					Message:            "NSX IPAddressAllocation has been successfully created/updated",
+					Reason:             "IPAddressAllocationReady",
+					LastTransitionTime: transitionTime,
+				},
+			},
+		},
+	}
+	newConditions1 := []v1alpha1.Condition{
+		{
+			Type:               v1alpha1.Ready,
+			Status:             v1.ConditionTrue,
+			Message:            "NSX IPAddressAllocation has been successfully created/updated",
+			Reason:             "IPAddressAllocationReady",
+			LastTransitionTime: transitionTime,
+		},
+	}
+
+	// EXPECT Status() should not be called because conditionsUpdated should be false
+	k8sClient.EXPECT().Status().Times(0)
+	updateIPAddressAllocationStatusConditions(k8sClient, ctx, dummyIPAddressAllocation1, newConditions1)
+
+	// Case 2: Matched condition found with change
+	dummyIPAddressAllocation2 := &v1alpha1.IPAddressAllocation{
+		Status: v1alpha1.IPAddressAllocationStatus{
+			Conditions: []v1alpha1.Condition{
+				{
+					Type:               v1alpha1.Ready,
+					Status:             v1.ConditionTrue,
+					Message:            "NSX IPAddressAllocation has been successfully created/updated",
+					Reason:             "IPAddressAllocationReady",
+					LastTransitionTime: transitionTime,
+				},
+			},
+		},
+	}
+	newConditions2 := []v1alpha1.Condition{
+		{
+			Type:               v1alpha1.Ready,
+			Status:             v1.ConditionFalse,
+			Message:            "NSX IPAddressAllocation failed",
+			Reason:             "IPAddressAllocationNotReady",
+			LastTransitionTime: transitionTime,
+		},
+	}
+
+	fakewriter := fakeStatusWriter{}
+	k8sClient.EXPECT().Status().Return(fakewriter).Times(1)
+	updateIPAddressAllocationStatusConditions(k8sClient, ctx, dummyIPAddressAllocation2, newConditions2)
+
+	assert.Equal(t, v1.ConditionFalse, dummyIPAddressAllocation2.Status.Conditions[0].Status)
+	assert.Equal(t, "NSX IPAddressAllocation failed", dummyIPAddressAllocation2.Status.Conditions[0].Message)
+	assert.Equal(t, "IPAddressAllocationNotReady", dummyIPAddressAllocation2.Status.Conditions[0].Reason)
+}
+
 type fakeStatusWriter struct {
 }
 

--- a/pkg/controllers/networkinfo/networkinfo_utils.go
+++ b/pkg/controllers/networkinfo/networkinfo_utils.go
@@ -178,12 +178,8 @@ func setVPCNetworkConfigurationStatusWithNoExternalIPBlock(ctx context.Context, 
 // TODO: abstract the logic of merging condition for common, which can be used by the other controller, e.g. security policy
 func mergeStatusCondition(conditions *[]v1alpha1.Condition, newCondition *v1alpha1.Condition) bool {
 	existingCondition := getExistingConditionOfType(newCondition.Type, *conditions)
-	if existingCondition != nil {
-		// Don't compare the timestamp.
-		existingCondition.LastTransitionTime = metav1.Time{}
-	}
 
-	if reflect.DeepEqual(existingCondition, newCondition) {
+	if existingCondition != nil && existingCondition.Status == newCondition.Status && existingCondition.Reason == newCondition.Reason && existingCondition.Message == newCondition.Message {
 		log.Trace("conditions already match", "New Condition", newCondition, "Existing Condition", existingCondition)
 		return false
 	}

--- a/pkg/controllers/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controllers/networkpolicy/networkpolicy_controller.go
@@ -73,12 +73,14 @@ func cleanNetworkPolicyErrorAnnotation(client client.Client, ctx context.Context
 	if networkPolicy.Annotations == nil {
 		return
 	}
-	delete(networkPolicy.Annotations, common.NSXOperatorError)
-	updateErr := client.Update(ctx, networkPolicy)
-	if updateErr != nil {
-		log.Error(updateErr, "Failed to clean NetworkPolicy annotation")
+	if _, exists := networkPolicy.Annotations[common.NSXOperatorError]; exists {
+		delete(networkPolicy.Annotations, common.NSXOperatorError)
+		updateErr := client.Update(ctx, networkPolicy)
+		if updateErr != nil {
+			log.Error(updateErr, "Failed to clean NetworkPolicy annotation")
+		}
+		log.Info("Clean NetworkPolicy annotation")
 	}
-	log.Info("Clean NetworkPolicy annotation")
 }
 
 func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -219,7 +218,7 @@ func updatePodStatusConditions(client client.Client, ctx context.Context, pod *v
 func mergePodStatusCondition(pod *v1.Pod, newCondition *v1.PodCondition) bool {
 	matchedCondition := getExistingConditionOfType(newCondition.Type, pod.Status.Conditions)
 
-	if reflect.DeepEqual(matchedCondition, newCondition) {
+	if isConditionSemanticEqual(matchedCondition, newCondition) {
 		log.Trace("Conditions already match", "New Condition", newCondition, "Existing Condition", matchedCondition)
 		return false
 	}
@@ -228,6 +227,7 @@ func mergePodStatusCondition(pod *v1.Pod, newCondition *v1.PodCondition) bool {
 		matchedCondition.Reason = newCondition.Reason
 		matchedCondition.Message = newCondition.Message
 		matchedCondition.Status = newCondition.Status
+		matchedCondition.LastTransitionTime = newCondition.LastTransitionTime
 	} else {
 		pod.Status.Conditions = append(pod.Status.Conditions, *newCondition)
 	}
@@ -241,6 +241,11 @@ func getExistingConditionOfType(conditionType v1.PodConditionType, existingCondi
 		}
 	}
 	return nil
+}
+
+// isConditionSemanticEqual checks if two pod conditions are semantically equal.
+func isConditionSemanticEqual(matchedCondition, newCondition *v1.PodCondition) bool {
+	return matchedCondition != nil && matchedCondition.Status == newCondition.Status && matchedCondition.Reason == newCondition.Reason && matchedCondition.Message == newCondition.Message
 }
 
 func (r *PodReconciler) GetNodeByName(nodeName string) (*model.HostTransportNode, error) {

--- a/pkg/controllers/securitypolicy/securitypolicy_controller.go
+++ b/pkg/controllers/securitypolicy/securitypolicy_controller.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"reflect"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -282,7 +281,7 @@ func updateSecurityPolicyStatusConditions(client client.Client, ctx context.Cont
 func mergeSecurityPolicyStatusCondition(secPolicy *v1alpha1.SecurityPolicy, newCondition *v1alpha1.Condition) bool {
 	matchedCondition := getExistingConditionOfType(newCondition.Type, secPolicy.Status.Conditions)
 
-	if reflect.DeepEqual(matchedCondition, newCondition) {
+	if isConditionSemanticEqual(matchedCondition, newCondition) {
 		log.Trace("Conditions already match", "New Condition", newCondition, "Existing Condition", matchedCondition)
 		return false
 	}
@@ -291,6 +290,7 @@ func mergeSecurityPolicyStatusCondition(secPolicy *v1alpha1.SecurityPolicy, newC
 		matchedCondition.Reason = newCondition.Reason
 		matchedCondition.Message = newCondition.Message
 		matchedCondition.Status = newCondition.Status
+		matchedCondition.LastTransitionTime = newCondition.LastTransitionTime
 	} else {
 		secPolicy.Status.Conditions = append(secPolicy.Status.Conditions, *newCondition)
 	}
@@ -304,6 +304,11 @@ func getExistingConditionOfType(conditionType v1alpha1.ConditionType, existingCo
 		}
 	}
 	return nil
+}
+
+// isConditionSemanticEqual checks if two legacy conditions are semantically equal.
+func isConditionSemanticEqual(matchedCondition, newCondition *v1alpha1.Condition) bool {
+	return matchedCondition != nil && matchedCondition.Status == newCondition.Status && matchedCondition.Reason == newCondition.Reason && matchedCondition.Message == newCondition.Message
 }
 
 func (r *SecurityPolicyReconciler) setupWithManager(mgr ctrl.Manager) error {

--- a/pkg/controllers/staticroute/staticroute_controller.go
+++ b/pkg/controllers/staticroute/staticroute_controller.go
@@ -147,7 +147,7 @@ func updateStaticRouteStatusConditions(client client.Client, ctx context.Context
 func mergeStaticRouteStatusCondition(staticRoute *v1alpha1.StaticRoute, newCondition *v1alpha1.StaticRouteCondition) bool {
 	matchedCondition := getExistingConditionOfType(v1alpha1.StaticRouteStatusCondition(newCondition.Type), staticRoute.Status.Conditions)
 
-	if reflect.DeepEqual(matchedCondition, newCondition) {
+	if isConditionSemanticEqual(matchedCondition, newCondition) {
 		log.Trace("Conditions already match", "New Condition", newCondition, "Existing Condition", matchedCondition)
 		return false
 	}
@@ -156,6 +156,7 @@ func mergeStaticRouteStatusCondition(staticRoute *v1alpha1.StaticRoute, newCondi
 		matchedCondition.Reason = newCondition.Reason
 		matchedCondition.Message = newCondition.Message
 		matchedCondition.Status = newCondition.Status
+		matchedCondition.LastTransitionTime = newCondition.LastTransitionTime
 	} else {
 		staticRoute.Status.Conditions = append(staticRoute.Status.Conditions, *newCondition)
 	}
@@ -169,6 +170,11 @@ func getExistingConditionOfType(conditionType v1alpha1.StaticRouteStatusConditio
 		}
 	}
 	return nil
+}
+
+// isConditionSemanticEqual checks if two static route conditions are semantically equal.
+func isConditionSemanticEqual(matchedCondition, newCondition *v1alpha1.StaticRouteCondition) bool {
+	return matchedCondition != nil && matchedCondition.Status == newCondition.Status && matchedCondition.Reason == newCondition.Reason && matchedCondition.Message == newCondition.Message
 }
 
 func (r *StaticRouteReconciler) setupWithManager(mgr ctrl.Manager) error {

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -441,7 +440,7 @@ func updateSubnetStatusConditions(client client.Client, ctx context.Context, sub
 func mergeSubnetStatusCondition(subnet *v1alpha1.Subnet, newCondition *v1alpha1.Condition) bool {
 	matchedCondition := getExistingConditionOfType(newCondition.Type, subnet.Status.Conditions)
 
-	if reflect.DeepEqual(matchedCondition, newCondition) {
+	if common.IsConditionSemanticEqual(matchedCondition, newCondition) {
 		log.Trace("Conditions already match", "New Condition", newCondition, "Existing Condition", matchedCondition)
 		return false
 	}
@@ -450,6 +449,7 @@ func mergeSubnetStatusCondition(subnet *v1alpha1.Subnet, newCondition *v1alpha1.
 		matchedCondition.Reason = newCondition.Reason
 		matchedCondition.Message = newCondition.Message
 		matchedCondition.Status = newCondition.Status
+		matchedCondition.LastTransitionTime = newCondition.LastTransitionTime
 	} else {
 		subnet.Status.Conditions = append(subnet.Status.Conditions, *newCondition)
 	}

--- a/pkg/controllers/subnetipreservation/subnetipreservation_controller.go
+++ b/pkg/controllers/subnetipreservation/subnetipreservation_controller.go
@@ -352,7 +352,7 @@ func updateStatusConditions(client client.Client, ctx context.Context, ipReserva
 
 func mergeStatusCondition(ipReservation *v1alpha1.SubnetIPReservation, newCondition *v1alpha1.Condition) bool {
 	matchedCondition := getExistingConditionOfType(newCondition.Type, ipReservation.Status.Conditions)
-	if reflect.DeepEqual(matchedCondition, newCondition) {
+	if common.IsConditionSemanticEqual(matchedCondition, newCondition) {
 		log.Trace("Conditions already match", "New Condition", newCondition, "Existing Condition", matchedCondition)
 		return false
 	}
@@ -361,6 +361,7 @@ func mergeStatusCondition(ipReservation *v1alpha1.SubnetIPReservation, newCondit
 		matchedCondition.Reason = newCondition.Reason
 		matchedCondition.Message = newCondition.Message
 		matchedCondition.Status = newCondition.Status
+		matchedCondition.LastTransitionTime = newCondition.LastTransitionTime
 	} else {
 		ipReservation.Status.Conditions = append(ipReservation.Status.Conditions, *newCondition)
 	}

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -826,7 +826,7 @@ func updateSubnetPortStatusConditions(client client.Client, ctx context.Context,
 func mergeSubnetPortStatusCondition(subnetPort *v1alpha1.SubnetPort, newCondition *v1alpha1.Condition) bool {
 	matchedCondition := getExistingConditionOfType(newCondition.Type, subnetPort.Status.Conditions)
 
-	if reflect.DeepEqual(matchedCondition, newCondition) {
+	if common.IsConditionSemanticEqual(matchedCondition, newCondition) {
 		log.Trace("conditions already match", "New Condition", newCondition, "Existing Condition", matchedCondition)
 		return false
 	}
@@ -835,6 +835,7 @@ func mergeSubnetPortStatusCondition(subnetPort *v1alpha1.SubnetPort, newConditio
 		matchedCondition.Reason = newCondition.Reason
 		matchedCondition.Message = newCondition.Message
 		matchedCondition.Status = newCondition.Status
+		matchedCondition.LastTransitionTime = newCondition.LastTransitionTime
 	} else {
 		subnetPort.Status.Conditions = append(subnetPort.Status.Conditions, *newCondition)
 	}
@@ -1323,14 +1324,8 @@ func newReadyCondition(resourceType string, transitionTime metav1.Time, e error)
 
 func mergeCondition(existingConditions []v1alpha1.Condition, newCondition *v1alpha1.Condition) ([]v1alpha1.Condition, bool) {
 	matchedCondition := getExistingConditionOfType(newCondition.Type, existingConditions)
-
-	newConditionCopy := newCondition.DeepCopy()
-	if matchedCondition != nil {
-		// Ignore LastTransitionTime mismatch
-		newConditionCopy.LastTransitionTime = matchedCondition.LastTransitionTime
-	}
-	if reflect.DeepEqual(matchedCondition, newConditionCopy) {
-		log.Trace("conditions already match", "New Condition", newCondition, "Existing Condition", matchedCondition)
+	if common.IsConditionSemanticEqual(matchedCondition, newCondition) {
+		log.Trace("Conditions already match", "New Condition", newCondition, "Existing Condition", matchedCondition)
 		return existingConditions, false
 	}
 
@@ -1338,6 +1333,7 @@ func mergeCondition(existingConditions []v1alpha1.Condition, newCondition *v1alp
 		matchedCondition.Reason = newCondition.Reason
 		matchedCondition.Message = newCondition.Message
 		matchedCondition.Status = newCondition.Status
+		matchedCondition.LastTransitionTime = newCondition.LastTransitionTime
 	} else {
 		existingConditions = append(existingConditions, *newCondition)
 	}

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -2496,7 +2496,7 @@ func TestSubnetPortReconciler_setAddressBindingStatus(t *testing.T) {
 							Status:             corev1.ConditionFalse,
 							Message:            fmt.Sprintf("error occurred while processing the %s CR. Error: %v", resourceType, fmt.Errorf("mock error")),
 							Reason:             fmt.Sprintf("%sNotReady", resourceType),
-							LastTransitionTime: metav1.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
 						}},
 						IPAddress: "",
 					}},

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -120,6 +120,9 @@ func (r *SubnetSetReconciler) UpdateSubnetSetForSubnetNames(ctx context.Context,
 		subnetInfo.DHCPServerAddresses = subnet.Status.DHCPServerAddresses
 		subnetInfoList = append(subnetInfoList, subnetInfo)
 	}
+	if reflect.DeepEqual(subnetsetCR.Status.Subnets, subnetInfoList) {
+		return nil
+	}
 	subnetsetCR.Status.Subnets = subnetInfoList
 	if err := r.Client.Status().Update(ctx, subnetsetCR); err != nil {
 		log.Error(err, "Failed to update SubnetSet status for SubnetNames")
@@ -413,7 +416,7 @@ func updateSubnetSetStatusConditions(client client.Client, ctx context.Context, 
 func mergeSubnetSetStatusCondition(subnetSet *v1alpha1.SubnetSet, newCondition *v1alpha1.Condition) bool {
 	matchedCondition := getExistingConditionOfType(newCondition.Type, subnetSet.Status.Conditions)
 
-	if reflect.DeepEqual(matchedCondition, newCondition) {
+	if common.IsConditionSemanticEqual(matchedCondition, newCondition) {
 		log.Trace("Conditions already match", "New Condition", newCondition, "Existing Condition", matchedCondition)
 		return false
 	}
@@ -422,6 +425,7 @@ func mergeSubnetSetStatusCondition(subnetSet *v1alpha1.SubnetSet, newCondition *
 		matchedCondition.Reason = newCondition.Reason
 		matchedCondition.Message = newCondition.Message
 		matchedCondition.Status = newCondition.Status
+		matchedCondition.LastTransitionTime = newCondition.LastTransitionTime
 	} else {
 		subnetSet.Status.Conditions = append(subnetSet.Status.Conditions, *newCondition)
 	}

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -372,6 +373,9 @@ func (service *SubnetService) UpdateSubnetSetStatus(obj *v1alpha1.SubnetSet) err
 			}
 		}
 		subnetInfoList = append(subnetInfoList, subnetInfo)
+	}
+	if reflect.DeepEqual(obj.Status.Subnets, subnetInfoList) {
+		return nil
 	}
 	obj.Status.Subnets = subnetInfoList
 	if err := service.Client.Status().Update(context.Background(), obj); err != nil {


### PR DESCRIPTION
Observed NSX Operator may update the CR status even if it is not changed.
This will result in a log of API calls in scaled testbed.
This PR reduce the number of update times for CR status.

Testing done:

Observe status update will be skipped when nothing change on status

```
2026-06-26 05:50:18.000 TRACE subnetset_controller.go:420 Conditions already match Existing Condition={"lastTransitionTime":"2026-06-18T07:24:50Z","message":"SubnetSet CR has been successfully created/updated","reason":"SubnetSetReady","status":"True","type":"Ready"} New Condition={"lastTransitionTime":"2026-06-26T05:50:18Z","message":"SubnetSet CR has been successfully created/updated","reason":"SubnetSetReady","status":"True","type":"Ready"}
```