### PR TITLE
Update CA in nsx-cert secret only when new CA is non-empty

### DIFF
--- a/pkg/nsx/services/nsxserviceaccount/cluster.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster.go
@@ -407,14 +407,14 @@ func (s *NSXServiceAccountService) ValidateAndUpdateRealizedNSXServiceAccount(ct
 	isUpdated := false
 	secret := &v1.Secret{}
 	isCheckCert := s.NSXClient.NSXCheckVersion(nsx.ServiceAccountCertRotation) && obj.Spec.EnableCertRotation
-	if ca != nil || isCheckCert {
+	if len(ca) > 0 || isCheckCert {
 		if err := s.Client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, secret); err != nil {
 			return err
 		}
 	}
 
 	// check CA is up-to-date
-	if ca != nil {
+	if len(ca) > 0 {
 		oldCA := secret.Data[CAName]
 		oldCAPool := x509.NewCertPool()
 		oldCAPool.AppendCertsFromPEM(oldCA)


### PR DESCRIPTION
ca is a []byte, so nil checks miss empty but non-nil slices.
Use `len(ca) > 0` to correctly skip CA update in nsx-cert secret when no new CA is provided.

Test summary:

- Enable antreaNSX in addonConfig, nsx-cert secret gets created with `ca.crt`, `tls.crt` and `tls.key`
- Manually edit `nsx-ncp-config` configmap in `vmware-system-nsx` namespace to remove nsx certificate.
- Restart `nsx-ncp` deployment.
- Wait for 10 mins, nsx-cert secret gets updated(`ca.crt` value is empty)
```
root@423a6b50944b4b997cf3e3ae176a4f39 [ ~ ]# kubectl get secret -n antrea-test cluster-default-antrea-nsx-cert -oyaml
apiVersion: v1
data:
  ca.crt: ""
...
```
- touch `/var/lib/node.cfg`
- `nsx-ncp-config` configmap in `vmware-system-nsx` namespace gets updated to restore nsx certificate, `nsx-ncp` deployment restarts and after 10 mins nsx-cert secret gets updated to restore `ca.crt` value.
- Manually edit `nsx-ncp-config` configmap in `vmware-system-nsx` namespace to remove nsx certificate.
- Update nsx-operator image from this patch, `nsx-ncp` deployment gets restarted.
- Wait for more than 10 mins, nsx-cert secret doesn't gets updated(`ca.crt` value is as it is and not empty) even when `nsx-ncp-config` configmap in `vmware-system-nsx` namespace doesn't have nsx certificate.
