### PR TITLE
Fix status not update issue

### DIFF
--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_controller.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_controller.go
@@ -87,7 +87,7 @@ func updateIPAddressAllocationStatusConditions(client client.Client, ctx context
 		if err := client.Status().Update(ctx, ipaddressallocation); err != nil {
 			log.Error(err, "Failed to update status", "Name", ipaddressallocation.Name, "Namespace", ipaddressallocation.Namespace)
 		} else {
-			log.Info("Updated IPAddressAllocation", "Name", ipaddressallocation.Name, "Namespace", ipaddressallocation.Namespace, "New Conditions", newConditions)
+			log.Info("Updated IPAddressAllocation", "Name", ipaddressallocation.Name, "Namespace", ipaddressallocation.Namespace, "Status", ipaddressallocation.Status)
 		}
 	}
 }
@@ -150,8 +150,10 @@ func (r *IPAddressAllocationReconciler) handleUpdate(ctx context.Context, obj *v
 		return resultRequeue, err
 	}
 	if updated {
-		r.StatusUpdater.UpdateSuccess(ctx, obj, setReadyStatusTrue)
+		// If the IPAddressAllocation is updated, we clear the conditions to ensure the status is updated anyway
+		obj.Status.Conditions = nil
 	}
+	r.StatusUpdater.UpdateSuccess(ctx, obj, setReadyStatusTrue)
 	return resultNormal, nil
 }
 

--- a/pkg/controllers/ipaddressallocation/ipaddressallocation_controller_test.go
+++ b/pkg/controllers/ipaddressallocation/ipaddressallocation_controller_test.go
@@ -472,3 +472,88 @@ func (m *MockManager) Add(runnable manager.Runnable) error {
 func (m *MockManager) Start(context.Context) error {
 	return nil
 }
+
+func TestIPAddressAllocationReconciler_handleUpdate(t *testing.T) {
+	r := &IPAddressAllocationReconciler{
+		StatusUpdater: ctlcommon.StatusUpdater{},
+		Service:       &ipaddressallocation.IPAddressAllocationService{},
+	}
+	ctx := context.TODO()
+
+	tests := []struct {
+		name         string
+		updated      bool
+		updateErr    error
+		initialConds []v1alpha1.Condition
+		expectConds  bool
+		expectErr    bool
+	}{
+		{
+			name:         "update true, clear conditions",
+			updated:      true,
+			updateErr:    nil,
+			initialConds: []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: v1.ConditionTrue}},
+			expectConds:  false,
+			expectErr:    false,
+		},
+		{
+			name:         "update false, keep conditions",
+			updated:      false,
+			updateErr:    nil,
+			initialConds: []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: v1.ConditionTrue}},
+			expectConds:  true,
+			expectErr:    false,
+		},
+		{
+			name:         "update error",
+			updated:      false,
+			updateErr:    errors.New("update err"),
+			initialConds: []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: v1.ConditionTrue}},
+			expectConds:  true,
+			expectErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &v1alpha1.IPAddressAllocation{
+				Status: v1alpha1.IPAddressAllocationStatus{
+					Conditions: tt.initialConds,
+				},
+			}
+
+			patches := gomonkey.ApplyMethod(reflect.TypeOf(r.Service), "CreateOrUpdateIPAddressAllocation",
+				func(_ *ipaddressallocation.IPAddressAllocationService, _ *v1alpha1.IPAddressAllocation, _ bool) (bool, error) {
+					return tt.updated, tt.updateErr
+				})
+			defer patches.Reset()
+
+			patches2 := gomonkey.ApplyMethod(reflect.TypeOf(&r.StatusUpdater), "UpdateSuccess",
+				func(_ *ctlcommon.StatusUpdater, _ context.Context, _ client.Object, _ ctlcommon.UpdateSuccessStatusFn, _ ...interface{}) {
+				})
+			defer patches2.Reset()
+
+			patches3 := gomonkey.ApplyMethod(reflect.TypeOf(&r.StatusUpdater), "UpdateFail",
+				func(_ *ctlcommon.StatusUpdater, _ context.Context, _ client.Object, _ error, _ string, _ ctlcommon.UpdateFailStatusFn, _ ...interface{}) {
+				})
+			defer patches3.Reset()
+
+			patches4 := gomonkey.ApplyMethod(reflect.TypeOf(&r.StatusUpdater), "IncreaseUpdateTotal",
+				func(_ *ctlcommon.StatusUpdater) {})
+			defer patches4.Reset()
+
+			_, err := r.handleUpdate(ctx, obj)
+			if tt.expectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			if tt.expectConds {
+				assert.NotNil(t, obj.Status.Conditions)
+			} else {
+				assert.Nil(t, obj.Status.Conditions)
+			}
+		})
+	}
+}

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -222,9 +222,14 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ResultRequeue, err
 	}
 	// Update status
