### PR TITLE
Add NSX version check for IPv6 fields in SubnetSet update

### DIFF
--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	controllercommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/realizestate"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
@@ -555,7 +556,9 @@ func (service *SubnetService) UpdateSubnetSet(ns string, vpcSubnets []*model.Vpc
 		// is only updated after the updating succeeds.
 		updatedSubnet := *vpcSubnets[i] // #nosec G602
 		updatedSubnet.Tags = newTags
-		updatedSubnet.IpAddressType = String(controllercommon.ConvertCRIPAddressTypeToNSX(subnetsetCR.Spec.IPAddressType))
+		if service.Service.NSXClient.NSXCheckVersion(nsx.IPv6) {
+			updatedSubnet.IpAddressType = String(controllercommon.ConvertCRIPAddressTypeToNSX(subnetsetCR.Spec.IPAddressType))
+		}
 		// Update the SubnetSet DHCP Config
 		if updatedSubnet.SubnetDhcpConfig != nil {
 			// Generate a new SubnetDhcpConfig for updatedSubnet to

--- a/pkg/nsx/services/subnet/subnet_test.go
+++ b/pkg/nsx/services/subnet/subnet_test.go
@@ -512,7 +512,8 @@ func TestSubnetService_UpdateSubnetSet(t *testing.T) {
 	defer mockCtl.Finish()
 	service := &SubnetService{
 		Service: common.Service{
-			Client: k8sClient,
+			Client:    k8sClient,
+			NSXClient: &nsx.Client{},
 			NSXConfig: &config.NSXOperatorConfig{
 				CoeConfig: &config.CoeConfig{
 					Cluster: "k8scl-one:test",
@@ -573,6 +574,10 @@ func TestSubnetService_UpdateSubnetSet(t *testing.T) {
 			return &model.VpcSubnet{Path: &fakeSubnetPath}, nil
 		})
 	defer patchesCreateOrUpdateSubnet.Reset()
+	patchesNSXCheckVersion := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+		return true
+	})
+	defer patchesNSXCheckVersion.Reset()
 	gomonkey.ApplyFunc(controllerscommon.IsNamespaceInTepLessMode,
 		func(_ client.Client, _ string) (bool, error) {
 			return false, nil


### PR DESCRIPTION
The SubnetSet update will also update ipaddresstype on NSX Subnet.
We also need to add the nsx version check for it.

Testing done:
Created a SubnetPort on vm-default SubnetSet.
Restarted the NSX Operator to observe the SubnetSet update can work with NSX 9.1.