### PR TITLE
[EAS] Generate CRD definition files for EAS API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ changecrd: manifests generate generate-api-docs
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="github.com/vmware-tanzu/nsx-operator/pkg/apis/legacy/v1alpha1" output:crd:artifacts:config=build/yaml/crd/legacy/
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1" output:crd:artifacts:config=build/yaml/crd/vpc/
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="github.com/vmware-tanzu/nsx-operator/pkg/apis/eas/v1alpha1" output:crd:artifacts:config=build/yaml/crd/eas/
 # NOTE: EAS types are served by the generic API server (via APIService), NOT as CRDs.
 # Do NOT run controller-gen crd for pkg/apis/eas/v1alpha1 — installing EAS CRDs alongside
 # the APIService causes duplicate-resource conflicts in kube-apiserver.

--- a/build/yaml/crd/eas/eas.nsx.vmware.com_ipblockusages.yaml
+++ b/build/yaml/crd/eas/eas.nsx.vmware.com_ipblockusages.yaml
@@ -1,0 +1,176 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: ipblockusages.eas.nsx.vmware.com
+spec:
+  group: eas.nsx.vmware.com
+  names:
+    kind: IPBlockUsage
+    listKind: IPBlockUsageList
+    plural: ipblockusages
+    singular: ipblockusage
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          IPBlockUsage is the usage information of an IPBlock.
+          It contains used IP ranges and available IP ranges statistics of an IPBlock.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          availableIPRanges:
+            description: Available IP ranges in an IPBlock.
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          availableIPsCount:
+            description: Available IP count in an IPBlock.
+            type: string
+          cidrUsages:
+            description: CIDR usage details for each CIDR in an IPBlock.
+            items:
+              description: Represents used and available IP statistics for CIDRs in
+                an IPBlock.
+              properties:
+                cidr:
+                  description: One CIDR in an IPBlock CIDRList.
+                  type: string
+                usageDetails:
+                  properties:
+                    availableIPRanges:
+                      description: Represents free IP ranges from the CIDR or IP range.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    availableIPsCount:
+                      description: Represents free IP count in the CIDR or IP range.
+                      type: string
+                    overallUsedIPRanges:
+                      description: Represents the overall IP ranges allocated from
+                        the CIDR or IP range across all orgs.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    overallUsedIPsCount:
+                      description: Represents the overall IP count allocated from
+                        the CIDR or IP range across all orgs.
+                      type: string
+                    usedIPRanges:
+                      description: Represents IP ranges that are allocated from the
+                        CIDR or IP range in the org scope.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    usedIPsCount:
+                      description: Represents IP count that are allocated from the
+                        CIDR or IP range in the org scope.
+                      type: string
+                  required:
+                  - availableIPsCount
+                  - overallUsedIPsCount
+                  - usedIPsCount
+                  type: object
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          overallIPsCount:
+            description: Total count of IPs which are present in this block.
+            type: string
+          rangeUsages:
+            description: Range usage details for each IP range in an IPBlock.
+            items:
+              description: Represents used and available IP statistics for IP ranges
+                in an IPBlock.
+              properties:
+                range:
+                  description: One range in an IPBlock range list.
+                  type: string
+                usageDetails:
+                  properties:
+                    availableIPRanges:
+                      description: Represents free IP ranges from the CIDR or IP range.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    availableIPsCount:
+                      description: Represents free IP count in the CIDR or IP range.
+                      type: string
+                    overallUsedIPRanges:
+                      description: Represents the overall IP ranges allocated from
+                        the CIDR or IP range across all orgs.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    overallUsedIPsCount:
+                      description: Represents the overall IP count allocated from
+                        the CIDR or IP range across all orgs.
+                      type: string
+                    usedIPRanges:
+                      description: Represents IP ranges that are allocated from the
+                        CIDR or IP range in the org scope.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    usedIPsCount:
+                      description: Represents IP count that are allocated from the
+                        CIDR or IP range in the org scope.
+                      type: string
+                  required:
+                  - availableIPsCount
+                  - overallUsedIPsCount
+                  - usedIPsCount
+                  type: object
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+          usedIPRanges:
+            description: Used IP ranges in an IPBlock.
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          usedIPsCount:
+            description: Used IPs count in an IPBlock.
+            type: string
+          visibility:
+            description: |-
+              Visibility of IPBlock.
+              Must be External or Private.
+            enum:
+            - External
+            - Private
+            type: string
+        required:
+        - availableIPsCount
+        - overallIPsCount
+        - usedIPsCount
+        type: object
+    served: true
+    storage: true