-	if err := r.updateSubnetStatus(subnetCR); err != nil {
+	updated, err := r.updateSubnetStatus(subnetCR)
+	if err != nil {
 		r.StatusUpdater.UpdateFail(ctx, subnetCR, err, "Failed to update Subnet status", setSubnetReadyStatusFalse)
 		return ResultRequeue, err
+	}
+	if updated {
+		// If the Subnet Status is updated, clear the conditions to ensure the status is updated anyway
+		subnetCR.Status.Conditions = nil
 	}
 	r.StatusUpdater.UpdateSuccess(ctx, subnetCR, setSubnetReadyStatusTrue)
 	return ctrl.Result{}, nil
@@ -291,18 +296,19 @@ func (r *SubnetReconciler) deleteSubnetByName(name, ns string) error {
 	return r.deleteSubnets(nsxSubnets)
 }
 
-func (r *SubnetReconciler) updateSubnetStatus(obj *v1alpha1.Subnet) error {
+func (r *SubnetReconciler) updateSubnetStatus(obj *v1alpha1.Subnet) (bool, error) {
 	nsxSubnets := r.SubnetService.GetSubnetsByIndex(servicecommon.TagScopeSubnetCRUID, string(obj.GetUID()))
 	if len(nsxSubnets) == 0 {
-		return fmt.Errorf("failed to get NSX Subnet from store")
+		return false, fmt.Errorf("failed to get NSX Subnet from store")
 	}
 	nsxSubnet := nsxSubnets[0]
+	originalStatus := obj.Status.DeepCopy()
 	obj.Status.NetworkAddresses = obj.Status.NetworkAddresses[:0]
 	obj.Status.GatewayAddresses = obj.Status.GatewayAddresses[:0]
 	obj.Status.DHCPServerAddresses = obj.Status.DHCPServerAddresses[:0]
 	statusList, err := r.SubnetService.GetSubnetStatus(nsxSubnet)
 	if err != nil {
-		return err
+		return false, err
 	}
 	for _, status := range statusList {
 		obj.Status.NetworkAddresses = append(obj.Status.NetworkAddresses, *status.NetworkAddress)
@@ -312,7 +318,7 @@ func (r *SubnetReconciler) updateSubnetStatus(obj *v1alpha1.Subnet) error {
 			obj.Status.DHCPServerAddresses = append(obj.Status.DHCPServerAddresses, *status.DhcpServerAddress)
 		}
 	}
-	return nil
+	return r.hasStatusChanged(originalStatus, &obj.Status), nil
 }
 
 // handleSharedSubnet manages a shared subnet annotated with an associated resource.

--- a/pkg/controllers/subnet/subnet_controller_test.go
+++ b/pkg/controllers/subnet/subnet_controller_test.go
@@ -1662,3 +1662,86 @@ func TestSetDefaultIPv4SubnetSizeValue(t *testing.T) {
 		})
 	}
 }
+
+func TestSubnetReconciler_updateSubnetStatus(t *testing.T) {
+	r := &SubnetReconciler{
+		SubnetService: &subnet.SubnetService{},
+	}
+	tests := []struct {
+		name         string
+		nsxSubnets   []*model.VpcSubnet
+		statusList   []model.VpcSubnetStatus
+		initialConds []v1alpha1.Condition
+		hasChanged   bool
+		expectErr    bool
+	}{
+		{
+			name:       "empty nsx subnets",
+			nsxSubnets: []*model.VpcSubnet{},
+			hasChanged: false,
+			expectErr:  true,
+		},
+		{
+			name:       "status updated",
+			nsxSubnets: []*model.VpcSubnet{{Id: common.String("subnet-1")}},
+			statusList: []model.VpcSubnetStatus{
+				{
+					NetworkAddress:    common.String("10.0.0.0/24"),
+					GatewayAddress:    common.String("10.0.0.1"),
+					DhcpServerAddress: common.String("10.0.0.2"),
+				},
+			},
+			hasChanged: true,
+			expectErr:  false,
+		},
+		{
+			name:       "status not updated",
+			nsxSubnets: []*model.VpcSubnet{{Id: common.String("subnet-1")}},
+			statusList: []model.VpcSubnetStatus{
+				{
+					NetworkAddress:    common.String("10.0.0.0/24"),
+					GatewayAddress:    common.String("10.0.0.1"),
+					DhcpServerAddress: common.String("10.0.0.2"),
+				},
+			},
+			hasChanged: false,
+			expectErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &v1alpha1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{UID: "uid-1"},
+				Status: v1alpha1.SubnetStatus{
+					NetworkAddresses:    []string{"10.0.0.0/24"},
+					GatewayAddresses:    []string{"10.0.0.1"},
+					DHCPServerAddresses: []string{"10.0.0.2"},
+				},
+			}
+			if tt.hasChanged {
+				obj.Status.NetworkAddresses = []string{}
+			}
+
+			patches := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetsByIndex",
+				func(_ *subnet.SubnetService, _ string, _ string) []*model.VpcSubnet {
+					return tt.nsxSubnets
+				})
+			defer patches.Reset()
+
+			patches2 := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetStatus",
+				func(_ *subnet.SubnetService, _ *model.VpcSubnet) ([]model.VpcSubnetStatus, error) {
+					return tt.statusList, nil
+				})
+			defer patches2.Reset()
+
+			changed, err := r.updateSubnetStatus(obj)
+			if tt.expectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.hasChanged, changed)
+			}
+		})
+	}
+}

