### PR TITLE
Reject allow-all egress rules with named ports in SecurityPolicy

### DIFF
--- a/pkg/nsx/services/securitypolicy/expand.go
+++ b/pkg/nsx/services/securitypolicy/expand.go
@@ -51,6 +51,12 @@ func (service *SecurityPolicyService) expandRule(obj *v1alpha1.SecurityPolicy, r
 		return nil, []*model.Rule{nsxRule}, nil
 	}
 
+	// The rule contains at least one named port. Named ports can only be resolved when the
+	// target pods are determinable, so reject rule shapes that make resolution impossible.
+	if err := validateNamedPortRule(rule); err != nil {
+		return nil, nil, err
+	}
+
 	var nsxRules []*model.Rule
 	// nsxGroups is a slice for the IPSet groups referred by a security Rule if named port is configured.
 	var nsxGroups []*model.Group
@@ -154,6 +160,33 @@ func (service *SecurityPolicyService) expandRuleByService(obj *v1alpha1.Security
 	}
 	log.Debug("Built rule by service entry", "nsxRule", nsxRule)
 	return nsxGroups, nsxRule, nil
+}
+
+// validateNamedPortRule rejects rule shapes whose named ports cannot be resolved. A named port is
+// resolved by looking up the target pods, so for an egress (OUT) rule the destination must select
+// pods. An allow-all egress rule (no destination peers) or one whose destinations are ipBlocks
+// provides no pods to resolve against, which would otherwise result in no NSX rule being realized.
+// This aligns with NCP's validation behavior. The caller must only invoke this for rules that
+// contain a named port.
+func validateNamedPortRule(rule *v1alpha1.SecurityPolicyRule) error {
+	ruleDirection, err := getRuleDirection(rule)
+	if err != nil {
+		return err
+	}
+	if ruleDirection != "OUT" {
+		return nil
+	}
+
+	outPeers := getRuleDestinationPeers(rule)
+	if len(outPeers) == 0 {
+		return &nsxutil.ValidationError{Desc: "Allow-all egress rules are not supported with named port"}
+	}
+	for _, peer := range outPeers {
+		if len(peer.IPBlocks) > 0 {
+			return &nsxutil.ValidationError{Desc: "ipBlock selectors in egress rules are not supported with named port"}
+		}
+	}
+	return nil
 }
 
 // Resolve a named port to port number by rule and policy selector.

