### PR TITLE
Clean tdnf cache at the end of Dockerfile

### DIFF
--- a/build/image/eas/Dockerfile
+++ b/build/image/eas/Dockerfile
@@ -8,7 +8,9 @@ RUN CGO_ENABLED=0 go build -o eas cmd_eas/main.go
 FROM photon
 
 RUN tdnf -y install shadow && \
-    useradd -s /bin/bash eas
+    useradd -s /bin/bash eas && \
+    tdnf clean all && \
+    rm -rf /var/cache/tdnf
 
 COPY --from=golang-build /source/eas /usr/local/bin/
 

--- a/build/image/photon/Dockerfile
+++ b/build/image/photon/Dockerfile
@@ -9,7 +9,9 @@ RUN CGO_ENABLED=0 go build -o clean cmd_clean/main.go
 FROM photon
 
 RUN tdnf -y install shadow && \
-    useradd -s /bin/bash nsx-operator
+    useradd -s /bin/bash nsx-operator && \
+    tdnf clean all && \
+    rm -rf /var/cache/tdnf
 
 COPY --from=golang-build /source/manager /usr/local/bin/
 COPY --from=golang-build /source/clean /usr/local/bin/


### PR DESCRIPTION
Clean tdnf cache at the end of Dockerfile to avoid BD reporting CVEs from non-installed packages.