--- a/pkg/controllers/subnetipreservation/subnetipreservation_controller.go
+++ b/pkg/controllers/subnetipreservation/subnetipreservation_controller.go
@@ -263,7 +263,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return common.ResultRequeue, nil
 	}
 
-	ipReservationCR.Status.IPs = ips
+	if !reflect.DeepEqual(ipReservationCR.Status.IPs, ips) {
+		log.Info("SubnetIPReservation IPs updated", "SubnetIPReservation", req.NamespacedName, "OldIPs", ipReservationCR.Status.IPs, "NewIPs", ips)
+		ipReservationCR.Status.IPs = ips
+		// If the IPReservation CR's IP updated, we clear the conditions to ensure the status is updated anyway
+		ipReservationCR.Status.Conditions = nil
+	}
+
 	// Update SubnetIPReservation with ready condition
 	r.StatusUpdater.UpdateSuccess(ctx, ipReservationCR, setReadyStatusTrue)
 	return common.ResultNormal, nil
@@ -371,7 +377,7 @@ func updateStatusConditions(client client.Client, ctx context.Context, ipReserva
 		if err := client.Status().Update(ctx, ipReservation); err != nil {
 			log.Error(err, "Failed to update SubnetIPReservation status", "Name", ipReservation.Name, "Namespace", ipReservation.Namespace)
 		} else {
-			log.Info("Updated SubnetIPReservation", "Name", ipReservation.Name, "Namespace", ipReservation.Namespace, "New Conditions", newConditions)
+			log.Info("Updated SubnetIPReservation", "Name", ipReservation.Name, "Namespace", ipReservation.Namespace, "Stauts", ipReservation.Status)
 		}
 	}
 }

--- a/pkg/controllers/subnetipreservation/subnetipreservation_controller_test.go
+++ b/pkg/controllers/subnetipreservation/subnetipreservation_controller_test.go
@@ -424,16 +424,83 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 			expectedResult: common.ResultNormal,
 		},
