### PR TITLE
[cherry-pick]Restart if service lb controller failed to get k8s version (#1487)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -246,10 +246,12 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			subnetport.NewSubnetPortReconciler(mgr, subnetPortService, subnetService, vpcService, ipAddressAllocationService),
 			pod.NewPodReconciler(mgr, subnetPortService, subnetService, vpcService, nodeService),
 			networkpolicycontroller.NewNetworkPolicyReconciler(mgr, commonService, vpcService),
-			service.NewServiceLbReconciler(mgr, commonService),
 			subnetbindingcontroller.NewReconciler(mgr, subnetService, subnetBindingService),
 			subnetipreservationcontroller.NewReconciler(mgr, subnetIPReservationService, subnetService),
 		)
+		if lbReconciler := service.NewServiceLbReconciler(mgr, commonService); lbReconciler != nil {
+			reconcilerList = append(reconcilerList, lbReconciler)
+		}
 		if cf.EnableInventory {
 			reconcilerList = append(reconcilerList, inventory.NewInventoryController(mgr.GetClient(), inventoryService, cf))
 		}

--- a/pkg/controllers/service/service_lb_controller.go
+++ b/pkg/controllers/service/service_lb_controller.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"os"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -138,29 +139,29 @@ func (r *ServiceLbReconciler) Start(mgr ctrl.Manager) error {
 	return nil
 }
 
