### PR TITLE
[Draft] backup/restore

### DIFF
--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -135,18 +135,15 @@ const (
 	SubnetPortGCInterval = 60 * time.Second
 	DefaultSNATID        = "DEFAULT"
 	AVISubnetLBID        = "_services"
-	// LBServiceIPAllocationID is the fixed NSX resource ID for the VPC-level LB service IPv4 allocation used in tepless mode.
-	// It's only used for backup/restore.
-	LBServiceIPAllocationID = "_DEFAULT--VPC_SERVICE_IP"
-	// LBServiceIPAllocationIDV6 is the fixed NSX resource ID for the VPC-level LB service IPv6 allocation used in tepless mode.
-	// It's only used for backup/restore.
-	LBServiceIPAllocationIDV6   = "_DEFAULT--VPC_SERVICE_IP_V6"
-	TagScopeVPCService          = "services/vpc_service"
-	TagValueUserSpecifiedIP     = "__DEFAULT--VPC_SERVICE_IP__"
-	// TODO: verify TagValueUserSpecifiedIPV6 against a real NSX dual-stack tepless VPC before merge.
-	// Run: GET /policy/api/v1/orgs/<org>/projects/<project>/vpcs/<vpc>/ip-address-allocations/_DEFAULT--VPC_SERVICE_IP_V6
-	// and check the tags[].tag field.
-	TagValueUserSpecifiedIPV6 = "__DEFAULT--VPC_SERVICE_IP_V6__"
+	// LBServiceIPAllocationID and LBServiceIPAllocationIDV6 are the well-known NSX resource IDs for the
+	// VPC-level LB SNAT IP allocations in tepless (VLANBackedVPC) mode. Used only during backup/restore.
+	LBServiceIPAllocationID   = "_DEFAULT--VPC_SERVICE_IP"
+	LBServiceIPAllocationIDV6 = "_DEFAULT--VPC_SERVICE_IP_V6"
+	TagScopeVPCService        = "services/vpc_service"
+	// TagValueUserSpecifiedIP is the NSX tag that marks a VPC LB service IP allocation as user-specified.
+	// NSX uses the same tag value for both IPv4 and IPv6 allocations.
+	TagValueUserSpecifiedIP   = "__DEFAULT--VPC_SERVICE_IP__"
+	TagValueUserSpecifiedIPV6 = "__DEFAULT--VPC_SERVICE_IP__"
 
 	NSXServiceAccountFinalizerName = "nsxserviceaccount.nsx.vmware.com/finalizer"
 	T1SecurityPolicyFinalizerName  = "securitypolicy.nsx.vmware.com/finalizer"

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -135,11 +135,18 @@ const (
 	SubnetPortGCInterval = 60 * time.Second
 	DefaultSNATID        = "DEFAULT"
 	AVISubnetLBID        = "_services"
-	// LBServiceIPAllocationID is the fixed NSX resource ID for the VPC-level LB service IP allocation used in tepless mode.
-	// It's only used for backup/restore
+	// LBServiceIPAllocationID is the fixed NSX resource ID for the VPC-level LB service IPv4 allocation used in tepless mode.
+	// It's only used for backup/restore.
 	LBServiceIPAllocationID = "_DEFAULT--VPC_SERVICE_IP"
-	TagScopeVPCService      = "services/vpc_service"
-	TagValueUserSpecifiedIP = "__DEFAULT--VPC_SERVICE_IP__"
+	// LBServiceIPAllocationIDV6 is the fixed NSX resource ID for the VPC-level LB service IPv6 allocation used in tepless mode.
+	// It's only used for backup/restore.
+	LBServiceIPAllocationIDV6   = "_DEFAULT--VPC_SERVICE_IP_V6"
+	TagScopeVPCService          = "services/vpc_service"
+	TagValueUserSpecifiedIP     = "__DEFAULT--VPC_SERVICE_IP__"
+	// TODO: verify TagValueUserSpecifiedIPV6 against a real NSX dual-stack tepless VPC before merge.
+	// Run: GET /policy/api/v1/orgs/<org>/projects/<project>/vpcs/<vpc>/ip-address-allocations/_DEFAULT--VPC_SERVICE_IP_V6
+	// and check the tags[].tag field.
+	TagValueUserSpecifiedIPV6 = "__DEFAULT--VPC_SERVICE_IP_V6__"
 
 	NSXServiceAccountFinalizerName = "nsxserviceaccount.nsx.vmware.com/finalizer"
 	T1SecurityPolicyFinalizerName  = "securitypolicy.nsx.vmware.com/finalizer"

--- a/pkg/nsx/services/vpc/builder.go
+++ b/pkg/nsx/services/vpc/builder.go
@@ -120,9 +120,9 @@ func buildNSXLBS(obj *v1alpha1.NetworkInfo, nsObj *v1.Namespace, cluster, lbsSiz
 	return lbs, nil
 }
 
-// buildNSXLBServiceIPAllocation builds the VpcIpAddressAllocation used to pin the LB service IP in tepless (VLANBackedVPC)
-// restore mode. The allocation uses the fixed well-known ID "_DEFAULT--VPC_SERVICE_IP" and carries the IP that was
-// previously reported in NetworkInfo.VPCs[0].LoadBalancerIPAddresses so that NSX re-uses the same address.
+// buildNSXLBServiceIPAllocation builds the VpcIpAddressAllocation used to pin the LB service IPv4 IP in tepless
+// (VLANBackedVPC) restore mode. The allocation uses the fixed well-known ID "_DEFAULT--VPC_SERVICE_IP" and carries
+// the IP that was previously reported in NetworkInfo so that NSX re-uses the same address.
 func buildNSXLBServiceIPAllocation(lbIP string) *model.VpcIpAddressAllocation {
 	visibility := model.VpcIpAddressAllocation_IP_ADDRESS_BLOCK_VISIBILITY_EXTERNAL
 	ipType := model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV4
@@ -136,6 +136,25 @@ func buildNSXLBServiceIPAllocation(lbIP string) *model.VpcIpAddressAllocation {
 			{
 				Scope: common.String(common.TagScopeVPCService),
 				Tag:   common.String(common.TagValueUserSpecifiedIP),
+			},
+		},
+	}
+}
+
+// buildNSXLBServiceIPv6Allocation builds the VpcIpAddressAllocation used to pin the LB service IPv6 IP in tepless
+// (VLANBackedVPC) restore mode. The allocation uses the fixed well-known ID "_DEFAULT--VPC_SERVICE_IP_V6".
+// IpAddressBlockVisibility is intentionally omitted: the NSX API does not accept it for IPv6 allocations.
+func buildNSXLBServiceIPv6Allocation(lbIP string) *model.VpcIpAddressAllocation {
+	ipType := model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV6
+	return &model.VpcIpAddressAllocation{
+		Id:           common.String(common.LBServiceIPAllocationIDV6),
+		DisplayName:  common.String(common.LBServiceIPAllocationIDV6),
+		AllocationIp: common.String(lbIP),
+		IpAddressType: &ipType,
+		Tags: []model.Tag{
+			{
+				Scope: common.String(common.TagScopeVPCService),
+				Tag:   common.String(common.TagValueUserSpecifiedIPV6),
 			},
 		},
 	}

--- a/pkg/nsx/services/vpc/builder.go
+++ b/pkg/nsx/services/vpc/builder.go
@@ -141,16 +141,18 @@ func buildNSXLBServiceIPAllocation(lbIP string) *model.VpcIpAddressAllocation {
 	}
 }
 
-// buildNSXLBServiceIPv6Allocation builds the VpcIpAddressAllocation used to pin the LB service IPv6 IP in tepless
-// (VLANBackedVPC) restore mode. The allocation uses the fixed well-known ID "_DEFAULT--VPC_SERVICE_IP_V6".
-// IpAddressBlockVisibility is intentionally omitted: the NSX API does not accept it for IPv6 allocations.
+// buildNSXLBServiceIPv6Allocation builds the VpcIpAddressAllocation to re-pin the LB service IPv6 SNAT IP
+// during tepless (VLANBackedVPC) restore. Ipv6AllocationPrefixLength must be 128 to request a single /128
+// host address; without it NSX defaults to /64 and rejects the allocation. IpAddressBlockVisibility is
+// omitted because the NSX API does not accept it for IPv6 allocations.
 func buildNSXLBServiceIPv6Allocation(lbIP string) *model.VpcIpAddressAllocation {
 	ipType := model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV6
 	return &model.VpcIpAddressAllocation{
-		Id:           common.String(common.LBServiceIPAllocationIDV6),
-		DisplayName:  common.String(common.LBServiceIPAllocationIDV6),
-		AllocationIp: common.String(lbIP),
-		IpAddressType: &ipType,
+		Id:                         common.String(common.LBServiceIPAllocationIDV6),
+		DisplayName:                common.String(common.LBServiceIPAllocationIDV6),
+		AllocationIp:               common.String(lbIP),
+		IpAddressType:              &ipType,
+		Ipv6AllocationPrefixLength: common.Int64(128),
 		Tags: []model.Tag{
 			{
 				Scope: common.String(common.TagScopeVPCService),

--- a/pkg/nsx/services/vpc/builder_test.go
+++ b/pkg/nsx/services/vpc/builder_test.go
@@ -342,6 +342,10 @@ func Test_buildNSXLBServiceIPv6Allocation(t *testing.T) {
 				// IpAddressBlockVisibility must NOT be set for IPv6 allocations.
 				assert.Nil(t, alloc.IpAddressBlockVisibility)
 				assert.Equal(t, model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV6, *alloc.IpAddressType)
+				// Ipv6AllocationPrefixLength must be 128 — without it NSX defaults to /64
+				// and rejects the allocation with "no spare capacity" (confirmed via live API test).
+				require.NotNil(t, alloc.Ipv6AllocationPrefixLength)
+				assert.Equal(t, int64(128), *alloc.Ipv6AllocationPrefixLength)
 				require.Len(t, alloc.Tags, 1)
 				assert.Equal(t, common.TagScopeVPCService, *alloc.Tags[0].Scope)
 				assert.Equal(t, common.TagValueUserSpecifiedIPV6, *alloc.Tags[0].Tag)

--- a/pkg/nsx/services/vpc/builder_test.go
+++ b/pkg/nsx/services/vpc/builder_test.go
@@ -294,7 +294,7 @@ func Test_buildNSXLBServiceIPAllocation(t *testing.T) {
 		check func(t *testing.T, alloc *model.VpcIpAddressAllocation)
 	}{
 		{
-			name: "builds allocation with correct fields",
+			name: "builds IPv4 allocation with correct fields",
 			lbIP: "10.0.0.5",
 			check: func(t *testing.T, alloc *model.VpcIpAddressAllocation) {
 				assert.Equal(t, common.LBServiceIPAllocationID, *alloc.Id)
@@ -320,6 +320,46 @@ func Test_buildNSXLBServiceIPAllocation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			alloc := buildNSXLBServiceIPAllocation(tt.lbIP)
+			require.NotNil(t, alloc)
+			tt.check(t, alloc)
+		})
+	}
+}
+
+func Test_buildNSXLBServiceIPv6Allocation(t *testing.T) {
+	tests := []struct {
+		name  string
+		lbIP  string
+		check func(t *testing.T, alloc *model.VpcIpAddressAllocation)
+	}{
+		{
+			name: "builds IPv6 allocation with correct fields",
+			lbIP: "2001:db8::1",
+			check: func(t *testing.T, alloc *model.VpcIpAddressAllocation) {
+				assert.Equal(t, common.LBServiceIPAllocationIDV6, *alloc.Id)
+				assert.Equal(t, common.LBServiceIPAllocationIDV6, *alloc.DisplayName)
+				assert.Equal(t, "2001:db8::1", *alloc.AllocationIp)
+				// IpAddressBlockVisibility must NOT be set for IPv6 allocations.
+				assert.Nil(t, alloc.IpAddressBlockVisibility)
+				assert.Equal(t, model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV6, *alloc.IpAddressType)
+				require.Len(t, alloc.Tags, 1)
+				assert.Equal(t, common.TagScopeVPCService, *alloc.Tags[0].Scope)
+				assert.Equal(t, common.TagValueUserSpecifiedIPV6, *alloc.Tags[0].Tag)
+			},
+		},
+		{
+			name: "AllocationIps field is nil (single IPv6 uses AllocationIp)",
+			lbIP: "fd00::1",
+			check: func(t *testing.T, alloc *model.VpcIpAddressAllocation) {
+				assert.Nil(t, alloc.AllocationIps)
+				assert.NotNil(t, alloc.AllocationIp)
+				assert.Equal(t, "fd00::1", *alloc.AllocationIp)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alloc := buildNSXLBServiceIPv6Allocation(tt.lbIP)
 			require.NotNil(t, alloc)
 			tt.check(t, alloc)
 		})

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -727,19 +727,14 @@ func (s *VPCService) checkVPCRealizationState(createdVpc *model.Vpc, newVpcPath 
 	return nil
 }
 
-// buildLBServiceIPAllocsForRestore returns the VpcIpAddressAllocation(s) that should be embedded in the HAPI
-// payload when restoring a tepless (VLANBackedVPC) VPC with NSX LB. It returns nil if the conditions are not
-// met (non-NSXLB provider or non-VLANBackedVPC network stack).
+// buildLBServiceIPAllocsForRestore returns the VpcIpAddressAllocation(s) to embed in the VPC HAPI payload
+// during restore for tepless (VLANBackedVPC) NSX LB VPCs. Returns nil for non-NSXLB or non-VLANBackedVPC.
 //
-// For dual-stack VPCs, both an IPv4 and an IPv6 allocation are returned. For single-stack VPCs only the
-// relevant family is returned.
-//
-// IP sources (in priority order):
-//  1. LoadBalancerBackendIPs — populated with all IPv4/IPv6 IPs since dual-stack support landed.
+// IP source priority:
+//  1. LoadBalancerBackendIPs — carries both IPv4 and IPv6 for dual-stack VPCs.
 //  2. LoadBalancerIPAddresses — fallback for older NetworkInfo CRs that pre-date LoadBalancerBackendIPs.
-//     The IP family is detected via util.IsIPv6 so the correct allocation type is always built.
 //
-// An error is returned when the network stack is VLANBackedVPC + NSXLB but no usable IP is found.
+// Returns an error if the VPC qualifies (VLANBackedVPC + NSXLB) but no usable IP is found.
 func (s *VPCService) buildLBServiceIPAllocsForRestore(obj *v1alpha1.NetworkInfo, nc *v1alpha1.VPCNetworkConfiguration, lbProvider LBProvider) ([]*model.VpcIpAddressAllocation, error) {
 	if lbProvider != NSXLB {
 		return nil, nil

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -492,7 +492,7 @@ func (s *VPCService) GetVpcConnectivityProfile(nc *v1alpha1.VPCNetworkConfigurat
 		log.Error(err, "Failed to parse NSX project in NetworkConfig", "ProjectPath", nc.Spec.NSXProject)
 		return nil, err
 	}
-	vpcConnectivityProfile, err := s.Service.NSXClient.VPCConnectivityProfilesClient.Get(org, project, vpcConnectivityProfileName)
+	vpcConnectivityProfile, err := s.NSXClient.VPCConnectivityProfilesClient.Get(org, project, vpcConnectivityProfileName)
 	if err != nil {
 		log.Error(err, "Failed to get NSX VPCConnectivityProfile object", "vpcConnectivityProfileName", vpcConnectivityProfileName)
 		return nil, err
@@ -881,7 +881,7 @@ func (s *VPCService) GetVpcConnectivityProfilePathByVpcPath(vpcPath string) (str
 		return "", err
 	}
 	// pre created VPC may have more than one attachment, list all the attachment and select the first one
-	vpcAttachmentsListResult, err := s.Service.NSXClient.VpcAttachmentClient.List(VPCResourceInfo.OrgID, VPCResourceInfo.ProjectID, VPCResourceInfo.VPCID, nil, nil, nil, nil, nil, nil)
+	vpcAttachmentsListResult, err := s.NSXClient.VpcAttachmentClient.List(VPCResourceInfo.OrgID, VPCResourceInfo.ProjectID, VPCResourceInfo.VPCID, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		log.Error(err, "Failed to list VPC attachment", "VPC Path", vpcPath)
 		return "", err
@@ -1139,7 +1139,7 @@ func (s *VPCService) getLBProvider(edgeEnable bool) LBProvider {
 				return false
 			}
 		}, func() error {
-			return GetAlbEndpoint(s.Service.NSXClient.Cluster)
+			return GetAlbEndpoint(s.NSXClient.Cluster)
 		}); err == nil {
 			albEndpointFound = true
 		}

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -606,11 +606,11 @@ func (s *VPCService) CreateOrUpdateVPC(ctx context.Context, obj *v1alpha1.Networ
 		}
 		createdLBS, _ = buildNSXLBS(obj, nsObj, s.NSXConfig.Cluster, lbsSize, vpcPath, relaxScaleValidation)
 	}
-	// In tepless (VLANBackedVPC) restore mode with NSX LB, pin the LB service IP that was previously allocated
-	// by embedding a VpcIpAddressAllocation child in the HAPI payload before the LBS.
-	var lbServiceIPAlloc *model.VpcIpAddressAllocation
+	// In tepless (VLANBackedVPC) restore mode with NSX LB, pin the previously allocated LB service IPs
+	// (IPv4 and/or IPv6) by embedding VpcIpAddressAllocation children in the HAPI payload before the LBS.
+	var lbServiceIPAllocs []*model.VpcIpAddressAllocation
 	if restoreMode {
-		lbServiceIPAlloc, err = s.buildLBServiceIPAllocForRestore(obj, nc, lbProvider)
+		lbServiceIPAllocs, err = s.buildLBServiceIPAllocsForRestore(obj, nc, lbProvider)
 		if err != nil {
 			return nil, err
 		}
@@ -641,7 +641,7 @@ func (s *VPCService) CreateOrUpdateVPC(ctx context.Context, obj *v1alpha1.Networ
 		return existingVPC[0], nil
 	}
 
-	orgRoot, err := s.WrapHierarchyVPC(org, project, createdVpc, lbServiceIPAlloc, createdLBS, createdAttachment)
+	orgRoot, err := s.WrapHierarchyVPC(org, project, createdVpc, lbServiceIPAllocs, createdLBS, createdAttachment)
 	if err != nil {
 		log.Error(err, "Failed to build HAPI request")
 		return nil, err
@@ -727,11 +727,20 @@ func (s *VPCService) checkVPCRealizationState(createdVpc *model.Vpc, newVpcPath 
 	return nil
 }
 
-// buildLBServiceIPAllocForRestore returns the VpcIpAddressAllocation that should be embedded in the HAPI payload
-// when restoring a tepless (VLANBackedVPC) VPC with NSX LB. It returns nil if the conditions are not met.
-// An error is returned when the network stack is VLANBackedVPC + NSXLB but the previously allocated IP is missing
-// from the NetworkInfo CR, which means the allocation cannot be restored.
-func (s *VPCService) buildLBServiceIPAllocForRestore(obj *v1alpha1.NetworkInfo, nc *v1alpha1.VPCNetworkConfiguration, lbProvider LBProvider) (*model.VpcIpAddressAllocation, error) {
+// buildLBServiceIPAllocsForRestore returns the VpcIpAddressAllocation(s) that should be embedded in the HAPI
+// payload when restoring a tepless (VLANBackedVPC) VPC with NSX LB. It returns nil if the conditions are not
+// met (non-NSXLB provider or non-VLANBackedVPC network stack).
+//
+// For dual-stack VPCs, both an IPv4 and an IPv6 allocation are returned. For single-stack VPCs only the
+// relevant family is returned.
+//
+// IP sources (in priority order):
+//  1. LoadBalancerBackendIPs — populated with all IPv4/IPv6 IPs since dual-stack support landed.
+//  2. LoadBalancerIPAddresses — fallback for older NetworkInfo CRs that pre-date LoadBalancerBackendIPs.
+//     The IP family is detected via util.IsIPv6 so the correct allocation type is always built.
+//
+// An error is returned when the network stack is VLANBackedVPC + NSXLB but no usable IP is found.
+func (s *VPCService) buildLBServiceIPAllocsForRestore(obj *v1alpha1.NetworkInfo, nc *v1alpha1.VPCNetworkConfiguration, lbProvider LBProvider) ([]*model.VpcIpAddressAllocation, error) {
 	if lbProvider != NSXLB {
 		return nil, nil
 	}
@@ -742,11 +751,48 @@ func (s *VPCService) buildLBServiceIPAllocForRestore(obj *v1alpha1.NetworkInfo, 
 	if networkStack != v1alpha1.VLANBackedVPC {
 		return nil, nil
 	}
-	if len(obj.VPCs) == 0 || len(obj.VPCs[0].LoadBalancerIPAddresses) == 0 {
-		return nil, fmt.Errorf("cannot restore LB service IP allocation for tepless VPC: LoadBalancerIPAddresses is not set in NetworkInfo %s", obj.Name)
+	if len(obj.VPCs) == 0 {
+		return nil, fmt.Errorf("cannot restore LB service IP allocations for tepless VPC: no VPC state in NetworkInfo %s", obj.Name)
 	}
-	log.Debug("Restoring LB service IP allocation for tepless VPC", "IP", obj.VPCs[0].LoadBalancerIPAddresses, "NetworkInfo", obj.Name)
-	return buildNSXLBServiceIPAllocation(obj.VPCs[0].LoadBalancerIPAddresses), nil
+
+	var ipv4IP, ipv6IP string
+
+	// Prefer LoadBalancerBackendIPs which carries both IPv4 and IPv6 for dual-stack VPCs.
+	for _, ip := range obj.VPCs[0].LoadBalancerBackendIPs {
+		if util.IsIPv6(ip) {
+			if ipv6IP == "" {
+				ipv6IP = ip
+			}
+		} else {
+			if ipv4IP == "" {
+				ipv4IP = ip
+			}
+		}
+	}
+
+	// Fallback: use LoadBalancerIPAddresses for NetworkInfo CRs created before LoadBalancerBackendIPs existed.
+	if ipv4IP == "" && ipv6IP == "" {
+		primary := obj.VPCs[0].LoadBalancerIPAddresses
+		if len(primary) == 0 {
+			return nil, fmt.Errorf("cannot restore LB service IP allocations for tepless VPC: LoadBalancerIPAddresses is not set in NetworkInfo %s", obj.Name)
+		}
+		if util.IsIPv6(primary) {
+			ipv6IP = primary
+		} else {
+			ipv4IP = primary
+		}
+	}
+
+	var allocs []*model.VpcIpAddressAllocation
+	if ipv4IP != "" {
+		log.Debug("Restoring IPv4 LB service IP allocation for tepless VPC", "IP", ipv4IP, "NetworkInfo", obj.Name)
+		allocs = append(allocs, buildNSXLBServiceIPAllocation(ipv4IP))
+	}
+	if ipv6IP != "" {
+		log.Debug("Restoring IPv6 LB service IP allocation for tepless VPC", "IP", ipv6IP, "NetworkInfo", obj.Name)
+		allocs = append(allocs, buildNSXLBServiceIPv6Allocation(ipv6IP))
+	}
+	return allocs, nil
 }
 
 func (s *VPCService) checkLBSRealization(createdLBS *model.LBService, createdVpc *model.Vpc, nc *v1alpha1.VPCNetworkConfiguration, newVpcPath string) error {

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -939,8 +939,8 @@ func TestValidateConnectionStatus(t *testing.T) {
 	}
 
 	service, _, _, _, _ := createService(t)
-	service.NSXClient.VPCConnectivityProfilesClient = fakeVPCConnectivityProfilesClient{}
-	service.NSXClient.TransitGatewayAttachmentClient = fakeTransitGatewayAttachmentClient{}
+	service.NSXClient.VPCConnectivityProfilesClient = &fakeVPCConnectivityProfilesClient{}
+	service.NSXClient.TransitGatewayAttachmentClient = &fakeTransitGatewayAttachmentClient{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(*testing.T) {
 			if tt.prepareFunc != nil {
@@ -3343,11 +3343,11 @@ func TestVPCService_buildLBServiceIPAllocsForRestore(t *testing.T) {
 			wantEmpty:  true,
 		},
 		{
-			name:       "NSXLB + VLANBackedVPC + empty VPCs returns error",
-			lbProvider: NSXLB,
-			obj:        &v1alpha1.NetworkInfo{ObjectMeta: metav1.ObjectMeta{Name: "ni-test"}, VPCs: nil},
-			nc:         &v1alpha1.VPCNetworkConfiguration{},
-			mockStack:  mockVLANBacked,
+			name:        "NSXLB + VLANBackedVPC + empty VPCs returns error",
+			lbProvider:  NSXLB,
+			obj:         &v1alpha1.NetworkInfo{ObjectMeta: metav1.ObjectMeta{Name: "ni-test"}, VPCs: nil},
+			nc:          &v1alpha1.VPCNetworkConfiguration{},
+			mockStack:   mockVLANBacked,
 			wantErrLike: "no VPC state in NetworkInfo ni-test",
 		},
 		{

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -3295,16 +3295,36 @@ func TestNetworkInfoReconciler_GetVpcConnectivityProfilePathByVpcPath(t *testing
 	}
 }
 
-func TestVPCService_buildLBServiceIPAllocForRestore(t *testing.T) {
+func TestVPCService_buildLBServiceIPAllocsForRestore(t *testing.T) {
+	mockVLANBacked := func() *gomonkey.Patches {
+		return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
+			func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
+				return v1alpha1.VLANBackedVPC, nil
+			})
+	}
+	mockFullStack := func() *gomonkey.Patches {
+		return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
+			func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
+				return v1alpha1.FullStackVPC, nil
+			})
+	}
+	mockStackErr := func() *gomonkey.Patches {
+		return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
+			func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
+				return v1alpha1.FullStackVPC, fmt.Errorf("nsx backend failure")
+			})
+	}
+
 	tests := []struct {
 		name        string
 		obj         *v1alpha1.NetworkInfo
 		nc          *v1alpha1.VPCNetworkConfiguration
 		lbProvider  LBProvider
 		mockStack   func() *gomonkey.Patches
-		wantNil     bool
+		wantEmpty   bool
 		wantErrLike string
-		wantIP      string
+		// expected allocations by ID -> expected AllocationIp value
+		wantAllocs map[string]string
 	}{
 		{
 			name:       "non-NSXLB provider returns nil without calling GetNetworkStackFromNC",
@@ -3312,78 +3332,114 @@ func TestVPCService_buildLBServiceIPAllocForRestore(t *testing.T) {
 			obj:        &v1alpha1.NetworkInfo{},
 			nc:         &v1alpha1.VPCNetworkConfiguration{},
 			mockStack:  func() *gomonkey.Patches { return nil },
-			wantNil:    true,
+			wantEmpty:  true,
 		},
 		{
 			name:       "NSXLB + FullStackVPC returns nil",
 			lbProvider: NSXLB,
 			obj:        &v1alpha1.NetworkInfo{},
 			nc:         &v1alpha1.VPCNetworkConfiguration{},
-			mockStack: func() *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
-					func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
-						return v1alpha1.FullStackVPC, nil
-					})
-			},
-			wantNil: true,
+			mockStack:  mockFullStack,
+			wantEmpty:  true,
 		},
 		{
 			name:       "NSXLB + VLANBackedVPC + empty VPCs returns error",
 			lbProvider: NSXLB,
 			obj:        &v1alpha1.NetworkInfo{ObjectMeta: metav1.ObjectMeta{Name: "ni-test"}, VPCs: nil},
 			nc:         &v1alpha1.VPCNetworkConfiguration{},
-			mockStack: func() *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
-					func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
-						return v1alpha1.VLANBackedVPC, nil
-					})
-			},
-			wantErrLike: "LoadBalancerIPAddresses is not set in NetworkInfo ni-test",
+			mockStack:  mockVLANBacked,
+			wantErrLike: "no VPC state in NetworkInfo ni-test",
 		},
 		{
-			name:       "NSXLB + VLANBackedVPC + empty LoadBalancerIPAddresses returns error",
+			name:       "NSXLB + VLANBackedVPC + both BackendIPs and primary empty returns error",
 			lbProvider: NSXLB,
 			obj: &v1alpha1.NetworkInfo{
 				ObjectMeta: metav1.ObjectMeta{Name: "ni-test"},
-				VPCs:       []v1alpha1.VPCState{{LoadBalancerIPAddresses: ""}},
+				VPCs:       []v1alpha1.VPCState{{LoadBalancerIPAddresses: "", LoadBalancerBackendIPs: nil}},
 			},
-			nc: &v1alpha1.VPCNetworkConfiguration{},
-			mockStack: func() *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
-					func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
-						return v1alpha1.VLANBackedVPC, nil
-					})
-			},
+			nc:          &v1alpha1.VPCNetworkConfiguration{},
+			mockStack:   mockVLANBacked,
 			wantErrLike: "LoadBalancerIPAddresses is not set in NetworkInfo ni-test",
 		},
 		{
-			name:       "NSXLB + VLANBackedVPC + valid IP returns correct allocation",
+			// IPv4-only via LoadBalancerBackendIPs (new field).
+			name:       "NSXLB + VLANBackedVPC + IPv4 BackendIP returns one IPv4 allocation",
+			lbProvider: NSXLB,
+			obj: &v1alpha1.NetworkInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: "ni-test"},
+				VPCs:       []v1alpha1.VPCState{{LoadBalancerBackendIPs: []string{"10.1.2.3"}}},
+			},
+			nc:        &v1alpha1.VPCNetworkConfiguration{},
+			mockStack: mockVLANBacked,
+			wantAllocs: map[string]string{
+				common.LBServiceIPAllocationID: "10.1.2.3",
+			},
+		},
+		{
+			// IPv6-only via LoadBalancerBackendIPs.
+			name:       "NSXLB + VLANBackedVPC + IPv6 BackendIP returns one IPv6 allocation",
+			lbProvider: NSXLB,
+			obj: &v1alpha1.NetworkInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: "ni-test"},
+				VPCs:       []v1alpha1.VPCState{{LoadBalancerBackendIPs: []string{"2001:db8::1"}}},
+			},
+			nc:        &v1alpha1.VPCNetworkConfiguration{},
+			mockStack: mockVLANBacked,
+			wantAllocs: map[string]string{
+				common.LBServiceIPAllocationIDV6: "2001:db8::1",
+			},
+		},
+		{
+			// Dual-stack: both IPs in LoadBalancerBackendIPs.
+			name:       "NSXLB + VLANBackedVPC + dual-stack BackendIPs returns two allocations",
+			lbProvider: NSXLB,
+			obj: &v1alpha1.NetworkInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: "ni-test"},
+				VPCs: []v1alpha1.VPCState{{
+					LoadBalancerBackendIPs: []string{"10.1.2.3", "2001:db8::1"},
+				}},
+			},
+			nc:        &v1alpha1.VPCNetworkConfiguration{},
+			mockStack: mockVLANBacked,
+			wantAllocs: map[string]string{
+				common.LBServiceIPAllocationID:   "10.1.2.3",
+				common.LBServiceIPAllocationIDV6: "2001:db8::1",
+			},
+		},
+		{
+			// Fallback: old CR with only LoadBalancerIPAddresses (IPv4).
+			name:       "fallback to LoadBalancerIPAddresses with IPv4 address",
 			lbProvider: NSXLB,
 			obj: &v1alpha1.NetworkInfo{
 				ObjectMeta: metav1.ObjectMeta{Name: "ni-test"},
 				VPCs:       []v1alpha1.VPCState{{LoadBalancerIPAddresses: "10.1.2.3"}},
 			},
-			nc: &v1alpha1.VPCNetworkConfiguration{},
-			mockStack: func() *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
-					func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
-						return v1alpha1.VLANBackedVPC, nil
-					})
+			nc:        &v1alpha1.VPCNetworkConfiguration{},
+			mockStack: mockVLANBacked,
+			wantAllocs: map[string]string{
+				common.LBServiceIPAllocationID: "10.1.2.3",
 			},