+		{
+			name: "Create IPReservation with IPs changed, conditions cleared",
+			objects: []client.Object{
+				&v1alpha1.SubnetIPReservation{
+					ObjectMeta: metav1.ObjectMeta{Name: "ipr-1", Namespace: "ns-1"},
+					Status: v1alpha1.SubnetIPReservationStatus{
+						Conditions: []v1alpha1.Condition{{Type: "Ready", Status: "True"}},
+						IPs:        []string{"10.0.0.1"},
+					},
+				},
+			},
+			preparedFunc: func(r *Reconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "validateSubnet", func(_ *Reconciler, ctx context.Context, ns string, name string) (*v1alpha1.Subnet, *errorWithRetry) {
+					return &v1alpha1.Subnet{}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetByCR", func(_ *subnet.SubnetService, subnet *v1alpha1.Subnet) (*model.VpcSubnet, error) {
+					return &model.VpcSubnet{Path: servicecommon.String("/orgs/default/projects/default/vpcs/ns-1/subnets/subnet-1")}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.IPReservationService), "CreateOrUpdateSubnetIPReservation", func(_ *subnetipreservation.IPReservationService, ipReservation *v1alpha1.SubnetIPReservation, subnetPath string, restoreMode bool) ([]string, error) {
+					return []string{"10.0.0.1", "10.0.0.2"}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.IPReservationService.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, feature int) bool {
+					return true
+				})
+				patches.ApplyMethod(reflect.TypeOf(&r.StatusUpdater), "UpdateSuccess", func(_ *common.StatusUpdater, _ context.Context, obj client.Object, _ common.UpdateSuccessStatusFn, _ ...interface{}) {
+					iprObj := obj.(*v1alpha1.SubnetIPReservation)
+					assert.Nil(t, iprObj.Status.Conditions)
+				})
+				return patches
+			},
+			expectedResult: common.ResultNormal,
+		},
+		{
+			name: "Create IPReservation with IPs unchanged, conditions retained",
+			objects: []client.Object{
+				&v1alpha1.SubnetIPReservation{
+					ObjectMeta: metav1.ObjectMeta{Name: "ipr-1", Namespace: "ns-1"},
+					Status: v1alpha1.SubnetIPReservationStatus{
+						Conditions: []v1alpha1.Condition{{Type: "Ready", Status: "True"}},
+						IPs:        []string{"10.0.0.1"},
+					},
+				},
+			},
+			preparedFunc: func(r *Reconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "validateSubnet", func(_ *Reconciler, ctx context.Context, ns string, name string) (*v1alpha1.Subnet, *errorWithRetry) {
+					return &v1alpha1.Subnet{}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetByCR", func(_ *subnet.SubnetService, subnet *v1alpha1.Subnet) (*model.VpcSubnet, error) {
+					return &model.VpcSubnet{Path: servicecommon.String("/orgs/default/projects/default/vpcs/ns-1/subnets/subnet-1")}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.IPReservationService), "CreateOrUpdateSubnetIPReservation", func(_ *subnetipreservation.IPReservationService, ipReservation *v1alpha1.SubnetIPReservation, subnetPath string, restoreMode bool) ([]string, error) {
+					return []string{"10.0.0.1"}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.IPReservationService.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, feature int) bool {
+					return true
+				})
+				patches.ApplyMethod(reflect.TypeOf(&r.StatusUpdater), "UpdateSuccess", func(_ *common.StatusUpdater, _ context.Context, obj client.Object, _ common.UpdateSuccessStatusFn, _ ...interface{}) {
+					iprObj := obj.(*v1alpha1.SubnetIPReservation)
+					assert.NotNil(t, iprObj.Status.Conditions)
+				})
+				return patches
+			},
+			expectedResult: common.ResultNormal,
+		},
 	}
 	for _, tc := range tests {
-		r := createFakeReconciler(tc.objects...)
-		patches := tc.preparedFunc(r)
-		result, err := r.Reconcile(context.TODO(), request)
-		assert.Nil(t, err)
-		assert.Equal(t, tc.expectedResult, result)
-		if patches != nil {
-			patches.Reset()
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			r := createFakeReconciler(tc.objects...)
+			patches := tc.preparedFunc(r)
+
+			result, err := r.Reconcile(context.TODO(), request)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedResult, result)
+			if patches != nil {
+				patches.Reset()
+			}
+		})
 	}
 }
 

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -188,6 +188,15 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					return common.ResultRequeue, err
 				}
 			}