-func isServiceLbStatusIpModeSupported(c *rest.Config) bool {
+func isServiceLbStatusIpModeSupported(c *rest.Config) (bool, error) {
 	version129, _ := version.ParseGeneric("v1.29.0")
 
 	clientset, err := clientset.NewForConfig(c)
 	if err != nil {
 		log.Error(err, "Failed to create clientset")
-		return false
+		return false, err
 	}
 
 	serverVersion, err := clientset.Discovery().ServerVersion()
 	if err != nil {
 		log.Error(err, "Failed to get server Kubernetes version")
-		return false
+		return false, err
 	}
 
 	runningVersion, err := version.ParseGeneric(serverVersion.String())
 	if err != nil {
 		log.Error(err, "Failed to parse server Kubernetes version", "K8sVersion", runningVersion.String())
-		return false
+		return false, err
 	}
 
 	log.Info("Running server Kubernetes version is", "K8sVersion", runningVersion.String())
-	return runningVersion.AtLeast(version129)
+	return runningVersion.AtLeast(version129), nil
 }
 
 func (r *ServiceLbReconciler) RestoreReconcile() error {
@@ -180,7 +181,13 @@ func (r *ServiceLbReconciler) CollectGarbage(ctx context.Context) error {
 }
 
 func NewServiceLbReconciler(mgr ctrl.Manager, commonService servicecommon.Service) *ServiceLbReconciler {
-	if isServiceLbStatusIpModeSupported(mgr.GetConfig()) {
+	supported, err := isServiceLbStatusIpModeSupported(mgr.GetConfig())
+	if err != nil {
+		log.Error(err, "Failed to check if Service LB status ipMode is supported")
+		os.Exit(1)
+	}
+
+	if supported {
 		serviceLbReconciler := &ServiceLbReconciler{
 			Client:   mgr.GetClient(),
 			Scheme:   mgr.GetScheme(),

--- a/pkg/controllers/service/service_lb_controller_test.go
+++ b/pkg/controllers/service/service_lb_controller_test.go
@@ -10,6 +10,10 @@ import (
 	"reflect"
 	"testing"
 
+	machineryversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	clientset "k8s.io/client-go/kubernetes"
+
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -248,8 +252,8 @@ func TestServiceLbReconciler_StartController(t *testing.T) {
 				patches := gomonkey.ApplyFunc(os.Exit, func(code int) {
 					assert.FailNow(t, "os.Exit should not be called")
 				})
-				patches.ApplyFunc(isServiceLbStatusIpModeSupported, func(c *rest.Config) bool {
-					return true
+				patches.ApplyFunc(isServiceLbStatusIpModeSupported, func(c *rest.Config) (bool, error) {
+					return true, nil
 				})
 				patches.ApplyMethod(reflect.TypeOf(&ServiceLbReconciler{}), "Start", func(_ *ServiceLbReconciler, r ctrl.Manager) error {
 					return nil
@@ -263,8 +267,8 @@ func TestServiceLbReconciler_StartController(t *testing.T) {
 			patches: func() *gomonkey.Patches {
 				patches := gomonkey.ApplyFunc(os.Exit, func(code int) {
 				})
-				patches.ApplyFunc(isServiceLbStatusIpModeSupported, func(c *rest.Config) bool {
-					return true
+				patches.ApplyFunc(isServiceLbStatusIpModeSupported, func(c *rest.Config) (bool, error) {
+					return true, nil
 				})
 				patches.ApplyPrivateMethod(reflect.TypeOf(&ServiceLbReconciler{}), "setupWithManager", func(_ *ServiceLbReconciler, mgr ctrl.Manager) error {
 					return errors.New("failed to setupWithManager")
@@ -289,4 +293,64 @@ func TestServiceLbReconciler_StartController(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsServiceLbStatusIpModeSupported(t *testing.T) {
+	c := &rest.Config{}
+
+	t.Run("NewForConfig returns error", func(t *testing.T) {
+		patches := gomonkey.ApplyFunc(clientset.NewForConfig, func(_ *rest.Config) (*clientset.Clientset, error) {
+			return nil, errors.New("mock NewForConfig error")
+		})
+		defer patches.Reset()
+
+		supported, err := isServiceLbStatusIpModeSupported(c)
+		assert.False(t, supported)
+		assert.ErrorContains(t, err, "mock NewForConfig error")
+	})
+
+	t.Run("ServerVersion returns error", func(t *testing.T) {
+		// Mock discovery client's ServerVersion method
+		patches := gomonkey.ApplyMethodFunc(reflect.TypeOf(&discovery.DiscoveryClient{}), "ServerVersion", func() (*machineryversion.Info, error) {
+			return nil, errors.New("mock ServerVersion error")
+		})
+		defer patches.Reset()
+
+		supported, err := isServiceLbStatusIpModeSupported(c)
+		assert.False(t, supported)
+		assert.ErrorContains(t, err, "mock ServerVersion error")
+	})
+
+	t.Run("ParseGeneric returns error", func(t *testing.T) {
+		patches := gomonkey.ApplyMethodFunc(reflect.TypeOf(&discovery.DiscoveryClient{}), "ServerVersion", func() (*machineryversion.Info, error) {
+			return &machineryversion.Info{GitVersion: "invalid"}, nil
+		})
+		defer patches.Reset()
+
+		supported, err := isServiceLbStatusIpModeSupported(c)
+		assert.False(t, supported)
+		assert.ErrorContains(t, err, "could not parse")
+	})
+
+	t.Run("version less than 1.29.0", func(t *testing.T) {
+		patches := gomonkey.ApplyMethodFunc(reflect.TypeOf(&discovery.DiscoveryClient{}), "ServerVersion", func() (*machineryversion.Info, error) {
+			return &machineryversion.Info{GitVersion: "v1.28.0"}, nil
+		})
+		defer patches.Reset()
+
+		supported, err := isServiceLbStatusIpModeSupported(c)
+		assert.False(t, supported)
+		assert.NoError(t, err)
+	})
+
+	t.Run("version greater than 1.29.0", func(t *testing.T) {
+		patches := gomonkey.ApplyMethodFunc(reflect.TypeOf(&discovery.DiscoveryClient{}), "ServerVersion", func() (*machineryversion.Info, error) {
+			return &machineryversion.Info{GitVersion: "v1.30.0"}, nil
+		})
+		defer patches.Reset()
+
+		supported, err := isServiceLbStatusIpModeSupported(c)
+		assert.True(t, supported)
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
If k8s version is failed to get when creating the Service lb controller, Service lb controller may not be start and result in lb service traffic issue.

We shall restart the nsx operator in this case.