-			wantNil: false,
-			wantIP:  "10.1.2.3",
 		},
 		{
-			name:       "GetNetworkStackFromNC error is propagated",
+			// Fallback: old CR with only LoadBalancerIPAddresses (IPv6) — latent bug fix.
+			name:       "fallback to LoadBalancerIPAddresses with IPv6 address builds correct IPv6 allocation",
 			lbProvider: NSXLB,
-			obj:        &v1alpha1.NetworkInfo{},
-			nc:         &v1alpha1.VPCNetworkConfiguration{},
-			mockStack: func() *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(&VPCService{}), "GetNetworkStackFromNC",
-					func(_ *VPCService, _ *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
-						return v1alpha1.FullStackVPC, fmt.Errorf("nsx backend failure")
-					})
+			obj: &v1alpha1.NetworkInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: "ni-test"},
+				VPCs:       []v1alpha1.VPCState{{LoadBalancerIPAddresses: "2001:db8::1"}},
 			},
+			nc:        &v1alpha1.VPCNetworkConfiguration{},
+			mockStack: mockVLANBacked,
+			wantAllocs: map[string]string{
+				common.LBServiceIPAllocationIDV6: "2001:db8::1",
+			},
+		},
+		{
+			name:        "GetNetworkStackFromNC error is propagated",
+			lbProvider:  NSXLB,
+			obj:         &v1alpha1.NetworkInfo{},
+			nc:          &v1alpha1.VPCNetworkConfiguration{},
+			mockStack:   mockStackErr,
 			wantErrLike: "nsx backend failure",
 		},
 	}