+			// In restore mode, we do not update the SubnetPort status to retian the status, so no need to check the realized bindings
+			// Check StaticIPAllocationType as mixed mode Subnet also have static ip allocation enabled but SubnetPort may be created in dhcp pool
+			if !r.restoreMode && util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) && subnetPort.Spec.StaticIPAllocationType != "None" {
+				if len(nsxSubnetPortState.RealizedBindings) == 0 {
+					err = errors.New("IP and MAC are missing for SubnetPort")
+					r.StatusUpdater.UpdateFail(ctx, subnetPort, err, "IP and MAC are missing for SubnetPort", setSubnetPortReadyStatusFalse, r.SubnetPortService, r.restoreMode)
+					return common.ResultNormal, err
+				}
+			}
 			subnetPort.Status.Attachment = v1alpha1.PortAttachment{ID: *nsxSubnetPortState.Attachment.Id}
 			subnetPort.Status.NetworkInterfaceConfig = v1alpha1.NetworkInterfaceConfig{
 				IPAddresses: []v1alpha1.NetworkInterfaceIPAddress{
@@ -806,6 +815,9 @@ func updateSubnetPortStatusConditions(client client.Client, ctx context.Context,
 		if err := client.Get(ctx, types.NamespacedName{Namespace: subnetPort.Namespace, Name: subnetPort.Name}, latestSubnetPort); err != nil {
 			return err
 		}
+		// subnetPort might be cleared to indicate a change in other fields in status, keep it to make sure
+		// the status is updated when conditions are unchanged while other fields are changed.
+		latestSubnetPort.Status.Conditions = subnetPort.Status.Conditions
 		conditionsUpdated := false
 		for i := range newConditions {
 			if mergeSubnetPortStatusCondition(latestSubnetPort, &newConditions[i]) {
@@ -815,12 +827,11 @@ func updateSubnetPortStatusConditions(client client.Client, ctx context.Context,
 		if conditionsUpdated {
 			latestSubnetPort.Status.Attachment = subnetPort.Status.Attachment
 			latestSubnetPort.Status.NetworkInterfaceConfig = subnetPort.Status.NetworkInterfaceConfig
+			log.Info("Updated SubnetPort Status", "Name", latestSubnetPort.Name, "Namespace", latestSubnetPort.Namespace, "Status", latestSubnetPort.Status)
 			return client.Status().Update(ctx, latestSubnetPort)
 		}
 		return nil
 	})
-	log.Debug("Updated SubnetPort CR", "Name", subnetPort.Name, "Namespace", subnetPort.Namespace,
-		"New Conditions", newConditions)
 }
 
 func mergeSubnetPortStatusCondition(subnetPort *v1alpha1.SubnetPort, newCondition *v1alpha1.Condition) bool {

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -514,6 +514,14 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 				},
 				MACAddress: "04:50:56:00:74:00",
 			},
+			Conditions: []v1alpha1.Condition{
+				{
+					Type:    v1alpha1.Ready,
+					Status:  corev1.ConditionTrue,
+					Message: "NSX subnet port has been successfully created/updated",
+					Reason:  "SubnetPortReady",
+				},
+			},
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "subnetport-1",
@@ -888,6 +896,80 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		k8sClient.EXPECT().Status().Return(fakewriter)
 		_, ret := r.Reconcile(ctx, req)
 		assert.Equal(t, fmt.Errorf("SubnetPort Attachment ID is not updated"), ret)
+	})
+
+	t.Run("Static IP missing realized bindings", func(t *testing.T) {
+		r.restoreMode = false
+
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
+			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+				v1sp := obj.(*v1alpha1.SubnetPort)
+				v1sp.Spec.Subnet = "subnet1"
+				v1sp.Spec.StaticIPAllocationType = "Static"
+				return nil
+			}).Times(2)
+		k8sClient.EXPECT().Status().Return(fakewriter)
+
+		portStateLocal := &model.SegmentPortState{
+			RealizedBindings: []model.AddressBindingEntry{},
+			Attachment: &model.SegmentPortAttachmentState{
+				Id: &attachmentID,
+			},
+		}
+
+		patches := gomonkey.ApplyMethod(reflect.TypeOf(&subnetport.SubnetPortService{}), "CreateOrUpdateSubnetPort", func(_ *subnetport.SubnetPortService, _ interface{}, _ *model.VpcSubnet, _ string, _ *map[string]string, _ bool, _ bool, _ v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+			return portStateLocal, nil
+		})
+		defer patches.Reset()
+
+		patches2 := gomonkey.ApplyMethod(reflect.TypeOf(&subnetport.SubnetPortService{}), "GetAddressBindingBySubnetPort", func(_ *subnetport.SubnetPortService, _ *v1alpha1.SubnetPort) *v1alpha1.AddressBinding {
+			return nil
+		})
+		defer patches2.Reset()
+
+		patchesIPAllocCreate := gomonkey.ApplyMethod(reflect.TypeOf(r.IpAddressAllocationService), "CreateIPAddressAllocationForAddressBinding", func(_ *mock.MockIPAddressAllocationProvider, _ *v1alpha1.AddressBinding, _ *v1alpha1.SubnetPort, _ bool) error {
+			return nil
+		})
+		defer patchesIPAllocCreate.Reset()
+
+		patchesIPAllocDelete := gomonkey.ApplyMethod(reflect.TypeOf(r.IpAddressAllocationService), "DeleteIPAddressAllocationForAddressBinding", func(_ *mock.MockIPAddressAllocationProvider, _ metav1.Object) error {
+			return nil
+		})
+		defer patchesIPAllocDelete.Reset()
+
+		patches3 := gomonkey.ApplyFunc(pkgutil.NSXSubnetStaticIPAllocationEnabled, func(_ *model.VpcSubnet) bool {
+			return true
+		})
+		defer patches3.Reset()
+
+		patches4 := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBySubnetPort", func(_ *SubnetPortReconciler, _ *v1alpha1.SubnetPort) (*model.VpcSubnet, error) {
+			return &model.VpcSubnet{}, nil
+		})
+		defer patches4.Reset()
+
+		patches5 := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetCR", func(_ *SubnetPortReconciler, _ context.Context, _ *v1alpha1.SubnetPort) (*v1alpha1.Subnet, error) {
+			return &v1alpha1.Subnet{}, nil
+		})
+		defer patches5.Reset()
+
+		patches6 := gomonkey.ApplyMethod(reflect.TypeOf(r), "CheckAndGetSubnetPathForSubnetPort", func(_ *SubnetPortReconciler, _ context.Context, _ *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+			return true, false, "/orgs/default/projects/default/vpcs/ns-1/subnets/subnet-1", nil, nil, "IPv4", nil
+		})
+		defer patches6.Reset()
+
+		patchesIsSharedSubnetPath := gomonkey.ApplyFunc(common.IsSharedSubnetPath, func(ctx context.Context, client client.Client, path string, ns string) (bool, error) {
+			return false, nil
+		})
+		defer patchesIsSharedSubnetPath.Reset()
+
+		patchesSetAddressBindingStatus := gomonkey.ApplyFunc(setAddressBindingStatusBySubnetPort,
+			func(client client.Client, ctx context.Context, subnetPort *v1alpha1.SubnetPort, subnetPortService *subnetport.SubnetPortService, transitionTime metav1.Time, e error) {
+			})
+		defer patchesSetAddressBindingStatus.Reset()
+
+		_, err := r.Reconcile(ctx, req)
+		assert.NotNil(t, err)
+		assert.Equal(t, "IP and MAC are missing for SubnetPort", err.Error())
 	})
 }
 
