### PR TITLE
securitypolicy: dynamically calculate VPC SecurityPolicy ID length limit

### DIFF
--- a/pkg/nsx/services/securitypolicy/builder.go
+++ b/pkg/nsx/services/securitypolicy/builder.go
@@ -53,7 +53,7 @@ func (service *SecurityPolicyService) buildSecurityPolicyName(obj *v1alpha1.Secu
 	return util.GenerateTruncName(common.MaxNameLength, obj.Name, "", "", "", "")
 }
 
-func (service *SecurityPolicyService) buildSecurityPolicyIDAndName(obj *v1alpha1.SecurityPolicy, createdFor string) (string, string) {
+func (service *SecurityPolicyService) buildSecurityPolicyIDAndName(obj *v1alpha1.SecurityPolicy, createdFor string, vpcInfo *common.VPCResourceInfo) (string, string) {
 	indexScope := common.TagValueScopeSecurityPolicyUID
 	if createdFor == common.ResourceTypeNetworkPolicy {
 		indexScope = common.TagScopeNetworkPolicyUID
@@ -76,7 +76,14 @@ func (service *SecurityPolicyService) buildSecurityPolicyIDAndName(obj *v1alpha1
 			Name: obj.GetName(),
 			UID:  types.UID(spUID),
 		}
-		return common.BuildUniqueIDWithSuffix(objForIdGeneration, suffixInUid, common.MaxIdLength, util.GenerateIDByObject, func(id string) bool {
+		limit := common.MaxIdLength
+		if vpcInfo != nil {
+			basePath := fmt.Sprintf("%s/security-policies", vpcInfo.GetVPCPath())
+			limit = 255 - len(basePath) - 1
+		}
+		return common.BuildUniqueIDWithSuffix(objForIdGeneration, suffixInUid, limit, func(o v1.Object) string {
+			return util.GenerateIDByObjectWithLimit(o, limit)
+		}, func(id string) bool {
 			return service.securityPolicyStore.GetByKey(id) != nil
 		}), service.buildSecurityPolicyName(obj)
 	}
@@ -120,7 +127,7 @@ func (service *SecurityPolicyService) buildSecurityPolicy(obj *v1alpha1.Security
 	nsxSecurityPolicy := &model.SecurityPolicy{}
 	tags := service.buildBasicTags(obj, createdFor)
 
-	policyID, policyName := service.buildSecurityPolicyIDAndName(obj, createdFor)
+	policyID, policyName := service.buildSecurityPolicyIDAndName(obj, createdFor, vpcInfo)
 	nsxSecurityPolicy.Id = String(policyID)
 	nsxSecurityPolicy.DisplayName = String(policyName)
 	// TODO: confirm the sequence number: offset

--- a/pkg/nsx/services/securitypolicy/builder_test.go
+++ b/pkg/nsx/services/securitypolicy/builder_test.go
@@ -1332,6 +1332,21 @@ func Test_BuildRuleDisplayName(t *testing.T) {
 }
 
 func Test_BuildExpandedRuleID(t *testing.T) {
+	mockVPCService := mock.MockVPCServiceProvider{}
+	mockVPCService.On("ListVPCInfo", "ns1").Return([]common.VPCResourceInfo{
+		{
+			OrgID:     "default",
+			ProjectID: "a45015f6-cec8-419a-9239-32bc7327d3ac",
+			VPCID:     "test-vpc-1-ext-chars",
+		},
+	})
+	mockVPCService.On("ListVPCInfo", "ns2").Return([]common.VPCResourceInfo{
+		{
+			OrgID:     "default",
+			ProjectID: "a45015f6-cec8-419a-9239-32bc7327d3ac",
+			VPCID:     "test-vpc-1-ext-chars",
+		},
+	})
 	svc := &SecurityPolicyService{
 		Service: common.Service{
 			NSXConfig: &config.NSXOperatorConfig{
@@ -1340,6 +1355,7 @@ func Test_BuildExpandedRuleID(t *testing.T) {
 				},
 			},
 		},
+		vpcService: &mockVPCService,
 	}
 
 	svc.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
@@ -1566,7 +1582,7 @@ func Test_BuildSecurityPolicyIDAndName(t *testing.T) {
 			},
 			createdFor: common.ResourceTypeNetworkPolicy,
 			expName:    fmt.Sprintf("%s_n5pcg", strings.Repeat("a", 249)),
-			expId:      fmt.Sprintf("%s_tdpcn", strings.Repeat("a", 249)),
+			expId:      fmt.Sprintf("%s_tdpcn", strings.Repeat("a", 145)),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1576,7 +1592,15 @@ func Test_BuildSecurityPolicyIDAndName(t *testing.T) {
 			if tc.existingSecurityPolicy != nil {
 				svc.securityPolicyStore.Add(tc.existingSecurityPolicy)
 			}
-			id, name := svc.buildSecurityPolicyIDAndName(tc.obj, tc.createdFor)
+			var vpcInfo *common.VPCResourceInfo
+			if tc.vpcEnabled {
+				vpcInfo = &common.VPCResourceInfo{
+					OrgID:     "default",
+					ProjectID: "a45015f6-cec8-419a-9239-32bc7327d3ac",
+					VPCID:     "test-vpc-1-ext-chars",
+				}
+			}
+			id, name := svc.buildSecurityPolicyIDAndName(tc.obj, tc.createdFor, vpcInfo)
 			assert.Equal(t, tc.expId, id)
 			assert.Equal(t, tc.expName, name)
 			assert.True(t, len(name) <= common.MaxNameLength)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -292,13 +292,8 @@ func TruncateUIDHash(uid string) string {
 	return Sha1WithCustomizedCharset(uid)[:common.UUIDHashLength]
 }
 
-// GenerateIDByObject generate string id for NSX resource using the provided Object's name and the hash of CR uid.
-// Note, this function is used on the resources with VPC scenario, and the provided obj is the K8s CR which is
-// used to generate the NSX resource.
-// Note: This function may use hash(obj.UID)[:5] as the return string's suffix. Since the hash suffix is short,
-// it may have collision with the existing NSX resources, the corresponding handle is provided by nsx services layer.
-func GenerateIDByObject(obj metav1.Object) string {
-	limit := common.MaxIdLength
+// GenerateIDByObjectWithLimit generate string id for NSX resource with a specified limit.
+func GenerateIDByObjectWithLimit(obj metav1.Object, limit int) string {
 	uidStr := string(obj.GetUID())
 	suffix := TruncateUIDHash(uidStr)
 	desiredName := connectStrings(common.ConnectorUnderline, obj.GetName(), suffix)
@@ -307,6 +302,15 @@ func GenerateIDByObject(obj metav1.Object) string {
 		desiredName = connectStrings(common.ConnectorUnderline, obj.GetName()[:valueLen], suffix)
 	}
 	return desiredName
+}
+
+// GenerateIDByObject generate string id for NSX resource using the provided Object's name and the hash of CR uid.
+// Note, this function is used on the resources with VPC scenario, and the provided obj is the K8s CR which is
+// used to generate the NSX resource.
+// Note: This function may use hash(obj.UID)[:5] as the return string's suffix. Since the hash suffix is short,
+// it may have collision with the existing NSX resources, the corresponding handle is provided by nsx services layer.
+func GenerateIDByObject(obj metav1.Object) string {
+	return GenerateIDByObjectWithLimit(obj, common.MaxIdLength)
 }
 
 // GenerateID generate id for NSX resource, some resources has complex index, so set its type to string.


### PR DESCRIPTION
securitypolicy: dynamically calculate VPC SecurityPolicy ID length limit
- NSX-T Policy API enforces a strict 255-character path length limit.
  Nested resources under VPC mode consume up to 100 characters in prefix,
  violating this limit (NSX error 500157).
- Implement a dynamic budget calculation for the VPC SecurityPolicy ID
  to fit within the remaining path limit dynamically.
- Keep the global MaxIdLength as 255, preserving user naming
  assets for standard mode and other paths.
- Update associated unit tests for securitypolicy and utility helpers.

Pending: not covered other resources may have such issue, like VPC/Subnet/Subnetport ..etc

Issue: #3732557