### PR TITLE
Fix hash collision by using full SHA-1 hash for SecurityPolicyRule

### DIFF
--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -418,7 +418,7 @@ func (service *SecurityPolicyService) buildAppliedGroupIDAndName(obj *v1alpha1.S
 	if IsVPCEnabled(service) {
 		ruleHash := ""
 		if ruleIdx != -1 {
-			ruleHash = service.buildLimitedRuleHashString(&(obj.Spec.Rules[ruleIdx]))
+			ruleHash = service.buildRuleHashString(&(obj.Spec.Rules[ruleIdx]))
 		}
 		group := service.getAppliedGroupByRuleID(createdFor, string(obj.GetUID()), ruleBaseID)
 		if group != nil {
@@ -453,7 +453,7 @@ func (service *SecurityPolicyService) buildAppliedGroupPath(obj *v1alpha1.Securi
 // build appliedTo group display name for both policy and rule levels.
 func (service *SecurityPolicyService) buildAppliedGroupName(obj *v1alpha1.SecurityPolicy, ruleIdx int) string {
 	if ruleIdx != -1 {
-		ruleHash := service.buildLimitedRuleHashString(&(obj.Spec.Rules[ruleIdx]))
+		ruleHash := service.buildRuleHashString(&(obj.Spec.Rules[ruleIdx]))
 		suffix := strings.Join([]string{ruleHash, common.TargetGroupSuffix}, common.ConnectorUnderline)
 		return util.GenerateTruncName(common.MaxNameLength, obj.Name, "", suffix, "", "")
 	}
@@ -642,7 +642,6 @@ func (service *SecurityPolicyService) buildRuleID(obj *v1alpha1.SecurityPolicy, 
 	ruleIndexHash := service.buildRuleHashString(&(obj.Spec.Rules[ruleIdx]))
 
 	if IsVPCEnabled(service) {
-		ruleIndexHash = service.buildLimitedRuleHashString(&(obj.Spec.Rules[ruleIdx]))
 		ruleID := service.getRuleIDByUUIDAndRuleHash(obj.GetUID(), ruleIndexHash, createdFor)
 		if ruleID != nil {
 			return *ruleID
@@ -821,7 +820,7 @@ func (service *SecurityPolicyService) buildRulePeerGroupID(obj *v1alpha1.Securit
 			return *peerGroup.Id
 		}
 
-		ruleHash := service.buildLimitedRuleHashString(&(obj.Spec.Rules[ruleIdx]))
+		ruleHash := service.buildRuleHashString(&(obj.Spec.Rules[ruleIdx]))
 		return service.buildVpcGroupIdByRuleAndGroupType(obj, ruleHash, suffix, func(id string) bool {
 			return service.groupStore.GetByKey(id) != nil
 		})
@@ -835,7 +834,7 @@ func (service *SecurityPolicyService) buildRulePeerGroupName(obj *v1alpha1.Secur
 	if isSource {
 		suffix = common.SrcGroupSuffix
 	}
-	ruleHash := service.buildLimitedRuleHashString(&(obj.Spec.Rules[ruleIdx]))
+	ruleHash := service.buildRuleHashString(&(obj.Spec.Rules[ruleIdx]))
 	suffix = strings.Join([]string{ruleHash, suffix}, common.ConnectorUnderline)
 
 	return util.GenerateTruncName(common.MaxNameLength, obj.Name, "", suffix, "", "")
@@ -1049,7 +1048,7 @@ func (service *SecurityPolicyService) buildRuleBasicInfo(obj *v1alpha1.SecurityP
 
 	basicTags := service.buildBasicTags(obj, createdFor)
 	if IsVPCEnabled(service) {
-		ruleIndexHash := service.buildLimitedRuleHashString(&(obj.Spec.Rules[ruleIdx]))
+		ruleIndexHash := service.buildRuleHashString(&(obj.Spec.Rules[ruleIdx]))
 		basicTags = append(basicTags,
 			[]model.Tag{
 				{
@@ -2005,11 +2004,6 @@ func (service *SecurityPolicyService) buildRulePortsNumberString(ports []v1alpha
 		portNumStrings[idx] = service.buildRulePortNumberString(port)
 	}
 	return strings.Join(portNumStrings, common.ConnectorUnderline)
-}
-
-func (service *SecurityPolicyService) buildLimitedRuleHashString(rule *v1alpha1.SecurityPolicyRule) string {
-	serializedBytes, _ := json.Marshal(rule)
-	return util.Sha1(string(serializedBytes))[:common.HashLength]
 }
 
 func (service *SecurityPolicyService) buildRuleHashString(rule *v1alpha1.SecurityPolicyRule) string {

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -217,25 +217,25 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 	defer patches.Reset()
 
 	podSelectorRule0Name00 := "rule-with-pod-ns-selector_ingress_allow"
-	podSelectorRule0IDPort000 := "spA-1e510e8a_re0bz_all"
+	podSelectorRule0IDPort000 := "spA-1e510e8ad94c103f4727e2bfc28bc637cb752831_re0bz_all"
 
 	podSelectorRule1Name00 := "rule-with-ns-selector_ingress_allow"
-	podSelectorRule1IDPort000 := "spA-304ea84a_re0bz_53"
+	podSelectorRule1IDPort000 := "spA-304ea84a85a12eae03f799a546ec5bfe1ffaaa64_re0bz_53"
 
 	vmSelectorRule0Name00 := "rule-with-VM-selector_egress_isolation"
-	vmSelectorRule0IDPort000 := "spB-db8116ce_9u8w9_all"
+	vmSelectorRule0IDPort000 := "spB-db8116ce8304671a055501343fa850eb93b76604_9u8w9_all"
 
 	vmSelectorRule1Name00 := "rule-with-ns-selector_egress_isolation"
-	vmSelectorRule1IDPort000 := "spB-52d139ca_9u8w9_all"
+	vmSelectorRule1IDPort000 := "spB-52d139ca30855b6286398468ff1fb83b6a80a67a_9u8w9_all"
 
 	vmSelectorRule2Name00 := "all_egress_isolation"
-	vmSelectorRule2IDPort000 := "spB-1241cf95_9u8w9_all"
+	vmSelectorRule2IDPort000 := "spB-1241cf958964f48b167979a831adbae3453dae99_9u8w9_all"
 
-	vpcRuleTags1 := appendRuleIDAndHashTags(vpcBasicTags, "1e510e8a", "spA-1e510e8a_re0bz")
-	vpcRuleTags2 := appendRuleIDAndHashTags(vpcBasicTags, "304ea84a", "spA-304ea84a_re0bz")
-	vpcRuleTags3 := appendRuleIDAndHashTags(vpcBasicTagsForSpWithVMSelector, "db8116ce", "spB-db8116ce_9u8w9")
-	vpcRuleTags4 := appendRuleIDAndHashTags(vpcBasicTagsForSpWithVMSelector, "52d139ca", "spB-52d139ca_9u8w9")
-	vpcRuleTags5 := appendRuleIDAndHashTags(vpcBasicTagsForSpWithVMSelector, "1241cf95", "spB-1241cf95_9u8w9")
+	vpcRuleTags1 := appendRuleIDAndHashTags(vpcBasicTags, "1e510e8ad94c103f4727e2bfc28bc637cb752831", "spA-1e510e8ad94c103f4727e2bfc28bc637cb752831_re0bz")
+	vpcRuleTags2 := appendRuleIDAndHashTags(vpcBasicTags, "304ea84a85a12eae03f799a546ec5bfe1ffaaa64", "spA-304ea84a85a12eae03f799a546ec5bfe1ffaaa64_re0bz")
+	vpcRuleTags3 := appendRuleIDAndHashTags(vpcBasicTagsForSpWithVMSelector, "db8116ce8304671a055501343fa850eb93b76604", "spB-db8116ce8304671a055501343fa850eb93b76604_9u8w9")
+	vpcRuleTags4 := appendRuleIDAndHashTags(vpcBasicTagsForSpWithVMSelector, "52d139ca30855b6286398468ff1fb83b6a80a67a", "spB-52d139ca30855b6286398468ff1fb83b6a80a67a_9u8w9")
+	vpcRuleTags5 := appendRuleIDAndHashTags(vpcBasicTagsForSpWithVMSelector, "1241cf958964f48b167979a831adbae3453dae99", "spB-1241cf958964f48b167979a831adbae3453dae99_9u8w9")
 
 	tests := []struct {
 		name             string
@@ -259,10 +259,10 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 						Id:                &podSelectorRule0IDPort000,
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
-						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA-1e510e8a-scope_re0bz"},
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA-1e510e8ad94c103f4727e2bfc28bc637cb752831-scope_re0bz"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-1e510e8a-src_re0bz"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-1e510e8ad94c103f4727e2bfc28bc637cb752831-src_re0bz"},
 						Action:            &nsxRuleActionAllow,
 						Tags:              vpcRuleTags1,
 					},
@@ -274,7 +274,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-304ea84a-src_re0bz"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-304ea84a85a12eae03f799a546ec5bfe1ffaaa64-src_re0bz"},
 						Action:            &nsxRuleActionAllow,
 						ServiceEntries:    []*data.StructValue{serviceEntry},
 						Tags:              vpcRuleTags2,
@@ -296,9 +296,9 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule0Name00,
 						Id:                &vmSelectorRule0IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB-db8116ce-dst_9u8w9"},
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB-db8116ce8304671a055501343fa850eb93b76604-dst_9u8w9"},
 						Direction:         &nsxRuleDirectionOut,
-						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB-db8116ce-scope_9u8w9"},
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB-db8116ce8304671a055501343fa850eb93b76604-scope_9u8w9"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
 						SourceGroups:      []string{"ANY"},
@@ -308,7 +308,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule1Name00,
 						Id:                &vmSelectorRule1IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spB-52d139ca-dst_9u8w9"},
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spB-52d139ca30855b6286398468ff1fb83b6a80a67a-dst_9u8w9"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
@@ -321,7 +321,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule2Name00,
 						Id:                &vmSelectorRule2IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB-1241cf95-dst_9u8w9"},
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spB-1241cf958964f48b167979a831adbae3453dae99-dst_9u8w9"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq2,
@@ -350,10 +350,10 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 						Id:                &podSelectorRule0IDPort000,
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
-						Scope:             []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spA-1e510e8a-scope_re0bz"},
+						Scope:             []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spA-1e510e8ad94c103f4727e2bfc28bc637cb752831-scope_re0bz"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/infra/domains/default/groups/spA-1e510e8a-src_re0bz"},
+						SourceGroups:      []string{"/infra/domains/default/groups/spA-1e510e8ad94c103f4727e2bfc28bc637cb752831-src_re0bz"},
 						Action:            &nsxRuleActionAllow,
 						Tags:              vpcRuleTags1,
 					},
@@ -365,7 +365,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/infra/domains/default/groups/spA-304ea84a-src_re0bz"},
+						SourceGroups:      []string{"/infra/domains/default/groups/spA-304ea84a85a12eae03f799a546ec5bfe1ffaaa64-src_re0bz"},
 						Action:            &nsxRuleActionAllow,
 						ServiceEntries:    []*data.StructValue{serviceEntry},
 						Tags:              vpcRuleTags2,
@@ -388,9 +388,9 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule0Name00,
 						Id:                &vmSelectorRule0IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spB-db8116ce-dst_9u8w9"},
+						DestinationGroups: []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spB-db8116ce8304671a055501343fa850eb93b76604-dst_9u8w9"},
 						Direction:         &nsxRuleDirectionOut,
-						Scope:             []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spB-db8116ce-scope_9u8w9"},
+						Scope:             []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spB-db8116ce8304671a055501343fa850eb93b76604-scope_9u8w9"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
 						SourceGroups:      []string{"ANY"},
@@ -400,7 +400,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule1Name00,
 						Id:                &vmSelectorRule1IDPort000,
-						DestinationGroups: []string{"/infra/domains/default/groups/spB-52d139ca-dst_9u8w9"},
+						DestinationGroups: []string{"/infra/domains/default/groups/spB-52d139ca30855b6286398468ff1fb83b6a80a67a-dst_9u8w9"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
@@ -413,7 +413,7 @@ func Test_BuildSecurityPolicyForVPC(t *testing.T) {
 					{
 						DisplayName:       &vmSelectorRule2Name00,
 						Id:                &vmSelectorRule2IDPort000,
-						DestinationGroups: []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spB-1241cf95-dst_9u8w9"},
+						DestinationGroups: []string{"/orgs/default/projects/default/vpcs/vpc1/groups/spB-1241cf958964f48b167979a831adbae3453dae99-dst_9u8w9"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq2,
@@ -1360,7 +1360,7 @@ func Test_BuildExpandedRuleID(t *testing.T) {
 			inputRule:           &securityPolicyWithMultipleNormalPorts.Spec.Rules[0],
 			ruleIdx:             0,
 			namedPort:           nil,
-			expectedRuleID:      "spMulPorts-d0b8e36c_auwh3_80_1234.1235",
+			expectedRuleID:      "spMulPorts-d0b8e36cf858e76624b9706c3c8e77b6006c0e10_auwh3_80_1234.1235",
 		},
 		{
 			name:                "build-ruleID-for-multiple-ports-0-for-T1",
@@ -1378,7 +1378,7 @@ func Test_BuildExpandedRuleID(t *testing.T) {
 			inputRule:           &securityPolicyWithMultipleNormalPorts.Spec.Rules[1],
 			ruleIdx:             1,
 			namedPort:           nil,
-			expectedRuleID:      "spMulPorts-555356be_auwh3_88_1236.1237",
+			expectedRuleID:      "spMulPorts-555356beadbe04a6638bd4ac8a90fedf1777607e_auwh3_88_1236.1237",
 		},
 		{
 			name:                "build-ruleID-for-multiple-ports-with-one-named-port-for-VPC",
@@ -1387,7 +1387,7 @@ func Test_BuildExpandedRuleID(t *testing.T) {
 			inputRule:           &securityPolicyWithOneNamedPort.Spec.Rules[0],
 			ruleIdx:             0,
 			namedPort:           newPortInfoForNamedPort(nsxutil.PortAddress{Port: 80}, "TCP"),
-			expectedRuleID:      "spNamedPorts-3f7c7d8c_364p1_80",
+			expectedRuleID:      "spNamedPorts-3f7c7d8c8449687178002f23599add04bf0c3250_364p1_80",
 		},
 		{
 			name:                "build-ruleID-for-multiple-ports-with-one-named-port-for-T1",
@@ -1405,7 +1405,7 @@ func Test_BuildExpandedRuleID(t *testing.T) {
 			inputRule:           &securityPolicyWithManyPorts.Spec.Rules[0],
 			ruleIdx:             0,
 			namedPort:           nil,
-			expectedRuleID:      "spManyPorts-6a4a02aa_5b4f2_10001_10002_10003_10004_10005_10006_10007_10008_10009_10010_10011_10012_10013_10014_10015_10016_10017_10018_10019_10020_10021_10022_10023_10024_10025_10026_10027_10028_10029_10030_10031_10032_10033_10034_10035_10036_100-9133c868",
+			expectedRuleID:      "spManyPorts-6a4a02aa6d8cb50943020198087aef40b5f86c97_5b4f2_10001_10002_10003_10004_10005_10006_10007_10008_10009_10010_10011_10012_10013_10014_10015_10016_10017_10018_10019_10020_10021_10022_10023_10024_10025_10026_10027_10028_10029_10030_10031_1-a83c3601",
 		},
 	}
 
@@ -1622,23 +1622,23 @@ func Test_BuildGroupIDAndName(t *testing.T) {
 				ruleIdx:   0,
 				isSource:  true,
 				enableVPC: true,
-				expName:   "sp1_d0b8e36c_src",
-				expId:     "sp1-d0b8e36c-src_gzkfa",
+				expName:   "sp1_d0b8e36cf858e76624b9706c3c8e77b6006c0e10_src",
+				expId:     "sp1-d0b8e36cf858e76624b9706c3c8e77b6006c0e10-src_gzkfa",
 			},
 			{
 				name:      "dst peer group for rule without user-defined name",
 				ruleIdx:   0,
 				isSource:  false,
 				enableVPC: true,
-				expName:   "sp1_d0b8e36c_dst",
-				expId:     "sp1-d0b8e36c-dst_gzkfa",
+				expName:   "sp1_d0b8e36cf858e76624b9706c3c8e77b6006c0e10_dst",
+				expId:     "sp1-d0b8e36cf858e76624b9706c3c8e77b6006c0e10-dst_gzkfa",
 			},
 			{
 				name:      "dst peer group for rule without user-defined name for T1",
 				ruleIdx:   0,
 				isSource:  false,
 				enableVPC: false,
-				expName:   "sp1_d0b8e36c_dst",
+				expName:   "sp1_d0b8e36cf858e76624b9706c3c8e77b6006c0e10_dst",
 				expId:     "sp_c5db1800-ce4c-11de-bedc-84a0de00c35b_0_dst",
 			},
 			{
@@ -1646,23 +1646,23 @@ func Test_BuildGroupIDAndName(t *testing.T) {
 				ruleIdx:   1,
 				isSource:  true,
 				enableVPC: true,
-				expName:   "sp1_555356be_src",
-				expId:     "sp1-555356be-src_gzkfa",
+				expName:   "sp1_555356beadbe04a6638bd4ac8a90fedf1777607e_src",
+				expId:     "sp1-555356beadbe04a6638bd4ac8a90fedf1777607e-src_gzkfa",
 			},
 			{
 				name:      "dst peer group for rule with user-defined name",
 				ruleIdx:   1,
 				isSource:  false,
 				enableVPC: true,
-				expName:   "sp1_555356be_dst",
-				expId:     "sp1-555356be-dst_gzkfa",
+				expName:   "sp1_555356beadbe04a6638bd4ac8a90fedf1777607e_dst",
+				expId:     "sp1-555356beadbe04a6638bd4ac8a90fedf1777607e-dst_gzkfa",
 			},
 			{
 				name:      "dst peer group for rule with user-defined name for T1",
 				ruleIdx:   1,
 				isSource:  false,
 				enableVPC: false,
-				expName:   "sp1_555356be_dst",
+				expName:   "sp1_555356beadbe04a6638bd4ac8a90fedf1777607e_dst",
 				expId:     "sp_c5db1800-ce4c-11de-bedc-84a0de00c35b_1_dst",
 			},
 		} {
@@ -1690,28 +1690,28 @@ func Test_BuildGroupIDAndName(t *testing.T) {
 				name:      "applied group for rule without user-defined name",
 				ruleIdx:   0,
 				enableVPC: true,
-				expName:   "sp1_d0b8e36c_scope",
-				expId:     "sp1-d0b8e36c-scope_gzkfa",
+				expName:   "sp1_d0b8e36cf858e76624b9706c3c8e77b6006c0e10_scope",
+				expId:     "sp1-d0b8e36cf858e76624b9706c3c8e77b6006c0e10-scope_gzkfa",
 			},
 			{
 				name:      "applied group for rule with user-defined name",
 				ruleIdx:   1,
 				enableVPC: true,
-				expName:   "sp1_555356be_scope",
-				expId:     "sp1-555356be-scope_gzkfa",
+				expName:   "sp1_555356beadbe04a6638bd4ac8a90fedf1777607e_scope",
+				expId:     "sp1-555356beadbe04a6638bd4ac8a90fedf1777607e-scope_gzkfa",
 			},
 			{
 				name:      "applied group for rule without user-defined name",
 				ruleIdx:   0,
 				enableVPC: false,
-				expName:   "sp1_d0b8e36c_scope",
+				expName:   "sp1_d0b8e36cf858e76624b9706c3c8e77b6006c0e10_scope",
 				expId:     "sp_c5db1800-ce4c-11de-bedc-84a0de00c35b_0_scope",
 			},
 			{
 				name:      "applied group fpr rule with user-defined name for T1",
 				ruleIdx:   1,
 				enableVPC: false,
-				expName:   "sp1_555356be_scope",
+				expName:   "sp1_555356beadbe04a6638bd4ac8a90fedf1777607e_scope",
 				expId:     "sp_c5db1800-ce4c-11de-bedc-84a0de00c35b_1_scope",
 			},
 			{
@@ -2216,8 +2216,8 @@ func Test_getRuleIDByUUIDAndRuleHash(t *testing.T) {
 	fakeService.vpcService = &mockVPCService
 	fakeService.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
 
-	spRuleTags := appendRuleIDAndHashTags(vpcBasicTags, "1e510e8a", "spA-1e510e8a_re0bz")
-	npRuleTags := appendRuleIDAndHashTags(npAllowBasicTags, "db8116ce", "npB-db8116ce_9u8w9")
+	spRuleTags := appendRuleIDAndHashTags(vpcBasicTags, "1e510e8ad94c103f4727e2bfc28bc637cb752831", "spA-1e510e8ad94c103f4727e2bfc28bc637cb752831_re0bz")
+	npRuleTags := appendRuleIDAndHashTags(npAllowBasicTags, "db8116ce8304671a055501343fa850eb93b76604", "npB-db8116ce8304671a055501343fa850eb93b76604_9u8w9")
 	rules := []model.Rule{
 		{
 			Id:   String("rule-1-80"),
@@ -2246,21 +2246,21 @@ func Test_getRuleIDByUUIDAndRuleHash(t *testing.T) {
 		{
 			name:           "get SecurityPolicy rule by UUID and Rule Hash",
 			uuid:           tagValuePolicyCRUID,
-			hash:           "1e510e8a",
+			hash:           "1e510e8ad94c103f4727e2bfc28bc637cb752831",
 			createdFor:     common.ResourceTypeSecurityPolicy,
-			expectedRuleID: String("spA-1e510e8a_re0bz"),
+			expectedRuleID: String("spA-1e510e8ad94c103f4727e2bfc28bc637cb752831_re0bz"),
 		},
 		{
 			name:           "get NetworkPolicy rule by UUID and Rule Hash",
 			uuid:           string(npWithNsSelecotr.UID + "_allow"),
-			hash:           "db8116ce",
+			hash:           "db8116ce8304671a055501343fa850eb93b76604",
 			createdFor:     common.ResourceTypeNetworkPolicy,
-			expectedRuleID: String("npB-db8116ce_9u8w9"),
+			expectedRuleID: String("npB-db8116ce8304671a055501343fa850eb93b76604_9u8w9"),
 		},
 		{
 			name:           "no matching rules with invalid uuid",
 			uuid:           "invaliduid",
-			hash:           "1e510e8a",
+			hash:           "1e510e8ad94c103f4727e2bfc28bc637cb752831",
 			createdFor:     common.ResourceTypeSecurityPolicy,
 			expectedRuleID: nil,
 		},
@@ -2335,7 +2335,7 @@ func Test_buildRuleID(t *testing.T) {
 			existingRuleID: nil,
 			checkFunc: func(t *testing.T, result string) {
 				assert.NotEmpty(t, result)
-				assert.Equal(t, "spA-1e510e8a_re0bz", result)
+				assert.Equal(t, "spA-1e510e8ad94c103f4727e2bfc28bc637cb752831_re0bz", result)
 			},
 		},
 		{
@@ -2358,10 +2358,10 @@ func Test_buildRuleID(t *testing.T) {
 			existingRuleID: nil,
 			rebuildRuleID:  true,
 			checkFunc: func(t *testing.T, result string) {
-				assert.NotEqual(t, "spA-1e510e8a_re0bz", result)
+				assert.NotEqual(t, "spA-1e510e8ad94c103f4727e2bfc28bc637cb752831_re0bz", result)
 				parts := strings.Split(result, common.ConnectorUnderline)
 				assert.Equal(t, 2, len(parts))
-				assert.Equal(t, "spA-1e510e8a", parts[0])
+				assert.Equal(t, "spA-1e510e8ad94c103f4727e2bfc28bc637cb752831", parts[0])
 				assert.NotEqual(t, "re0bz", parts[1])
 			},
 		},
@@ -2374,7 +2374,7 @@ func Test_buildRuleID(t *testing.T) {
 			existingRuleID: nil,
 			checkFunc: func(t *testing.T, result string) {
 				assert.NotEmpty(t, result)
-				assert.Equal(t, "np-app-access-allow-3ccf8bbb_aoqj8", result)
+				assert.Equal(t, "np-app-access-allow-3ccf8bbb2c2c8a1eeb11151831b6cc95fdea46f6_aoqj8", result)
 			},
 		},
 		{
@@ -2404,7 +2404,7 @@ func Test_buildRuleID(t *testing.T) {
 
 				// Set up rule store if we need to test existing rule ID lookup
 				if tt.existingRuleID != nil {
-					ruleHash := service.buildLimitedRuleHashString(&(tt.obj.Spec.Rules[tt.ruleIdx]))
+					ruleHash := service.buildRuleHashString(&(tt.obj.Spec.Rules[tt.ruleIdx]))
 					var ruleTags []model.Tag
 					if tt.createdFor == common.ResourceTypeSecurityPolicy {
 						ruleTags = appendRuleIDAndHashTags(vpcBasicTags, ruleHash, *tt.existingRuleID)
@@ -2422,10 +2422,10 @@ func Test_buildRuleID(t *testing.T) {
 					ruleStore.Apply(&rules)
 				} else if tt.rebuildRuleID {
 					// Set up rule store with existing ruleID for rebuild testing
-					// "spA-1e510e8a_re0bz" should be the same with spWithPodSelector's first rule generated ID,
+					// "spA-1e510e8ad94c103f4727e2bfc28bc637cb752831_re0bz" should be the same with spWithPodSelector's first rule generated ID,
 					// so that it will rebuilt it
-					ruleTags := appendRuleIDAndHashTags(vpcBasicTags, "hash", "spA-1e510e8a_re0bz")
-					nsxRuleID := String("spA-1e510e8a_re0bz" + "portSuffix")
+					ruleTags := appendRuleIDAndHashTags(vpcBasicTags, "hash", "spA-1e510e8ad94c103f4727e2bfc28bc637cb752831_re0bz")
+					nsxRuleID := String("spA-1e510e8ad94c103f4727e2bfc28bc637cb752831_re0bz" + "portSuffix")
 					rules := []model.Rule{
 						{
 							Id:   nsxRuleID,

--- a/pkg/nsx/services/securitypolicy/expand_test.go
+++ b/pkg/nsx/services/securitypolicy/expand_test.go
@@ -416,10 +416,10 @@ func Test_ExpandRule(t *testing.T) {
 		}
 	}
 
-	npRuleTags1 := appendRuleIDAndHashTags(npRuleTags, "26e848bd", "p1-26e848bd_ogcol")
-	npRuleTags2 := appendRuleIDAndHashTags(npRuleTags, "2a54787a", "p1-2a54787a_ogcol")
-	npRuleTags3 := appendRuleIDAndHashTags(npRuleTags, "94b44028", "p1-94b44028_ogcol")
-	spVPCRuleTags1 := appendRuleIDAndHashTags(spVPCRuleTags, "94b44028", "p1-94b44028_ogcol")
+	npRuleTags1 := appendRuleIDAndHashTags(npRuleTags, "26e848bd5724c09acc141b8c30b05d59533e694b", "p1-26e848bd5724c09acc141b8c30b05d59533e694b_ogcol")
+	npRuleTags2 := appendRuleIDAndHashTags(npRuleTags, "2a54787ab7a813c379d67051283b4de550d38360", "p1-2a54787ab7a813c379d67051283b4de550d38360_ogcol")
+	npRuleTags3 := appendRuleIDAndHashTags(npRuleTags, "94b44028488f3e719879abbc27c75e5cb44872b7", "p1-94b44028488f3e719879abbc27c75e5cb44872b7_ogcol")
+	spVPCRuleTags1 := appendRuleIDAndHashTags(spVPCRuleTags, "94b44028488f3e719879abbc27c75e5cb44872b7", "p1-94b44028488f3e719879abbc27c75e5cb44872b7_ogcol")
 
 	for _, tc := range []struct {
 		name        string
@@ -438,7 +438,7 @@ func Test_ExpandRule(t *testing.T) {
 			createdFor: common.ResourceTypeNetworkPolicy,
 			expRules: []*model.Rule{
 				{
-					Id:             common.String("p1-26e848bd_ogcol_all"),
+					Id:             common.String("p1-26e848bd5724c09acc141b8c30b05d59533e694b_ogcol_all"),
 					DisplayName:    common.String("rule1"),
 					Direction:      common.String(string("IN")),
 					SequenceNumber: Int64(int64(0)),
@@ -454,7 +454,7 @@ func Test_ExpandRule(t *testing.T) {
 			createdFor: common.ResourceTypeNetworkPolicy,
 			expRules: []*model.Rule{
 				{
-					Id:             common.String("p1-2a54787a_ogcol_1000_1234.1235"),
+					Id:             common.String("p1-2a54787ab7a813c379d67051283b4de550d38360_ogcol_1000_1234.1235"),
 					DisplayName:    common.String("rule2"),
 					Direction:      common.String(string("IN")),
 					SequenceNumber: Int64(int64(1)),
@@ -473,11 +473,11 @@ func Test_ExpandRule(t *testing.T) {
 			ruleIdx:    2,
 			createdFor: common.ResourceTypeNetworkPolicy,
 			expGroups: []*model.Group{
-				getTestIPsetGroup("p1-94b44028_ogcol_8080_ipset", "TCP.http_UDP.1236.1237.TCP.8080_ingress_allow_ipset", "p1-94b44028_ogcol", true, "network_policy"),
+				getTestIPsetGroup("p1-94b44028488f3e719879abbc27c75e5cb44872b7_ogcol_8080_ipset", "TCP.http_UDP.1236.1237.TCP.8080_ingress_allow_ipset", "p1-94b44028488f3e719879abbc27c75e5cb44872b7_ogcol", true, "network_policy"),
 			},
 			expRules: []*model.Rule{
 				{
-					Id:                common.String("p1-94b44028_ogcol_8080"),
+					Id:                common.String("p1-94b44028488f3e719879abbc27c75e5cb44872b7_ogcol_8080"),
 					DisplayName:       common.String("TCP.http_UDP.1236.1237.TCP.8080_ingress_allow"),
 					Direction:         common.String("IN"),
 					SequenceNumber:    Int64(int64(2)),
@@ -485,9 +485,9 @@ func Test_ExpandRule(t *testing.T) {
 					Services:          []string{"ANY"},
 					ServiceEntries:    []*data.StructValue{getRuleServiceEntries(8080, 0, "TCP")},
 					Tags:              npRuleTags3,
-					DestinationGroups: []string{"/orgs/default/projects/pro1/vpcs/vpc1/groups/p1-94b44028_ogcol_8080_ipset"},
+					DestinationGroups: []string{"/orgs/default/projects/pro1/vpcs/vpc1/groups/p1-94b44028488f3e719879abbc27c75e5cb44872b7_ogcol_8080_ipset"},
 				}, {
-					Id:             common.String("p1-94b44028_ogcol_1236.1237"),
+					Id:             common.String("p1-94b44028488f3e719879abbc27c75e5cb44872b7_ogcol_1236.1237"),
 					DisplayName:    common.String("TCP.http_UDP.1236.1237.UDP.1236.1237_ingress_allow"),
 					Direction:      common.String("IN"),
 					SequenceNumber: Int64(int64(2)),
@@ -503,11 +503,11 @@ func Test_ExpandRule(t *testing.T) {
 			ruleIdx:    2,
 			createdFor: common.ResourceTypeSecurityPolicy,
 			expGroups: []*model.Group{
-				getTestIPsetGroup("p1-94b44028_ogcol_8080_ipset", "TCP.http_UDP.1236.1237.TCP.8080_ingress_allow_ipset", "p1-94b44028_ogcol", true, "security_policy"),
+				getTestIPsetGroup("p1-94b44028488f3e719879abbc27c75e5cb44872b7_ogcol_8080_ipset", "TCP.http_UDP.1236.1237.TCP.8080_ingress_allow_ipset", "p1-94b44028488f3e719879abbc27c75e5cb44872b7_ogcol", true, "security_policy"),
 			},
 			expRules: []*model.Rule{
 				{
-					Id:                common.String("p1-94b44028_ogcol_8080"),
+					Id:                common.String("p1-94b44028488f3e719879abbc27c75e5cb44872b7_ogcol_8080"),
 					DisplayName:       common.String("TCP.http_UDP.1236.1237.TCP.8080_ingress_allow"),
 					Direction:         common.String("IN"),
 					SequenceNumber:    Int64(int64(2)),
@@ -515,9 +515,9 @@ func Test_ExpandRule(t *testing.T) {
 					Services:          []string{"ANY"},
 					ServiceEntries:    []*data.StructValue{getRuleServiceEntries(8080, 0, "TCP")},
 					Tags:              spVPCRuleTags1,
-					DestinationGroups: []string{"/orgs/default/projects/pro1/vpcs/vpc1/groups/p1-94b44028_ogcol_8080_ipset"},
+					DestinationGroups: []string{"/orgs/default/projects/pro1/vpcs/vpc1/groups/p1-94b44028488f3e719879abbc27c75e5cb44872b7_ogcol_8080_ipset"},
 				}, {
-					Id:             common.String("p1-94b44028_ogcol_1236.1237"),
+					Id:             common.String("p1-94b44028488f3e719879abbc27c75e5cb44872b7_ogcol_1236.1237"),
 					DisplayName:    common.String("TCP.http_UDP.1236.1237.UDP.1236.1237_ingress_allow"),
 					Direction:      common.String("IN"),
 					SequenceNumber: Int64(int64(2)),

--- a/pkg/nsx/services/securitypolicy/firewall_test.go
+++ b/pkg/nsx/services/securitypolicy/firewall_test.go
@@ -2992,8 +2992,8 @@ func Test_GetFinalSecurityPolicyResourceForVPC(t *testing.T) {
 
 	serviceEntry := getRuleServiceEntries(53, 0, "UDP")
 
-	ruleTags1 := appendRuleIDAndHashTags(vpcBasicTags, "1e510e8a", "spA-1e510e8a_re0bz")
-	ruleTags2 := appendRuleIDAndHashTags(vpcBasicTags, "304ea84a", "spA-304ea84a_re0bz")
+	ruleTags1 := appendRuleIDAndHashTags(vpcBasicTags, "1e510e8ad94c103f4727e2bfc28bc637cb752831", "spA-1e510e8ad94c103f4727e2bfc28bc637cb752831_re0bz")
+	ruleTags2 := appendRuleIDAndHashTags(vpcBasicTags, "304ea84a85a12eae03f799a546ec5bfe1ffaaa64", "spA-304ea84a85a12eae03f799a546ec5bfe1ffaaa64_re0bz")
 
 	type args struct {
 		spObj      *v1alpha1.SecurityPolicy
@@ -3038,25 +3038,25 @@ func Test_GetFinalSecurityPolicyResourceForVPC(t *testing.T) {
 				Rules: []model.Rule{
 					{
 						DisplayName:       common.String("rule-with-pod-ns-selector_ingress_allow"),
-						Id:                common.String("spA-1e510e8a_re0bz_all"),
+						Id:                common.String("spA-1e510e8ad94c103f4727e2bfc28bc637cb752831_re0bz_all"),
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
-						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA-1e510e8a-scope_re0bz"},
+						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/spA-1e510e8ad94c103f4727e2bfc28bc637cb752831-scope_re0bz"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-1e510e8a-src_re0bz"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-1e510e8ad94c103f4727e2bfc28bc637cb752831-src_re0bz"},
 						Action:            &nsxRuleActionAllow,
 						Tags:              ruleTags1,
 					},
 					{
 						DisplayName:       common.String("rule-with-ns-selector_ingress_allow"),
-						Id:                common.String("spA-304ea84a_re0bz_53"),
+						Id:                common.String("spA-304ea84a85a12eae03f799a546ec5bfe1ffaaa64_re0bz_53"),
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-304ea84a-src_re0bz"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/spA-304ea84a85a12eae03f799a546ec5bfe1ffaaa64-src_re0bz"},
 						Action:            &nsxRuleActionAllow,
 						ServiceEntries:    []*data.StructValue{serviceEntry},
 						Tags:              ruleTags2,
@@ -3250,11 +3250,11 @@ func Test_GetFinalSecurityPolicyResourceFromNetworkPolicy(t *testing.T) {
 	ingressServiceEntry := getRuleServiceEntries(6001, 0, "TCP")
 	egressServiceEntry := getRuleServiceEntries(3366, 0, "TCP")
 
-	allowRuleTags1 := appendRuleIDAndHashTags(npAllowBasicTags, "41134081", "np-app-access-allow-41134081_aoqj8")
-	allowRuleTags2 := appendRuleIDAndHashTags(npAllowBasicTags, "d66432a3", "np-app-access-allow-d66432a3_aoqj8")
+	allowRuleTags1 := appendRuleIDAndHashTags(npAllowBasicTags, "411340818595b23e32e713f0737ff9ec3e777dd2", "np-app-access-allow-411340818595b23e32e713f0737ff9ec3e777dd2_aoqj8")
+	allowRuleTags2 := appendRuleIDAndHashTags(npAllowBasicTags, "d66432a3d57a030336da5b01097ea3157436b396", "np-app-access-allow-d66432a3d57a030336da5b01097ea3157436b396_aoqj8")
 
-	isolationRuleTags1 := appendRuleIDAndHashTags(npIsolationBasicTags, "114fed10", "np-app-access-isolation-114fed10_aoqj8")
-	isolationRuleTags2 := appendRuleIDAndHashTags(npIsolationBasicTags, "8cae63ab", "np-app-access-isolation-8cae63ab_aoqj8")
+	isolationRuleTags1 := appendRuleIDAndHashTags(npIsolationBasicTags, "114fed106ef3b5eae2a583f312435e84c02ca97f", "np-app-access-isolation-114fed106ef3b5eae2a583f312435e84c02ca97f_aoqj8")
+	isolationRuleTags2 := appendRuleIDAndHashTags(npIsolationBasicTags, "8cae63abb024b98f33fcd199b0e9fd40552f8c15", "np-app-access-isolation-8cae63abb024b98f33fcd199b0e9fd40552f8c15_aoqj8")
 
 	patches := gomonkey.ApplyMethod(reflect.TypeOf(&fakeService.Service), "GetNamespaceUID",
 		func(s *common.Service, ns string) types.UID {
@@ -3289,21 +3289,21 @@ func Test_GetFinalSecurityPolicyResourceFromNetworkPolicy(t *testing.T) {
 				Rules: []model.Rule{
 					{
 						DisplayName:       common.String("TCP.6001_ingress_allow"),
-						Id:                common.String("np-app-access-allow-41134081_aoqj8_6001"),
+						Id:                common.String("np-app-access-allow-411340818595b23e32e713f0737ff9ec3e777dd2_aoqj8_6001"),
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq0,
 						Services:          []string{"ANY"},
-						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access-allow-41134081-src_aoqj8"},
+						SourceGroups:      []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access-allow-411340818595b23e32e713f0737ff9ec3e777dd2-src_aoqj8"},
 						Action:            &nsxRuleActionAllow,
 						ServiceEntries:    []*data.StructValue{ingressServiceEntry},
 						Tags:              allowRuleTags1,
 					},
 					{
 						DisplayName:       common.String("TCP.3366_egress_allow"),
-						Id:                common.String("np-app-access-allow-d66432a3_aoqj8_3366"),
-						DestinationGroups: []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access-allow-d66432a3-dst_aoqj8"},
+						Id:                common.String("np-app-access-allow-d66432a3d57a030336da5b01097ea3157436b396_aoqj8_3366"),
+						DestinationGroups: []string{"/orgs/default/projects/projectQuality/infra/domains/default/groups/np-app-access-allow-d66432a3d57a030336da5b01097ea3157436b396-dst_aoqj8"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"ANY"},
 						SequenceNumber:    &seq1,
@@ -3324,7 +3324,7 @@ func Test_GetFinalSecurityPolicyResourceFromNetworkPolicy(t *testing.T) {
 				Rules: []model.Rule{
 					{
 						DisplayName:       common.String("ingress_isolation"),
-						Id:                common.String("np-app-access-isolation-114fed10_aoqj8_all"),
+						Id:                common.String("np-app-access-isolation-114fed106ef3b5eae2a583f312435e84c02ca97f_aoqj8_all"),
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionIn,
 						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/np-app-access-isolation-scope_aoqj8"},
@@ -3336,7 +3336,7 @@ func Test_GetFinalSecurityPolicyResourceFromNetworkPolicy(t *testing.T) {
 					},
 					{
 						DisplayName:       common.String("egress_isolation"),
-						Id:                common.String("np-app-access-isolation-8cae63ab_aoqj8_all"),
+						Id:                common.String("np-app-access-isolation-8cae63abb024b98f33fcd199b0e9fd40552f8c15_aoqj8_all"),
 						DestinationGroups: []string{"ANY"},
 						Direction:         &nsxRuleDirectionOut,
 						Scope:             []string{"/orgs/default/projects/projectQuality/vpcs/vpc1/groups/np-app-access-isolation-scope_aoqj8"},

--- a/test/e2e/nsx_security_policy_test.go
+++ b/test/e2e/nsx_security_policy_test.go
@@ -211,18 +211,18 @@ func testSecurityPolicyMatchExpression(t *testing.T) {
 	// Create pods
 	podPath, _ := filepath.Abs("./manifest/testSecurityPolicy/allow-client-a-via-pod-selector-with-match-expressions.yaml")
 	require.NoError(t, applyYAML(podPath, ns))
-	defer deleteYAML(podPath, "")
+	defer deleteYAML(podPath, ns)
 
 	clientA := "client-a"
 	clientB := "client-b"
 	podA := "pod-a"
 	// Wait for pods
 	_, err := testData.podWaitForIPs(defaultTimeout, clientA, ns)
-	assert.NoError(t, err, "Error when waiting for IP for Pod %s", clientA)
+	require.NoError(t, err, "Error when waiting for IP for Pod %s", clientA)
 	_, err = testData.podWaitForIPs(defaultTimeout, clientB, ns)
-	assert.NoError(t, err, "Error when waiting for IP for Pod %s", clientB)
+	require.NoError(t, err, "Error when waiting for IP for Pod %s", clientB)
 	iPs, err := testData.podWaitForIPs(defaultTimeout, podA, ns)
-	assert.NoError(t, err, "Error when waiting for IP for Pod %s", podA)
+	require.NoError(t, err, "Error when waiting for IP for Pod %s", podA)
 
 	// Test traffic from clientA to podA
 	require.True(t, checkTrafficByCurl(ns, clientA, clientA, iPs.ipv4.String(), podPort, true), "TestSecurityPolicyMatchExpression traffic should work")
@@ -424,7 +424,7 @@ func testSecurityPolicyNamedPortWithoutPod(t *testing.T) {
 
 	psb, err := testData.deploymentWaitForNames(defaultTimeout, nsWeb, labelWeb)
 	log.Trace("Pods", "pods", psb)
-	assert.NoError(t, err, "Error when waiting for IP for Pod %s", webA)
+	require.NoError(t, err, "Error when waiting for IP for Pod %s", webA)
 	assureSecurityPolicyReady(t, nsWeb, securityPolicyCRName)
 
 	// Check NSX resource existing


### PR DESCRIPTION
1. removed the buildLimitedRuleHashString function (which truncated the SHA-1 hash to 8 characters) and replaced all its usages with buildRuleHashString (which returns the full 40-character SHA-1 hash).
2. updated all the hardcoded expected hash strings in the test files (builder_test.go, expand_test.go, and firewall_test.go) from the old 8-character format to the new 40-character format.
3. for upgrade:
NSX operator fetches the existing rules and groups from NSX-T (which have the old 8-character hash IDs). It then generates the expected rules and groups using the new logic (which have the new 40-character hash IDs).
Because the IDs and names no longer match, the operator's comparison logic (common.CompareResources) will classify all the old 8-character rules/groups as "stale" and all the 40-character rules/groups as "new".
NSX operator will send a Hierarchical API (HAPI) request to NSX-T that explicitly marks the old rules and groups for deletion (MarkedForDelete: true) and includes the new rules and groups to be created.

Issue: #[3730430](https://bugzilla-vcf.lvn.broadcom.net/show_bug.cgi?id=3730430)

Testing Done:
create a SecurityPolicy with 2 rules:
```
root@42333a0884efc6d4a62bb939142c574e [ ~ ]# k -n ns1 get securitypolicy -o yaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  kind: SecurityPolicy
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SecurityPolicy","metadata":{"annotations":{},"creationTimestamp":"2026-06-19T03:20:23Z","generation":2,"name":"test-sp-2","namespace":"ns1","resourceVersion":"3647698","uid":"07c11731-c324-4a78-bcf0-0db8a82d5163"},"spec":{"appliedTo":[{"podSelector":{"matchLabels":{"app":"app"}}}],"rules":[{"action":"allow","direction":"in","from":[{"ipBlocks":[{"cidr":"10.0.54.200/32"}]}],"ports":[{"port":6000,"protocol":"TCP"}]},{"action":"allow","direction":"in","from":[{"ipBlocks":[{"cidr":"10.0.156.251/32"}]}],"ports":[{"port":6000,"protocol":"TCP"}]}]}}
    creationTimestamp: "2026-06-30T07:56:28Z"
    generation: 1
    name: test-sp-2
    namespace: ns1
    resourceVersion: "1027777"
    uid: 5bb0c07f-2a4a-4071-87b5-e943a05926e2
  spec:
    appliedTo:
    - podSelector:
        matchLabels:
          app: app
    rules:
    - action: allow
      direction: in
      from:
      - ipBlocks:
        - cidr: 10.0.54.200/32
      ports:
      - port: 6000
        protocol: TCP
    - action: allow
      direction: in
      from:
      - ipBlocks:
        - cidr: 10.0.156.251/32
      ports:
      - port: 6000
        protocol: TCP
  status:
    conditions:
    - lastTransitionTime: "2026-06-30T07:56:31Z"
      message: NSX Security Policy has been successfully created/updated
      reason: SecurityPolicyReady
      status: "True"
      type: Ready
kind: List
metadata:
  resourceVersion: ""
```

2 DFW rules created:
```
curl -k -u 'admin:G8*MsXVZ+J#H9Sfw' https://10.70.178.146/policy/api/v1/orgs/default/projects/project-quality/vpcs/ns1_m4dor/security-policies/test-sp-2_9q3d6
{
  "rules" : [ {
    "action" : "ALLOW",
    "resource_type" : "Rule",
    "id" : "test-sp-2-a3e6b13b8059bf5be7609fd02632c66f002bee8c_9q3d6_6000",
    "display_name" : "TCP.6000_ingress_allow",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "2f4f2d1d-95a5-4805-8b1c-70a93a196632"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace",
      "tag" : "ns1"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "5e546d05-4b46-4ada-bf31-2b4986d2bf87"
    }, {
      "scope" : "nsx-op/security_policy_name",
      "tag" : "test-sp-2"
    }, {
      "scope" : "nsx-op/security_policy_uid",
      "tag" : "5bb0c07f-2a4a-4071-87b5-e943a05926e2"
    }, {
      "scope" : "nsx-op/rule_hash",
      "tag" : "a3e6b13b8059bf5be7609fd02632c66f002bee8c"
    }, {
      "scope" : "nsx-op/rule_id",
      "tag" : "test-sp-2-a3e6b13b8059bf5be7609fd02632c66f002bee8c_9q3d6"
    } ],
    "path" : "/orgs/default/projects/project-quality/vpcs/ns1_m4dor/security-policies/test-sp-2_9q3d6/rules/test-sp-2-a3e6b13b8059bf5be7609fd02632c66f002bee8c_9q3d6_6000",
    "relative_path" : "test-sp-2-a3e6b13b8059bf5be7609fd02632c66f002bee8c_9q3d6_6000",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/ns1_m4dor/security-policies/test-sp-2_9q3d6",
    "remote_path" : "",
    "unique_id" : "00000000-0000-0000-0000-000000001011",
    "realization_id" : "00000000-0000-0000-0000-000000001011",
    "owner_id" : "41e76e9c-62cd-43be-a30a-8ef63eefc426",
    "marked_for_delete" : false,
    "overridden" : false,
    "rule_id" : 1011,
    "sequence_number" : 0,
    "sources_excluded" : false,
    "destinations_excluded" : false,
    "source_groups" : [ "/orgs/default/projects/project-quality/vpcs/ns1_m4dor/groups/test-sp-2-a3e6b13b8059bf5be7609fd02632c66f002bee8c-src_9q3d6" ],
    "destination_groups" : [ "ANY" ],
    "services" : [ "ANY" ],
    "service_entries" : [ {
      "l4_protocol" : "TCP",
      "source_ports" : [ ],
      "destination_ports" : [ "6000" ],
      "resource_type" : "L4PortSetServiceEntry",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    } ],
    "profiles" : [ "ANY" ],
    "logged" : false,
    "scope" : [ "ANY" ],
    "disabled" : false,
    "direction" : "IN",
    "ip_protocol" : "IPV4_IPV6",
    "is_default" : false,
    "_system_owned" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_create_time" : 1782806189057,
    "_create_user" : "wcp-cluster-user-2f4f2d1d-95a5-4805-8b1c-70a93a196632-8b228de8-50dc-4c26-a048-fde87859dd4b",
    "_last_modified_time" : 1782806189057,
    "_last_modified_user" : "wcp-cluster-user-2f4f2d1d-95a5-4805-8b1c-70a93a196632-8b228de8-50dc-4c26-a048-fde87859dd4b",
    "_revision" : 0
  }, {
    "action" : "ALLOW",
    "resource_type" : "Rule",
    "id" : "test-sp-2-a3e6b13b9b816b8f3923ef5556a443e40c1d9443_9q3d6_6000",
    "display_name" : "TCP.6000_ingress_allow",
    "tags" : [ {
      "scope" : "nsx-op/cluster",
      "tag" : "2f4f2d1d-95a5-4805-8b1c-70a93a196632"
    }, {
      "scope" : "nsx-op/version",
      "tag" : "1.0.0"
    }, {
      "scope" : "nsx-op/namespace",
      "tag" : "ns1"
    }, {
      "scope" : "nsx-op/namespace_uid",
      "tag" : "5e546d05-4b46-4ada-bf31-2b4986d2bf87"
    }, {
      "scope" : "nsx-op/security_policy_name",
      "tag" : "test-sp-2"
    }, {
      "scope" : "nsx-op/security_policy_uid",
      "tag" : "5bb0c07f-2a4a-4071-87b5-e943a05926e2"
    }, {
      "scope" : "nsx-op/rule_hash",
      "tag" : "a3e6b13b9b816b8f3923ef5556a443e40c1d9443"
    }, {
      "scope" : "nsx-op/rule_id",
      "tag" : "test-sp-2-a3e6b13b9b816b8f3923ef5556a443e40c1d9443_9q3d6"
    } ],
    "path" : "/orgs/default/projects/project-quality/vpcs/ns1_m4dor/security-policies/test-sp-2_9q3d6/rules/test-sp-2-a3e6b13b9b816b8f3923ef5556a443e40c1d9443_9q3d6_6000",
    "relative_path" : "test-sp-2-a3e6b13b9b816b8f3923ef5556a443e40c1d9443_9q3d6_6000",
    "parent_path" : "/orgs/default/projects/project-quality/vpcs/ns1_m4dor/security-policies/test-sp-2_9q3d6",
    "remote_path" : "",
    "unique_id" : "00000000-0000-0000-0000-000000001010",
    "realization_id" : "00000000-0000-0000-0000-000000001010",
    "owner_id" : "41e76e9c-62cd-43be-a30a-8ef63eefc426",
    "marked_for_delete" : false,
    "overridden" : false,
    "rule_id" : 1010,
    "sequence_number" : 1,
    "sources_excluded" : false,
    "destinations_excluded" : false,
    "source_groups" : [ "/orgs/default/projects/project-quality/vpcs/ns1_m4dor/groups/test-sp-2-a3e6b13b9b816b8f3923ef5556a443e40c1d9443-src_9q3d6" ],
    "destination_groups" : [ "ANY" ],
    "services" : [ "ANY" ],
    "service_entries" : [ {
      "l4_protocol" : "TCP",
      "source_ports" : [ ],
      "destination_ports" : [ "6000" ],
      "resource_type" : "L4PortSetServiceEntry",
      "marked_for_delete" : false,
      "overridden" : false,
      "_protection" : "NOT_PROTECTED"
    } ],
    "profiles" : [ "ANY" ],
    "logged" : false,
    "scope" : [ "ANY" ],
    "disabled" : false,
    "direction" : "IN",
    "ip_protocol" : "IPV4_IPV6",
    "is_default" : false,
    "_system_owned" : false,
    "_protection" : "REQUIRE_OVERRIDE",
    "_create_time" : 1782806189027,
    "_create_user" : "wcp-cluster-user-2f4f2d1d-95a5-4805-8b1c-70a93a196632-8b228de8-50dc-4c26-a048-fde87859dd4b",
    "_last_modified_time" : 1782806189027,
    "_last_modified_user" : "wcp-cluster-user-2f4f2d1d-95a5-4805-8b1c-70a93a196632-8b228de8-50dc-4c26-a048-fde87859dd4b",
    "_revision" : 0
  } ],
  "logging_enabled" : false,
  "resource_type" : "SecurityPolicy",
  "id" : "test-sp-2_9q3d6",
  "display_name" : "test-sp-2",
  "tags" : [ {
    "scope" : "nsx-op/cluster",
    "tag" : "2f4f2d1d-95a5-4805-8b1c-70a93a196632"
  }, {
    "scope" : "nsx-op/version",
    "tag" : "1.0.0"
  }, {
    "scope" : "nsx-op/namespace",
    "tag" : "ns1"
  }, {
    "scope" : "nsx-op/namespace_uid",
    "tag" : "5e546d05-4b46-4ada-bf31-2b4986d2bf87"
  }, {
    "scope" : "nsx-op/security_policy_name",
    "tag" : "test-sp-2"
  }, {
    "scope" : "nsx-op/security_policy_uid",
    "tag" : "5bb0c07f-2a4a-4071-87b5-e943a05926e2"
  } ],
  "path" : "/orgs/default/projects/project-quality/vpcs/ns1_m4dor/security-policies/test-sp-2_9q3d6",
  "relative_path" : "test-sp-2_9q3d6",
  "parent_path" : "/orgs/default/projects/project-quality/vpcs/ns1_m4dor",
  "remote_path" : "",
  "unique_id" : "31c244fe-8ad5-436c-b18c-b1ecd6143635",
  "realization_id" : "31c244fe-8ad5-436c-b18c-b1ecd6143635",
  "owner_id" : "41e76e9c-62cd-43be-a30a-8ef63eefc426",
  "marked_for_delete" : false,
  "overridden" : false,
  "sequence_number" : 0,
  "internal_sequence_number" : 66000000,
  "category" : "Application",
  "stateful" : true,
  "tcp_strict" : true,
  "locked" : false,
  "lock_modified_time" : 0,
  "scope" : [ "/orgs/default/projects/project-quality/vpcs/ns1_m4dor/groups/test-sp-2-scope_9q3d6" ],
  "rule_count" : 2,
  "is_default" : false,
  "_system_owned" : false,
  "_protection" : "REQUIRE_OVERRIDE",
  "_create_time" : 1782806189006,
  "_create_user" : "wcp-cluster-user-2f4f2d1d-95a5-4805-8b1c-70a93a196632-8b228de8-50dc-4c26-a048-fde87859dd4b",
  "_last_modified_time" : 1782806189006,
  "_last_modified_user" : "wcp-cluster-user-2f4f2d1d-95a5-4805-8b1c-70a93a196632-8b228de8-50dc-4c26-a048-fde87859dd4b",
  "_revision" : 0
}
```