@@ -3065,4 +3147,68 @@ func TestSubnetPortReconciler_UpdateSubnetPortIPType(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, v1alpha1.StaticIPAllocationTypeNone, subnetPort.Spec.StaticIPAllocationType)
 	})
+}
+
+func TestSubnetPortReconciler_updateSubnetPortStatusConditions(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+	k8sClient := mock_client.NewMockClient(mockCtl)
+
+	tests := []struct {
+		name             string
+		subnetPort       *v1alpha1.SubnetPort
+		latestSubnetPort *v1alpha1.SubnetPort
+		newConditions    []v1alpha1.Condition
+		expectErr        bool
+		expectConditions bool
+	}{
+		{
+			name: "conditions updated",
+			subnetPort: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{Name: "sp-1", Namespace: "ns-1"},
+				Status:     v1alpha1.SubnetPortStatus{},
+			},
+			latestSubnetPort: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{Name: "sp-1", Namespace: "ns-1"},
+				Status: v1alpha1.SubnetPortStatus{
+					Conditions: []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: corev1.ConditionTrue}},
+				},
+			},
+			newConditions:    []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: corev1.ConditionFalse}},
+			expectErr:        false,
+			expectConditions: true,
+		},
+		{
+			name: "conditions unchanged",
+			subnetPort: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{Name: "sp-2", Namespace: "ns-1"},
+				Status: v1alpha1.SubnetPortStatus{
+					Conditions: []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: corev1.ConditionTrue}},
+				},
+			},
+			latestSubnetPort: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{Name: "sp-2", Namespace: "ns-1"},
+				Status: v1alpha1.SubnetPortStatus{
+					Conditions: []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: corev1.ConditionTrue}},
+				},
+			},
+			newConditions:    []v1alpha1.Condition{{Type: v1alpha1.Ready, Status: corev1.ConditionTrue}},
+			expectErr:        false,
+			expectConditions: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, key types.NamespacedName, obj *v1alpha1.SubnetPort, opts ...client.GetOption) error {
+				obj.Status = tt.latestSubnetPort.Status
+				return nil
+			})
+			if tt.expectConditions {
+				fakewriter := fakeStatusWriter{}
+				k8sClient.EXPECT().Status().Return(fakewriter)
+			}
+			updateSubnetPortStatusConditions(k8sClient, context.TODO(), tt.subnetPort, tt.newConditions)
+		})
+	}
 }

