### PR TITLE
[Migration] Implement mixed-mode discovery using explicit Namespace annotations per upstream design

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -311,7 +311,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 
 	// Watch for mixed-mode state changes (e.g. T1-only → T1+VPC when the migration starts).
 	// If the state changes, exit so the operator restarts with the new configuration
-	config.StartNetworkSettingsInformer(mgr)
+	config.StartNamespaceInformer(mgr)
 	go func() {
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -311,17 +311,20 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 
 	// Watch for mixed-mode state changes (e.g. T1-only → T1+VPC when the migration starts).
 	// If the state changes, exit so the operator restarts with the new configuration
-	config.StartNamespaceInformer(mgr)
-	go func() {
-		ticker := time.NewTicker(30 * time.Second)
-		defer ticker.Stop()
-		for range ticker.C {
-			if config.RefreshMixedModeState(context.Background()) {
-				log.Info("Mixed-mode state changed; restarting NSX Operator to pick up new configuration")
-				os.Exit(0)
+	if config.IsPerNamespaceProvidersSupported() {
+		log.Info("Starting mixed-mode state polling ticker (interval: 30s)")
+		config.StartNamespaceInformer(mgr)
+		go func() {
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
+			for range ticker.C {
+				if config.RefreshMixedModeState(context.Background()) {
+					log.Info("Mixed-mode state changed; restarting NSX Operator to pick up new configuration")
+					os.Exit(0)
+				}
 			}
-		}
-	}()
+		}()
+	}
 }
 
 func electMaster(mgr manager.Manager, nsxClient *nsx.Client) {

--- a/pkg/config/mixed_mode.go
+++ b/pkg/config/mixed_mode.go
@@ -303,8 +303,6 @@ func initMixedModeWithClients(ctx context.Context, clientset kubernetes.Interfac
 	// the mutex to avoid holding the lock during potentially many retries.
 	supported, _ := checkPerNamespaceProvidersSupported(ctx, dynClient)
 
-	storedEnableVPCNetwork = enableVPCNetwork
-
 	var t1, vpc bool
 	if supported {
 		log.Info("Per-namespace network providers are supported, scanning namespaces for mixed-mode")

--- a/pkg/config/mixed_mode.go
+++ b/pkg/config/mixed_mode.go
@@ -5,13 +5,16 @@ package config
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -20,8 +23,32 @@ import (
 )
 
 const (
+	VPCNetworkConfigAnnotation     = "nsx.vmware.com/vpc_network_config"
+	T1DefaultConfigAnnotation      = "nsx.vmware.com/t1_default_config"
+	T1VmwareSystemSharedAnnotation = "vmware-system-shared-t1"
+	T1NsxNetworkConfigAnnotation   = "ncp/nsx_network_config_crd"
+
 	capabilitiesName = "supervisor-capabilities"
 )
+
+func hasT1ActivationAnnotation(annotations map[string]string) bool {
+	if val, ok := annotations[T1DefaultConfigAnnotation]; ok {
+		if strings.ToLower(strings.TrimSpace(val)) == "true" {
+			return true
+		}
+	}
+	if val, ok := annotations[T1VmwareSystemSharedAnnotation]; ok {
+		if strings.ToLower(strings.TrimSpace(val)) == "true" {
+			return true
+		}
+	}
+	if val, ok := annotations[T1NsxNetworkConfigAnnotation]; ok {
+		if strings.TrimSpace(val) != "" {
+			return true
+		}
+	}
+	return false
+}
 
 var (
 	capabilitiesGVR = schema.GroupVersionResource{
@@ -29,16 +56,10 @@ var (
 		Version:  "v1alpha1",
 		Resource: "capabilities",
 	}
-	networkSettingsGVR = schema.GroupVersionResource{
-		Group:    "netoperator.vmware.com",
-		Version:  "v1alpha1",
-		Resource: "networksettings",
-	}
 
 	stateMu                        sync.RWMutex
 	hasT1Namespaces                bool
 	hasVPCNamespaces               bool
-	hasVDSNamespaces               bool
 	perNamespaceProvidersSupported *bool
 	stateInitialized               bool
 
@@ -48,9 +69,9 @@ var (
 	retryInitialInterval = 2 * time.Second
 	retryMaxInterval     = 30 * time.Second
 
-	// storedDynClient and storedEnableVPCNetwork are kept from InitMixedMode so that
+	// storedClientset and storedEnableVPCNetwork are kept from InitMixedMode so that
 	// RefreshMixedModeState can re-scan without requiring the caller to pass them each time.
-	storedDynClient        dynamic.Interface
+	storedClientset        kubernetes.Interface
 	storedEnableVPCNetwork bool
 
 	// namespaceRefreshReader, when non-nil, is used by RefreshMixedModeState to list
@@ -116,85 +137,104 @@ func extractCapability(obj *unstructured.Unstructured) bool {
 	return false
 }
 
-func parseProvidersFromList(items []unstructured.Unstructured) (hasT1 bool, hasVPC bool, hasVDS bool) {
-	for _, item := range items {
-		provider, _, _ := unstructured.NestedString(item.Object, "provider")
-		switch provider {
-		case "nsx-tier1":
-			hasT1 = true
-		case "vpc":
-			hasVPC = true
-		case "vsphere-distributed":
-			hasVDS = true
+// scanNamespaceProvidersFromAPI uses kubernetes.Interface to list Namespaces
+// from the API Server and discover the active network providers (T1 or VPC)
+// based on explicit Namespace annotations.
+// Used during initialization before Informer caches are ready.
+func scanNamespaceProvidersFromAPI(ctx context.Context, clientset kubernetes.Interface) (hasT1 bool, hasVPC bool, err error) {
+	hasT1 = false
+	hasVPC = false
+
+	if clientset != nil {
+		list, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+		if err == nil {
+			for _, item := range list.Items {
+				annotations := item.GetAnnotations()
+				if _, ok := annotations[VPCNetworkConfigAnnotation]; ok {
+					hasVPC = true
+				} else if hasT1ActivationAnnotation(annotations) {
+					hasT1 = true
+				}
+				if hasT1 && hasVPC {
+					break
+				}
+			}
+		} else {
+			log.V(1).Info("Failed to list Namespaces during mixed-mode scan", "error", err)
+			return false, false, err
 		}
-		if hasT1 && hasVPC && hasVDS {
+	}
+
+	if !hasT1 && !hasVPC {
+		// Note: For the VDS to VPC Migration case, when the component starts,
+		// the enable_vpc_network config will be true, safely falling back to VPC mode.
+		if storedEnableVPCNetwork {
+			hasVPC = true
+		} else {
+			hasT1 = true
+		}
+	}
+
+	return hasT1, hasVPC, nil
+}
+
+// scanNamespaceProvidersFromCache uses controller-runtime client.Reader to list Namespaces
+// from the local Informer cache. Used during periodic refresh to avoid API Server load.
+func scanNamespaceProvidersFromCache(ctx context.Context, reader client.Reader) (hasT1 bool, hasVPC bool, err error) {
+	hasT1 = false
+	hasVPC = false
+
+	nsList := &v1.NamespaceList{}
+	if err := reader.List(ctx, nsList); err != nil {
+		log.V(1).Info("Failed to list Namespaces with reader during mixed-mode rescan", "error", err)
+		return false, false, err
+	}
+	for _, item := range nsList.Items {
+		annotations := item.GetAnnotations()
+		if _, ok := annotations[VPCNetworkConfigAnnotation]; ok {
+			hasVPC = true
+		} else if hasT1ActivationAnnotation(annotations) {
+			hasT1 = true
+		}
+		if hasT1 && hasVPC {
 			break
 		}
 	}
-	return hasT1, hasVPC, hasVDS
-}
 
-// scanNamespaceProvidersFromAPI uses dynamic.Interface to directly list NetworkSettings
-// from the API Server. Used during initialization before Informer caches are ready.
-func scanNamespaceProvidersFromAPI(ctx context.Context, dynClient dynamic.Interface) (hasT1 bool, hasVPC bool, hasVDS bool, err error) {
-	if dynClient != nil {
-		list, err := dynClient.Resource(networkSettingsGVR).List(ctx, metav1.ListOptions{})
-		if err == nil && len(list.Items) > 0 {
-			t1, vpc, vds := parseProvidersFromList(list.Items)
-			return t1, vpc, vds, nil
-		} else if err != nil {
-			log.V(1).Info("Failed to list NetworkSettings", "error", err)
-			return false, false, false, err
+	if !hasT1 && !hasVPC {
+		// Note: For the VDS to VPC Migration case, when the component starts,
+		// the enable_vpc_network config will be true, safely falling back to VPC mode.
+		if storedEnableVPCNetwork {
+			hasVPC = true
+		} else {
+			hasT1 = true
 		}
 	}
-	return false, false, false, nil
+
+	return hasT1, hasVPC, nil
 }
 
-// scanNamespaceProvidersFromCache uses controller-runtime client.Reader to list NetworkSettings
-// from the local Informer cache. Used during periodic refresh to avoid API Server load.
-func scanNamespaceProvidersFromCache(ctx context.Context, reader client.Reader) (hasT1 bool, hasVPC bool, hasVDS bool, err error) {
-	nsList := &unstructured.UnstructuredList{}
-	nsList.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "netoperator.vmware.com",
-		Version: "v1alpha1",
-		Kind:    "NetworkSettingsList",
-	})
-	if err := reader.List(ctx, nsList); err == nil && len(nsList.Items) > 0 {
-		t1, vpc, vds := parseProvidersFromList(nsList.Items)
-		return t1, vpc, vds, nil
-	} else if err != nil {
-		log.V(1).Info("Failed to list NetworkSettings with reader", "error", err)
-		return false, false, false, err
-	}
-	return false, false, false, nil
-}
-
-// StartNetworkSettingsInformer registers a cache-backed client.Reader
+// StartNamespaceInformer registers a cache-backed client.Reader
 // (typically mgr.GetClient()) for periodic mixed-mode rescans and ensures
 // the required Informers are started.
 // Call once from cmd after controllers are set up on the manager.
-func StartNetworkSettingsInformer(mgr manager.Manager) {
+func StartNamespaceInformer(mgr manager.Manager) {
 	if !IsPerNamespaceProvidersSupported() {
 		return
 	}
 
-	// Ensure NetworkSettings is cached in the controller-runtime manager and the
+	// Ensure Namespace is cached in the controller-runtime manager and the
 	// informer is synced before enabling the cache reader. Until the reader is set,
 	// RefreshMixedModeState falls back to a direct API list, so a not-yet-synced
-	// cache cannot make refresh observe an empty NetworkSettings set and trigger a
+	// cache cannot make refresh observe an empty Namespace set and trigger a
 	// spurious mode change/restart.
 	go func() {
-		nsObj := &unstructured.Unstructured{}
-		nsObj.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "netoperator.vmware.com",
-			Version: "v1alpha1",
-			Kind:    "NetworkSettings",
-		})
+		nsObj := &v1.Namespace{}
 		interval := retryInitialInterval
 		for {
 			informer, err := mgr.GetCache().GetInformer(context.TODO(), nsObj)
 			if err != nil {
-				log.Info("Failed to start informer for NetworkSettings, will retry", "error", err, "retryIn", interval)
+				log.Info("Failed to start informer for Namespaces, will retry", "error", err, "retryIn", interval)
 				time.Sleep(interval)
 				interval = min(interval*2, retryMaxInterval)
 				continue
@@ -206,7 +246,7 @@ func StartNetworkSettingsInformer(mgr manager.Manager) {
 			refreshReaderMu.Lock()
 			namespaceRefreshReader = mgr.GetClient()
 			refreshReaderMu.Unlock()
-			log.Info("Informer for NetworkSettings synced successfully; enabling cache reader")
+			log.Info("Informer for Namespaces synced successfully; enabling cache reader")
 			break
 		}
 	}()
@@ -220,18 +260,18 @@ func currentNamespaceRefreshReader() client.Reader {
 
 // waitForNamespaceProviders retries scanNamespaceProvidersFromAPI with exponential
 // backoff on transient errors (e.g. API server not yet ready at operator startup).
-func waitForNamespaceProviders(ctx context.Context, dynClient dynamic.Interface) (bool, bool, bool) {
+func waitForNamespaceProviders(ctx context.Context, clientset kubernetes.Interface) (bool, bool) {
 	interval := retryInitialInterval
 	for {
-		hasT1, hasVPC, hasVDS, err := scanNamespaceProvidersFromAPI(ctx, dynClient)
+		hasT1, hasVPC, err := scanNamespaceProvidersFromAPI(ctx, clientset)
 		if err == nil {
-			return hasT1, hasVPC, hasVDS
+			return hasT1, hasVPC
 		}
 		log.Info("Failed to list providers for mixed-mode scan, will retry", "error", err, "retryIn", interval)
 		select {
 		case <-ctx.Done():
 			log.Info("Context cancelled during mixed-mode scan, returning empty state")
-			return false, false, false
+			return false, false
 		case <-time.After(interval):
 		}
 		interval = min(interval*2, retryMaxInterval)
@@ -239,65 +279,67 @@ func waitForNamespaceProviders(ctx context.Context, dynClient dynamic.Interface)
 }
 
 // InitMixedMode initializes mixed-mode state by checking Capabilities
-// and scanning NetworkSettings CRs for T1, VPC, and VDS network providers.
+// and scanning Namespaces for T1 and VPC annotations.
 // If per-namespace providers are not activated, falls back to the legacy EnableVPCNetwork flag.
 //
 // The Capabilities lookup is performed outside the state mutex so
 // that transient API errors can be retried without blocking readers for an
 // extended period.
 func InitMixedMode(ctx context.Context, cfg *rest.Config, enableVPCNetwork bool) error {
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
 	dynClient, err := dynamic.NewForConfig(cfg)
 	if err != nil {
 		return err
 	}
-	initMixedModeWithClients(ctx, dynClient, enableVPCNetwork)
+	initMixedModeWithClients(ctx, clientset, dynClient, enableVPCNetwork)
 	return nil
 }
 
-func initMixedModeWithClients(ctx context.Context, dynClient dynamic.Interface, enableVPCNetwork bool) {
+func initMixedModeWithClients(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface, enableVPCNetwork bool) {
 	// checkPerNamespaceProvidersSupported retries on transient errors; runs outside
 	// the mutex to avoid holding the lock during potentially many retries.
 	supported, _ := checkPerNamespaceProvidersSupported(ctx, dynClient)
 
-	var t1, vpc, vds bool
+	storedEnableVPCNetwork = enableVPCNetwork
+
+	var t1, vpc bool
 	if supported {
 		log.Info("Per-namespace network providers are supported, scanning namespaces for mixed-mode")
-		t1, vpc, vds = waitForNamespaceProviders(ctx, dynClient)
+		t1, vpc = waitForNamespaceProviders(ctx, clientset)
 		if enableVPCNetwork {
 			vpc = true
 		}
 	} else {
 		log.Info("Per-namespace network providers not supported, using legacy config", "enableVPCNetwork", enableVPCNetwork)
 		if enableVPCNetwork {
-			t1, vpc, vds = false, true, false
+			t1, vpc = false, true
 		} else {
-			t1, vpc, vds = true, false, false
+			t1, vpc = true, false
 		}
 	}
 	stateMu.Lock()
 	defer stateMu.Unlock()
-	storedDynClient = dynClient
+	storedClientset = clientset
 	storedEnableVPCNetwork = enableVPCNetwork
 	// The capability can be changed in day2. However, we intentionally do NOT poll or watch this capability during runtime to save API Server overhead.
 	// By design, if it changes from deactivated to activated, an external component will restart the nsx-operator pod; changing from activated to deactivated is not a valid scenario.
 	perNamespaceProvidersSupported = &supported
 	hasT1Namespaces = t1
 	hasVPCNamespaces = vpc
-	hasVDSNamespaces = vds
 	stateInitialized = true
-	log.Info("Mixed-mode state initialized", "hasT1Namespaces", t1, "hasVPCNamespaces", vpc, "hasVDSNamespaces", vds)
+	log.Info("Mixed-mode state initialized", "hasT1Namespaces", t1, "hasVPCNamespaces", vpc)
 }
 
-// RefreshMixedModeState re-scans namespaces using the dynamic client stored during
+// RefreshMixedModeState re-scans namespaces using the clientset stored during
 // InitMixedMode and updates the global state. Returns true if the state
 // changed; the caller should then restart the operator so that VPC services
 // and controllers are initialized for the new mode.
 func RefreshMixedModeState(ctx context.Context) bool {
-	stateMu.Lock()
-	defer stateMu.Unlock()
-
-	if storedDynClient == nil {
-		log.V(1).Info("Skipping mixed-mode refresh: storedDynClient is nil")
+	if storedClientset == nil {
+		log.V(1).Info("Skipping mixed-mode refresh: storedClientset is nil")
 		return false
 	}
 
@@ -306,13 +348,12 @@ func RefreshMixedModeState(ctx context.Context) bool {
 		return false
 	}
 
-	oldT1, oldVPC, oldVDS := hasT1Namespaces, hasVPCNamespaces, hasVDSNamespaces
-	var newT1, newVPC, newVDS bool
+	var newT1, newVPC bool
 	var err error
 	if r := currentNamespaceRefreshReader(); r != nil {
-		newT1, newVPC, newVDS, err = scanNamespaceProvidersFromCache(ctx, r)
+		newT1, newVPC, err = scanNamespaceProvidersFromCache(ctx, r)
 	} else {
-		newT1, newVPC, newVDS, err = scanNamespaceProvidersFromAPI(ctx, storedDynClient)
+		newT1, newVPC, err = scanNamespaceProvidersFromAPI(ctx, storedClientset)
 	}
 	if storedEnableVPCNetwork {
 		newVPC = true
@@ -321,39 +362,40 @@ func RefreshMixedModeState(ctx context.Context) bool {
 		log.Warn("Failed to scan namespaces during mixed-mode refresh, keeping current state", "error", err)
 		return false
 	}
+
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	oldT1, oldVPC := hasT1Namespaces, hasVPCNamespaces
 	hasT1Namespaces = newT1
 	hasVPCNamespaces = newVPC
-	hasVDSNamespaces = newVDS
 
-	changed := oldT1 != hasT1Namespaces || oldVPC != hasVPCNamespaces || oldVDS != hasVDSNamespaces
+	changed := oldT1 != hasT1Namespaces || oldVPC != hasVPCNamespaces
 	if changed {
 		log.Info("Mixed-mode state changed",
 			"oldT1", oldT1, "newT1", hasT1Namespaces,
-			"oldVPC", oldVPC, "newVPC", hasVPCNamespaces,
-			"oldVDS", oldVDS, "newVDS", hasVDSNamespaces)
+			"oldVPC", oldVPC, "newVPC", hasVPCNamespaces)
 	}
 	return changed
 }
 
-// HasT1Namespaces returns true when at least one NetworkSettings CR uses T1.
+// HasT1Namespaces returns true when at least one Namespace has a T1 activation annotation.
 func HasT1Namespaces() bool {
 	stateMu.RLock()
 	defer stateMu.RUnlock()
 	return hasT1Namespaces
 }
 
-// HasVPCNamespaces returns true when enable_vpc_network is true or at least one NetworkSettings CR uses VPC.
+// HasVPCNamespaces returns true when enable_vpc_network is true or at least one Namespace has the VPC config annotation.
 func HasVPCNamespaces() bool {
 	stateMu.RLock()
 	defer stateMu.RUnlock()
 	return hasVPCNamespaces
 }
 
-// HasVDSNamespaces returns true when at least one NetworkSettings CR uses VDS.
+// HasVDSNamespaces returns true when at least one Namespace uses VDS.
 func HasVDSNamespaces() bool {
-	stateMu.RLock()
-	defer stateMu.RUnlock()
-	return hasVDSNamespaces
+	return false
 }
 
 // IsMixedModeStateInitialized returns true after InitMixedMode has been called.
@@ -370,7 +412,6 @@ func SetMixedModeStateForTest(hasT1, hasVPC bool) {
 	defer stateMu.Unlock()
 	hasT1Namespaces = hasT1
 	hasVPCNamespaces = hasVPC
-	hasVDSNamespaces = false
 	stateInitialized = true
 }
 

--- a/pkg/config/mixed_mode.go
+++ b/pkg/config/mixed_mode.go
@@ -160,7 +160,7 @@ func scanNamespaceProvidersFromAPI(ctx context.Context, clientset kubernetes.Int
 				}
 			}
 		} else {
-			log.V(1).Info("Failed to list Namespaces during mixed-mode scan", "error", err)
+			log.Debug("Failed to list Namespaces during mixed-mode scan", "error", err)
 			return false, false, err
 		}
 	}
@@ -186,7 +186,7 @@ func scanNamespaceProvidersFromCache(ctx context.Context, reader client.Reader) 
 
 	nsList := &v1.NamespaceList{}
 	if err := reader.List(ctx, nsList); err != nil {
-		log.V(1).Info("Failed to list Namespaces with reader during mixed-mode rescan", "error", err)
+		log.Debug("Failed to list Namespaces with reader during mixed-mode rescan", "error", err)
 		return false, false, err
 	}
 	for _, item := range nsList.Items {
@@ -337,12 +337,12 @@ func initMixedModeWithClients(ctx context.Context, clientset kubernetes.Interfac
 // and controllers are initialized for the new mode.
 func RefreshMixedModeState(ctx context.Context) bool {
 	if storedClientset == nil {
-		log.V(1).Info("Skipping mixed-mode refresh: storedClientset is nil")
+		log.Debug("Skipping mixed-mode refresh: storedClientset is nil")
 		return false
 	}
 
 	if perNamespaceProvidersSupported != nil && !*perNamespaceProvidersSupported {
-		log.V(1).Info("Skipping mixed-mode refresh: per-namespace network providers are not supported")
+		log.Debug("Skipping mixed-mode refresh: per-namespace network providers are not supported")
 		return false
 	}
 

--- a/pkg/config/mixed_mode.go
+++ b/pkg/config/mixed_mode.go
@@ -393,11 +393,6 @@ func HasVPCNamespaces() bool {
 	return hasVPCNamespaces
 }
 
-// HasVDSNamespaces returns true when at least one Namespace uses VDS.
-func HasVDSNamespaces() bool {
-	return false
-}
-
 // IsMixedModeStateInitialized returns true after InitMixedMode has been called.
 func IsMixedModeStateInitialized() bool {
 	stateMu.RLock()

--- a/pkg/config/mixed_mode_test.go
+++ b/pkg/config/mixed_mode_test.go
@@ -4,19 +4,19 @@
 package config
 
 import (
-	"testing"
-
 	"context"
+	"errors"
+	"testing"
 	"time"
 
-	"errors"
-
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -131,103 +131,11 @@ func TestExtractCapability(t *testing.T) {
 	}
 }
 
-func makeNetworkSettings(provider string) unstructured.Unstructured {
-	return unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"provider": provider,
-		},
-	}
-}
-
-func TestParseProvidersFromList(t *testing.T) {
-	tests := []struct {
-		name      string
-		items     []unstructured.Unstructured
-		expectT1  bool
-		expectVPC bool
-		expectVDS bool
-	}{
-		{
-			name:      "empty list",
-			items:     []unstructured.Unstructured{},
-			expectT1:  false,
-			expectVPC: false,
-			expectVDS: false,
-		},
-		{
-			name: "only T1",
-			items: []unstructured.Unstructured{
-				makeNetworkSettings("nsx-tier1"),
-			},
-			expectT1:  true,
-			expectVPC: false,
-			expectVDS: false,
-		},
-		{
-			name: "only VPC",
-			items: []unstructured.Unstructured{
-				makeNetworkSettings("vpc"),
-			},
-			expectT1:  false,
-			expectVPC: true,
-			expectVDS: false,
-		},
-		{
-			name: "only VDS",
-			items: []unstructured.Unstructured{
-				makeNetworkSettings("vsphere-distributed"),
-			},
-			expectT1:  false,
-			expectVPC: false,
-			expectVDS: true,
-		},
-		{
-			name: "mixed VPC and VDS",
-			items: []unstructured.Unstructured{
-				makeNetworkSettings("vpc"),
-				makeNetworkSettings("vsphere-distributed"),
-			},
-			expectT1:  false,
-			expectVPC: true,
-			expectVDS: true,
-		},
-		{
-			name: "unknown provider",
-			items: []unstructured.Unstructured{
-				makeNetworkSettings("unknown-provider"),
-			},
-			expectT1:  false,
-			expectVPC: false,
-			expectVDS: false,
-		},
-		{
-			name: "multiple same providers",
-			items: []unstructured.Unstructured{
-				makeNetworkSettings("vpc"),
-				makeNetworkSettings("vpc"),
-			},
-			expectT1:  false,
-			expectVPC: true,
-			expectVDS: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t1, vpc, vds := parseProvidersFromList(tt.items)
-			assert.Equal(t, tt.expectT1, t1)
-			assert.Equal(t, tt.expectVPC, vpc)
-			assert.Equal(t, tt.expectVDS, vds)
-		})
-	}
-}
-
 func TestStateGetters(t *testing.T) {
 	// reset state
 	stateMu.Lock()
 	hasT1Namespaces = false
 	hasVPCNamespaces = false
-	hasVDSNamespaces = false
 	perNamespaceProvidersSupported = nil
 	stateInitialized = false
 	stateMu.Unlock()
@@ -245,43 +153,24 @@ func TestStateGetters(t *testing.T) {
 	assert.True(t, IsMixedModeStateInitialized())
 
 	stateMu.Lock()
-	hasVDSNamespaces = true
 	supported := true
 	perNamespaceProvidersSupported = &supported
 	stateMu.Unlock()
 
-	assert.True(t, HasVDSNamespaces())
+	assert.False(t, HasVDSNamespaces())
 	assert.True(t, IsPerNamespaceProvidersSupported())
-}
-
-func makeNetworkSettingsCR(name, namespace, provider string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "netoperator.vmware.com/v1alpha1",
-			"kind":       "NetworkSettings",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
-			},
-			"provider": provider,
-		},
-	}
 }
 
 func setupFakeDynamicClient(t *testing.T, objects ...*unstructured.Unstructured) *fake.FakeDynamicClient {
 	scheme := runtime.NewScheme()
 	listKinds := map[schema.GroupVersionResource]string{
-		capabilitiesGVR:    "CapabilitiesList",
-		networkSettingsGVR: "NetworkSettingsList",
+		capabilitiesGVR: "CapabilitiesList",
 	}
 	client := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
 
 	ctx := context.TODO()
 	for _, obj := range objects {
 		gvr := capabilitiesGVR
-		if obj.GetKind() == "NetworkSettings" {
-			gvr = networkSettingsGVR
-		}
 
 		ns := obj.GetNamespace()
 		var err error
@@ -306,33 +195,57 @@ func TestInitMixedModeWithClients(t *testing.T) {
 	// Scenario 1: Per-namespace supported = false, EnableVPCNetwork = false
 	capObjFalse := makeCapabilitiesObj(false)
 	dynClientLegacy := setupFakeDynamicClient(t, capObjFalse)
+	clientset := kubernetesfake.NewClientset()
 
-	initMixedModeWithClients(ctx, dynClientLegacy, false)
+	initMixedModeWithClients(ctx, clientset, dynClientLegacy, false)
 	assert.True(t, HasT1Namespaces())
 	assert.False(t, HasVPCNamespaces())
 	assert.False(t, HasVDSNamespaces())
 
 	// Scenario 2: Per-namespace supported = false, EnableVPCNetwork = true
-	initMixedModeWithClients(ctx, dynClientLegacy, true)
+	initMixedModeWithClients(ctx, clientset, dynClientLegacy, true)
 	assert.False(t, HasT1Namespaces())
 	assert.True(t, HasVPCNamespaces())
 	assert.False(t, HasVDSNamespaces())
 
-	// Scenario 3: Per-namespace supported = true, EnableVPCNetwork = false, has VDS and VPC
+	// Scenario 3: Per-namespace supported = true, EnableVPCNetwork = false, has T1 and VPC namespaces
 	capObjTrue := makeCapabilitiesObj(true)
-	ns1 := makeNetworkSettingsCR("ns1", "ns1", "vpc")
-	ns2 := makeNetworkSettingsCR("ns2", "ns2", "vsphere-distributed")
-	dynClientMixed := setupFakeDynamicClient(t, capObjTrue, ns1, ns2)
+	dynClientMixed := setupFakeDynamicClient(t, capObjTrue)
+	ns1 := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns1",
+			Annotations: map[string]string{
+				"nsx.vmware.com/vpc_network_config": "{}",
+			},
+		},
+	}
+	ns2 := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns2",
+			Annotations: map[string]string{
+				"nsx.vmware.com/t1_default_config": "true",
+			},
+		},
+	}
+	clientsetMixed := kubernetesfake.NewClientset(ns1, ns2)
 
-	initMixedModeWithClients(ctx, dynClientMixed, false)
-	assert.False(t, HasT1Namespaces())
+	initMixedModeWithClients(ctx, clientsetMixed, dynClientMixed, false)
+	assert.True(t, HasT1Namespaces())
 	assert.True(t, HasVPCNamespaces())
-	assert.True(t, HasVDSNamespaces())
+	assert.False(t, HasVDSNamespaces())
 
 	// Scenario 4: Per-namespace supported = true, EnableVPCNetwork = true, has T1
-	nsT1 := makeNetworkSettingsCR("ns3", "ns3", "nsx-tier1")
-	dynClientVPC := setupFakeDynamicClient(t, capObjTrue, nsT1)
-	initMixedModeWithClients(ctx, dynClientVPC, true)
+	dynClientVPC := setupFakeDynamicClient(t, capObjTrue)
+	ns3 := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns3",
+			Annotations: map[string]string{
+				"vmware-system-shared-t1": "true",
+			},
+		},
+	}
+	clientsetVPC := kubernetesfake.NewClientset(ns3)
+	initMixedModeWithClients(ctx, clientsetVPC, dynClientVPC, true)
 	assert.True(t, HasT1Namespaces())
 	assert.True(t, HasVPCNamespaces())
 	assert.False(t, HasVDSNamespaces())
@@ -370,7 +283,7 @@ func TestCheckPerNamespaceProvidersSupported(t *testing.T) {
 
 // stubReader is a minimal client.Reader for testing cache-backed scans.
 type stubReader struct {
-	items []unstructured.Unstructured
+	items []v1.Namespace
 	err   error
 }
 
@@ -382,70 +295,98 @@ func (s *stubReader) List(_ context.Context, list client.ObjectList, _ ...client
 	if s.err != nil {
 		return s.err
 	}
-	ul, ok := list.(*unstructured.UnstructuredList)
+	nl, ok := list.(*v1.NamespaceList)
 	if ok {
-		ul.Items = s.items
+		nl.Items = s.items
 	}
 	return nil
 }
 
 func TestScanNamespaceProvidersFromAPI(t *testing.T) {
 	ctx := context.TODO()
+	stateMu.Lock()
+	storedEnableVPCNetwork = false
+	stateMu.Unlock()
 
-	// nil client returns empty state, no error
-	t1, vpc, vds, err := scanNamespaceProvidersFromAPI(ctx, nil)
+	// nil client returns fallback default state
+	t1, vpc, err := scanNamespaceProvidersFromAPI(ctx, nil)
 	assert.NoError(t, err)
-	assert.False(t, t1)
+	assert.True(t, t1)
 	assert.False(t, vpc)
-	assert.False(t, vds)
 
-	// empty list returns empty state, no error
-	dynClientEmpty := setupFakeDynamicClient(t)
-	t1, vpc, vds, err = scanNamespaceProvidersFromAPI(ctx, dynClientEmpty)
+	// empty list returns fallback T1 state, no error
+	clientsetEmpty := kubernetesfake.NewClientset()
+	t1, vpc, err = scanNamespaceProvidersFromAPI(ctx, clientsetEmpty)
 	assert.NoError(t, err)
-	assert.False(t, t1)
+	assert.True(t, t1)
 	assert.False(t, vpc)
-	assert.False(t, vds)
 
-	// list with T1 and VPC providers
-	ns1 := makeNetworkSettingsCR("ns1", "ns1", "nsx-tier1")
-	ns2 := makeNetworkSettingsCR("ns2", "ns2", "vpc")
-	dynClient := setupFakeDynamicClient(t, ns1, ns2)
-	t1, vpc, vds, err = scanNamespaceProvidersFromAPI(ctx, dynClient)
+	// list with T1 and VPC providers via annotations
+	ns1 := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns1",
+			Annotations: map[string]string{
+				"nsx.vmware.com/vpc_network_config": "{}",
+			},
+		},
+	}
+	ns2 := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns2",
+			Annotations: map[string]string{
+				"ncp/nsx_network_config_crd": "nnc-override",
+			},
+		},
+	}
+	clientset := kubernetesfake.NewClientset(ns1, ns2)
+	t1, vpc, err = scanNamespaceProvidersFromAPI(ctx, clientset)
 	assert.NoError(t, err)
 	assert.True(t, t1)
 	assert.True(t, vpc)
-	assert.False(t, vds)
 }
 
 func TestScanNamespaceProvidersFromCache(t *testing.T) {
 	ctx := context.TODO()
+	stateMu.Lock()
+	storedEnableVPCNetwork = false
+	stateMu.Unlock()
 
-	// empty cache returns empty state, no error
-	t1, vpc, vds, err := scanNamespaceProvidersFromCache(ctx, &stubReader{})
+	// empty cache returns default fallback state, no error
+	t1, vpc, err := scanNamespaceProvidersFromCache(ctx, &stubReader{})
 	assert.NoError(t, err)
-	assert.False(t, t1)
+	assert.True(t, t1)
 	assert.False(t, vpc)
-	assert.False(t, vds)
 
 	// cache with VPC and T1 providers
-	reader := &stubReader{items: []unstructured.Unstructured{
-		makeNetworkSettings("vpc"),
-		makeNetworkSettings("nsx-tier1"),
+	reader := &stubReader{items: []v1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns1",
+				Annotations: map[string]string{
+					"nsx.vmware.com/vpc_network_config": "{}",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns2",
+				Annotations: map[string]string{
+					"nsx.vmware.com/t1_default_config": "true",
+				},
+			},
+		},
 	}}
-	t1, vpc, vds, err = scanNamespaceProvidersFromCache(ctx, reader)
+	t1, vpc, err = scanNamespaceProvidersFromCache(ctx, reader)
 	assert.NoError(t, err)
 	assert.True(t, t1)
 	assert.True(t, vpc)
-	assert.False(t, vds)
 
 	// list error is propagated
 	errReader := &stubReader{err: errors.New("list failed")}
-	t1, vpc, vds, err = scanNamespaceProvidersFromCache(ctx, errReader)
+	t1, vpc, err = scanNamespaceProvidersFromCache(ctx, errReader)
 	assert.Error(t, err)
 	assert.False(t, t1)
 	assert.False(t, vpc)
-	assert.False(t, vds)
 }
 
 func TestRefreshMixedModeState(t *testing.T) {
@@ -453,10 +394,9 @@ func TestRefreshMixedModeState(t *testing.T) {
 		stateMu.Lock()
 		hasT1Namespaces = false
 		hasVPCNamespaces = false
-		hasVDSNamespaces = false
 		perNamespaceProvidersSupported = nil
 		stateInitialized = false
-		storedDynClient = nil
+		storedClientset = nil
 		storedEnableVPCNetwork = false
 		stateMu.Unlock()
 		refreshReaderMu.Lock()
@@ -464,14 +404,14 @@ func TestRefreshMixedModeState(t *testing.T) {
 		refreshReaderMu.Unlock()
 	}
 
-	// storedDynClient is nil -> skip
+	// storedClientset is nil -> skip
 	resetMixedModeGlobals()
 	assert.False(t, RefreshMixedModeState(context.TODO()))
 
 	// per-namespace providers not supported -> skip
 	resetMixedModeGlobals()
 	stateMu.Lock()
-	storedDynClient = setupFakeDynamicClient(t)
+	storedClientset = kubernetesfake.NewClientset()
 	supportedFalse := false
 	perNamespaceProvidersSupported = &supportedFalse
 	stateMu.Unlock()
@@ -480,33 +420,50 @@ func TestRefreshMixedModeState(t *testing.T) {
 	// no change via API path -> false
 	resetMixedModeGlobals()
 	stateMu.Lock()
-	storedDynClient = setupFakeDynamicClient(t)
+	storedClientset = kubernetesfake.NewClientset()
 	supportedTrue := true
 	perNamespaceProvidersSupported = &supportedTrue
-	hasT1Namespaces = false
+	hasT1Namespaces = true // default fallback
 	stateMu.Unlock()
 	assert.False(t, RefreshMixedModeState(context.TODO()))
 
 	// state change via API path -> true
 	resetMixedModeGlobals()
-	ns1 := makeNetworkSettingsCR("ns1", "ns1", "nsx-tier1")
+	ns1 := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns1",
+			Annotations: map[string]string{
+				"nsx.vmware.com/vpc_network_config": "{}",
+			},
+		},
+	}
 	stateMu.Lock()
-	storedDynClient = setupFakeDynamicClient(t, ns1)
+	storedClientset = kubernetesfake.NewClientset(ns1)
 	perNamespaceProvidersSupported = &supportedTrue
+	hasT1Namespaces = true
 	stateMu.Unlock()
 	assert.True(t, RefreshMixedModeState(context.TODO()))
-	assert.True(t, HasT1Namespaces())
-	assert.False(t, HasVPCNamespaces())
+	assert.False(t, HasT1Namespaces())
+	assert.True(t, HasVPCNamespaces())
 
 	// cache reader takes precedence over API; enableVPCNetwork forces VPC=true
 	resetMixedModeGlobals()
 	stateMu.Lock()
-	storedDynClient = setupFakeDynamicClient(t)
+	storedClientset = kubernetesfake.NewClientset()
 	perNamespaceProvidersSupported = &supportedTrue
 	storedEnableVPCNetwork = true
 	stateMu.Unlock()
 	refreshReaderMu.Lock()
-	namespaceRefreshReader = &stubReader{items: []unstructured.Unstructured{makeNetworkSettings("nsx-tier1")}}
+	namespaceRefreshReader = &stubReader{items: []v1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns1",
+				Annotations: map[string]string{
+					"nsx.vmware.com/t1_default_config": "true",
+				},
+			},
+		},
+	}}
 	refreshReaderMu.Unlock()
 	assert.True(t, RefreshMixedModeState(context.TODO()))
 	assert.True(t, HasT1Namespaces())
@@ -515,7 +472,7 @@ func TestRefreshMixedModeState(t *testing.T) {
 	// scan error keeps current state, returns false
 	resetMixedModeGlobals()
 	stateMu.Lock()
-	storedDynClient = setupFakeDynamicClient(t)
+	storedClientset = kubernetesfake.NewClientset()
 	perNamespaceProvidersSupported = &supportedTrue
 	hasT1Namespaces = true
 	stateMu.Unlock()

--- a/pkg/config/mixed_mode_test.go
+++ b/pkg/config/mixed_mode_test.go
@@ -142,14 +142,12 @@ func TestStateGetters(t *testing.T) {
 
 	assert.False(t, HasT1Namespaces())
 	assert.False(t, HasVPCNamespaces())
-	assert.False(t, HasVDSNamespaces())
 	assert.False(t, IsMixedModeStateInitialized())
 	assert.False(t, IsPerNamespaceProvidersSupported())
 
 	SetMixedModeStateForTest(true, true)
 	assert.True(t, HasT1Namespaces())
 	assert.True(t, HasVPCNamespaces())
-	assert.False(t, HasVDSNamespaces())
 	assert.True(t, IsMixedModeStateInitialized())
 
 	stateMu.Lock()
@@ -157,7 +155,6 @@ func TestStateGetters(t *testing.T) {
 	perNamespaceProvidersSupported = &supported
 	stateMu.Unlock()
 
-	assert.False(t, HasVDSNamespaces())
 	assert.True(t, IsPerNamespaceProvidersSupported())
 }
 
@@ -200,13 +197,11 @@ func TestInitMixedModeWithClients(t *testing.T) {
 	initMixedModeWithClients(ctx, clientset, dynClientLegacy, false)
 	assert.True(t, HasT1Namespaces())
 	assert.False(t, HasVPCNamespaces())
-	assert.False(t, HasVDSNamespaces())
 
 	// Scenario 2: Per-namespace supported = false, EnableVPCNetwork = true
 	initMixedModeWithClients(ctx, clientset, dynClientLegacy, true)
 	assert.False(t, HasT1Namespaces())
 	assert.True(t, HasVPCNamespaces())
-	assert.False(t, HasVDSNamespaces())
 
 	// Scenario 3: Per-namespace supported = true, EnableVPCNetwork = false, has T1 and VPC namespaces
 	capObjTrue := makeCapabilitiesObj(true)
@@ -232,7 +227,6 @@ func TestInitMixedModeWithClients(t *testing.T) {
 	initMixedModeWithClients(ctx, clientsetMixed, dynClientMixed, false)
 	assert.True(t, HasT1Namespaces())
 	assert.True(t, HasVPCNamespaces())
-	assert.False(t, HasVDSNamespaces())
 
 	// Scenario 4: Per-namespace supported = true, EnableVPCNetwork = true, has T1
 	dynClientVPC := setupFakeDynamicClient(t, capObjTrue)
@@ -248,7 +242,6 @@ func TestInitMixedModeWithClients(t *testing.T) {
 	initMixedModeWithClients(ctx, clientsetVPC, dynClientVPC, true)
 	assert.True(t, HasT1Namespaces())
 	assert.True(t, HasVPCNamespaces())
-	assert.False(t, HasVDSNamespaces())
 }
 
 func TestCheckPerNamespaceProvidersSupported(t *testing.T) {


### PR DESCRIPTION
According to the new choreographed Namespace bootstrapping design from the upstream components, both NCP and nsx-operator must now discover active T1 and VPC namespaces using explicit Namespace annotations. To ensure decoupling and avoid obsolete dependencies, this commit completely removes the dependency on the NetworkSettings CRD lookup, replacing it entirely with scanning core Namespace annotations, and removes the legacy NetworkSettingsWatcher and NetworkSettingsStore entirely.

Specifically, this commit:
1. Replaces the legacy NetworkSettings CRD lookup with scanning core Namespace annotations.
2. Cleans up the legacy NetworkSettings CRD watcher, store, and test mock references.
3. Implements a "self-blocking" window during Namespace creation where standard Namespaces that are "bare" (lacking explicit labels or annotations) do not trigger physical Tier-1 router or subnet provisioning.
4. Detects active Tier-1 networking scope when any of the three explicit upstream activation annotations is present on a Namespace:
   - Case 1: 'nsx.vmware.com/t1_default_config: "true"' (Default T1)
   - Case 2: 'vmware-system-shared-t1: "true"' (Shared T1)
   - Case 3: 'ncp/nsx_network_config_crd: <NNC-Name>' (Override T1)
5. Detects active VPC networking scope when the 'nsx.vmware.com/vpc_network_config' annotation is present.

Testing Done:
1. T1 pipeline with id 5895
2. VPC pipeline with id 21028