### PR TITLE
Rename NetworkIPAllcation to NetworkIPAllocationName in static route

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_staticroutes.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_staticroutes.yaml
@@ -20,8 +20,8 @@ spec:
       name: Network
       type: string
     - description: IPAddressAllocation CR name
-      jsonPath: .spec.networkIpAllocation
-      name: NetworkIPAllocation
+      jsonPath: .spec.networkIpAllocationName
+      name: NetworkIPAllocationName
       type: string
     - description: Next Hops
       jsonPath: .spec.nextHops[*].ipAddress
@@ -55,10 +55,10 @@ spec:
               network:
                 description: |-
                   Specify network address in CIDR format.
-                  Mutually exclusive with networkIpAllocation.
+                  Mutually exclusive with networkIpAllocationName.
                 format: cidr
                 type: string
-              networkIpAllocation:
+              networkIpAllocationName:
                 description: |-
                   Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as
                   the static route network. Mutually exclusive with network.
@@ -81,8 +81,9 @@ spec:
             - nextHops
             type: object
             x-kubernetes-validations:
-            - message: spec.network and spec.networkIpAllocation are mutually exclusive
-              rule: '!has(self.network) || !has(self.networkIpAllocation)'
+            - message: spec.network and spec.networkIpAllocationName are mutually
+                exclusive
+              rule: '!has(self.network) || !has(self.networkIpAllocationName)'
           status:
             description: StaticRouteStatus defines the observed state of StaticRoute.
             properties:

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -784,8 +784,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `network` _string_ | Specify network address in CIDR format.<br />Mutually exclusive with networkIpAllocation. |  | Format: cidr <br /> |
-| `networkIpAllocation` _string_ | Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as<br />the static route network. Mutually exclusive with network. |  |  |
+| `network` _string_ | Specify network address in CIDR format.<br />Mutually exclusive with networkIpAllocationName. |  | Format: cidr <br /> |
+| `networkIpAllocationName` _string_ | Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as<br />the static route network. Mutually exclusive with network. |  |  |
 | `nextHops` _[NextHop](#nexthop) array_ | Next hop gateway |  | MinItems: 1 <br /> |
 
 

--- a/pkg/apis/vpc/v1alpha1/staticroute_types.go
+++ b/pkg/apis/vpc/v1alpha1/staticroute_types.go
@@ -13,17 +13,17 @@ type StaticRouteStatusCondition string
 type StaticRouteCondition Condition
 
 // StaticRouteSpec defines static routes configuration on VPC.
-// +kubebuilder:validation:XValidation:rule="!has(self.network) || !has(self.networkIpAllocation)",message="spec.network and spec.networkIpAllocation are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!has(self.network) || !has(self.networkIpAllocationName)",message="spec.network and spec.networkIpAllocationName are mutually exclusive"
 type StaticRouteSpec struct {
 	// Specify network address in CIDR format.
-	// Mutually exclusive with networkIpAllocation.
+	// Mutually exclusive with networkIpAllocationName.
 	// +kubebuilder:validation:Format=cidr
 	// +optional
 	Network string `json:"network,omitempty"`
 	// Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as
 	// the static route network. Mutually exclusive with network.
 	// +optional
-	NetworkIPAllocation string `json:"networkIpAllocation,omitempty"`
+	NetworkIPAllocationName string `json:"networkIpAllocationName,omitempty"`
 	// Next hop gateway
 	// +kubebuilder:validation:MinItems=1
 	NextHops []NextHop `json:"nextHops"`
@@ -48,7 +48,7 @@ type StaticRouteStatus struct {
 
 // StaticRoute is the Schema for the staticroutes API.
 // +kubebuilder:printcolumn:name="Network",type=string,JSONPath=`.spec.network`,description="Network in CIDR format"
-// +kubebuilder:printcolumn:name="NetworkIPAllocation",type=string,JSONPath=`.spec.networkIpAllocation`,description="IPAddressAllocation CR name"
+// +kubebuilder:printcolumn:name="NetworkIPAllocationName",type=string,JSONPath=`.spec.networkIpAllocationName`,description="IPAddressAllocation CR name"
 // +kubebuilder:printcolumn:name="NextHops",type=string,JSONPath=`.spec.nextHops[*].ipAddress`,description="Next Hops"
 type StaticRoute struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook_test.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_webhook_test.go
@@ -39,7 +39,7 @@ func TestIPAddressAllocationValidator_Handle(t *testing.T) {
 			log.Info("Invalid object", "type", reflect.TypeOf(obj))
 			return []string{}
 		} else {
-			return []string{sr.Spec.NetworkIPAllocation}
+			return []string{sr.Spec.NetworkIPAllocationName}
 		}
 	}
 	reqDelete, _ := json.Marshal(&v1alpha1.IPAddressAllocation{
@@ -127,7 +127,7 @@ func TestIPAddressAllocationValidator_Handle(t *testing.T) {
 				client.Create(ctx, &v1alpha1.StaticRoute{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "sr1"},
 					Spec: v1alpha1.StaticRouteSpec{
-						NetworkIPAllocation: "ip1",
+						NetworkIPAllocationName: "ip1",
 					},
 				})
 				return nil

--- a/pkg/controllers/staticroute/staticroute_controller.go
+++ b/pkg/controllers/staticroute/staticroute_controller.go
@@ -282,10 +282,10 @@ func staticrouteAssociatedResourceIndexFunc(obj client.Object) []string {
 		log.Info("Invalid object", "type", reflect.TypeOf(obj))
 		return []string{}
 	} else {
-		if staticRoute.Spec.NetworkIPAllocation == "" {
+		if staticRoute.Spec.NetworkIPAllocationName == "" {
 			return []string{}
 		}
-		return []string{staticRoute.Spec.NetworkIPAllocation}
+		return []string{staticRoute.Spec.NetworkIPAllocationName}
 	}
 }
 

--- a/pkg/controllers/staticroute/staticroute_controller_test.go
+++ b/pkg/controllers/staticroute/staticroute_controller_test.go
@@ -490,27 +490,27 @@ func Test_staticrouteAssociatedResourceIndexFunc(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "Valid StaticRoute with NetworkIPAllocation",
+			name: "Valid StaticRoute with NetworkIPAllocationName",
 			obj: &v1alpha1.StaticRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route",
 					Namespace: "default",
 				},
 				Spec: v1alpha1.StaticRouteSpec{
-					NetworkIPAllocation: "/orgs/default/projects/p1/vpcs/v1/ip-address-allocations/ipa-1",
+					NetworkIPAllocationName: "/orgs/default/projects/p1/vpcs/v1/ip-address-allocations/ipa-1",
 				},
 			},
 			want: []string{"/orgs/default/projects/p1/vpcs/v1/ip-address-allocations/ipa-1"},
 		},
 		{
-			name: "StaticRoute with empty NetworkIPAllocation",
+			name: "StaticRoute with empty NetworkIPAllocationName",
 			obj: &v1alpha1.StaticRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route-empty",
 					Namespace: "default",
 				},
 				Spec: v1alpha1.StaticRouteSpec{
-					NetworkIPAllocation: "",
+					NetworkIPAllocationName: "",
 				},
 			},
 			want: []string{},

--- a/pkg/nsx/services/staticroute/builder.go
+++ b/pkg/nsx/services/staticroute/builder.go
@@ -34,7 +34,7 @@ func validateStaticRoute(obj *v1alpha1.StaticRoute) error {
 
 // buildStaticRoute converts a StaticRoute CR into a model.StaticRoutes for the NSX API.
 // networkIPAllocationPath, when non-empty, is the NSX policy path of a VpcIpAddressAllocation
-// (spec.networkIpAllocation mode): NSX resolves the allocated IP and treats it as a /32 network.
+// (spec.networkIpAllocationName mode): NSX resolves the allocated IP and treats it as a /32 network.
 // When empty, spec.network (a CIDR string) is used directly (spec.network mode).
 // The two fields are mutually exclusive on the NSX side.
 func (service *StaticRouteService) buildStaticRoute(obj *v1alpha1.StaticRoute, networkIPAllocationPath string) (*model.StaticRoutes, error) {

--- a/pkg/nsx/services/staticroute/staticroute.go
+++ b/pkg/nsx/services/staticroute/staticroute.go
@@ -101,9 +101,9 @@ func (service *StaticRouteService) CreateOrUpdateStaticRoute(ctx context.Context
 	// Resolve the network: either a static CIDR (spec.network) or a reference to an
 	// IPAddressAllocation CR whose NSX policy path becomes the network_ip_allocation_path.
 	var networkIPAllocationPath string
-	if obj.Spec.NetworkIPAllocation != "" {
+	if obj.Spec.NetworkIPAllocationName != "" {
 		var err error
-		networkIPAllocationPath, err = service.resolveNetworkIPAllocationPath(ctx, namespace, obj.Spec.NetworkIPAllocation)
+		networkIPAllocationPath, err = service.resolveNetworkIPAllocationPath(ctx, namespace, obj.Spec.NetworkIPAllocationName)
 		if err != nil {
 			return err
 		}

--- a/pkg/nsx/services/staticroute/staticroute_test.go
+++ b/pkg/nsx/services/staticroute/staticroute_test.go
@@ -820,10 +820,10 @@ func TestResolveNetworkIPAllocationPath(t *testing.T) {
 	})
 }
 
-// TestCreateOrUpdateStaticRoute_WithNetworkIPAllocation verifies that when
-// spec.networkIpAllocation is set, CreateOrUpdateStaticRoute resolves the
+// TestCreateOrUpdateStaticRoute_WithNetworkIPAllocationName verifies that when
+// spec.networkIpAllocationName is set, CreateOrUpdateStaticRoute resolves the
 // IPAddressAllocation CR before calling buildStaticRoute.
-func TestCreateOrUpdateStaticRoute_WithNetworkIPAllocation(t *testing.T) {
+func TestCreateOrUpdateStaticRoute_WithNetworkIPAllocationName(t *testing.T) {
 	const ns = "test-ns"
 	const crName = "my-alloc"
 	const nsxPath = "/orgs/default/projects/p1/vpcs/v1/ip-address-allocations/alloc-1"
@@ -834,8 +834,8 @@ func TestCreateOrUpdateStaticRoute_WithNetworkIPAllocation(t *testing.T) {
 	staticRouteCR := &v1alpha1.StaticRoute{
 		ObjectMeta: v1.ObjectMeta{Name: "sr1", Namespace: ns},
 		Spec: v1alpha1.StaticRouteSpec{
-			NetworkIPAllocation: crName,
-			NextHops:            []v1alpha1.NextHop{{IPAddress: "10.1.1.1"}},
+			NetworkIPAllocationName: crName,
+			NextHops:                []v1alpha1.NextHop{{IPAddress: "10.1.1.1"}},
 		},
 	}
 

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -7,4 +7,4 @@ const AddressBindingIPAddressAllocationNameIndexKey = "spec.ipAddressAllocationN
 const SubnetPortMACInNeed = "index/subnetport/macInNeed"
 const SubnetAssociatedResource = "index/subnet/associatedResource"
 
-const StaticRouteIPAddressAllocationNameIndexKey = "spec.networkIpAllocation"
+const StaticRouteIPAddressAllocationNameIndexKey = "spec.networkIpAllocationName"


### PR DESCRIPTION

Per jianjun's comment to allign all property to k8s naming convention, rename NetworkIPAllcoation to NetworkIPAllcationName in static route spec and update CRD yaml file.