### PR TITLE
Use NSX product version

### DIFF
--- a/pkg/apis/vpc/v1alpha1/subnetport_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetport_types.go
@@ -67,12 +67,12 @@ type PortAttachment struct {
 
 type NetworkInterfaceConfig struct {
 	// NSX Logical Switch UUID of the Subnet.
-	LogicalSwitchUUID string                      `json:"logicalSwitchUUID,omitempty"`
+	LogicalSwitchUUID string `json:"logicalSwitchUUID,omitempty"`
 	// ID of the Subnet. e.g. /projects/proj1/vpcs/vpc1/subnets/subnet1
 	SubnetID string `json:"subnetID,omitempty"`
 	// ID of the SubnetPortSetting. e.g. /projects/proj1/vpcs/vpc1/subnets/subnet1/port-settings/port-setting1
 	PortSettingID string                      `json:"portSettingID,omitempty"`
-	IPAddresses       []NetworkInterfaceIPAddress `json:"ipAddresses,omitempty"`
+	IPAddresses   []NetworkInterfaceIPAddress `json:"ipAddresses,omitempty"`
 	// The MAC address.
 	MACAddress string `json:"macAddress,omitempty"`
 	// DHCPDeactivatedOnSubnet indicates whether DHCP is deactivated on the Subnet.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -193,10 +193,6 @@ type Validate interface {
 	validate() error
 }
 
-type NsxVersion struct {
-	NodeVersion string `json:"node_version"`
-}
-
 func AddFlags() {
 	flag.StringVar(&configFilePath, "nsxconfig", nsxOperatorDefaultConf, "NSX Operator configuration file path")
 	flag.StringVar(&ProbeAddr, "health-probe-bind-address", ":8384", "The address the probe endpoint binds to.")

--- a/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
+++ b/pkg/controllers/nsxserviceaccount/nsxserviceaccount_controller_test.go
@@ -236,7 +236,7 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 				}))
 				cluster := &nsx.Cluster{}
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *nsx.Cluster) (*nsx.NsxVersion, error) {
-					nsxVersion := &nsx.NsxVersion{NodeVersion: "4.0.1"}
+					nsxVersion := &nsx.NsxVersion{ProductVersion: "4.0.1"}
 					return nsxVersion, nil
 				})
 				patches.ApplyMethodSeq(r.Service, "UpdateProxyEndpointsIfNeeded", []gomonkey.OutputCell{{
@@ -281,7 +281,7 @@ func TestNSXServiceAccountReconciler_Reconcile(t *testing.T) {
 				}))
 				cluster := &nsx.Cluster{}
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *nsx.Cluster) (*nsx.NsxVersion, error) {
-					nsxVersion := &nsx.NsxVersion{NodeVersion: "4.1.2"}
+					nsxVersion := &nsx.NsxVersion{ProductVersion: "4.1.2"}
 					return nsxVersion, nil
 				})
 				patches.ApplyMethodSeq(r.Service, "RestoreRealizedNSXServiceAccount", []gomonkey.OutputCell{{

--- a/pkg/controllers/subnet/subnet_webhook_test.go
+++ b/pkg/controllers/subnet/subnet_webhook_test.go
@@ -485,7 +485,7 @@ func TestSubnetValidator_Handle(t *testing.T) {
 			}
 			patches := gomonkey.ApplyMethod(reflect.TypeOf(v.nsxClient.Cluster), "GetVersion", func(_ *nsx.Cluster) (*nsx.NsxVersion, error) {
 				return &nsx.NsxVersion{
-					NodeVersion: "9.0.0.0.12345",
+					ProductVersion: "9.0.0.0.12345",
 				}, nil
 			})
 			patches.ApplyFunc(controllercommon.CheckAccessModeOrVisibility, func(_ client.Client, ctx context.Context, ns string, accessMode string, resourceType string) error {

--- a/pkg/controllers/subnetset/subnetset_webhook_test.go
+++ b/pkg/controllers/subnetset/subnetset_webhook_test.go
@@ -790,7 +790,7 @@ func TestSubnetSetValidator(t *testing.T) {
 			req.OldObject.Raw = oldJsonData
 			patches := gomonkey.ApplyMethod(reflect.TypeOf(validator.nsxClient.Cluster), "GetVersion", func(_ *nsx.Cluster) (*nsx.NsxVersion, error) {
 				return &nsx.NsxVersion{
-					NodeVersion: "9.0.0.0.12345",
+					ProductVersion: "9.0.0.0.12345",
 				}, nil
 			})
 			patches.ApplyFunc(controllercommon.CheckAccessModeOrVisibility, func(_ client.Client, ctx context.Context, ns string, accessMode string, resourceType string) error {
@@ -1409,7 +1409,7 @@ func TestSubnetSetValidator_IPAddressTypeValidation(t *testing.T) {
 
 			patches := gomonkey.ApplyMethod(reflect.TypeOf(validator.nsxClient.Cluster), "GetVersion", func(_ *nsx.Cluster) (*nsx.NsxVersion, error) {
 				return &nsx.NsxVersion{
-					NodeVersion: "9.0.0.0.12345",
+					ProductVersion: "9.0.0.0.12345",
 				}, nil
 			})
 			patches.ApplyFunc(controllercommon.CheckAccessModeOrVisibility, func(_ client.Client, ctx context.Context, ns string, accessMode string, resourceType string) error {

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -330,9 +330,9 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 		DnsZoneClient:                     dnsZoneClient,
 		DnsRecordsClient:                  dnsRecordsClient,
 	}
-	nsxClient.Cluster.SetOnNodeVersionChanged(func(oldVer, newVer string) {
+	nsxClient.Cluster.SetOnProductVersionChanged(func(oldVer, newVer string) {
 		nsxClient.resetNSXVersionFeatureCache()
-		log.Info("NSX node version changed; cleared cached feature support gates", "oldVersion", oldVer, "newVersion", newVer)
+		log.Info("NSX product version changed; cleared cached feature support gates", "oldVersion", oldVer, "newVersion", newVer)
 	})
 	// NSX version check will be restarted during SecurityPolicy reconcile
 	// So, it's unnecessary to exit even if failed in the first time
@@ -417,7 +417,7 @@ func (client *Client) NSXCheckVersion(feature int) bool {
 	}
 
 	if !nsxVersion.featureSupported(feature) {
-		log.Warn(FeaturesName[feature]+" feature is not supported", "current NSX version", nsxVersion.NodeVersion)
+		log.Warn(FeaturesName[feature]+" feature is not supported", "current NSX version", nsxVersion.ProductVersion)
 		return false
 	}
 	client.NSXVerChecker.featureSupported[feature] = true

--- a/pkg/nsx/client_test.go
+++ b/pkg/nsx/client_test.go
@@ -74,7 +74,7 @@ func TestGetClient(t *testing.T) {
 
 	cluster := &Cluster{}
 	patches := gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
-		nsxVersion := &NsxVersion{NodeVersion: "3.1.1"}
+		nsxVersion := &NsxVersion{ProductVersion: "3.1.1"}
 		return nsxVersion, nil
 	})
 
@@ -88,7 +88,7 @@ func TestGetClient(t *testing.T) {
 	assert.False(t, client.NSXCheckVersion(ServiceAccountCertRotation))
 
 	patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
-		nsxVersion := &NsxVersion{NodeVersion: "3.2.1"}
+		nsxVersion := &NsxVersion{ProductVersion: "3.2.1"}
 		return nsxVersion, nil
 	})
 	client = GetClient(&cf)
@@ -101,7 +101,7 @@ func TestGetClient(t *testing.T) {
 	assert.False(t, client.NSXCheckVersion(ServiceAccountCertRotation))
 
 	patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
-		nsxVersion := &NsxVersion{NodeVersion: "4.1.0"}
+		nsxVersion := &NsxVersion{ProductVersion: "4.1.0"}
 		return nsxVersion, nil
 	})
 	client = GetClient(&cf)
@@ -114,7 +114,7 @@ func TestGetClient(t *testing.T) {
 	assert.False(t, client.NSXCheckVersion(ServiceAccountCertRotation))
 
 	patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
-		nsxVersion := &NsxVersion{NodeVersion: "4.1.2"}
+		nsxVersion := &NsxVersion{ProductVersion: "4.1.2"}
 		return nsxVersion, nil
 	})
 	client = GetClient(&cf)
@@ -127,7 +127,7 @@ func TestGetClient(t *testing.T) {
 	assert.False(t, client.NSXCheckVersion(ServiceAccountCertRotation))
 
 	patches = gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
-		nsxVersion := &NsxVersion{NodeVersion: "4.1.3"}
+		nsxVersion := &NsxVersion{ProductVersion: "4.1.3"}
 		return nsxVersion, nil
 	})
 	client = GetClient(&cf)
@@ -162,7 +162,7 @@ func TestSRGetClient(t *testing.T) {
 
 	cluster := &Cluster{}
 	patches := gomonkey.ApplyMethod(reflect.TypeOf(cluster), "GetVersion", func(_ *Cluster) (*NsxVersion, error) {
-		nsxVersion := &NsxVersion{NodeVersion: "4.1.3"}
+		nsxVersion := &NsxVersion{ProductVersion: "4.1.3"}
 		return nsxVersion, nil
 	})
 	defer patches.Reset()
@@ -226,7 +226,7 @@ func TestRestConnectorAllowOverwrite(t *testing.T) {
 	cluster, _ := NewCluster(config)
 	nsxVersion, err := cluster.GetVersion()
 	assert.Equal(t, err, nil)
-	assert.Equal(t, nsxVersion.NodeVersion, "3.1.3.3.0.18844962")
+	assert.Equal(t, nsxVersion.ProductVersion, "3.1.3.3.0.18844959")
 
 	client := search.NewQueryClient(cluster.NewRestConnectorAllowOverwrite())
 	client.List("search", nil, nil, nil, nil, nil)

--- a/pkg/nsx/cluster.go
+++ b/pkg/nsx/cluster.go
@@ -61,11 +61,13 @@ type Cluster struct {
 	sync.Mutex
 	nsxVersion         *NsxVersion
 	lastTimeGetVersion time.Time
-	// onNodeVersionChanged is invoked after a successful HTTP refresh when node_version changes (non-empty old and new, and different).
-	onNodeVersionChanged func(oldVersion, newVersion string)
+	// onProductVersionChanged is invoked after a successful HTTP refresh when product_version changes (non-empty old and new, and different).
+	onProductVersionChanged func(oldVersion, newVersion string)
 }
 type NsxVersion struct {
-	NodeVersion string `json:"node_version"`
+	// Node version will be updated once MP is updated, while the NSX functionality
+	// works only after the product version is updated.
+	ProductVersion string `json:"product_version"`
 }
 
 var (
@@ -358,24 +360,24 @@ func (cluster *Cluster) Health() ClusterHealth {
 	return ORANGE
 }
 
-// SetOnNodeVersionChanged registers a callback run after GetVersion successfully refreshes
-// from NSX and detects a non-empty node_version change. Used to invalidate client-side
+// SetonProductVersionChanged registers a callback run after GetVersion successfully refreshes
+// from NSX and detects a non-empty product_version change. Used to invalidate client-side
 // feature caches. Safe to call once during operator init; fn may be nil to clear.
-func (cluster *Cluster) SetOnNodeVersionChanged(fn func(oldVersion, newVersion string)) {
+func (cluster *Cluster) SetOnProductVersionChanged(fn func(oldVersion, newVersion string)) {
 	cluster.Mutex.Lock()
 	defer cluster.Mutex.Unlock()
-	cluster.onNodeVersionChanged = fn
+	cluster.onProductVersionChanged = fn
 }
 
 func (cluster *Cluster) GetVersion() (*NsxVersion, error) {
-	if cluster.nsxVersion != nil && len(cluster.nsxVersion.NodeVersion) > 0 && time.Since(cluster.lastTimeGetVersion) < GetNsxVersionInterval {
-		log.Debug("Get version from cache", "version", cluster.nsxVersion.NodeVersion)
+	if cluster.nsxVersion != nil && len(cluster.nsxVersion.ProductVersion) > 0 && time.Since(cluster.lastTimeGetVersion) < GetNsxVersionInterval {
+		log.Debug("Get version from cache", "version", cluster.nsxVersion.ProductVersion)
 		return cluster.nsxVersion, nil
 	}
 
 	oldVersion := ""
 	if cluster.nsxVersion != nil {
-		oldVersion = cluster.nsxVersion.NodeVersion
+		oldVersion = cluster.nsxVersion.ProductVersion
 	}
 
 	ep := cluster.endpoints[0]
@@ -402,11 +404,11 @@ func (cluster *Cluster) GetVersion() (*NsxVersion, error) {
 		cluster.lastTimeGetVersion = time.Now()
 		newVersion := ""
 		if cluster.nsxVersion != nil {
-			newVersion = cluster.nsxVersion.NodeVersion
+			newVersion = cluster.nsxVersion.ProductVersion
 		}
 		if oldVersion != "" && newVersion != "" && oldVersion != newVersion {
 			cluster.Mutex.Lock()
-			cb := cluster.onNodeVersionChanged
+			cb := cluster.onProductVersionChanged
 			cluster.Mutex.Unlock()
 			if cb != nil {
 				cb(oldVersion, newVersion)
@@ -515,10 +517,10 @@ func (cluster *Cluster) HttpPatch(url string, requestBody interface{}) (map[stri
 
 func (nsxVersion *NsxVersion) Validate() error {
 	re, _ := regexp.Compile(`^([\d]+).([\d]+).([\d]+)`)
-	result := re.Find([]byte(nsxVersion.NodeVersion))
+	result := re.Find([]byte(nsxVersion.ProductVersion))
 	if len(result) < 1 {
 		err := errors.New("error version format")
-		log.Error(err, "Failed to check NSX version", "version", nsxVersion.NodeVersion)
+		log.Error(err, "Failed to check NSX version", "version", nsxVersion.ProductVersion)
 		return err
 	}
 
@@ -575,9 +577,9 @@ func (nsxVersion *NsxVersion) featureSupported(feature int) bool {
 
 	if validFeature {
 		// only compared major.minor.patch
-		// NodeVersion should have at least three sections
+		// ProductVersion should have at least three sections
 		// each section only have digital value
-		buff := strings.Split(nsxVersion.NodeVersion, ".")
+		buff := strings.Split(nsxVersion.ProductVersion, ".")
 		sections := make([]int64, len(buff))
 		for i, str := range buff {
 			val, err := strconv.ParseInt(str, 10, 64)

--- a/pkg/nsx/cluster_test.go
+++ b/pkg/nsx/cluster_test.go
@@ -149,85 +149,85 @@ func TestCluster_Health(t *testing.T) {
 func TestCluster_enableFeature(t *testing.T) {
 	// Test case for enabling feature SecurityPolicy
 	nsxVersion := &NsxVersion{}
-	nsxVersion.NodeVersion = "3.1.3.3.0.18844962"
+	nsxVersion.ProductVersion = "3.1.3.3.0.18844962"
 	assert.False(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
-	nsxVersion.NodeVersion = "3.2.0.3.0.18844962"
+	nsxVersion.ProductVersion = "3.2.0.3.0.18844962"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
-	nsxVersion.NodeVersion = "3.11.0.3.0.18844962"
+	nsxVersion.ProductVersion = "3.11.0.3.0.18844962"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
-	nsxVersion.NodeVersion = "4.0.0"
+	nsxVersion.ProductVersion = "4.0.0"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
-	nsxVersion.NodeVersion = "4.0.1"
+	nsxVersion.ProductVersion = "4.0.1"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
-	nsxVersion.NodeVersion = "4.1.0"
+	nsxVersion.ProductVersion = "4.1.0"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
-	nsxVersion.NodeVersion = "4.1.2"
+	nsxVersion.ProductVersion = "4.1.2"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccountRestore))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
-	nsxVersion.NodeVersion = "4.1.3"
+	nsxVersion.ProductVersion = "4.1.3"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccountRestore))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
-	nsxVersion.NodeVersion = "3.2.0"
+	nsxVersion.ProductVersion = "3.2.0"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountRestore))
 	assert.False(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
-	nsxVersion.NodeVersion = "4.2.0"
+	nsxVersion.ProductVersion = "4.2.0"
 	assert.True(t, nsxVersion.featureSupported(SecurityPolicy))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccount))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccountRestore))
 	assert.True(t, nsxVersion.featureSupported(ServiceAccountCertRotation))
 	assert.False(t, nsxVersion.featureSupported(IPv6))
 
-	nsxVersion.NodeVersion = "9.2.0"
+	nsxVersion.ProductVersion = "9.2.0"
 	assert.True(t, nsxVersion.featureSupported(IPv6))
 
 	// Test case for invalid feature
 	feature := 3
-	nsxVersion.NodeVersion = "3.1.3.3.0.18844962"
+	nsxVersion.ProductVersion = "3.1.3.3.0.18844962"
 	assert.False(t, nsxVersion.featureSupported(feature))
-	nsxVersion.NodeVersion = "3.2.0"
+	nsxVersion.ProductVersion = "3.2.0"
 	assert.False(t, nsxVersion.featureSupported(feature))
 }
 
 func TestCluster_validate(t *testing.T) {
 	nsxVersion := &NsxVersion{}
-	nsxVersion.NodeVersion = "12"
+	nsxVersion.ProductVersion = "12"
 	expect := errors.New("error version format")
 	err := nsxVersion.Validate()
 	assert.Equal(t, err, expect)
 
-	nsxVersion.NodeVersion = "12.3"
+	nsxVersion.ProductVersion = "12.3"
 	err = nsxVersion.Validate()
 	assert.Equal(t, err, expect)
 
-	nsxVersion.NodeVersion = "3.2.3.3.0.18844962"
+	nsxVersion.ProductVersion = "3.2.3.3.0.18844962"
 	err = nsxVersion.Validate()
 	assert.Equal(t, err, nil)
 
-	nsxVersion.NodeVersion = "3.2.3"
+	nsxVersion.ProductVersion = "3.2.3"
 	err = nsxVersion.Validate()
 	assert.Equal(t, err, nil)
 }
@@ -257,10 +257,10 @@ func TestCluster_getVersion(t *testing.T) {
 	cluster, _ := NewCluster(config)
 	nsxVersion, err := cluster.GetVersion()
 	assert.Equal(t, err, nil)
-	assert.Equal(t, nsxVersion.NodeVersion, "3.1.3.3.0.18844962")
+	assert.Equal(t, nsxVersion.ProductVersion, "3.1.3.3.0.18844959")
 }
 
-func TestCluster_GetVersion_invokesOnNodeVersionChangedWhenNodeVersionChanges(t *testing.T) {
+func TestCluster_GetVersion_invokesOnProductVersionChangedWhenProductVersionChanges(t *testing.T) {
 	var (
 		callbackCalls int
 		gotOld        string
@@ -281,9 +281,9 @@ func TestCluster_GetVersion_invokesOnNodeVersionChangedWhenNodeVersionChanges(t 
 			versionCalls++
 			var body string
 			if versionCalls == 1 {
-				body = `{"node_version":"9.1.0.0.0.10000000","product_version":"9.1.0"}`
+				body = `{"node_version":"9.1.0.0.0.10000000","product_version":"9.1.0.0200.25524170"}`
 			} else {
-				body = `{"node_version":"9.2.0.0.0.20000000","product_version":"9.2.0"}`
+				body = `{"node_version":"9.2.0.0.0.20000000","product_version":"9.2.0.0.25588556"}`
 			}
 			_, _ = w.Write([]byte(body))
 			return
@@ -298,26 +298,26 @@ func TestCluster_GetVersion_invokesOnNodeVersionChangedWhenNodeVersionChanges(t 
 	cluster, err := NewCluster(config)
 	assert.NoError(t, err)
 
-	cluster.SetOnNodeVersionChanged(func(oldV, newV string) {
+	cluster.SetOnProductVersionChanged(func(oldV, newV string) {
 		callbackCalls++
 		gotOld, gotNew = oldV, newV
 	})
 
 	ver1, err := cluster.GetVersion()
 	assert.NoError(t, err)
-	assert.Equal(t, "9.1.0.0.0.10000000", ver1.NodeVersion)
-	assert.Equal(t, 0, callbackCalls, "first successful fetch has no prior node_version, callback must not run")
+	assert.Equal(t, "9.1.0.0200.25524170", ver1.ProductVersion)
+	assert.Equal(t, 0, callbackCalls, "first successful fetch has no prior product_version, callback must not run")
 
 	cluster.lastTimeGetVersion = time.Now().Add(-40 * time.Minute)
 	ver2, err := cluster.GetVersion()
 	assert.NoError(t, err)
-	assert.Equal(t, "9.2.0.0.0.20000000", ver2.NodeVersion)
+	assert.Equal(t, "9.2.0.0.25588556", ver2.ProductVersion)
 	assert.Equal(t, 1, callbackCalls)
-	assert.Equal(t, "9.1.0.0.0.10000000", gotOld)
-	assert.Equal(t, "9.2.0.0.0.20000000", gotNew)
+	assert.Equal(t, "9.1.0.0200.25524170", gotOld)
+	assert.Equal(t, "9.2.0.0.25588556", gotNew)
 }
 
-func TestCluster_GetVersion_noOnNodeVersionChangedWhenVersionUnchanged(t *testing.T) {
+func TestCluster_GetVersion_noOnProductVersionChangedWhenVersionUnchanged(t *testing.T) {
 	var callbackCalls int
 	versionCalls := 0
 	resHealth := `{
@@ -346,7 +346,7 @@ func TestCluster_GetVersion_noOnNodeVersionChangedWhenVersionUnchanged(t *testin
 	cluster, err := NewCluster(config)
 	assert.NoError(t, err)
 
-	cluster.SetOnNodeVersionChanged(func(_, _ string) {
+	cluster.SetOnProductVersionChanged(func(_, _ string) {
 		callbackCalls++
 	})
 
@@ -358,7 +358,7 @@ func TestCluster_GetVersion_noOnNodeVersionChangedWhenVersionUnchanged(t *testin
 	assert.Equal(t, 0, callbackCalls)
 }
 
-func TestCluster_GetVersion_noPanicWhenOnNodeVersionChangedNil(t *testing.T) {
+func TestCluster_GetVersion_noPanicWhenOnProductVersionChangedNil(t *testing.T) {
 	versionCalls := 0
 	resHealth := `{
 					"healthy" : true,
@@ -389,7 +389,7 @@ func TestCluster_GetVersion_noPanicWhenOnNodeVersionChangedNil(t *testing.T) {
 	cluster, err := NewCluster(config)
 	assert.NoError(t, err)
 
-	cluster.SetOnNodeVersionChanged(nil)
+	cluster.SetOnProductVersionChanged(nil)
 	_, err = cluster.GetVersion()
 	assert.NoError(t, err)
 	cluster.lastTimeGetVersion = time.Now().Add(-40 * time.Minute)


### PR DESCRIPTION
During upgrade, NSX node version will be updated before NSX final upgrade.
NSX Operator should check product version instead of node version for feature supporting.