--- a/build/yaml/crd/eas/eas.nsx.vmware.com_subnetdhcpserverstats.yaml
+++ b/build/yaml/crd/eas/eas.nsx.vmware.com_subnetdhcpserverstats.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: subnetdhcpserverstats.eas.nsx.vmware.com
+spec:
+  group: eas.nsx.vmware.com
+  names:
+    kind: SubnetDHCPServerStats
+    listKind: SubnetDHCPServerStatsList
+    plural: subnetdhcpserverstats
+    singular: subnetdhcpserverstats
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          SubnetDHCPServerStats exposes the Subnet's DHCP server statistics.
+          The SubnetDHCPServerStats name should be the same as the Subnet CR name.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          ipPoolStats:
+            description: DHCP IP pool usage statistics.
+            items:
+              description: DHCPIPPoolUsage represents DHCP IP pool usage statistics.
+              properties:
+                allocatedNumber:
+                  description: Allocated number.
+                  format: int64
+                  type: integer
+                allocatedPercentage:
+                  description: Allocated percentage.
+                  format: int64
+                  type: integer
+                consumedNumber:
+                  description: Total number of IP addresses consumed by DHCP clients.
+                  format: int64
+                  type: integer
+                poolSize:
+                  description: Pool size.
+                  format: int64
+                  type: integer
+              required:
+              - allocatedNumber
+              - allocatedPercentage
+              - consumedNumber
+              - poolSize
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/build/yaml/crd/eas/eas.nsx.vmware.com_subnetippools.yaml
+++ b/build/yaml/crd/eas/eas.nsx.vmware.com_subnetippools.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: subnetippools.eas.nsx.vmware.com
+spec:
+  group: eas.nsx.vmware.com
+  names:
+    kind: SubnetIPPools
+    listKind: SubnetIPPoolsList
+    plural: subnetippools
+    singular: subnetippools
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          SubnetIPPools describes IP pools of a Subnet.
+          The SubnetIPPools name is the same as subnet CR name.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          ipAddressType:
+            description: |-
+              Type of IP address.
+              Must be IPv4 or IPv6.
+            enum:
+            - IPv4
+            - IPv6
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          poolUsage:
+            description: IP pool usage statistics.
+            properties:
+              allocatedIPAllocations:
+                description: Number of allocated IP allocations.
+                format: int64
+                type: integer
+              availableIPs:
+                description: Number of available IPs.
+                format: int64
+                type: integer
+              requestedIPAllocations:
+                description: Number of requested IP allocations.
+                format: int64
+                type: integer
+              totalIPs:
+                description: Total number of IPs in the pool.
+                format: int64
+                type: integer
+            required:
+            - allocatedIPAllocations
+            - availableIPs
+            - requestedIPAllocations
+            - totalIPs
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/build/yaml/crd/eas/eas.nsx.vmware.com_vpcipaddressusages.yaml
+++ b/build/yaml/crd/eas/eas.nsx.vmware.com_vpcipaddressusages.yaml
@@ -1,0 +1,170 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: vpcipaddressusages.eas.nsx.vmware.com
+spec:
+  group: eas.nsx.vmware.com
+  names:
+    kind: VPCIPAddressUsage
+    listKind: VPCIPAddressUsageList
+    plural: vpcipaddressusages
+    singular: vpcipaddressusage
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VPCIPAddressUsage is the usage information for IP addresses within a specific VPC. This information provides insights
+          into the allocation and utilization of IP addresses by the VPC and its subnets.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          ipBlocks:
+            description: Array of VPC IP address block.
+            items:
+              description: VPC IP address block.
+              properties:
+                allocatedByVPC:
+                  description: AllocatedByVPC contains the CIDR, used IP range and
+                    subnet access mode etc.
+                  properties:
+                    accessMode:
+                      description: |-
+                        Access mode of the subnet allocated from the IP Block.
+                        Must be Public, PrivateTGW or Private.
+                      enum:
+                      - Public
+                      - PrivateTGW
+                      - Private
+                      type: string
+                    count:
+                      description: Count of used IPs by VPC from the IP Block.
+                      format: int64
+                      type: integer
+                    ipAddresses:
+                      description: IPAddresses contains CIDR and subnet or IP address
+                        allocation.
+                      items:
+                        properties:
+                          address:
+                            type: string
+                          ipAddressAllocationName:
+                            description: |-
+                              The name of the IPAddressAllocation to which the IP address is allocated.
+                              Only one of subnetName and ipAddressAllocationName will be set.
+                            type: string
+                          subnetName:
+                            description: |-
+                              The name of the Subnet to which the IP address is allocated.
+                              Only one of subnetName and ipAddressAllocationName will be set.
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    percentageUsed:
+                      description: Percentage of used IP address resources by VPC.
+                      type: string
+                  required:
+                  - count
+                  type: object
+                available:
+                  description: Available IP address space.
+                  format: int64
+                  type: integer
+                cidr:
+                  description: |-
+                    CIDR address for IPBlock.
+                    Deprecated: Use CIDRs instead.
+                  type: string
+                cidrs:
+                  description: The list of CIDRs.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                excludedIPs:
+                  description: The list of excluded IP address in the form of start
+                    and end IPs.
+                  items:
+                    description: A set of IPv4 or IPv6 addresses defined by a start
+                      and end address.
+                    properties:
+                      end:
+                        description: 'The end IP Address of the IP range. format:
+                          IP.'
+                        type: string
+                      start:
+                        description: 'The start IP Address of the IP range. format:
+                          IP.'
+                        type: string
+                    required:
+                    - end
+                    - start
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                ipBlockName:
+                  description: Name of the IPBlock.
+                  type: string
+                percentageUsed:
+                  description: Percentage of used IP address space.
+                  type: string
+                ranges:
+                  description: The list of IP address ranges in the form of start
+                    and end IPs.
+                  items:
+                    description: A set of IPv4 or IPv6 addresses defined by a start
+                      and end address.
+                    properties:
+                      end:
+                        description: 'The end IP Address of the IP range. format:
+                          IP.'
+                        type: string
+                      start:
+                        description: 'The start IP Address of the IP range. format:
+                          IP.'
+                        type: string
+                    required:
+                    - end
+                    - start
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                total:
+                  description: Total IP address space.
+                  format: int64
+                  type: integer
+                visibility:
+                  description: Visibility of IP Block. Must be External or Private.
+                  enum:
+                  - External
+                  - Private
+                  type: string
+              required:
+              - available
+              - total
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
Although eas server is using generic api which do not require CRD definitions, but the CRD file could clearly shows the data structure and other teams may use the CRDs to define their work