@@ -3396,27 +3452,40 @@ func TestVPCService_buildLBServiceIPAllocForRestore(t *testing.T) {
 				defer patches.Reset()
 			}
 
-			alloc, err := service.buildLBServiceIPAllocForRestore(tt.obj, tt.nc, tt.lbProvider)
+			allocs, err := service.buildLBServiceIPAllocsForRestore(tt.obj, tt.nc, tt.lbProvider)
 
 			if tt.wantErrLike != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErrLike)
-				assert.Nil(t, alloc)
+				assert.Nil(t, allocs)
 				return
 			}
 			require.NoError(t, err)
-			if tt.wantNil {
-				assert.Nil(t, alloc)
+			if tt.wantEmpty {
+				assert.Empty(t, allocs)
 				return
 			}
-			require.NotNil(t, alloc)
-			assert.Equal(t, common.LBServiceIPAllocationID, *alloc.Id)
-			assert.Equal(t, tt.wantIP, *alloc.AllocationIp)
-			assert.Equal(t, model.VpcIpAddressAllocation_IP_ADDRESS_BLOCK_VISIBILITY_EXTERNAL, *alloc.IpAddressBlockVisibility)
-			assert.Equal(t, model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV4, *alloc.IpAddressType)
-			require.Len(t, alloc.Tags, 1)
-			assert.Equal(t, common.TagScopeVPCService, *alloc.Tags[0].Scope)
-			assert.Equal(t, common.TagValueUserSpecifiedIP, *alloc.Tags[0].Tag)
+			require.Len(t, allocs, len(tt.wantAllocs))
+			byID := make(map[string]*model.VpcIpAddressAllocation, len(allocs))
+			for _, a := range allocs {
+				byID[*a.Id] = a
+			}
+			for wantID, wantIP := range tt.wantAllocs {
+				a, ok := byID[wantID]
+				require.True(t, ok, "expected allocation with ID %s", wantID)
+				assert.Equal(t, wantIP, *a.AllocationIp)
+				require.Len(t, a.Tags, 1)
+				assert.Equal(t, common.TagScopeVPCService, *a.Tags[0].Scope)
+				if wantID == common.LBServiceIPAllocationID {
+					assert.Equal(t, model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV4, *a.IpAddressType)
+					assert.NotNil(t, a.IpAddressBlockVisibility)
+					assert.Equal(t, common.TagValueUserSpecifiedIP, *a.Tags[0].Tag)
+				} else {
+					assert.Equal(t, model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV6, *a.IpAddressType)
+					assert.Nil(t, a.IpAddressBlockVisibility)
+					assert.Equal(t, common.TagValueUserSpecifiedIPV6, *a.Tags[0].Tag)
+				}
+			}
 		})
 	}
 }

