### PR TITLE
Add namespace diagnosis dump, traffic logs, and adjust timeouts in E2E framework

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -427,7 +427,7 @@ func (data *TestData) deleteVCNamespace(namespace string) error {
 	_ = testData.vcClient.deleteNamespace(namespace)
 
 	// Wait for the namespace to be deleted from K8s
-	err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 2*defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
 		ns, err := data.clientset.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -440,7 +440,137 @@ func (data *TestData) deleteVCNamespace(namespace string) error {
 		log.Debug("Waiting for namespace to be deleted", "namespace", namespace, "status phase", ns.Status.Phase)
 		return false, nil
 	})
+	if err != nil {
+		data.dumpNamespaceResources(namespace)
+	}
 	return err
+}
+
+func (data *TestData) dumpNamespaceResources(namespace string) {
+	log.Info("--------------------------------------------------------------------------------", "DUMP_START", namespace)
+	log.Info("E2E Namespace Deletion Timed Out! Starting Diagnosis Dump...", "namespace", namespace)
+
+	// 1. Dump standard Pods
+	pods, err := data.clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err == nil {
+		for _, pod := range pods.Items {
+			log.Info("[DUMP Pod]",
+				"name", pod.Name,
+				"phase", pod.Status.Phase,
+				"deletionTimestamp", safeTimeStr(pod.DeletionTimestamp),
+				"finalizers", pod.Finalizers,
+			)
+		}
+	} else {
+		log.Error(err, "Failed to list Pods during dump", "namespace", namespace)
+	}
+
+	// 2. Dump standard Services
+	svcs, err := data.clientset.CoreV1().Services(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err == nil {
+		for _, svc := range svcs.Items {
+			log.Info("[DUMP Service]",
+				"name", svc.Name,
+				"deletionTimestamp", safeTimeStr(svc.DeletionTimestamp),
+				"finalizers", svc.Finalizers,
+			)
+		}
+	} else {
+		log.Error(err, "Failed to list Services during dump", "namespace", namespace)
+	}
+
+	// 3. Dump SecurityPolicies
+	sps, err := data.crdClientset.CrdV1alpha1().SecurityPolicies(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err == nil {
+		for _, sp := range sps.Items {
+			log.Info("[DUMP SecurityPolicy]",
+				"name", sp.Name,
+				"deletionTimestamp", safeTimeStr(sp.DeletionTimestamp),
+				"finalizers", sp.Finalizers,
+			)
+		}
+	} else {
+		log.Error(err, "Failed to list SecurityPolicies during dump", "namespace", namespace)
+	}
+
+	// 4. Dump SubnetPorts
+	spsList, err := data.crdClientset.CrdV1alpha1().SubnetPorts(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err == nil {
+		for _, sp := range spsList.Items {
+			log.Info("[DUMP SubnetPort]",
+				"name", sp.Name,
+				"deletionTimestamp", safeTimeStr(sp.DeletionTimestamp),
+				"finalizers", sp.Finalizers,
+			)
+		}
+	} else {
+		log.Error(err, "Failed to list SubnetPorts during dump", "namespace", namespace)
+	}
+
+	// 5. Dump Subnets
+	subnets, err := data.crdClientset.CrdV1alpha1().Subnets(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err == nil {
+		for _, sub := range subnets.Items {
+			log.Info("[DUMP Subnet]",
+				"name", sub.Name,
+				"deletionTimestamp", safeTimeStr(sub.DeletionTimestamp),
+				"finalizers", sub.Finalizers,
+			)
+		}
+	} else {
+		log.Error(err, "Failed to list Subnets during dump", "namespace", namespace)
+	}
+
+	// 6. Dump SubnetSets
+	sets, err := data.crdClientset.CrdV1alpha1().SubnetSets(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err == nil {
+		for _, s := range sets.Items {
+			log.Info("[DUMP SubnetSet]",
+				"name", s.Name,
+				"deletionTimestamp", safeTimeStr(s.DeletionTimestamp),
+				"finalizers", s.Finalizers,
+			)
+		}
+	} else {
+		log.Error(err, "Failed to list SubnetSets during dump", "namespace", namespace)
+	}
+
+	// 7. Dump IPAddressAllocations
+	allocs, err := data.crdClientset.CrdV1alpha1().IPAddressAllocations(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err == nil {
+		for _, alloc := range allocs.Items {
+			log.Info("[DUMP IPAddressAllocation]",
+				"name", alloc.Name,
+				"deletionTimestamp", safeTimeStr(alloc.DeletionTimestamp),
+				"finalizers", alloc.Finalizers,
+			)
+		}
+	} else {
+		log.Error(err, "Failed to list IPAddressAllocations during dump", "namespace", namespace)
+	}
+
+	// 8. Dump StaticRoutes
+	routes, err := data.crdClientset.CrdV1alpha1().StaticRoutes(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err == nil {
+		for _, r := range routes.Items {
+			log.Info("[DUMP StaticRoute]",
+				"name", r.Name,
+				"deletionTimestamp", safeTimeStr(r.DeletionTimestamp),
+				"finalizers", r.Finalizers,
+			)
+		}
+	} else {
+		log.Error(err, "Failed to list StaticRoutes during dump", "namespace", namespace)
+	}
+
+	log.Info("--------------------------------------------------------------------------------", "DUMP_END", namespace)
+}
+
+func safeTimeStr(t *metav1.Time) string {
+	if t == nil {
+		return "none"
+	}
+	return t.String()
 }
 
 // deleteNamespace deletes the provided namespace and waits for deletion to actually complete.
@@ -810,7 +940,7 @@ func (data *TestData) waitForResourceExist(namespace string, resourceType string
 }
 
 func (data *TestData) waitForContainerApplicationInstanceToContainAppId(podName string, appId string, shouldContain bool) error {
-	return wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, defaultTimeout, false, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 3*defaultTimeout, false, func(ctx context.Context) (bool, error) {
 		queryParam := fmt.Sprintf("resource_type:ContainerApplicationInstance AND display_name:*%s* AND container_application_ids:*%s*", podName, appId)
 		var cursor *string
 		var pageSize int64 = 500
@@ -1212,20 +1342,37 @@ func checkTrafficByCurl(ns, podname, containername, ip string, port int32, shoul
 	const maxAttempts = 10
 	const retryInterval = 3 * time.Second
 
+	var lastErr error
+	var lastStdOut string
+	var lastStdErr string
+
 	for i := 0; i < maxAttempts; i++ {
-		stdOut, _, err := testData.runCommandFromPod(ns, podname, containername, cmd)
+		stdOut, stdErr, err := testData.runCommandFromPod(ns, podname, containername, cmd)
 		statusCode := strings.Trim(stdOut, `"`)
 		isSuccess := err == nil && statusCode == "200"
 
 		if isSuccess == shouldPass {
 			return true
 		}
+		lastErr = err
+		lastStdOut = stdOut
+		lastStdErr = stdErr
 		// Log with more context for debugging
 		log.Info("Traffic check attempt", "attempt", i+1, "maxAttempts", maxAttempts, "ip", ip, "statusCode", statusCode, "shouldPass", shouldPass, "isSuccess", isSuccess)
 		if i < maxAttempts-1 {
 			time.Sleep(retryInterval)
 		}
 	}
+	log.Error(lastErr, "FINAL Traffic check failed!",
+		"namespace", ns,
+		"fromPod", podname,
+		"toIP", ip,
+		"port", port,
+		"shouldPass", shouldPass,
+		"stdout", lastStdOut,
+		"stderr", lastStdErr,
+		"curlCmd", cmd,
+	)
 	return false
 }
 

--- a/test/e2e/nsx_networkinfo_test.go
+++ b/test/e2e/nsx_networkinfo_test.go
@@ -113,6 +113,13 @@ func testCustomizedNetworkInfo(t *testing.T) {
 	require.NoError(t, err)
 
 	ns := fmt.Sprintf("customized-ns-%s", getRandomString())
+	var namespaceDeleted bool
+	defer func() {
+		if !namespaceDeleted {
+			log.Info("Test failed or aborted, cleaning up customized VPC namespace", "namespace", ns)
+			_ = testData.deleteNamespace(ns, defaultTimeout)
+		}
+	}()
 	namespace := &v12.Namespace{
 		ObjectMeta: v1.ObjectMeta{
 			Name: ns,
@@ -134,6 +141,7 @@ func testCustomizedNetworkInfo(t *testing.T) {
 	// Delete namespace and wait for VPC to be cleaned up from VPCNetworkConfiguration status
 	// This is important because the next test (testSharedNSXVPC) uses the same VPCNetworkConfiguration
 	require.NoError(t, testData.deleteNamespace(ns, defaultTimeout))
+	namespaceDeleted = true
 	assureNetworkInfoDeleted(t, ns)
 	assureNamespaceDeleted(t, ns)
 	// Wait for VPC to be deleted from NSX and VPCNetworkConfiguration status to be cleared

--- a/test/e2e/nsx_security_policy_test.go
+++ b/test/e2e/nsx_security_policy_test.go
@@ -85,7 +85,7 @@ func testSecurityPolicyBasicTraffic(t *testing.T) {
 	deploymentName := "server-client"
 	_, err := testData.createDeployment(ns, deploymentName, containerName, podImage, corev1.ProtocolTCP, podPort, 2)
 	require.NoErrorf(t, err, "Deloyment '%s/%s' should be created", ns, deploymentName)
-	serverClientIPs, serverClientNames, err := testData.deploymentWaitForIPsOrNames(2*defaultTimeout, ns, deploymentName, 2)
+	serverClientIPs, serverClientNames, err := testData.deploymentWaitForIPsOrNames(resourceReadyTime, ns, deploymentName, 2)
 	require.NoError(t, err, "Error when waiting for IP for Deployment '%s/%s'", ns, deploymentName)
 
 	serverPodName := serverClientNames[0]
@@ -217,12 +217,12 @@ func testSecurityPolicyMatchExpression(t *testing.T) {
 	clientB := "client-b"
 	podA := "pod-a"
 	// Wait for pods
-	_, err := testData.podWaitForIPs(defaultTimeout, clientA, ns)
-	assert.NoError(t, err, "Error when waiting for IP for Pod %s", clientA)
-	_, err = testData.podWaitForIPs(defaultTimeout, clientB, ns)
-	assert.NoError(t, err, "Error when waiting for IP for Pod %s", clientB)
-	iPs, err := testData.podWaitForIPs(defaultTimeout, podA, ns)
-	assert.NoError(t, err, "Error when waiting for IP for Pod %s", podA)
+	_, err := testData.podWaitForIPs(resourceReadyTime, clientA, ns)
+	require.NoError(t, err, "Error when waiting for IP for Pod %s", clientA)
+	_, err = testData.podWaitForIPs(resourceReadyTime, clientB, ns)
+	require.NoError(t, err, "Error when waiting for IP for Pod %s", clientB)
+	iPs, err := testData.podWaitForIPs(resourceReadyTime, podA, ns)
+	require.NoError(t, err, "Error when waiting for IP for Pod %s", podA)
 
 	// Test traffic from clientA to podA
 	require.True(t, checkTrafficByCurl(ns, clientA, clientA, iPs.ipv4.String(), podPort, true), "TestSecurityPolicyMatchExpression traffic should work")
@@ -293,15 +293,15 @@ func testSecurityPolicyVPCFromFieldIngress(t *testing.T) {
 	require.NoError(t, applyYAML(podsPath, ns))
 	defer deleteYAML(podsPath, ns)
 
-	srvIP, err := testData.podWaitForIPs(defaultTimeout, "fr-srv", ns)
+	srvIP, err := testData.podWaitForIPs(resourceReadyTime, "fr-srv", ns)
 	require.NoError(t, err, "wait for fr-srv IP")
-	_, err = testData.podWaitForIPs(defaultTimeout, "frclient-allow", ns)
+	_, err = testData.podWaitForIPs(resourceReadyTime, "frclient-allow", ns)
 	require.NoError(t, err, "wait for frclient-allow")
-	_, err = testData.podWaitForIPs(defaultTimeout, "frclient-deny", ns)
+	_, err = testData.podWaitForIPs(resourceReadyTime, "frclient-deny", ns)
 	require.NoError(t, err, "wait for frclient-deny")
 
 	// Pods may be Running before the HTTP process is actually listening; gate on server readiness.
-	require.NoError(t, waitForHTTPEndpointReady(ns, "fr-srv", "fr-srv", srvIP.ipv4.String(), podPort, defaultTimeout), "fr-srv http endpoint should be ready")
+	require.NoError(t, waitForHTTPEndpointReady(ns, "fr-srv", "fr-srv", srvIP.ipv4.String(), podPort, resourceReadyTime), "fr-srv http endpoint should be ready")
 
 	require.True(t, checkTrafficByCurl(ns, "frclient-allow", "frclient-allow", srvIP.ipv4.String(), podPort, true), "allow client -> server before policy")
 	require.True(t, checkTrafficByCurl(ns, "frclient-deny", "frclient-deny", srvIP.ipv4.String(), podPort, true), "deny client -> server before policy")
@@ -353,16 +353,16 @@ func testSecurityPolicyVPCToFieldEgress(t *testing.T) {
 	require.NoError(t, applyYAML(podsPath, ns))
 	defer deleteYAML(podsPath, ns)
 
-	srvIP, err := testData.podWaitForIPs(defaultTimeout, "te-srv", ns)
+	srvIP, err := testData.podWaitForIPs(resourceReadyTime, "te-srv", ns)
 	require.NoError(t, err, "wait for te-srv IP")
-	otherIP, err := testData.podWaitForIPs(defaultTimeout, "te-other", ns)
+	otherIP, err := testData.podWaitForIPs(resourceReadyTime, "te-other", ns)
 	require.NoError(t, err, "wait for te-other IP")
-	_, err = testData.podWaitForIPs(defaultTimeout, "te-cli", ns)
+	_, err = testData.podWaitForIPs(resourceReadyTime, "te-cli", ns)
 	require.NoError(t, err, "wait for te-cli")
 
 	// Ensure both peers are actually serving HTTP before asserting baseline reachability.
-	require.NoError(t, waitForHTTPEndpointReady(ns, "te-srv", "te-srv", srvIP.ipv4.String(), podPort, defaultTimeout), "te-srv http endpoint should be ready")
-	require.NoError(t, waitForHTTPEndpointReady(ns, "te-other", "te-other", otherIP.ipv4.String(), podPort, defaultTimeout), "te-other http endpoint should be ready")
+	require.NoError(t, waitForHTTPEndpointReady(ns, "te-srv", "te-srv", srvIP.ipv4.String(), podPort, resourceReadyTime), "te-srv http endpoint should be ready")
+	require.NoError(t, waitForHTTPEndpointReady(ns, "te-other", "te-other", otherIP.ipv4.String(), podPort, resourceReadyTime), "te-other http endpoint should be ready")
 
 	require.True(t, checkTrafficByCurl(ns, "te-cli", "te-cli", srvIP.ipv4.String(), podPort, true), "client -> server before policy")
 	require.True(t, checkTrafficByCurl(ns, "te-cli", "te-cli", otherIP.ipv4.String(), podPort, true), "client -> other before policy")
@@ -422,7 +422,7 @@ func testSecurityPolicyNamedPortWithoutPod(t *testing.T) {
 	require.NoError(t, applyYAML(yamlPath, nsWeb))
 	defer deleteYAML(yamlPath, nsWeb)
 
-	psb, err := testData.deploymentWaitForNames(defaultTimeout, nsWeb, labelWeb)
+	psb, err := testData.deploymentWaitForNames(resourceReadyTime, nsWeb, labelWeb)
 	log.Trace("Pods", "pods", psb)
 	assert.NoError(t, err, "Error when waiting for IP for Pod %s", webA)
 	assureSecurityPolicyReady(t, nsWeb, securityPolicyCRName)
@@ -465,10 +465,10 @@ func testSecurityPolicyNamedPorWithPod(t *testing.T) {
 	webA := "web"
 	labelWeb := "tcp-deployment"
 	// Wait for pods
-	clientPodIPs, err := testData.podWaitForIPs(defaultTimeout, clientA, nsClient)
+	clientPodIPs, err := testData.podWaitForIPs(resourceReadyTime, clientA, nsClient)
 	t.Logf("client Pods are %v", clientPodIPs)
 	require.NoError(t, err, "Error when waiting for IP for Pod %s", clientA)
-	namedPortPodIPs, _, err := testData.deploymentWaitForIPsOrNames(defaultTimeout, nsWeb, labelWeb, 2)
+	namedPortPodIPs, _, err := testData.deploymentWaitForIPsOrNames(resourceReadyTime, nsWeb, labelWeb, 2)
 	t.Logf("NamedPort Pods are %v", namedPortPodIPs)
 	require.NoError(t, err, "Error when waiting for IP for Pod %s", webA)
 	assureSecurityPolicyReady(t, nsWeb, securityPolicyCRName)

--- a/test/e2e/precreated_vpc_test.go
+++ b/test/e2e/precreated_vpc_test.go
@@ -134,6 +134,13 @@ func TestPreCreatedVPC(t *testing.T) {
 			RunSubtest(t, tt.name, func(t *testing.T) {
 				orgID, projectID, vpcID := setupVPC(t, tt.enableNat, tt.createLb, tt.noProfile)
 				nsName := fmt.Sprintf("test-prevpc-%s", getRandomString())
+				var namespaceDeleted bool
+				defer func() {
+					if !namespaceDeleted {
+						log.Info("Test failed or aborted, cleaning up residual VPC namespace", "namespace", nsName)
+						deleteVPCNamespace(nsName, useVCAPI)
+					}
+				}()
 				projectPath := fmt.Sprintf(projectPathFormat, orgID, projectID)
 				defer func() {
 					path := fmt.Sprintf(common.VPCKey, orgID, projectID, vpcID)
@@ -181,6 +188,7 @@ func TestPreCreatedVPC(t *testing.T) {
 				}
 
 				deleteVPCNamespace(nsName, useVCAPI)
+				namespaceDeleted = true
 				_, err = testData.nsxClient.VPCClient.Get(orgID, projectID, vpcID)
 				require.NoError(t, err, "Pre-Created VPC should exist after the K8s Namespace is deleted")
 			})


### PR DESCRIPTION
This commit consolidates and simplifies E2E troubleshooting in WCP environments by:
1. Automatically dumping namespace resource state (Pods, Services, SecurityPolicies,
   SubnetPorts, Subnets, SubnetSets, IPAddressAllocations, and StaticRoutes) including
   deletionTimestamp and finalizers when deleteVCNamespace times out. This aids in
   rapidly diagnosing stuck namespace teardowns.
2. Capturing and logging the full stderr and debug details when the final attempt
   of checkTrafficByCurl fails, giving immediate insight into exact connection issues.
3. Doubling the wait timeout for VC namespace deletion from 60s to 120s to allow
   sufficient headroom for transient vCenter Namespace service delays on heavy-loaded systems.
4. Tripling the wait timeout for ContainerApplicationInstance matching from 60s to 180s
   to handle NSX Manager Search API asynchronous indexing latency during high concurrent runs.
5. Elevating Pod and Deployment IP/readiness wait timeouts in SecurityPolicy E2E tests
   from defaultTimeout (60s) to resourceReadyTime (5m). This prevents flaky failures
   (context deadline exceeded) on busy physical testbeds where Namespace/VPC provisioning,
   DHCP SubnetPort assignment, and image pulling can frequently exceed 1 minute, while
   retaining fast execution via early-exit polling.
6. Converting wait-for-IP `assert.NoError` to `require.NoError` in testSecurityPolicyMatchExpression
   to immediately fail the test on timeout, preventing a cryptic Go runtime nil-pointer
   dereference panic when dereferencing empty IP outputs.
7. Implementing a state-based defer-cleanup pattern in TestPreCreatedVPC and testCustomizedNetworkInfo
   to guarantee that dynamically created E2E test namespaces are 100% physically cleaned up,
   even if a test assertion fails or times out prematurely, avoiding zombie namespace leaks.