--- a/pkg/nsx/services/ipaddressallocation/ipaddressallocation.go
+++ b/pkg/nsx/services/ipaddressallocation/ipaddressallocation.go
@@ -97,6 +97,12 @@ func (service *IPAddressAllocationService) CreateOrUpdateIPAddressAllocation(obj
 
 	if !ipAddressAllocationUpdated {
 		log.Info("IPAddressAllocation is not changed", "UID", obj.UID)
+		// If nsx operator is stopped between IPAddressAllocation creation and CR status update,
+		// we need to trigger the status update when IPAddressAllocation matching the spec exists.
+		if obj.Status.AllocationIPs != *existingIPAddressAllocation.AllocationIps {
+			obj.Status.AllocationIPs = *existingIPAddressAllocation.AllocationIps
+			return true, nil
+		}
 		return false, nil
 	}
 
@@ -115,17 +121,19 @@ func (service *IPAddressAllocationService) CreateOrUpdateIPAddressAllocation(obj
 	}
 	if restoreMode {
 		if obj.Status.AllocationIPs == *allocation_ips {
-			// The status may be updated with error by the previous restore process,
-			// return updated as true to make sure the condition will be updated to ready
 			log.Info("Successfully restored IPAddressAllocation CR", "Name", obj.Name, "Namespace", obj.Namespace)
-			return true, nil
+			return false, nil
 		} else {
 			err = fmt.Errorf("IP mismatches for the restored IPAddressAllocation CR %s: got %s, expecting %s", obj.GetUID(), *allocation_ips, obj.Status.AllocationIPs)
 			return false, err
 		}
 	}
-	obj.Status.AllocationIPs = *allocation_ips
-	return true, nil
+	if obj.Status.AllocationIPs != *allocation_ips {
+		log.Info("IPAddressAllocation IPs updated", "IPAddressAllocation", obj.UID, "OldIPs", obj.Status.AllocationIPs, "NewIPs", *allocation_ips)
+		obj.Status.AllocationIPs = *allocation_ips
+		return true, nil
+	}
+	return false, nil
 }
 
 // CreateIPAddressAllocationForAddressBinding is only for the restore of external address binding.

