### PR TITLE
Add e2e test for NetworkPolicy egress with named port and IPBlock

### DIFF
--- a/test/e2e/manifest/testNetworkPolicy/egress-named-port-ipblock.yaml
+++ b/test/e2e/manifest/testNetworkPolicy/egress-named-port-ipblock.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: egress-named-port-ipblock-np-ns
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: db-pod
+  namespace: egress-named-port-ipblock-np-ns
+  labels:
+    app: db
+spec:
+  containers:
+  - name: db-container
+    image: "netfvt-docker-local.packages.vcfd.broadcom.net/humanux/http_https_echo:latest"
+    ports:
+    - containerPort: 6001
+      name: http
+      protocol: TCP
+    - containerPort: 7001
+      name: db
+      protocol: UDP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-np-egress-ipblock
+  namespace: egress-named-port-ipblock-np-ns
+spec:
+  podSelector:
+    matchLabels:
+      app: db
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - port: 6000
+      protocol: TCP
+    - port: http
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 40.200.123.123/32

--- a/test/e2e/nsx_security_policy_test.go
+++ b/test/e2e/nsx_security_policy_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,6 +51,7 @@ func TestSecurityPolicy(t *testing.T) {
 		RunSubtest(t, "testSecurityPolicyVPCFromFieldIngress", func(t *testing.T) { testSecurityPolicyVPCFromFieldIngress(t) })
 		RunSubtest(t, "testSecurityPolicyVPCToFieldEgress", func(t *testing.T) { testSecurityPolicyVPCToFieldEgress(t) })
 		RunSubtest(t, "testSecurityPolicyNamedPortWithoutPod", func(t *testing.T) { testSecurityPolicyNamedPortWithoutPod(t) })
+		RunSubtest(t, "testNetworkPolicyEgressNamedPortWithIPBlock", func(t *testing.T) { testNetworkPolicyEgressNamedPortWithIPBlock(t) })
 		RunSubtest(t, "testSecurityPolicyNamedPorWithPod", func(t *testing.T) { testSecurityPolicyNamedPorWithPod(t) })
 	})
 
@@ -489,6 +491,56 @@ func testSecurityPolicyNamedPorWithPod(t *testing.T) {
 	// Test traffic from clientA to pod1
 	require.True(t, checkTrafficByCurl(nsClient, clientA, clientA, namedPortPodIPs[1], podPort, true), "testSecurityPolicyNamedPort traffic should work")
 	log.Info("Verified traffic from client Pod to Pod1")
+}
+
+func testNetworkPolicyEgressNamedPortWithIPBlock(t *testing.T) {
+	ns := "egress-named-port-ipblock-np-ns"
+	networkPolicyCRName := "test-np-egress-ipblock"
+	yamlPath, _ := filepath.Abs("./manifest/testNetworkPolicy/egress-named-port-ipblock.yaml")
+	_ = applyYAML(yamlPath, ns)
+	defer deleteYAML(yamlPath, ns)
+
+	// Wait for pod
+	podName := "db-pod"
+	_, err := testData.podWaitForIPs(defaultTimeout, podName, ns)
+	require.NoError(t, err, "Error when waiting for IP for Pod %s", podName)
+
+	// Check nsx-t resource existing. NetworkPolicy is translated to SecurityPolicy
+	err = testData.waitForResourceExistOrNot(ns, common.ResourceTypeNetworkPolicy, networkPolicyCRName, true)
+	assert.NoError(t, err)
+
+	// Verify that exactly 1 allow rule is generated (for TCP 6000), and no rule is generated for the named port
+	err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, defaultTimeout, false, func(ctx context.Context) (bool, error) {
+		queryParam := fmt.Sprintf("resource_type:Rule AND tags.tag:%s AND action:ALLOW", networkPolicyCRName)
+		var cursor *string
+		var pageSize int64 = 500
+		response, err := testData.nsxClient.QueryClient.List(queryParam, cursor, nil, &pageSize, nil, nil)
+		if err != nil {
+			return false, err
+		}
+
+		if len(response.Results) == 1 {
+			obj, errs := common.NewConverter().ConvertToGolang(response.Results[0], model.RuleBindingType())
+			if len(errs) > 0 {
+				return false, fmt.Errorf("%v", errs)
+			}
+			if rule, ok := obj.(model.Rule); ok {
+				if len(rule.ServiceEntries) > 0 {
+					obj, errs := common.NewConverter().ConvertToGolang(rule.ServiceEntries[0], model.L4PortSetServiceEntryBindingType())
+					if len(errs) > 0 {
+						return false, fmt.Errorf("%v", errs)
+					}
+					if entry, ok := obj.(model.L4PortSetServiceEntry); ok {
+						if len(entry.DestinationPorts) > 0 && entry.DestinationPorts[0] == "6000" {
+							return true, nil
+						}
+					}
+				}
+			}
+		}
+		return false, nil
+	})
+	assert.NoError(t, err, "Should have exactly 1 allow rule with destination port 6000")
 }
 
 func assureSecurityPolicyReady(t *testing.T, ns, spName string) {


### PR DESCRIPTION
Add e2e test for NetworkPolicy egress with named port and IPBlock

Add an e2e test to verify the behavior of NetworkPolicy egress rules that use both numeric and named ports alongside an `ipBlock`. The test confirms that exactly one NSX-T allow rule is generated for the numeric port, while no rule is generated for the named port.

Changes:
- Add `testNetworkPolicyEgressNamedPortWithIPBlock` in `test/e2e/nsx_security_policy_test.go`.
- Create corresponding test manifest `egress-named-port-ipblock.yaml` with the Pod and NetworkPolicy definitions.