--- a/pkg/nsx/services/securitypolicy/expand_test.go
+++ b/pkg/nsx/services/securitypolicy/expand_test.go
@@ -5,6 +5,7 @@ package securitypolicy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -28,6 +29,7 @@ import (
 	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 func TestSecurityPolicyService_buildRuleIPGroup(t *testing.T) {
@@ -324,6 +326,37 @@ var secPolicy = &v1alpha1.SecurityPolicy{
 }
 
 func Test_ExpandRule(t *testing.T) {
+	testSecPolicy := secPolicy.DeepCopy()
+	testSecPolicy.Spec.Rules = append(testSecPolicy.Spec.Rules, v1alpha1.SecurityPolicyRule{
+		Name:      "rule4",
+		Action:    &allowAction,
+		Direction: &directionOut,
+		Ports: []v1alpha1.SecurityPolicyPort{
+			{
+				Protocol: "TCP",
+				Port:     intstr.IntOrString{Type: intstr.String, StrVal: "http"},
+			},
+		},
+		To: []v1alpha1.SecurityPolicyPeer{},
+	})
+	testSecPolicy.Spec.Rules = append(testSecPolicy.Spec.Rules, v1alpha1.SecurityPolicyRule{
+		Name:      "rule5",
+		Action:    &allowAction,
+		Direction: &directionOut,
+		Ports: []v1alpha1.SecurityPolicyPort{
+			{
+				Protocol: "TCP",
+				Port:     intstr.IntOrString{Type: intstr.String, StrVal: "http"},
+			},
+		},
+		To: []v1alpha1.SecurityPolicyPeer{
+			{
+				IPBlocks: []v1alpha1.IPBlock{
+					{CIDR: "192.168.1.0/24"},
+				},
+			},
+		},
+	})
 	ruleTagsFn := func(policyType string) []model.Tag {
 		return []model.Tag{
 			{Scope: common.String("nsx-op/cluster"), Tag: common.String("k8scl-one")},
@@ -557,6 +590,18 @@ func Test_ExpandRule(t *testing.T) {
 					Tags:           spT1RuleTags,
 				},
 			},
+		}, {
+			name:       "VPC: rule with named ports for SecurityPolicy but empty To (Egress)",
+			vpcEnabled: true,
+			ruleIdx:    3,
+			createdFor: common.ResourceTypeSecurityPolicy,
+			expErr:     "Allow-all egress rules are not supported with named port",
+		}, {
+			name:       "VPC: rule with named ports for SecurityPolicy but IPBlocks in To (Egress)",
+			vpcEnabled: true,
+			ruleIdx:    4,
+			createdFor: common.ResourceTypeSecurityPolicy,
+			expErr:     "ipBlock selectors in egress rules are not supported with named port",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -582,12 +627,16 @@ func Test_ExpandRule(t *testing.T) {
 				vpcService: &mockVPCService,
 			}
 			svc.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
-			ruleBaseID := svc.buildRuleID(secPolicy, tc.ruleIdx, tc.createdFor)
+			ruleBaseID := svc.buildRuleID(testSecPolicy, tc.ruleIdx, tc.createdFor)
 
-			rule := secPolicy.Spec.Rules[tc.ruleIdx]
-			nsxGroups, nsxRules, err := svc.expandRule(secPolicy, &rule, tc.ruleIdx, ruleBaseID, tc.createdFor, &VPCInfo[0])
+			rule := testSecPolicy.Spec.Rules[tc.ruleIdx]
+			nsxGroups, nsxRules, err := svc.expandRule(testSecPolicy, &rule, tc.ruleIdx, ruleBaseID, tc.createdFor, &VPCInfo[0])
 			if tc.expErr != "" {
 				require.EqualError(t, err, tc.expErr)
+				// The error must be a *ValidationError so that controllers matching it via
+				// errors.As can surface a validation failure to the user.
+				var validationErr *nsxutil.ValidationError
+				assert.True(t, errors.As(err, &validationErr))
 			} else {
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
Allow-all egress rules with named ports are not supported because the target pods cannot be determined to resolve the named ports. This behavior is specifically aligned with NCP's validation behavior (where it raises NetworkPolicySpecNotSupported) and avoids silent failure where no security policy rule is realized on NSX.

Testing done:
The NSX Operator can report the error for the following security policies or network policies:
- Case 1. egress rule with named port but without `to` field
SecurityPolicy:
```
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SecurityPolicy
...
spec:
  appliedTo:
  - podSelector:
      matchLabels:
        app: my-app
  rules:
  - action: allow
    direction: out
    ports:
    - port: http
      protocol: TCP
status:
  conditions:
  - lastTransitionTime: "2026-06-30T06:50:00Z"
    message: 'error occurred while processing the SecurityPolicy CR. Error: Allow-all
      egress rules are not supported with named port'
    reason: SecurityPolicyNotReady
    status: "False"
    type: Ready
```
NetworkPolicy:
```
Name:         np-named-port-allow-all-egress
Namespace:    svc-cci-ns-r8pxz
Created on:   2026-06-30 06:50:45 +0000 UTC
Labels:       <none>
Annotations:  nsx-op/error: NETWORK_POLICY_VALIDATION_FAILED
Spec:
  PodSelector:     app=my-app
  Not affecting ingress traffic
  Allowing egress traffic:
    To Port: http/TCP
    To: <any> (traffic not restricted by destination)
  Policy Types: Egress
```
- Case 2. egress with named port and only `ipBlock` in `to` field
SecurityPolicy:
```
Name:         named-port-ipblock-egress
Namespace:    svc-cci-ns-r8pxz
...
Spec:
  Applied To:
    Pod Selector:
      Match Labels:
        App:  my-app
  Rules:
    Action:     allow
    Direction:  out
    Ports:
      Port:      http
      Protocol:  TCP
    To:
      Ip Blocks:
        Cidr:  192.168.1.0/24
Status:
  Conditions:
    Last Transition Time:  2026-06-30T06:51:27Z
    Message:               error occurred while processing the SecurityPolicy CR. Error: ipBlock selectors in egress rules are not supported with named port
    Reason:                SecurityPolicyNotReady
    Status:                False
    Type:                  Ready
Events:
  Type     Reason      Age                  From                       Message
  ----     ------      ----                 ----                       -------
  Warning  FailUpdate  105s                 securitypolicy-controller  ipBlock selectors in egress rules are not supported with named port
```
NetworkPolicy:
```
Name:         np-named-port-ipblock-egress
Namespace:    svc-cci-ns-r8pxz
Created on:   2026-06-30 06:54:01 +0000 UTC
Labels:       <none>
Annotations:  nsx-op/error: NETWORK_POLICY_VALIDATION_FAILED
Spec:
  PodSelector:     app=my-app
  Not affecting ingress traffic
  Allowing egress traffic:
    To Port: http/TCP
    To:
      IPBlock:
        CIDR: 192.168.1.0/24
        Except:
  Policy Types: Egress
```