--- a/pkg/nsx/services/vpc/wrap.go
+++ b/pkg/nsx/services/vpc/wrap.go
@@ -8,17 +8,19 @@ import (
 )
 
 // WrapHierarchyVPC assembles the HAPI OrgRoot payload for creating/updating a VPC and its children.
-// lbServiceIPAlloc, when non-nil, is added as the first VPC child (before LBS) and is used in tepless
-// restore mode to pin the LB service IP to the previously allocated address.
-func (s *VPCService) WrapHierarchyVPC(org, nsxtProject string, vpc *model.Vpc, lbServiceIPAlloc *model.VpcIpAddressAllocation, lbs *model.LBService, attachment *model.VpcAttachment) (*model.OrgRoot, error) {
+// lbServiceIPAllocs, when non-empty, are added as the first VPC children (before LBS) and are used in
+// tepless restore mode to pin the LB service IPs (IPv4 and/or IPv6) to their previously allocated addresses.
+func (s *VPCService) WrapHierarchyVPC(org, nsxtProject string, vpc *model.Vpc, lbServiceIPAllocs []*model.VpcIpAddressAllocation, lbs *model.LBService, attachment *model.VpcAttachment) (*model.OrgRoot, error) {
 	var vpcChildren []*data.StructValue
-	if lbServiceIPAlloc != nil {
-		log.Debug("Wrapping LB Service IP Allocation", "LB Service IP Allocation", lbServiceIPAlloc.Id, "Allocation IP", lbServiceIPAlloc.AllocationIp)
-		childIPAlloc, err := common.WrapVpcIpAddressAllocation(lbServiceIPAlloc)
+	for _, alloc := range lbServiceIPAllocs {
+		log.Debug("Wrapping LB Service IP Allocation", "LB Service IP Allocation", alloc.Id, "Allocation IP", alloc.AllocationIp)
+		childIPAlloc, err := common.WrapVpcIpAddressAllocation(alloc)
 		if err != nil {
 			return nil, err
 		}
 		vpcChildren = append(vpcChildren, childIPAlloc)
+	}
+	if len(lbServiceIPAllocs) > 0 {
 		vpc.Children = vpcChildren
 	}
 	if lbs != nil {

--- a/pkg/nsx/services/vpc/wrap_test.go
+++ b/pkg/nsx/services/vpc/wrap_test.go
@@ -14,12 +14,12 @@ import (
 
 func TestVPCService_WrapHierarchyVPC(t *testing.T) {
 	type args struct {
-		org              string
-		nsxtProject      string
-		vpc              *model.Vpc
-		lbServiceIPAlloc *model.VpcIpAddressAllocation
-		lbs              *model.LBService
-		attachment       *model.VpcAttachment
+		org               string
+		nsxtProject       string
+		vpc               *model.Vpc
+		lbServiceIPAllocs []*model.VpcIpAddressAllocation
+		lbs               *model.LBService
+		attachment        *model.VpcAttachment
 	}
 	tests := []struct {
 		name            string
@@ -30,14 +30,14 @@ func TestVPCService_WrapHierarchyVPC(t *testing.T) {
 		wantErr         assert.ErrorAssertionFunc
 	}{
 		{
-			name: "without lbServiceIPAlloc",
+			name: "no lbServiceIPAllocs (nil slice)",
 			args: args{
-				org:              "testorg",
-				nsxtProject:      "testproject",
-				vpc:              &model.Vpc{},
-				lbServiceIPAlloc: nil,
-				lbs:              &model.LBService{},
-				attachment:       &model.VpcAttachment{},
+				org:               "testorg",
+				nsxtProject:       "testproject",
+				vpc:               &model.Vpc{},
+				lbServiceIPAllocs: nil,
+				lbs:               &model.LBService{},
+				attachment:        &model.VpcAttachment{},
 			},
 			want:            &model.OrgRoot{ResourceType: util.Ptr("OrgRoot")},
 			wantOrgChildren: 1,
@@ -45,29 +45,49 @@ func TestVPCService_WrapHierarchyVPC(t *testing.T) {
 			wantErr:         assert.NoError,
 		},
 		{
-			name: "with lbServiceIPAlloc",
+			name: "single IPv4 lbServiceIPAlloc",
 			args: args{
-				org:              "testorg",
-				nsxtProject:      "testproject",
-				vpc:              &model.Vpc{},
-				lbServiceIPAlloc: &model.VpcIpAddressAllocation{Id: common.String(common.LBServiceIPAllocationID)},
-				lbs:              &model.LBService{},
-				attachment:       &model.VpcAttachment{},
+				org:         "testorg",
+				nsxtProject: "testproject",
+				vpc:         &model.Vpc{},
+				lbServiceIPAllocs: []*model.VpcIpAddressAllocation{
+					{Id: common.String(common.LBServiceIPAllocationID)},
+				},
+				lbs:        &model.LBService{},
+				attachment: &model.VpcAttachment{},
 			},
 			want:            &model.OrgRoot{ResourceType: util.Ptr("OrgRoot")},
 			wantOrgChildren: 1,
-			wantVPCChildren: 3, // IPAlloc + LBS + Attachment
+			wantVPCChildren: 3, // IPv4 IPAlloc + LBS + Attachment
 			wantErr:         assert.NoError,
 		},
 		{
-			name: "nil lbs and nil attachment",
+			name: "dual-stack lbServiceIPAllocs (IPv4 + IPv6)",
 			args: args{
-				org:              "testorg",
-				nsxtProject:      "testproject",
-				vpc:              &model.Vpc{},
-				lbServiceIPAlloc: nil,
-				lbs:              nil,
-				attachment:       nil,
+				org:         "testorg",
+				nsxtProject: "testproject",
+				vpc:         &model.Vpc{},
+				lbServiceIPAllocs: []*model.VpcIpAddressAllocation{
+					{Id: common.String(common.LBServiceIPAllocationID)},
+					{Id: common.String(common.LBServiceIPAllocationIDV6)},
+				},
+				lbs:        &model.LBService{},
+				attachment: &model.VpcAttachment{},
+			},
+			want:            &model.OrgRoot{ResourceType: pointy.String("OrgRoot")},
+			wantOrgChildren: 1,
+			wantVPCChildren: 4, // IPv4 IPAlloc + IPv6 IPAlloc + LBS + Attachment
+			wantErr:         assert.NoError,
+		},
+		{
+			name: "nil lbs and nil attachment, no allocs",
+			args: args{
+				org:               "testorg",
+				nsxtProject:       "testproject",
+				vpc:               &model.Vpc{},
+				lbServiceIPAllocs: nil,
+				lbs:               nil,
+				attachment:        nil,
 			},
 			want:            &model.OrgRoot{ResourceType: util.Ptr("OrgRoot")},
 			wantOrgChildren: 1,
@@ -75,33 +95,52 @@ func TestVPCService_WrapHierarchyVPC(t *testing.T) {
 			wantErr:         assert.NoError,
 		},
 		{
-			name: "only lbServiceIPAlloc, no lbs or attachment",
+			name: "only IPv4 lbServiceIPAlloc, no lbs or attachment",
 			args: args{
-				org:              "testorg",
-				nsxtProject:      "testproject",
-				vpc:              &model.Vpc{},
-				lbServiceIPAlloc: &model.VpcIpAddressAllocation{Id: common.String(common.LBServiceIPAllocationID)},
-				lbs:              nil,
-				attachment:       nil,
+				org:         "testorg",
+				nsxtProject: "testproject",
+				vpc:         &model.Vpc{},
+				lbServiceIPAllocs: []*model.VpcIpAddressAllocation{
+					{Id: common.String(common.LBServiceIPAllocationID)},
+				},
+				lbs:        nil,
+				attachment: nil,
 			},
 			want:            &model.OrgRoot{ResourceType: util.Ptr("OrgRoot")},
 			wantOrgChildren: 1,
-			wantVPCChildren: 1, // only IPAlloc
+			wantVPCChildren: 1, // only IPv4 IPAlloc
+			wantErr:         assert.NoError,
+		},
+		{
+			name: "only IPv6 lbServiceIPAlloc, no lbs or attachment",
+			args: args{
+				org:         "testorg",
+				nsxtProject: "testproject",
+				vpc:         &model.Vpc{},
+				lbServiceIPAllocs: []*model.VpcIpAddressAllocation{
+					{Id: common.String(common.LBServiceIPAllocationIDV6)},
+				},
+				lbs:        nil,
+				attachment: nil,
+			},
+			want:            &model.OrgRoot{ResourceType: util.Ptr("OrgRoot")},
+			wantOrgChildren: 1,
+			wantVPCChildren: 1, // only IPv6 IPAlloc
 			wantErr:         assert.NoError,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &VPCService{}
-			got, err := s.WrapHierarchyVPC(tt.args.org, tt.args.nsxtProject, tt.args.vpc, tt.args.lbServiceIPAlloc, tt.args.lbs, tt.args.attachment)
-			if !tt.wantErr(t, err, fmt.Sprintf("WrapHierarchyVPC(%v, %v, %v, %v, %v)", tt.args.org, tt.args.nsxtProject, tt.args.vpc, tt.args.lbServiceIPAlloc, tt.args.lbs)) {
+			got, err := s.WrapHierarchyVPC(tt.args.org, tt.args.nsxtProject, tt.args.vpc, tt.args.lbServiceIPAllocs, tt.args.lbs, tt.args.attachment)
+			if !tt.wantErr(t, err, fmt.Sprintf("WrapHierarchyVPC(%v, %v, %v, %v, %v)", tt.args.org, tt.args.nsxtProject, tt.args.vpc, tt.args.lbServiceIPAllocs, tt.args.lbs)) {
 				return
 			}
 			require.NotNil(t, got)
 			assert.Equalf(t, tt.wantOrgChildren, len(got.Children), "OrgRoot children count")
 			assert.Equalf(t, tt.wantVPCChildren, len(tt.args.vpc.Children), "VPC children count")
 			got.Children = nil
-			assert.Equalf(t, tt.want, got, "WrapHierarchyVPC(%v, %v, %v, %v, %v)", tt.args.org, tt.args.nsxtProject, tt.args.vpc, tt.args.lbServiceIPAlloc, tt.args.lbs)
+			assert.Equalf(t, tt.want, got, "WrapHierarchyVPC(%v, %v, %v, %v, %v)", tt.args.org, tt.args.nsxtProject, tt.args.vpc, tt.args.lbServiceIPAllocs, tt.args.lbs)
 		})
 	}
 }

--- a/pkg/nsx/services/vpc/wrap_test.go
+++ b/pkg/nsx/services/vpc/wrap_test.go
@@ -74,7 +74,7 @@ func TestVPCService_WrapHierarchyVPC(t *testing.T) {
 				lbs:        &model.LBService{},
 				attachment: &model.VpcAttachment{},
 			},
-			want:            &model.OrgRoot{ResourceType: pointy.String("OrgRoot")},
+			want:            &model.OrgRoot{ResourceType: util.Ptr("OrgRoot")},
 			wantOrgChildren: 1,
 			wantVPCChildren: 4, // IPv4 IPAlloc + IPv6 IPAlloc + LBS + Attachment
 			wantErr:         assert.NoError,


### PR DESCRIPTION
The operator restored LB SNAT IPs for tepless VPCs after NSX restore, but only for IPv4.
This PR adds IPv6 support so dual-stack and IPv6-only VPCs have their SNAT IPs correctly
re-pinned after restore.

Extends the restore logic to:
1. Detect and restore IPv4, IPv6, or both SNAT IPs from LoadBalancerBackendIPs
   (dual-stack). Falls back to LoadBalancerIPAddresses for older NetworkInfo CRs,
   correctly routing the IP to the IPv4 or IPv6 allocation builder based on address family.
2. Implement buildNSXLBServiceIPv6Allocation — creates _DEFAULT--VPC_SERVICE_IP_V6
   with Ipv6AllocationPrefixLength=128. Without /128, NSX defaults to /64 and
   silently rejects the allocation with "no spare capacity".
3. Fix TagValueUserSpecifiedIPV6: NSX uses the same tag value
   (__DEFAULT--VPC_SERVICE_IP__) for both IPv4 and IPv6 allocations.

Test Steps and Outputs
**Step 1** — Create namespace, verify IPv4 LB allocation created by operator
```
kubectl create namespace test-restore-1627
kubectl get networkinfo -n test-restore-1627 -o yaml | grep -A5 "loadBalancerBackendIPs"
```

```
loadBalancerBackendIPs:
- 192.168.0.7
loadBalancerIPAddresses: 192.168.0.7
name: test-restore-1627_heuaz
networkStack: VLANBackedVPC
```
**Step 2** — Manually create IPv6 allocation to set up dual-stack backup state

```
curl -ks -u "$CREDS" -X PUT \
  "https://$NSX/.../vpcs/test-restore-1627_heuaz/ip-address-allocations/_DEFAULT--VPC_SERVICE_IP_V6" \
  -H 'Content-Type: application/json' \
  -d '{"ip_address_type":"IPV6","allocation_ips":"2001:db8::1","ipv6_allocation_prefix_length":128,
       "tags":[{"scope":"services/vpc_service","tag":"__DEFAULT--VPC_SERVICE_IP__"}]}'
```

Trigger reconcile → NetworkInfo reflects both IPs:
```
kubectl annotate networkinfo test-restore-1627 -n test-restore-1627 reconcile="$(date +%s)" --overwrite
kubectl get networkinfo -n test-restore-1627 -o yaml | grep -A5 "loadBalancerBackendIPs"
```

```
loadBalancerBackendIPs:
- 192.168.0.7
- 2001:db8::1
loadBalancerIPAddresses: 192.168.0.7
```

**Step 3** — Take NSX backup (clean state without test VPC)
```
kubectl delete namespace test-restore-1627   # delete VPC from NSX first
# Take NSX backup from Manager UI: System → Backup & Restore → Backup Now
kubectl create namespace test-restore-1627   # recreate namespace (after backup)
# Re-add IPv6 allocation + reconcile → NetworkInfo has both IPs again
```
**Step 4** — Wipe NSX Manager and restore from backup

```
ssh root@10.161.199.130
/opt/vmware/bin/nsx_proton_cleanup -r
# All services stopped and restarted as fresh appliance
# NSX Manager UI → System → Backup & Restore → Restore (select backup from Step 3)
```
After restore, NSX reverts to the backup snapshot — test-restore-1627_heuaz VPC is gone from NSX. The K8s namespace and NetworkInfo (with both IPs) are unaffected since NSX restore does not touch Kubernetes.

**Step 5** — Operator detects NSX restore, enters restore mode
```
kubectl delete pod $POD -n vmware-system-nsx   # restart operator
kubectl logs -n vmware-system-nsx -l component=nsx-ncp -c nsx-operator --since=2m \
  | grep -iE "restore|Enter normal"
```
```
Get restore status from NSX  restoreStatus=...
NSX restore mode determined  restoreMode=true
Enter restore mode
...
Restore reconcile succeeds in restore mode
Restore config update succeeds, restart to enter normal mode...
Enter normal mode
```
**Step 6** — Verify both allocations recreated in NSX with same IPs

```
NEW_VPC="test-restore-1627_6tw39"   # new VPC ID assigned during restore

curl -ks -u "$CREDS" \
  ".../vpcs/$NEW_VPC/ip-address-allocations/_DEFAULT--VPC_SERVICE_IP" \
  | python3 -m json.tool | grep '"allocation_ips"\|"id"'
```

```
"allocation_ips": "192.168.0.7",
"id": "_DEFAULT--VPC_SERVICE_IP"
```
```
curl -ks -u "$CREDS" \
  ".../vpcs/$NEW_VPC/ip-address-allocations/_DEFAULT--VPC_SERVICE_IP_V6" \
  | python3 -m json.tool | grep '"allocation_ips"\|"id"\|"ipv6_allocation_prefix_length"'
```
```
"allocation_ips": "2001:db8::1",
"ipv6_allocation_prefix_length": 128,
"id": "_DEFAULT--VPC_SERVICE_IP_V6"
```
NetworkInfo after restore:
```
kubectl get networkinfo -n test-restore-1627 -o yaml | grep -A6 "loadBalancerBackendIPs"
```
```
loadBalancerBackendIPs:
- 192.168.0.7      # same IPv4 as before restore ✅
- 2001:db8::1      # IPv6 restored ✅
name: test-restore-1627_6tw39   # new VPC ID, same IPs
```
The VPC gets a new NSX-assigned ID after restore (expected). The LB SNAT IPs are re-pinned to the same addresses from NetworkInfo, ensuring existing load balancer services continue working without reconfiguration.