--- a/pkg/nsx/services/ipaddressallocation/ipaddressallocation_test.go
+++ b/pkg/nsx/services/ipaddressallocation/ipaddressallocation_test.go
@@ -171,6 +171,7 @@ func TestIPAddressAllocationService_CreateOrUpdateIPAddressAllocation(t *testing
 	namespace := "ns-1"
 	nsUUID := "nsUuid"
 	vpcPath := "/orgs/default/projects/project-1/vpcs/vpc-1"
+	size := int64(256)
 	alloc := model.VpcIpAddressAllocation{
 		Id:          &nsxAllocID,
 		DisplayName: &name,
@@ -203,6 +204,7 @@ func TestIPAddressAllocationService_CreateOrUpdateIPAddressAllocation(t *testing
 		ParentPath:               &vpcPath,
 		Path:                     String(fmt.Sprintf("%s/ip-address-allocations/%s", vpcPath, nsxAllocID)),
 		AllocationIps:            common.String("192.168.1.0/24"),
+		AllocationSize:           &size,
 		IpAddressBlockVisibility: common.String("PRIVATE"),
 		IpAddressType:            common.String(model.VpcIpAddressAllocation_IP_ADDRESS_TYPE_IPV4),
 	}
@@ -267,13 +269,42 @@ func TestIPAddressAllocationService_CreateOrUpdateIPAddressAllocation(t *testing
 		assert.Nil(t, err)
 	})
 
+	t.Run("test update CR status when operator is restarted", func(t *testing.T) {
+		patchGetByUID := gomonkey.ApplyMethod(reflect.TypeOf(returnservice.ipAddressAllocationStore), "GetByUID", func(_ *IPAddressAllocationStore,
+			_ types.UID) (*model.VpcIpAddressAllocation, error) {
+			return &alloc, nil
+		})
+		defer patchGetByUID.Reset()
+
+		ipAddressAllocationWithoutStatus := &v1alpha1.IPAddressAllocation{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				UID:       types.UID(allocCRUID),
+			},
+			Spec: v1alpha1.IPAddressAllocationSpec{
+				AllocationSize:           256,
+				IPAddressBlockVisibility: "Private",
+			},
+		}
+
+		changed, err := returnservice.CreateOrUpdateIPAddressAllocation(ipAddressAllocationWithoutStatus, false)
+		assert.Nil(t, err)
+		assert.True(t, changed)
+		assert.Equal(t, "192.168.1.0/24", ipAddressAllocationWithoutStatus.Status.AllocationIPs)
+	})
+
 	t.Run("test restore IPAddressAllocation", func(t *testing.T) {
 		// restore 192.168.1.0/24
 		mockVPCIPAddressallocationclient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(alloc, nil).Times(1)
 		mockVPCIPAddressallocationclient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+		// Expected allocation for the restored alloc
+		restoredAlloc := alloc
+		restoredAlloc.AllocationSize = nil
 		// Expected allocation for the update with a single IP reconciled after restored.
 		updatedAlloc := alloc
 		updatedAlloc.AllocationIps = common.String("192.168.1.4")
+		updatedAlloc.AllocationSize = nil
 		patchGetByUIDInRestore := gomonkey.ApplyMethodSeq(reflect.TypeOf(returnservice.ipAddressAllocationStore), "GetByUID", []gomonkey.OutputCell{{
 			Values: gomonkey.Params{
 				nil,
@@ -284,7 +315,11 @@ func TestIPAddressAllocationService_CreateOrUpdateIPAddressAllocation(t *testing
 				&alloc,
 				nil,
 			},
-			Times: 2,
+		}, {
+			Values: gomonkey.Params{
+				&restoredAlloc,
+				nil,
+			},
 		}, {
 			Values: gomonkey.Params{
 				&updatedAlloc,


### PR DESCRIPTION
NSX Operator relies on setReadyStatusTrue to update the CR status. But
setReadyStatusTrue only update the CR status when condition changes.
Previously PR 1480 reduces the status no-op update by not comparing
timestamps inside the condition. This results in that if some of the other
fields in status change while the condition is unchanged, the status will
not be updated.

This PR fixes the issue in SubnetPort/Subnet/SubnetIPReservation/IPAddressAllocation
status update to make sure the status will always be update if condition
is unchanged but other fields in status is updated.

Testing done:

Created a Subnet, update the gatewayAddress of the subnet, observed the Subnet status is updated

```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"Subnet","metadata":{"annotations":{},"name":"subnet-1","namespace":"ns-1"},"spec":{"accessMode":"Public","advancedConfig":{"gatewayAddresses":["192.168.0.34/27"],"staticIPAllocation":{"enabled":true}},"ipAddressType":"IPv4","ipAddresses":["192.168.0.32/27"],"subnetDHCPConfig":{"mode":"DHCPDeactivated"}}}
  creationTimestamp: "2026-07-08T08:35:01Z"
  generation: 4
  name: subnet-1
  namespace: ns-1
  resourceVersion: "148463"
  uid: f155563c-5836-4808-a8cc-95b192bcebdb
spec:
  accessMode: Public
  advancedConfig:
    connectivityState: Connected
    gatewayAddresses:
    - 192.168.0.34/27
    staticIPAllocation:
      enabled: true
  ipAddressType: IPv4
  ipAddresses:
  - 192.168.0.32/27
  subnetDHCPConfig:
    dhcpServerAdditionalConfig: {}
    mode: DHCPDeactivated
  subnetDHCPv6Config:
    dhcpv6ServerAdditionalConfig: {}
  vpcName: project-quality:ns-1_qif7m
status:
  conditions:
  - lastTransitionTime: "2026-07-08T08:35:35Z"
    message: 'NSX Subnet with DHCPv4: DHCPDeactivated has been successfully created/updated'
    reason: SubnetReady
    status: "True"
    type: Ready
  gatewayAddresses:
  - 192.168.0.34/27
  networkAddresses:
  - 192.168.0.32/27
  shared: false
  vlanExtension: {}
```

Created a SubnetIPReservation, updated the reservedIPs, observed the SubnetIPReservation status is updated

```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetIPReservation
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetIPReservation","metadata":{"annotations":{},"name":"subnet-ipr-1","namespace":"ns-1"},"spec":{"reservedIPs":["192.168.0.37-192.168.0.39"],"subnet":"subnet-1"}}
  creationTimestamp: "2026-07-08T08:38:11Z"
  generation: 2
  name: subnet-ipr-1
  namespace: ns-1
  resourceVersion: "150252"
  uid: fb3ac9d7-8524-4efe-91e9-fe833da354c9
spec:
  reservedIPs:
  - 192.168.0.37-192.168.0.39
  subnet: subnet-1
status:
  conditions:
  - lastTransitionTime: "2026-07-08T08:38:39Z"
    message: NSX SubnetIPReservation has been successfully created/updated
    reason: SubnetIPReservationReady
    status: "True"
    type: Ready
  ips:
  - 192.168.0.37-192.168.0.39
```

Create an IPAddressAllocation, clear the status to mock a status not updated case, observed the status will be recovered

```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: IPAddressAllocation
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"IPAddressAllocation","metadata":{"annotations":{},"name":"ipa-2","namespace":"ns-1"},"spec":{"allocationSize":256,"ipAddressBlockVisibility":"External"}}
  creationTimestamp: "2026-07-09T03:52:00Z"
  generation: 1
  name: ipa-2
  namespace: ns-1
  resourceVersion: "834630"
  uid: 7a5e40e5-6826-48aa-ba10-c90c8c230886
spec:
  allocationSize: 256
  ipAddressBlockVisibility: External
  ipAddressType: IPv4
status:
  allocationIPs: 192.168.1.0/24
  conditions:
  - lastTransitionTime: "2026-07-09T04:21:15Z"
    message: NSX IPAddressAllocation has been successfully created/updated
    reason: IPAddressAllocationReady
    status: "True"
    type: Ready
```

Tested the regression case for SubnetPort/Subnet/SubnetIPReservation/IPAddressAllocation restore