### PR TITLE
Restart if service lb controller failed to get k8s version

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -253,10 +253,12 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			subnetport.NewSubnetPortReconciler(mgr, subnetPortService, subnetService, vpcService, ipAddressAllocationService),
 			pod.NewPodReconciler(mgr, subnetPortService, subnetService, vpcService, nodeService),
 			networkpolicycontroller.NewNetworkPolicyReconciler(mgr, commonService, vpcService),
-			service.NewServiceLbReconciler(mgr, commonService, dnsRecordService),
 			subnetbindingcontroller.NewReconciler(mgr, subnetService, subnetBindingService),
 			subnetipreservationcontroller.NewReconciler(mgr, subnetIPReservationService, subnetService),
 		)
+		if lbReconciler := service.NewServiceLbReconciler(mgr, commonService, dnsRecordService); lbReconciler != nil {
+			reconcilerList = append(reconcilerList, lbReconciler)
+		}
 		// StatefulSet controller is always registered so that after NSX upgrades (e.g. to 9.2.0+)
 		// replica/GC logic can run without restarting the operator. Reconcile and CollectGarbage
 		// no-op until NSX version supports STS pods and vpc_wcp_enhance=true in config; delete cleanup still runs.

--- a/pkg/controllers/service/service_lb_controller.go
+++ b/pkg/controllers/service/service_lb_controller.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -187,29 +188,29 @@ func (r *ServiceLbReconciler) Start(mgr ctrl.Manager) error {
 	return nil
 }
 
-func isServiceLbStatusIpModeSupported(c *rest.Config) bool {
+func isServiceLbStatusIpModeSupported(c *rest.Config) (bool, error) {
 	version129, _ := version.ParseGeneric("v1.29.0")
 
 	clientset, err := clientset.NewForConfig(c)
 	if err != nil {
 		log.Error(err, "Failed to create clientset")
-		return false
+		return false, err
 	}
 
 	serverVersion, err := clientset.Discovery().ServerVersion()
 	if err != nil {
 		log.Error(err, "Failed to get server Kubernetes version")
-		return false
+		return false, err
 	}
 
 	runningVersion, err := version.ParseGeneric(serverVersion.String())
 	if err != nil {
 		log.Error(err, "Failed to parse server Kubernetes version", "K8sVersion", runningVersion.String())
-		return false
+		return false, err
 	}
 
 	log.Info("Running server Kubernetes version is", "K8sVersion", runningVersion.String())
-	return runningVersion.AtLeast(version129)
+	return runningVersion.AtLeast(version129), nil
 }
 
 func (r *ServiceLbReconciler) RestoreReconcile() error {
@@ -242,7 +243,13 @@ func (r *ServiceLbReconciler) CollectGarbage(ctx context.Context) error {
 }
 
 func NewServiceLbReconciler(mgr ctrl.Manager, commonService servicecommon.Service, dnsRecordService *dns.DNSRecordService) *ServiceLbReconciler {
-	if isServiceLbStatusIpModeSupported(mgr.GetConfig()) {
+	supported, err := isServiceLbStatusIpModeSupported(mgr.GetConfig())
+	if err != nil {
+		log.Error(err, "Failed to check if Service LB status ipMode is supported")
+		os.Exit(1)
+	}
+
+	if supported {
 		var dnsProv dns.DNSRecordProvider
 		if dnsRecordService != nil {
 			dnsProv = dnsRecordService

--- a/pkg/controllers/service/service_lb_controller_test.go
+++ b/pkg/controllers/service/service_lb_controller_test.go
@@ -5,8 +5,14 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"reflect"
 	"testing"
+
+	machineryversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/go-logr/logr"
@@ -609,7 +615,7 @@ func TestNewServiceLbReconciler_whenIpModeSupported(t *testing.T) {
 	commonService := common.Service{Client: fakeClient}
 	mockMgr := &MockManager{scheme: runtime.NewScheme(), config: &rest.Config{}}
 
-	patches := gomonkey.ApplyFunc(isServiceLbStatusIpModeSupported, func(c *rest.Config) bool { return true })
+	patches := gomonkey.ApplyFunc(isServiceLbStatusIpModeSupported, func(c *rest.Config) (bool, error) { return true, nil })
 	defer patches.Reset()
 
 	r := NewServiceLbReconciler(mockMgr, commonService, nil)
@@ -705,4 +711,64 @@ func TestEnqueueLBServiceRequestsFromNetworkInfo_skipAnnotation(t *testing.T) {
 // failingClient needs to override List to return an error for this test
 func (c *failingClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	return fmt.Errorf("list error")
+}
+
+func TestIsServiceLbStatusIpModeSupported(t *testing.T) {
+	c := &rest.Config{}
+
+	t.Run("NewForConfig returns error", func(t *testing.T) {
+		patches := gomonkey.ApplyFunc(clientset.NewForConfig, func(_ *rest.Config) (*clientset.Clientset, error) {
+			return nil, errors.New("mock NewForConfig error")
+		})
+		defer patches.Reset()
+
+		supported, err := isServiceLbStatusIpModeSupported(c)
+		assert.False(t, supported)
+		assert.ErrorContains(t, err, "mock NewForConfig error")
+	})
+
+	t.Run("ServerVersion returns error", func(t *testing.T) {
+		// Mock discovery client's ServerVersion method
+		patches := gomonkey.ApplyMethodFunc(reflect.TypeOf(&discovery.DiscoveryClient{}), "ServerVersion", func() (*machineryversion.Info, error) {
+			return nil, errors.New("mock ServerVersion error")
+		})
+		defer patches.Reset()
+
+		supported, err := isServiceLbStatusIpModeSupported(c)
+		assert.False(t, supported)
+		assert.ErrorContains(t, err, "mock ServerVersion error")
+	})
+
+	t.Run("ParseGeneric returns error", func(t *testing.T) {
+		patches := gomonkey.ApplyMethodFunc(reflect.TypeOf(&discovery.DiscoveryClient{}), "ServerVersion", func() (*machineryversion.Info, error) {
+			return &machineryversion.Info{GitVersion: "invalid"}, nil
+		})
+		defer patches.Reset()
+
+		supported, err := isServiceLbStatusIpModeSupported(c)
+		assert.False(t, supported)
+		assert.ErrorContains(t, err, "could not parse")
+	})
+
+	t.Run("version less than 1.29.0", func(t *testing.T) {
+		patches := gomonkey.ApplyMethodFunc(reflect.TypeOf(&discovery.DiscoveryClient{}), "ServerVersion", func() (*machineryversion.Info, error) {
+			return &machineryversion.Info{GitVersion: "v1.28.0"}, nil
+		})
+		defer patches.Reset()
+
+		supported, err := isServiceLbStatusIpModeSupported(c)
+		assert.False(t, supported)
+		assert.NoError(t, err)
+	})
+
+	t.Run("version greater than 1.29.0", func(t *testing.T) {
+		patches := gomonkey.ApplyMethodFunc(reflect.TypeOf(&discovery.DiscoveryClient{}), "ServerVersion", func() (*machineryversion.Info, error) {
+			return &machineryversion.Info{GitVersion: "v1.30.0"}, nil
+		})
+		defer patches.Reset()
+
+		supported, err := isServiceLbStatusIpModeSupported(c)
+		assert.True(t, supported)
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
If k8s version is failed to get when creating the Service lb controller,
Service lb controller may not be start and result in lb service traffic issue.

We shall restart the nsx operator in this case.