### PR TITLE
Support Subnetport multi ip addressbindings 

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
@@ -57,8 +57,12 @@ spec:
             description: SubnetPortSpec defines the desired state of SubnetPort.
             properties:
               addressBindings:
-                description: AddressBindings defines static address bindings used
-                  for the SubnetPort.
+                description: |-
+                  AddressBindings defines static address bindings used for the SubnetPort. Multiple
+                  bindings sharing one MAC address are supported (NSX 9.2+) for use cases such as
+                  Blueprint VM creation where a single interface needs several IP addresses. NSX
+                  requires all non-empty MACAddress values across entries to match, and rejects
+                  changing the number of entries once the SubnetPort has been created.
                 items:
                   description: PortAddressBinding defines static addresses for the
                     Port.

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
@@ -59,7 +59,7 @@ spec:
               addressBindings:
                 description: |-
                   AddressBindings defines static address bindings used for the SubnetPort.
-                  Multiple bindings sharing one MAC address are supported from VCF 9.2.
+                  Multiple bindings sharing one MAC address are supported starting with VCF 9.2.0.
                 items:
                   description: PortAddressBinding defines static addresses for the
                     Port.

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
@@ -58,11 +58,8 @@ spec:
             properties:
               addressBindings:
                 description: |-
-                  AddressBindings defines static address bindings used for the SubnetPort. Multiple
-                  bindings sharing one MAC address are supported (NSX 9.2+) for use cases such as
-                  Blueprint VM creation where a single interface needs several IP addresses. NSX
-                  requires all non-empty MACAddress values across entries to match, and rejects
-                  changing the number of entries once the SubnetPort has been created.
+                  AddressBindings defines static address bindings used for the SubnetPort.
+                  Multiple bindings sharing one MAC address are supported from VCF 9.2.
                 items:
                   description: PortAddressBinding defines static addresses for the
                     Port.

--- a/build/yaml/samples/nsx_v1alpha1_subnetport.yaml
+++ b/build/yaml/samples/nsx_v1alpha1_subnetport.yaml
@@ -67,3 +67,35 @@ status:
       ipAddress: 172.26.0.3/28
     logicalSwitchUUID: 49fa0a2d-8fd2-4c85-87ca-2495e8a86d06
     macAddress: 04:50:56:00:94:00
+---
+# SubnetPort CR sample with multiple IP addresses sharing one MAC address
+# (Blueprint VM creation scenario, requires NSX 9.2+). NSX rejects changing the
+# number of addressBindings entries once the SubnetPort has been created.
+apiVersion: crd.nsx.vmware.com/v1alpha1
+kind: SubnetPort
+metadata:
+  name: subnetport-sample-d
+spec:
+  subnet: vm-subnet
+  addressBindings:
+  - ipAddress: 172.26.0.3
+    macAddress: 04:50:56:00:94:00
+  - ipAddress: 172.26.0.4
+    macAddress: 04:50:56:00:94:00
+status:
+  attachment:
+    id: 35323036-6439-4932-ad36-3930372d3438
+  conditions:
+  - lastTransitionTime: "2024-11-20T22:23:10Z"
+    message: NSX subnet port has been successfully created/updated
+    reason: SubnetPortReady
+    status: "True"
+    type: Ready
+  networkInterfaceConfig:
+    ipAddresses:
+    - gateway: 172.26.0.1
+      ipAddress: 172.26.0.3/28
+    - gateway: 172.26.0.1
+      ipAddress: 172.26.0.4/28
+    logicalSwitchUUID: 49fa0a2d-8fd2-4c85-87ca-2495e8a86d06
+    macAddress: 04:50:56:00:94:00

--- a/docs/ref/apis/legacy.md
+++ b/docs/ref/apis/legacy.md
@@ -29,7 +29,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -121,7 +121,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 
@@ -265,7 +265,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br />Optional: \{\} <br /> |
+| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br /> |
 | `allocationSize` _integer_ | AllocationSize specifies the size of IPv4 allocationIPs to be allocated.<br />It should be a power of 2. |  | Minimum: 1 <br /> |
 | `allocationIPs` _string_ | AllocationIPs specifies the Allocated IP addresses in CIDR or single IP Address format. |  |  |
 | `ipv6AllocationPrefixLength` _integer_ | IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses.<br />Defaults to 64 when ipAddressType is IPv6 and this field is not specified.<br />Supported starting with VCF 9.2.0. |  | Maximum: 128 <br />Minimum: 64 <br /> |
@@ -734,7 +734,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the current state of the ServiceEndpoint. |  | Optional: \{\} <br /> |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the current state of the ServiceEndpoint. |  |  |
 
 
 #### SharedSubnet
@@ -770,7 +770,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Activate or deactivate static IP allocation for VPC Subnet Ports.<br />If the DHCP mode is DHCPDeactivated or not set, its default value is true.<br />If the DHCP mode is DHCPServer, its default value is false.<br />If the DHCP mode is DHCPRelay, its default value is false. |  |  |
-| `poolRanges` _string array_ | PoolRanges specifies the IP address ranges for static IP allocation.<br />Each entry is either a single IP address (e.g. "192.168.1.5") or a<br />dash-separated range (e.g. "192.168.1.10-192.168.1.20"). Both IPv4 and<br />IPv6 entries may appear in a single list.<br />Example value: ["192.168.1.1", "192.168.1.3-192.168.1.100"] |  | Optional: \{\} <br /> |
+| `poolRanges` _string array_ | PoolRanges specifies the IP address ranges for static IP allocation.<br />Each entry is either a single IP address (e.g. "192.168.1.5") or a<br />dash-separated range (e.g. "192.168.1.10-192.168.1.20"). Both IPv4 and<br />IPv6 entries may appear in a single list.<br />Example value: ["192.168.1.1", "192.168.1.3-192.168.1.100"] |  |  |
 
 
 #### StaticIPAllocationType
@@ -826,7 +826,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 
@@ -844,8 +844,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `network` _string_ | Specify network address in CIDR format.<br />Mutually exclusive with networkIpAllocationName. |  | Format: cidr <br />Optional: \{\} <br /> |
-| `networkIpAllocationName` _string_ | Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as<br />the static route network. Mutually exclusive with network. |  | Optional: \{\} <br /> |
+| `network` _string_ | Specify network address in CIDR format.<br />Mutually exclusive with networkIpAllocationName. |  | Format: cidr <br /> |
+| `networkIpAllocationName` _string_ | Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as<br />the static route network. Mutually exclusive with network. |  |  |
 | `nextHops` _[NextHop](#nexthop) array_ | Next hop gateway |  | MinItems: 1 <br /> |
 
 
@@ -1154,7 +1154,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `subnet` _string_ | Subnet defines the parent Subnet name of the SubnetPort. |  |  |
 | `subnetSet` _string_ | SubnetSet defines the parent SubnetSet name of the SubnetPort. |  |  |
-| `addressBindings` _[PortAddressBinding](#portaddressbinding) array_ | AddressBindings defines static address bindings used for the SubnetPort. |  |  |
+| `addressBindings` _[PortAddressBinding](#portaddressbinding) array_ | AddressBindings defines static address bindings used for the SubnetPort.<br />Multiple bindings sharing one MAC address are supported from VCF 9.2. |  |  |
 | `interfaceIPType` _[IPAddressType](#ipaddresstype)_ | InterfaceIPType decides the address families of static IP allocation, when<br />DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType<br />is set, IP families of InterfaceIPType should be a superset of<br />StaticIPAllocationType.<br />Supported starting with VCF 9.2.0. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
 | `staticIPAllocationType` _[StaticIPAllocationType](#staticipallocationtype)_ | StaticIPAllocationType explicitly requests static IP allocation of the<br />specified the address families. In a mixed-mode Subnet (where both DHCP<br />and static allocation are enabled), use this to define which families<br />should be allocated from the static IP pools. If not specified, this field<br />will be back-filled based on InterfaceIPType and Subnet configuration.<br />Supported starting with VCF 9.2.0. |  | Enum: [IPv4 IPv6 IPv4IPv6 None] <br /> |
 | `portSettingName` _string_ | Name of PortSetting associated with this SubnetPort. |  |  |
@@ -1348,7 +1348,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the current state of the VPCEndpoint. |  | Optional: \{\} <br /> |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the current state of the VPCEndpoint. |  |  |
 
 
 #### VPCInfo
@@ -1406,8 +1406,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  | Optional: \{\} <br /> |
-| `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  | Optional: \{\} <br /> |
+| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  |  |
+| `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  |  |
 | `nsxProject` _string_ | NSX Project the Namespace is associated with. |  |  |
 | `vpcConnectivityProfile` _string_ | VPCConnectivityProfile Path. This profile has configuration related to creating VPC transit gateway attachment. |  |  |
 | `privateIPs` _string array_ | Private IPs. |  |  |

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -1154,7 +1154,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `subnet` _string_ | Subnet defines the parent Subnet name of the SubnetPort. |  |  |
 | `subnetSet` _string_ | SubnetSet defines the parent SubnetSet name of the SubnetPort. |  |  |
-| `addressBindings` _[PortAddressBinding](#portaddressbinding) array_ | AddressBindings defines static address bindings used for the SubnetPort.<br />Multiple bindings sharing one MAC address are supported from VCF 9.2. |  |  |
+| `addressBindings` _[PortAddressBinding](#portaddressbinding) array_ | AddressBindings defines static address bindings used for the SubnetPort.<br />Multiple bindings sharing one MAC address are supported starting with VCF 9.2.0. |  |  |
 | `interfaceIPType` _[IPAddressType](#ipaddresstype)_ | InterfaceIPType decides the address families of static IP allocation, when<br />DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType<br />is set, IP families of InterfaceIPType should be a superset of<br />StaticIPAllocationType.<br />Supported starting with VCF 9.2.0. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
 | `staticIPAllocationType` _[StaticIPAllocationType](#staticipallocationtype)_ | StaticIPAllocationType explicitly requests static IP allocation of the<br />specified the address families. In a mixed-mode Subnet (where both DHCP<br />and static allocation are enabled), use this to define which families<br />should be allocated from the static IP pools. If not specified, this field<br />will be back-filled based on InterfaceIPType and Subnet configuration.<br />Supported starting with VCF 9.2.0. |  | Enum: [IPv4 IPv6 IPv4IPv6 None] <br /> |
 | `portSettingName` _string_ | Name of PortSetting associated with this SubnetPort. |  |  |

--- a/pkg/apis/vpc/v1alpha1/subnetport_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetport_types.go
@@ -23,7 +23,11 @@ type SubnetPortSpec struct {
 	Subnet string `json:"subnet,omitempty"`
 	// SubnetSet defines the parent SubnetSet name of the SubnetPort.
 	SubnetSet string `json:"subnetSet,omitempty"`
-	// AddressBindings defines static address bindings used for the SubnetPort.
+	// AddressBindings defines static address bindings used for the SubnetPort. Multiple
+	// bindings sharing one MAC address are supported (NSX 9.2+) for use cases such as
+	// Blueprint VM creation where a single interface needs several IP addresses. NSX
+	// requires all non-empty MACAddress values across entries to match, and rejects
+	// changing the number of entries once the SubnetPort has been created.
 	AddressBindings []PortAddressBinding `json:"addressBindings,omitempty"`
 	// InterfaceIPType decides the address families of static IP allocation, when
 	// DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType

--- a/pkg/apis/vpc/v1alpha1/subnetport_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetport_types.go
@@ -24,7 +24,7 @@ type SubnetPortSpec struct {
 	// SubnetSet defines the parent SubnetSet name of the SubnetPort.
 	SubnetSet string `json:"subnetSet,omitempty"`
 	// AddressBindings defines static address bindings used for the SubnetPort.
-	// Multiple bindings sharing one MAC address are supported from VCF 9.2.
+	// Multiple bindings sharing one MAC address are supported starting with VCF 9.2.0.
 	AddressBindings []PortAddressBinding `json:"addressBindings,omitempty"`
 	// InterfaceIPType decides the address families of static IP allocation, when
 	// DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType

--- a/pkg/apis/vpc/v1alpha1/subnetport_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetport_types.go
@@ -23,11 +23,8 @@ type SubnetPortSpec struct {
 	Subnet string `json:"subnet,omitempty"`
 	// SubnetSet defines the parent SubnetSet name of the SubnetPort.
 	SubnetSet string `json:"subnetSet,omitempty"`
-	// AddressBindings defines static address bindings used for the SubnetPort. Multiple
-	// bindings sharing one MAC address are supported (NSX 9.2+) for use cases such as
-	// Blueprint VM creation where a single interface needs several IP addresses. NSX
-	// requires all non-empty MACAddress values across entries to match, and rejects
-	// changing the number of entries once the SubnetPort has been created.
+	// AddressBindings defines static address bindings used for the SubnetPort.
+	// Multiple bindings sharing one MAC address are supported from VCF 9.2.
 	AddressBindings []PortAddressBinding `json:"addressBindings,omitempty"`
 	// InterfaceIPType decides the address families of static IP allocation, when
 	// DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType

--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -115,8 +115,11 @@ func ResolveEffectiveStaticIPAllocationType(rawStaticIPAllocationType v1alpha1.S
 	return util.ComputeDefaultStaticIPAllocationType(nsxSubnet, interfaceIPType)
 }
 
-// Get a Subnet with available IPs from the pre-created SubnetSet
-func GetSubnetFromSubnetSet(client k8sclient.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, error) {
+// Get a Subnet with available IPs from the pre-created SubnetSet. Also returns the
+// StaticIPAllocationType actually resolved for the winning Subnet, so callers can release
+// the same pool capacity they reserved without having to recompute it later from state that
+// may no longer be available (e.g. if a later step fails).
+func GetSubnetFromSubnetSet(client k8sclient.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, v1alpha1.StaticIPAllocationType, error) {
 	var errList []error
 	defaultSubnetSetFor := util.GetSubnetSetKind(subnetSet)
 	subnetPathsFromConfig := sets.New[string]()
@@ -126,7 +129,7 @@ func GetSubnetFromSubnetSet(client k8sclient.Client, subnetSet *v1alpha1.SubnetS
 		subnetPathsFromConfig, err = getSubnetFromVPCNetworkConfiguration(vpcService, subnetSet.Namespace, defaultSubnetSetFor)
 		if err != nil {
 			log.Error(err, "Failed to get Subnet for default Network in VPCNetworkConfiguration")
-			return "", err
+			return "", "", err
 		}
 	}
 	for _, subnetName := range *subnetSet.Spec.SubnetNames {
@@ -160,13 +163,13 @@ func GetSubnetFromSubnetSet(client k8sclient.Client, subnetSet *v1alpha1.SubnetS
 			continue
 		}
 		if canAllocate {
-			return *nsxSubnet.Path, nil
+			return *nsxSubnet.Path, effectiveStaticType, nil
 		}
 	}
 	if len(errList) > 0 {
-		return "", errors.Join(errList...)
+		return "", "", errors.Join(errList...)
 	}
-	return "", fmt.Errorf("all Subnets for SubnetSet %s/%s are not available", subnetSet.Namespace, subnetSet.Name)
+	return "", "", fmt.Errorf("all Subnets for SubnetSet %s/%s are not available", subnetSet.Namespace, subnetSet.Name)
 }
 
 // IsNamespaceInTepLessMode checks if the namespace has a VLAN-backed VPC (tepless mode).
@@ -197,10 +200,13 @@ func IsNamespaceInTepLessMode(client k8sclient.Client, namespace string) (bool, 
 	return networkInfo.VPCs[0].NetworkStack == v1alpha1.VLANBackedVPC, nil
 }
 
-func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, *types.UID, *sync.RWMutex, error) {
+// AllocateSubnetFromSubnetSet also returns the StaticIPAllocationType actually resolved for
+// the Subnet it picked, so callers can release the same pool capacity they reserved without
+// having to recompute it later from state that may no longer be available.
+func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, v1alpha1.StaticIPAllocationType, *types.UID, *sync.RWMutex, error) {
 	if subnetSet.Spec.SubnetDHCPConfig.Mode == v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeRelay) {
 		// From NSX Operator 9.1.1, DHCPRelay SubnetSet is no longer supported.
-		return "", nil, nil, fmt.Errorf("Creating SubnetPort on DHCPRelay SubnetSet is not supported")
+		return "", "", nil, nil, fmt.Errorf("Creating SubnetPort on DHCPRelay SubnetSet is not supported")
 	}
 	if subnetSet.Spec.SubnetNames != nil {
 		// Use Read lock to allow SubnetPorts created parallelly on the pre-created SubnetSet
@@ -208,10 +214,10 @@ func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Re
 		subnetSetLock := RLockSubnetSet(subnetSet.UID)
 		// Retrieve the SubnetSet again to avoid it being updated before acquiring the lock
 		if err := apiReader.Get(context.Background(), types.NamespacedName{Namespace: subnetSet.Namespace, Name: subnetSet.Name}, subnetSet); err != nil {
-			return "", &subnetSet.UID, subnetSetLock, err
+			return "", "", &subnetSet.UID, subnetSetLock, err
 		}
-		nsxSubnet, err := GetSubnetFromSubnetSet(client, subnetSet, vpcService, subnetService, subnetPortService, interfaceIPType, rawStaticIPAllocationType, addressBindings)
-		return nsxSubnet, &subnetSet.UID, subnetSetLock, err
+		nsxSubnet, staticIPAllocationType, err := GetSubnetFromSubnetSet(client, subnetSet, vpcService, subnetService, subnetPortService, interfaceIPType, rawStaticIPAllocationType, addressBindings)
+		return nsxSubnet, staticIPAllocationType, &subnetSet.UID, subnetSetLock, err
 	}
 	// Use SubnetSet uuid lock to make sure when multiple ports are created on the same SubnetSet, only one Subnet will be created
 	subnetSetLock := WLockSubnetSet(subnetSet.GetUID())
@@ -221,36 +227,36 @@ func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Re
 		effectiveStaticType := ResolveEffectiveStaticIPAllocationType(rawStaticIPAllocationType, nsxSubnet, interfaceIPType)
 		canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, false, interfaceIPType, effectiveStaticType, addressBindings)
 		if err != nil {
-			return "", nil, nil, err
+			return "", "", nil, nil, err
 		}
 		if canAllocate {
-			return *nsxSubnet.Path, nil, nil, nil
+			return *nsxSubnet.Path, effectiveStaticType, nil, nil, nil
 		}
 	}
 	tags := subnetService.GenerateSubnetNSTags(subnetSet)
 	if tags == nil {
-		return "", nil, nil, errors.New("failed to generate subnet tags")
+		return "", "", nil, nil, errors.New("failed to generate subnet tags")
 	}
 	log.Info("The existing subnets are not available, creating new subnet", "subnetList", subnetList, "subnetSet.Name", subnetSet.Name, "subnetSet.Namespace", subnetSet.Namespace)
 	vpcInfoList := vpcService.ListVPCInfo(subnetSet.Namespace)
 	if len(vpcInfoList) == 0 {
 		err := errors.New("no VPC found")
 		log.Error(err, "Failed to allocate Subnet")
-		return "", nil, nil, err
+		return "", "", nil, nil, err
 	}
 	nsxSubnet, err := subnetService.CreateOrUpdateSubnet(subnetSet, vpcInfoList[0], tags)
 	if err != nil {
-		return "", nil, nil, err
+		return "", "", nil, nil, err
 	}
 	effectiveStaticType := ResolveEffectiveStaticIPAllocationType(rawStaticIPAllocationType, nsxSubnet, interfaceIPType)
 	canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, false, interfaceIPType, effectiveStaticType, addressBindings)
 	if err != nil {
-		return "", nil, nil, err
+		return "", "", nil, nil, err
 	}
 	if canAllocate {
-		return *nsxSubnet.Path, nil, nil, nil
+		return *nsxSubnet.Path, effectiveStaticType, nil, nil, nil
 	}
-	return "", nil, nil, fmt.Errorf("cannot allocate Port from SubnetSet %s", subnetSet.Name)
+	return "", "", nil, nil, fmt.Errorf("cannot allocate Port from SubnetSet %s", subnetSet.Name)
 }
 
 func GetDefaultSubnetSetByNamespace(client k8sclient.Client, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {

--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -105,8 +105,18 @@ func getSubnetFromVPCNetworkConfiguration(vpcService servicecommon.VPCServicePro
 	return subnetPaths, nil
 }
 
+// ResolveEffectiveStaticIPAllocationType returns the StaticIPAllocationType a SubnetPort
+// actually allocates from for the given candidate Subnet: the CR-set value if present,
+// otherwise the same default the SubnetPort controller backfills the CR with.
+func ResolveEffectiveStaticIPAllocationType(rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, nsxSubnet *model.VpcSubnet, interfaceIPType v1alpha1.IPAddressType) v1alpha1.StaticIPAllocationType {
+	if rawStaticIPAllocationType != "" {
+		return rawStaticIPAllocationType
+	}
+	return util.ComputeDefaultStaticIPAllocationType(nsxSubnet, interfaceIPType)
+}
+
 // Get a Subnet with available IPs from the pre-created SubnetSet
-func GetSubnetFromSubnetSet(client k8sclient.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType) (string, error) {
+func GetSubnetFromSubnetSet(client k8sclient.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, error) {
 	var errList []error
 	defaultSubnetSetFor := util.GetSubnetSetKind(subnetSet)
 	subnetPathsFromConfig := sets.New[string]()
@@ -142,7 +152,8 @@ func GetSubnetFromSubnetSet(client k8sclient.Client, subnetSet *v1alpha1.SubnetS
 				continue
 			}
 		}
-		canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, servicecommon.IsSharedSubnet(subnetCR), interfaceIPType)
+		effectiveStaticType := ResolveEffectiveStaticIPAllocationType(rawStaticIPAllocationType, nsxSubnet, interfaceIPType)
+		canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, servicecommon.IsSharedSubnet(subnetCR), interfaceIPType, effectiveStaticType, addressBindings)
 		if err != nil {
 			log.Error(err, "Failed to check capacity of NSX Subnet", "Subnet", subnetName, "SubnetSet", subnetSet.Name, "Namespace", subnetSet.Namespace, "NSXSubnet", nsxSubnet.Id)
 			errList = append(errList, err)
@@ -186,7 +197,7 @@ func IsNamespaceInTepLessMode(client k8sclient.Client, namespace string) (bool, 
 	return networkInfo.VPCs[0].NetworkStack == v1alpha1.VLANBackedVPC, nil
 }
 
-func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType) (string, *types.UID, *sync.RWMutex, error) {
+func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, *types.UID, *sync.RWMutex, error) {
 	if subnetSet.Spec.SubnetDHCPConfig.Mode == v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeRelay) {
 		// From NSX Operator 9.1.1, DHCPRelay SubnetSet is no longer supported.
 		return "", nil, nil, fmt.Errorf("Creating SubnetPort on DHCPRelay SubnetSet is not supported")
@@ -199,7 +210,7 @@ func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Re
 		if err := apiReader.Get(context.Background(), types.NamespacedName{Namespace: subnetSet.Namespace, Name: subnetSet.Name}, subnetSet); err != nil {
 			return "", &subnetSet.UID, subnetSetLock, err
 		}
-		nsxSubnet, err := GetSubnetFromSubnetSet(client, subnetSet, vpcService, subnetService, subnetPortService, interfaceIPType)
+		nsxSubnet, err := GetSubnetFromSubnetSet(client, subnetSet, vpcService, subnetService, subnetPortService, interfaceIPType, rawStaticIPAllocationType, addressBindings)
 		return nsxSubnet, &subnetSet.UID, subnetSetLock, err
 	}
 	// Use SubnetSet uuid lock to make sure when multiple ports are created on the same SubnetSet, only one Subnet will be created
@@ -207,7 +218,8 @@ func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Re
 	defer WUnlockSubnetSet(subnetSet.GetUID(), subnetSetLock)
 	subnetList := subnetService.GetSubnetsByIndex(servicecommon.TagScopeSubnetSetCRUID, string(subnetSet.GetUID()))
 	for _, nsxSubnet := range subnetList {
-		canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, false, interfaceIPType)
+		effectiveStaticType := ResolveEffectiveStaticIPAllocationType(rawStaticIPAllocationType, nsxSubnet, interfaceIPType)
+		canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, false, interfaceIPType, effectiveStaticType, addressBindings)
 		if err != nil {
 			return "", nil, nil, err
 		}
@@ -230,7 +242,8 @@ func AllocateSubnetFromSubnetSet(client k8sclient.Client, apiReader k8sclient.Re
 	if err != nil {
 		return "", nil, nil, err
 	}
-	canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, false, interfaceIPType)
+	effectiveStaticType := ResolveEffectiveStaticIPAllocationType(rawStaticIPAllocationType, nsxSubnet, interfaceIPType)
+	canAllocate, err := subnetPortService.AllocatePortFromSubnet(nsxSubnet, false, interfaceIPType, effectiveStaticType, addressBindings)
 	if err != nil {
 		return "", nil, nil, err
 	}

--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -98,8 +98,8 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 		},
 	}
 	k8sclient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(subnetSet).Build()
-	patches := gomonkey.ApplyFunc(GetSubnetFromSubnetSet, func(client client.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, error) {
-		return expectedSubnetPath, nil
+	patches := gomonkey.ApplyFunc(GetSubnetFromSubnetSet, func(client client.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, v1alpha1.StaticIPAllocationType, error) {
+		return expectedSubnetPath, "", nil
 	})
 	defer patches.Reset()
 	tests := []struct {
@@ -197,7 +197,7 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 			ssp := &pkg_mock.MockSubnetServiceProvider{}
 			spsp := &pkg_mock.MockSubnetPortServiceProvider{}
 			tt.prepareFunc(t, vps, ssp, spsp)
-			subnetPath, subnetSetUID, subnetSetLock, err := AllocateSubnetFromSubnetSet(k8sclient, k8sclient, tt.subnetSet, vps, ssp, spsp, "", "", nil)
+			subnetPath, _, subnetSetUID, subnetSetLock, err := AllocateSubnetFromSubnetSet(k8sclient, k8sclient, tt.subnetSet, vps, ssp, spsp, "", "", nil)
 			if subnetSetLock != nil {
 				RUnlockSubnetSet(*subnetSetUID, subnetSetLock)
 			}
@@ -872,7 +872,7 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			}
 
 			// Execute
-			result, err := GetSubnetFromSubnetSet(client, tt.subnetSet, mockVpcSvc, mockSubnetSvc, mockPortSvc, "", "", nil)
+			result, _, err := GetSubnetFromSubnetSet(client, tt.subnetSet, mockVpcSvc, mockSubnetSvc, mockPortSvc, "", "", nil)
 
 			// Assert
 			if tt.wantErr {

--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -98,7 +98,7 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 		},
 	}
 	k8sclient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(subnetSet).Build()
-	patches := gomonkey.ApplyFunc(GetSubnetFromSubnetSet, func(client client.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType) (string, error) {
+	patches := gomonkey.ApplyFunc(GetSubnetFromSubnetSet, func(client client.Client, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceIPType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, error) {
 		return expectedSubnetPath, nil
 	})
 	defer patches.Reset()
@@ -122,7 +122,7 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 						},
 					})
 				spsp.(*pkg_mock.MockSubnetPortServiceProvider).On("GetPortsOfSubnet", mock.Anything).Return([]*model.VpcSubnetPort{})
-				spsp.(*pkg_mock.MockSubnetPortServiceProvider).On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
+				spsp.(*pkg_mock.MockSubnetPortServiceProvider).On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 			},
 			expectedResult: expectedSubnetPath,
 			subnetSet:      subnetSet,
@@ -146,7 +146,7 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 				ssp.(*pkg_mock.MockSubnetServiceProvider).On("GenerateSubnetNSTags", mock.Anything)
 				vsp.(*pkg_mock.MockVPCServiceProvider).On("ListVPCInfo", mock.Anything).Return([]servicecommon.VPCResourceInfo{{}})
 				ssp.(*pkg_mock.MockSubnetServiceProvider).On("CreateOrUpdateSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&model.VpcSubnet{Path: &expectedSubnetPath}, nil)
-				spsp.(*pkg_mock.MockSubnetPortServiceProvider).On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
+				spsp.(*pkg_mock.MockSubnetPortServiceProvider).On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 			},
 			expectedResult: expectedSubnetPath,
 			subnetSet: &v1alpha1.SubnetSet{
@@ -197,7 +197,7 @@ func TestAllocateSubnetFromSubnetSet(t *testing.T) {
 			ssp := &pkg_mock.MockSubnetServiceProvider{}
 			spsp := &pkg_mock.MockSubnetPortServiceProvider{}
 			tt.prepareFunc(t, vps, ssp, spsp)
-			subnetPath, subnetSetUID, subnetSetLock, err := AllocateSubnetFromSubnetSet(k8sclient, k8sclient, tt.subnetSet, vps, ssp, spsp, "")
+			subnetPath, subnetSetUID, subnetSetLock, err := AllocateSubnetFromSubnetSet(k8sclient, k8sclient, tt.subnetSet, vps, ssp, spsp, "", "", nil)
 			if subnetSetLock != nil {
 				RUnlockSubnetSet(*subnetSetUID, subnetSetLock)
 			}
@@ -733,7 +733,7 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			mockSetup: func(ms *pkg_mock.MockSubnetServiceProvider, mp *pkg_mock.MockSubnetPortServiceProvider) *gomonkey.Patches {
 				// We use mock.Anything here to avoid pointer address issues
 				ms.On("GetSubnetByCR", mock.Anything).Return(nsxSubnet1, nil)
-				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
+				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 				return nil
 			},
 			expectedPath: path1,
@@ -752,8 +752,8 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			mockSetup: func(ms *pkg_mock.MockSubnetServiceProvider, mp *pkg_mock.MockSubnetPortServiceProvider) *gomonkey.Patches {
 				ms.On("GetSubnetByCR", mock.Anything).Return(nsxSubnet1, nil)
 				// First call returns false (full), second call returns true
-				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Once()
-				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Once()
+				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Once()
+				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Once()
 				return nil
 			},
 			expectedPath: path1,
@@ -778,7 +778,7 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			mockSetup: func(ms *pkg_mock.MockSubnetServiceProvider, mp *pkg_mock.MockSubnetPortServiceProvider) *gomonkey.Patches {
 				ms.On("GetSubnetByCR", mock.Anything).Return(nsxSubnet1, nil).Once()
 				ms.On("GetSubnetByCR", mock.Anything).Return(nsxSubnet2, nil).Once()
-				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Once()
+				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Once()
 				patches := gomonkey.ApplyFunc(GetVpcNetworkConfig, func(service servicecommon.VPCServiceProvider, ns string) (*v1alpha1.VPCNetworkConfiguration, error) {
 					return &v1alpha1.VPCNetworkConfiguration{
 						Spec: v1alpha1.VPCNetworkConfigurationSpec{
@@ -805,7 +805,7 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			},
 			mockSetup: func(ms *pkg_mock.MockSubnetServiceProvider, mp *pkg_mock.MockSubnetPortServiceProvider) *gomonkey.Patches {
 				ms.On("GetSubnetByCR", mock.Anything).Return(nsxSubnet1, nil)
-				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
+				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
 				return nil
 			},
 			expectedPath: "",
@@ -851,7 +851,7 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			},
 			mockSetup: func(ms *pkg_mock.MockSubnetServiceProvider, mp *pkg_mock.MockSubnetPortServiceProvider) *gomonkey.Patches {
 				ms.On("GetSubnetByCR", mock.Anything).Return(nsxSubnet1, nil)
-				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything).Return(false, errors.New("capacity-check-failed"))
+				mp.On("AllocatePortFromSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false, errors.New("capacity-check-failed"))
 				return nil
 			},
 			wantErr:     true,
@@ -872,7 +872,7 @@ func TestGetSubnetFromSubnetSet(t *testing.T) {
 			}
 
 			// Execute
-			result, err := GetSubnetFromSubnetSet(client, tt.subnetSet, mockVpcSvc, mockSubnetSvc, mockPortSvc, "")
+			result, err := GetSubnetFromSubnetSet(client, tt.subnetSet, mockVpcSvc, mockSubnetSvc, mockPortSvc, "", "", nil)
 
 			// Assert
 			if tt.wantErr {

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -85,7 +85,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	if !common.PodIsDeleted(pod) {
 		r.StatusUpdater.IncreaseUpdateTotal()
-		isExisting, nsxSubnetPath, subnetSetUID, subnetSetLock, interfaceIPType, err := r.GetSubnetPathForPod(ctx, pod)
+		isExisting, nsxSubnetPath, subnetSetUID, subnetSetLock, interfaceIPType, staticIPAllocationType, err := r.GetSubnetPathForPod(ctx, pod)
 		if subnetSetLock != nil {
 			defer common.RUnlockSubnetSet(*subnetSetUID, subnetSetLock)
 		}
@@ -94,15 +94,8 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			r.StatusUpdater.UpdateFail(ctx, pod, err, "", nil)
 			return common.ResultRequeue, err
 		}
-		// nsxSubnet is resolved below; the Release closure reads it lazily so it sees the
-		// resolved Subnet even though it's registered before the Subnet is fetched.
-		var nsxSubnet *model.VpcSubnet
 		if !isExisting {
 			defer func() {
-				staticIPAllocationType := v1alpha1.StaticIPAllocationTypeNone
-				if nsxSubnet != nil {
-					staticIPAllocationType = util.ComputeDefaultStaticIPAllocationType(nsxSubnet, interfaceIPType)
-				}
 				r.SubnetPortService.ReleasePortInSubnet(nsxSubnetPath, interfaceIPType, staticIPAllocationType, nil)
 			}()
 		}
@@ -119,7 +112,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			log.Error(err, "Failed to check if the Subnet is a shared Subnet", "path", nsxSubnetPath)
 			return common.ResultNormal, err
 		}
-		nsxSubnet, err = r.SubnetService.GetSubnetByPath(nsxSubnetPath, inSharedSubnet)
+		nsxSubnet, err := r.SubnetService.GetSubnetByPath(nsxSubnetPath, inSharedSubnet)
 		if err != nil {
 			r.StatusUpdater.UpdateFail(ctx, pod, err, "", nil)
 			return common.ResultRequeue, err
@@ -418,12 +411,16 @@ func (r *PodReconciler) getSubnetByPod(pod *v1.Pod, subnetSet *v1alpha1.SubnetSe
 	return common.GetSubnetByIP(subnets, net.ParseIP(pod.Status.PodIP))
 }
 
-func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+// GetSubnetPathForPod also returns the StaticIPAllocationType actually resolved when
+// allocating the Subnet (only meaningful when existing is false), so the caller can release
+// the same pool capacity it reserved without recomputing it later from state that may no
+// longer be available (e.g. if a later step in Reconcile fails).
+func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
 	var subnetSetLock *sync.RWMutex
 	var subnetSetUID *types.UID
 	subnetSet, err := common.GetDefaultSubnetSetByNamespace(r.SubnetPortService.Client, pod.Namespace, servicecommon.DefaultPodNetwork)
 	if err != nil {
-		return false, "", subnetSetUID, subnetSetLock, "", err
+		return false, "", subnetSetUID, subnetSetLock, "", "", err
 	}
 	// Resolve the interface IP type from the SubnetSet up front so it stays correct on every
 	// reconcile, not just the one that first creates the SubnetPort - buildSubnetPort's static
@@ -435,7 +432,7 @@ func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (b
 	subnetPath := r.SubnetPortService.GetSubnetPathForSubnetPortFromStore(pod.GetUID())
 	if len(subnetPath) > 0 {
 		log.Debug("NSX SubnetPort had been created, returning the existing NSX Subnet path", "pod.UID", pod.UID, "subnetPath", subnetPath)
-		return true, subnetPath, subnetSetUID, subnetSetLock, interfacetype, nil
+		return true, subnetPath, subnetSetUID, subnetSetLock, interfacetype, "", nil
 	}
 	log.Info("Got default SubnetSet for Pod, allocating the NSX Subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "pod.Name", pod.Name, "pod.UID", pod.UID)
 	if r.restoreMode {
@@ -444,22 +441,22 @@ func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (b
 			subnetPath, err = r.getSubnetByPod(pod, subnetSet)
 			if err != nil {
 				log.Error(err, "Failed to find Subnet for restored Pod", "Pod", pod)
-				return false, "", subnetSetUID, subnetSetLock, "", err
+				return false, "", subnetSetUID, subnetSetLock, "", "", err
 			}
 			log.Debug("NSX SubnetPort will be restored on the existing NSX Subnet", "pod.UID", pod.UID, "subnetPath", subnetPath)
-			return true, subnetPath, subnetSetUID, subnetSetLock, interfacetype, nil
+			return true, subnetPath, subnetSetUID, subnetSetLock, interfacetype, "", nil
 		}
 	}
 	// SubnetSet can be created without IPAddressType, we need to wait for the value initialized by subnetset controller
 	if subnetSet.Spec.IPAddressType == "" {
-		return false, "", subnetSetUID, subnetSetLock, "", fmt.Errorf("default Pod SubnetSet IPAddressType is under calculation")
+		return false, "", subnetSetUID, subnetSetLock, "", "", fmt.Errorf("default Pod SubnetSet IPAddressType is under calculation")
 	}
-	subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfacetype, "", nil)
+	subnetPath, staticIPAllocationType, subnetSetUID, subnetSetLock, err := common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfacetype, "", nil)
 	if err != nil {
-		return false, subnetPath, subnetSetUID, subnetSetLock, interfacetype, err
+		return false, subnetPath, subnetSetUID, subnetSetLock, interfacetype, staticIPAllocationType, err
 	}
 	log.Info("Allocated NSX Subnet for Pod", "nsxSubnetPath", subnetPath, "pod.Name", pod.Name, "pod.UID", pod.UID)
-	return false, subnetPath, subnetSetUID, subnetSetLock, interfacetype, nil
+	return false, subnetPath, subnetSetUID, subnetSetLock, interfacetype, staticIPAllocationType, nil
 }
 
 func (r *PodReconciler) deleteSubnetPortByPodName(ctx context.Context, ns string, name string) error {

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -94,8 +94,17 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			r.StatusUpdater.UpdateFail(ctx, pod, err, "", nil)
 			return common.ResultRequeue, err
 		}
+		// nsxSubnet is resolved below; the Release closure reads it lazily so it sees the
+		// resolved Subnet even though it's registered before the Subnet is fetched.
+		var nsxSubnet *model.VpcSubnet
 		if !isExisting {
-			defer r.SubnetPortService.ReleasePortInSubnet(nsxSubnetPath, interfaceIPType)
+			defer func() {
+				staticIPAllocationType := v1alpha1.StaticIPAllocationTypeNone
+				if nsxSubnet != nil {
+					staticIPAllocationType = util.ComputeDefaultStaticIPAllocationType(nsxSubnet, interfaceIPType)
+				}
+				r.SubnetPortService.ReleasePortInSubnet(nsxSubnetPath, interfaceIPType, staticIPAllocationType, nil)
+			}()
 		}
 		log.Info("Got NSX Subnet for Pod", "NSX Subnet path", nsxSubnetPath, "pod.Name", pod.Name, "pod.UID", pod.UID)
 		node, err := r.GetNodeByName(pod.Spec.NodeName)
@@ -110,7 +119,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			log.Error(err, "Failed to check if the Subnet is a shared Subnet", "path", nsxSubnetPath)
 			return common.ResultNormal, err
 		}
-		nsxSubnet, err := r.SubnetService.GetSubnetByPath(nsxSubnetPath, inSharedSubnet)
+		nsxSubnet, err = r.SubnetService.GetSubnetByPath(nsxSubnetPath, inSharedSubnet)
 		if err != nil {
 			r.StatusUpdater.UpdateFail(ctx, pod, err, "", nil)
 			return common.ResultRequeue, err
@@ -445,7 +454,7 @@ func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (b
 	if subnetSet.Spec.IPAddressType == "" {
 		return false, "", subnetSetUID, subnetSetLock, "", fmt.Errorf("default Pod SubnetSet IPAddressType is under calculation")
 	}
-	subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfacetype)
+	subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfacetype, "", nil)
 	if err != nil {
 		return false, subnetPath, subnetSetUID, subnetSetLock, interfacetype, err
 	}

--- a/pkg/controllers/pod/pod_controller_test.go
+++ b/pkg/controllers/pod/pod_controller_test.go
@@ -640,7 +640,7 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 						}, nil
 					})
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType) (string, *types.UID, *sync.RWMutex, error) {
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, *types.UID, *sync.RWMutex, error) {
 						return "", nil, nil, errors.New("failed to create subnet")
 					})
 				return patches
@@ -668,7 +668,7 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 						}, nil
 					})
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType) (string, *types.UID, *sync.RWMutex, error) {
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, *types.UID, *sync.RWMutex, error) {
 						return subnetPath, nil, nil, nil
 					})
 				return patches
@@ -697,7 +697,7 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 						}, nil
 					})
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType) (string, *types.UID, *sync.RWMutex, error) {
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, *types.UID, *sync.RWMutex, error) {
 						return subnetPath, nil, nil, nil
 					})
 				return patches

--- a/pkg/controllers/pod/pod_controller_test.go
+++ b/pkg/controllers/pod/pod_controller_test.go
@@ -132,8 +132,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 				})
 
 				patchesGetSubnetPathForPod := gomonkey.ApplyFunc((*PodReconciler).GetSubnetPathForPod,
-					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-						return false, "", nil, nil, "", errors.New("failed to get subnet path")
+					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+						return false, "", nil, nil, "", "", errors.New("failed to get subnet path")
 					})
 
 				return patchesGetSubnetPathForPod
@@ -158,8 +158,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 					return nil
 				})
 				patches := gomonkey.ApplyFunc((*PodReconciler).GetSubnetPathForPod,
-					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-						return false, "subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+						return false, "subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, v1alpha1.StaticIPAllocationTypeIPv4, nil
 					})
 				patches.ApplyFunc((*PodReconciler).GetNodeByName,
 					func(r *PodReconciler, nodeName string) (*model.HostTransportNode, error) {
@@ -179,8 +179,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 					return nil
 				})
 				patches := gomonkey.ApplyFunc((*PodReconciler).GetSubnetPathForPod,
-					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-						return false, "subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+						return false, "subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, v1alpha1.StaticIPAllocationTypeIPv4, nil
 					})
 				patches.ApplyFunc((*PodReconciler).GetNodeByName,
 					func(r *PodReconciler, nodeName string) (*model.HostTransportNode, error) {
@@ -208,8 +208,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 					return nil
 				})
 				patches := gomonkey.ApplyFunc((*PodReconciler).GetSubnetPathForPod,
-					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-						return false, "subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+						return false, "subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, v1alpha1.StaticIPAllocationTypeIPv4, nil
 					})
 				patches.ApplyFunc((*PodReconciler).GetNodeByName,
 					func(r *PodReconciler, nodeName string) (*model.HostTransportNode, error) {
@@ -241,8 +241,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 					return nil
 				})
 				patches := gomonkey.ApplyFunc((*PodReconciler).GetSubnetPathForPod,
-					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-						return false, "subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+						return false, "subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, v1alpha1.StaticIPAllocationTypeIPv4, nil
 					})
 				patches.ApplyFunc((*PodReconciler).GetNodeByName,
 					func(r *PodReconciler, nodeName string) (*model.HostTransportNode, error) {
@@ -291,8 +291,8 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 					return nil
 				})
 				patches := gomonkey.ApplyFunc((*PodReconciler).GetSubnetPathForPod,
-					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-						return false, "/orgs/default/projects/default/vpcs/ns-1/subnets/subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+					func(r *PodReconciler, ctx context.Context, pod *v1.Pod) (bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+						return false, "/orgs/default/projects/default/vpcs/ns-1/subnets/subnet-path-1", nil, nil, v1alpha1.IPAddressTypeIPv4, "", nil
 					})
 				patches.ApplyFunc(common.IsSharedSubnetPath, func(ctx context.Context, client client.Client, path string, ns string) (bool, error) {
 					return false, nil
@@ -640,8 +640,8 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 						}, nil
 					})
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, *types.UID, *sync.RWMutex, error) {
-						return "", nil, nil, errors.New("failed to create subnet")
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, v1alpha1.StaticIPAllocationType, *types.UID, *sync.RWMutex, error) {
+						return "", "", nil, nil, errors.New("failed to create subnet")
 					})
 				return patches
 			},
@@ -668,8 +668,8 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 						}, nil
 					})
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, *types.UID, *sync.RWMutex, error) {
-						return subnetPath, nil, nil, nil
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, v1alpha1.StaticIPAllocationType, *types.UID, *sync.RWMutex, error) {
+						return subnetPath, v1alpha1.StaticIPAllocationTypeIPv4, nil, nil, nil
 					})
 				return patches
 			},
@@ -697,8 +697,8 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 						}, nil
 					})
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, *types.UID, *sync.RWMutex, error) {
-						return subnetPath, nil, nil, nil
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, v1alpha1.StaticIPAllocationType, *types.UID, *sync.RWMutex, error) {
+						return subnetPath, v1alpha1.StaticIPAllocationTypeIPv4, nil, nil, nil
 					})
 				return patches
 			},
@@ -741,7 +741,7 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 			patches := tt.prepareFunc(t, r)
 			defer patches.Reset()
 			r.restoreMode = tt.restoreMode
-			isExisting, path, _, _, interfaceType, err := r.GetSubnetPathForPod(context.TODO(), &v1.Pod{
+			isExisting, path, _, _, interfaceType, _, err := r.GetSubnetPathForPod(context.TODO(), &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod-1",
 					Namespace: "ns-1",

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -198,51 +198,28 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				}
 			}
 			subnetPort.Status.Attachment = v1alpha1.PortAttachment{ID: *nsxSubnetPortState.Attachment.Id}
+			// Placeholder sizing until RealizedBindings arrives below and replaces it outright.
+			preSeedCount := 1
+			if subnetPort.Spec.InterfaceIPType == v1alpha1.IPAddressTypeIPv4IPv6 {
+				preSeedCount = 2
+			}
+			if len(subnetPort.Spec.AddressBindings) > preSeedCount {
+				preSeedCount = len(subnetPort.Spec.AddressBindings)
+			}
 			subnetPort.Status.NetworkInterfaceConfig = v1alpha1.NetworkInterfaceConfig{
-				IPAddresses: []v1alpha1.NetworkInterfaceIPAddress{
-					{
-						Gateway: "",
-					},
-				},
+				IPAddresses:               make([]v1alpha1.NetworkInterfaceIPAddress, preSeedCount),
 				DHCPDeactivatedOnSubnet:   !util.NSXSubnetDHCPEnabled(nsxSubnet),
 				DHCPv6DeactivatedOnSubnet: !util.NSXSubnetDHCPv6Enabled(nsxSubnet),
 			}
-			// Append one more ipaddress for dual stack SubnetPort
-			if subnetPort.Spec.InterfaceIPType == v1alpha1.IPAddressTypeIPv4IPv6 {
-				subnetPort.Status.NetworkInterfaceConfig.IPAddresses = append(
-					subnetPort.Status.NetworkInterfaceConfig.IPAddresses,
-					v1alpha1.NetworkInterfaceIPAddress{Gateway: ""},
-				)
-			}
 			if util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) || len(subnetPort.Spec.AddressBindings) > 0 {
 				if len(nsxSubnetPortState.RealizedBindings) > 0 {
-					// Process all realized bindings and populate IPAddresses array
-					// RealizedBindings can contain up to 2 entries (IPv4 and IPv6)
-					// The MAC address is updated here when the SubnetPort's StaticIPAllocation
-					// is enabled or spec.AddressBindings is specific. For the other cases, the MAC
-					// address will be updated in the VIF polling.
-					macAddress := ""
-					for i, binding := range nsxSubnetPortState.RealizedBindings {
-						if binding.Binding != nil && binding.Binding.IpAddress != nil {
-							if macAddress == "" && binding.Binding.MacAddress != nil {
-								macAddress = strings.Trim(*binding.Binding.MacAddress, "\"")
-							}
-							if len(subnetPort.Status.NetworkInterfaceConfig.IPAddresses) <= i {
-								// TODO: revisit this when supporting multiple addressbindings per IPAddressType
-								log.Warn("More IPs are realized on SubnetPort", "Namespace", subnetPort.Namespace, "SubnetPort", subnetPort.Name, "RealizedBindings", nsxSubnetPortState.RealizedBindings)
-								subnetPort.Status.NetworkInterfaceConfig.IPAddresses = append(
-									subnetPort.Status.NetworkInterfaceConfig.IPAddresses,
-									v1alpha1.NetworkInterfaceIPAddress{Gateway: "", IPAddress: *binding.Binding.IpAddress},
-								)
-							} else {
-								subnetPort.Status.NetworkInterfaceConfig.IPAddresses[i].IPAddress = *binding.Binding.IpAddress
-							}
-						}
+					realizedIPAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(nsxSubnetPortState.RealizedBindings)
+					if len(realizedIPAddresses) > 0 {
+						subnetPort.Status.NetworkInterfaceConfig.IPAddresses = realizedIPAddresses
 					}
-					// MAC address is consistent across all bindings, set it once
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
 				} else if !util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) && len(subnetPort.Spec.AddressBindings) > 0 {
-					// If StaticIPAllocation is disabled, propagate the MAC from spec.addressBinding to status
+					// StaticIPAllocation disabled: propagate MAC from spec since there's no realized binding yet.
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = subnetPort.Spec.AddressBindings[0].MACAddress
 				}
 			}
@@ -1031,6 +1008,25 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 		log.Info("Allocated Subnet for SubnetPort", "subnetPath", subnetPath, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 	}
 	return
+}
+
+// networkInterfaceIPAddressesFromRealizedBindings builds one entry per realized
+// binding with an IP, plus the shared MAC address, independent of binding count.
+func networkInterfaceIPAddressesFromRealizedBindings(realizedBindings []model.AddressBindingEntry) ([]v1alpha1.NetworkInterfaceIPAddress, string) {
+	macAddress := ""
+	ipAddresses := make([]v1alpha1.NetworkInterfaceIPAddress, 0, len(realizedBindings))
+	for _, binding := range realizedBindings {
+		if binding.Binding != nil && binding.Binding.IpAddress != nil {
+			if macAddress == "" && binding.Binding.MacAddress != nil {
+				macAddress = strings.Trim(*binding.Binding.MacAddress, "\"")
+			}
+			ipAddresses = append(ipAddresses, v1alpha1.NetworkInterfaceIPAddress{
+				Gateway:   "",
+				IPAddress: *binding.Binding.IpAddress,
+			})
+		}
+	}
+	return ipAddresses, macAddress
 }
 
 func (r *SubnetPortReconciler) updateSubnetStatusOnSubnetPort(subnetPort *v1alpha1.SubnetPort, nsxSubnet *model.VpcSubnet) error {

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -170,6 +170,9 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err != nil {
 			return common.ResultNormal, err
 		}
+		if staticIPAllocationType == "" {
+			staticIPAllocationType = subnetPort.Spec.StaticIPAllocationType
+		}
 		raDeactivated, err := r.VPCService.IsRADeactivatedByVPCPath(nsxSubnetPath)
 		if err != nil {
 			log.Error(err, "Failed to determine RA mode for SubnetPort's VPC", "SubnetPort", subnetPort, "nsxSubnetPath", nsxSubnetPath)

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -120,7 +120,11 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return common.ResultRequeue, err
 		}
 		if !isExisting {
-			defer r.SubnetPortService.ReleasePortInSubnet(nsxSubnetPath, interfaceIPType)
+			// Read subnetPort.Spec lazily: StaticIPAllocationType is backfilled later in this
+			// Reconcile (updateSubnetPortIPType), and Release must match what Allocate used.
+			defer func() {
+				r.SubnetPortService.ReleasePortInSubnet(nsxSubnetPath, interfaceIPType, subnetPort.Spec.StaticIPAllocationType, subnetPort.Spec.AddressBindings)
+			}()
 		}
 
 		var labels *map[string]string
@@ -961,7 +965,8 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 		}
 		var canAllocate bool
 		interfaceType = subnetport.GetDefaultInterfaceIPType(subnetPort.Spec.InterfaceIPType, subnetCR.Spec.IPAddressType)
-		canAllocate, err = r.SubnetPortService.AllocatePortFromSubnet(nsxSubnet, servicecommon.IsSharedSubnet(subnetCR), interfaceType)
+		effectiveStaticType := common.ResolveEffectiveStaticIPAllocationType(subnetPort.Spec.StaticIPAllocationType, nsxSubnet, interfaceType)
+		canAllocate, err = r.SubnetPortService.AllocatePortFromSubnet(nsxSubnet, servicecommon.IsSharedSubnet(subnetCR), interfaceType, effectiveStaticType, subnetPort.Spec.AddressBindings)
 		if err != nil {
 			return
 		}
@@ -991,7 +996,7 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 		}
 		interfaceType = subnetport.GetDefaultInterfaceIPType(subnetPort.Spec.InterfaceIPType, subnetSet.Spec.IPAddressType)
 		log.Info("Got SubnetSet for SubnetPort CR, allocating the NSX subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
-		subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfaceType)
+		subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfaceType, subnetPort.Spec.StaticIPAllocationType, subnetPort.Spec.AddressBindings)
 		log.Info("Allocated Subnet for SubnetPort", "subnetPath", subnetPath, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 		if err != nil {
 			return
@@ -1013,7 +1018,7 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 		}
 		log.Info("Got default SubnetSet for SubnetPort CR, allocating the NSX Subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 		interfaceType = subnetport.GetDefaultInterfaceIPType(subnetPort.Spec.InterfaceIPType, subnetSet.Spec.IPAddressType)
-		subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfaceType)
+		subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfaceType, subnetPort.Spec.StaticIPAllocationType, subnetPort.Spec.AddressBindings)
 		if err != nil {
 			return
 		}

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -232,14 +232,14 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				DHCPv6DeactivatedOnSubnet: !util.NSXSubnetDHCPv6Enabled(nsxSubnet),
 				RADeactivated:             raDeactivated,
 			}
-			if util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) || len(subnetPort.Spec.AddressBindings) > 0 {
+			if staticIPAllocationType != v1alpha1.StaticIPAllocationTypeNone || len(subnetPort.Spec.AddressBindings) > 0 {
 				if len(nsxSubnetPortState.RealizedBindings) > 0 {
 					realizedIPAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(nsxSubnetPortState.RealizedBindings)
-					if len(realizedIPAddresses) > 0 {
+					if staticIPAllocationType != v1alpha1.StaticIPAllocationTypeNone && len(realizedIPAddresses) > 0 {
 						subnetPort.Status.NetworkInterfaceConfig.IPAddresses = realizedIPAddresses
 					}
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
-				} else if !util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) && len(subnetPort.Spec.AddressBindings) > 0 {
+				} else if staticIPAllocationType == v1alpha1.StaticIPAllocationTypeNone && len(subnetPort.Spec.AddressBindings) > 0 {
 					// StaticIPAllocation disabled: propagate MAC from spec since there's no realized binding yet.
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = subnetPort.Spec.AddressBindings[0].MACAddress
 				}

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -210,8 +210,10 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 			// In restore mode, we do not update the SubnetPort status to retian the status, so no need to check the realized bindings
 			// Check StaticIPAllocationType as mixed mode Subnet also have static ip allocation enabled but SubnetPort may be created in dhcp pool
-			if !r.restoreMode && util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) && subnetPort.Spec.StaticIPAllocationType != "None" {
-				if len(nsxSubnetPortState.RealizedBindings) == 0 {
+			if !r.restoreMode && util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) && staticIPAllocationType != v1alpha1.StaticIPAllocationTypeNone {
+				// Wait until every requested static family is realized, not just any binding,
+				// since mixed-mode Subnets can realize the DHCP family first.
+				if !realizedBindingsCoverStaticFamilies(nsxSubnetPortState.RealizedBindings, staticIPAllocationType) {
 					err = errors.New("IP and MAC are missing for SubnetPort")
 					r.StatusUpdater.UpdateFail(ctx, subnetPort, err, "IP and MAC are missing for SubnetPort", setSubnetPortReadyStatusFalse, r.SubnetPortService, r.restoreMode)
 					return common.ResultNormal, err
@@ -1025,6 +1027,36 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 		log.Info("Allocated Subnet for SubnetPort", "subnetPath", subnetPath, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 	}
 	return
+}
+
+// realizedBindingsCoverStaticFamilies reports whether realizedBindings has an IP for
+// every address family in staticIPAllocationType.
+func realizedBindingsCoverStaticFamilies(realizedBindings []model.AddressBindingEntry, staticIPAllocationType v1alpha1.StaticIPAllocationType) bool {
+	hasIPv4, hasIPv6 := false, false
+	for _, binding := range realizedBindings {
+		if binding.Binding == nil || binding.Binding.IpAddress == nil {
+			continue
+		}
+		ip := net.ParseIP(*binding.Binding.IpAddress)
+		if ip == nil {
+			continue
+		}
+		if ip.To4() != nil {
+			hasIPv4 = true
+		} else {
+			hasIPv6 = true
+		}
+	}
+	switch staticIPAllocationType {
+	case v1alpha1.StaticIPAllocationTypeIPv4:
+		return hasIPv4
+	case v1alpha1.StaticIPAllocationTypeIPv6:
+		return hasIPv6
+	case v1alpha1.StaticIPAllocationTypeIPv4IPv6:
+		return hasIPv4 && hasIPv6
+	default:
+		return false
+	}
 }
 
 // networkInterfaceIPAddressesFromRealizedBindings builds one entry per realized

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -106,7 +106,7 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		r.StatusUpdater.IncreaseUpdateTotal()
 
 		old_status := subnetPort.Status.DeepCopy()
-		isExisting, isParentResourceTerminating, nsxSubnetPath, subnetSetUID, subnetSetLock, interfaceIPType, err := r.CheckAndGetSubnetPathForSubnetPort(ctx, subnetPort)
+		isExisting, isParentResourceTerminating, nsxSubnetPath, subnetSetUID, subnetSetLock, interfaceIPType, staticIPAllocationType, err := r.CheckAndGetSubnetPathForSubnetPort(ctx, subnetPort)
 		if subnetSetLock != nil {
 			defer common.RUnlockSubnetSet(*subnetSetUID, subnetSetLock)
 		}
@@ -120,10 +120,10 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return common.ResultRequeue, err
 		}
 		if !isExisting {
-			// Read subnetPort.Spec lazily: StaticIPAllocationType is backfilled later in this
-			// Reconcile (updateSubnetPortIPType), and Release must match what Allocate used.
+			// staticIPAllocationType is the value actually resolved and used by Allocate above,
+			// not re-derived later from subnetPort.Spec (which may still be blank at this point).
 			defer func() {
-				r.SubnetPortService.ReleasePortInSubnet(nsxSubnetPath, interfaceIPType, subnetPort.Spec.StaticIPAllocationType, subnetPort.Spec.AddressBindings)
+				r.SubnetPortService.ReleasePortInSubnet(nsxSubnetPath, interfaceIPType, staticIPAllocationType, subnetPort.Spec.AddressBindings)
 			}()
 		}
 
@@ -920,7 +920,7 @@ func (r *SubnetPortReconciler) getSubnetBySubnetPort(subnetPort *v1alpha1.Subnet
 	return common.GetSubnetByIP(subnets, gatewayIP)
 }
 
-func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Context, subnetPort *v1alpha1.SubnetPort) (existing bool, isStale bool, subnetPath string, subnetSetUID *types.UID, subnetSetLock *sync.RWMutex, interfaceType v1alpha1.IPAddressType, err error) {
+func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Context, subnetPort *v1alpha1.SubnetPort) (existing bool, isStale bool, subnetPath string, subnetSetUID *types.UID, subnetSetLock *sync.RWMutex, interfaceType v1alpha1.IPAddressType, staticIPAllocationType v1alpha1.StaticIPAllocationType, err error) {
 	var subnetCR *v1alpha1.Subnet
 	subnetCR, isStale, err = r.getSubnetCR(ctx, subnetPort)
 	if err != nil {
@@ -930,7 +930,7 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 	existingSubnetPort, err := r.SubnetPortService.SubnetPortStore.GetVpcSubnetPortByUID(subnetPort.GetUID())
 	if err != nil {
 		log.Error(err, "failed to use the SubnetPort CR to search VpcSubnetPort", "CR UID", subnetPort.GetUID())
-		return false, false, "", nil, nil, "", err
+		return false, false, "", nil, nil, "", "", err
 	}
 	if existingSubnetPort != nil && existingSubnetPort.ParentPath != nil && len(*existingSubnetPort.ParentPath) > 0 {
 		subnetPath = *existingSubnetPort.ParentPath
@@ -965,8 +965,8 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 		}
 		var canAllocate bool
 		interfaceType = subnetport.GetDefaultInterfaceIPType(subnetPort.Spec.InterfaceIPType, subnetCR.Spec.IPAddressType)
-		effectiveStaticType := common.ResolveEffectiveStaticIPAllocationType(subnetPort.Spec.StaticIPAllocationType, nsxSubnet, interfaceType)
-		canAllocate, err = r.SubnetPortService.AllocatePortFromSubnet(nsxSubnet, servicecommon.IsSharedSubnet(subnetCR), interfaceType, effectiveStaticType, subnetPort.Spec.AddressBindings)
+		staticIPAllocationType = common.ResolveEffectiveStaticIPAllocationType(subnetPort.Spec.StaticIPAllocationType, nsxSubnet, interfaceType)
+		canAllocate, err = r.SubnetPortService.AllocatePortFromSubnet(nsxSubnet, servicecommon.IsSharedSubnet(subnetCR), interfaceType, staticIPAllocationType, subnetPort.Spec.AddressBindings)
 		if err != nil {
 			return
 		}
@@ -996,7 +996,7 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 		}
 		interfaceType = subnetport.GetDefaultInterfaceIPType(subnetPort.Spec.InterfaceIPType, subnetSet.Spec.IPAddressType)
 		log.Info("Got SubnetSet for SubnetPort CR, allocating the NSX subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
-		subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfaceType, subnetPort.Spec.StaticIPAllocationType, subnetPort.Spec.AddressBindings)
+		subnetPath, staticIPAllocationType, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfaceType, subnetPort.Spec.StaticIPAllocationType, subnetPort.Spec.AddressBindings)
 		log.Info("Allocated Subnet for SubnetPort", "subnetPath", subnetPath, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 		if err != nil {
 			return
@@ -1018,7 +1018,7 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 		}
 		log.Info("Got default SubnetSet for SubnetPort CR, allocating the NSX Subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 		interfaceType = subnetport.GetDefaultInterfaceIPType(subnetPort.Spec.InterfaceIPType, subnetSet.Spec.IPAddressType)
-		subnetPath, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfaceType, subnetPort.Spec.StaticIPAllocationType, subnetPort.Spec.AddressBindings)
+		subnetPath, staticIPAllocationType, subnetSetUID, subnetSetLock, err = common.AllocateSubnetFromSubnetSet(r.Client, r.APIReader, subnetSet, r.VPCService, r.SubnetService, r.SubnetPortService, interfaceType, subnetPort.Spec.StaticIPAllocationType, subnetPort.Spec.AddressBindings)
 		if err != nil {
 			return
 		}

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -214,52 +214,29 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				}
 			}
 			subnetPort.Status.Attachment = v1alpha1.PortAttachment{ID: *nsxSubnetPortState.Attachment.Id}
+			// Placeholder sizing until RealizedBindings arrives below and replaces it outright.
+			preSeedCount := 1
+			if subnetPort.Spec.InterfaceIPType == v1alpha1.IPAddressTypeIPv4IPv6 {
+				preSeedCount = 2
+			}
+			if len(subnetPort.Spec.AddressBindings) > preSeedCount {
+				preSeedCount = len(subnetPort.Spec.AddressBindings)
+			}
 			subnetPort.Status.NetworkInterfaceConfig = v1alpha1.NetworkInterfaceConfig{
-				IPAddresses: []v1alpha1.NetworkInterfaceIPAddress{
-					{
-						Gateway: "",
-					},
-				},
+				IPAddresses:               make([]v1alpha1.NetworkInterfaceIPAddress, preSeedCount),
 				DHCPDeactivatedOnSubnet:   !util.NSXSubnetDHCPEnabled(nsxSubnet),
 				DHCPv6DeactivatedOnSubnet: !util.NSXSubnetDHCPv6Enabled(nsxSubnet),
 				RADeactivated:             raDeactivated,
 			}
-			// Append one more ipaddress for dual stack SubnetPort
-			if subnetPort.Spec.InterfaceIPType == v1alpha1.IPAddressTypeIPv4IPv6 {
-				subnetPort.Status.NetworkInterfaceConfig.IPAddresses = append(
-					subnetPort.Status.NetworkInterfaceConfig.IPAddresses,
-					v1alpha1.NetworkInterfaceIPAddress{Gateway: ""},
-				)
-			}
 			if util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) || len(subnetPort.Spec.AddressBindings) > 0 {
 				if len(nsxSubnetPortState.RealizedBindings) > 0 {
-					// Process all realized bindings and populate IPAddresses array
-					// RealizedBindings can contain up to 2 entries (IPv4 and IPv6)
-					// The MAC address is updated here when the SubnetPort's StaticIPAllocation
-					// is enabled or spec.AddressBindings is specific. For the other cases, the MAC
-					// address will be updated in the VIF polling.
-					macAddress := ""
-					for i, binding := range nsxSubnetPortState.RealizedBindings {
-						if binding.Binding != nil && binding.Binding.IpAddress != nil {
-							if macAddress == "" && binding.Binding.MacAddress != nil {
-								macAddress = strings.Trim(*binding.Binding.MacAddress, "\"")
-							}
-							if len(subnetPort.Status.NetworkInterfaceConfig.IPAddresses) <= i {
-								// TODO: revisit this when supporting multiple addressbindings per IPAddressType
-								log.Warn("More IPs are realized on SubnetPort", "Namespace", subnetPort.Namespace, "SubnetPort", subnetPort.Name, "RealizedBindings", nsxSubnetPortState.RealizedBindings)
-								subnetPort.Status.NetworkInterfaceConfig.IPAddresses = append(
-									subnetPort.Status.NetworkInterfaceConfig.IPAddresses,
-									v1alpha1.NetworkInterfaceIPAddress{Gateway: "", IPAddress: *binding.Binding.IpAddress},
-								)
-							} else {
-								subnetPort.Status.NetworkInterfaceConfig.IPAddresses[i].IPAddress = *binding.Binding.IpAddress
-							}
-						}
+					realizedIPAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(nsxSubnetPortState.RealizedBindings)
+					if len(realizedIPAddresses) > 0 {
+						subnetPort.Status.NetworkInterfaceConfig.IPAddresses = realizedIPAddresses
 					}
-					// MAC address is consistent across all bindings, set it once
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
 				} else if !util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) && len(subnetPort.Spec.AddressBindings) > 0 {
-					// If StaticIPAllocation is disabled, propagate the MAC from spec.addressBinding to status
+					// StaticIPAllocation disabled: propagate MAC from spec since there's no realized binding yet.
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = subnetPort.Spec.AddressBindings[0].MACAddress
 				}
 			}
@@ -1043,6 +1020,25 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 		log.Info("Allocated Subnet for SubnetPort", "subnetPath", subnetPath, "subnetPort.Name", subnetPort.Name, "subnetPort.UID", subnetPort.UID)
 	}
 	return
+}
+
+// networkInterfaceIPAddressesFromRealizedBindings builds one entry per realized
+// binding with an IP, plus the shared MAC address, independent of binding count.
+func networkInterfaceIPAddressesFromRealizedBindings(realizedBindings []model.AddressBindingEntry) ([]v1alpha1.NetworkInterfaceIPAddress, string) {
+	macAddress := ""
+	ipAddresses := make([]v1alpha1.NetworkInterfaceIPAddress, 0, len(realizedBindings))
+	for _, binding := range realizedBindings {
+		if binding.Binding != nil && binding.Binding.IpAddress != nil {
+			if macAddress == "" && binding.Binding.MacAddress != nil {
+				macAddress = strings.Trim(*binding.Binding.MacAddress, "\"")
+			}
+			ipAddresses = append(ipAddresses, v1alpha1.NetworkInterfaceIPAddress{
+				Gateway:   "",
+				IPAddress: *binding.Binding.IpAddress,
+			})
+		}
+	}
+	return ipAddresses, macAddress
 }
 
 func (r *SubnetPortReconciler) updateSubnetStatusOnSubnetPort(subnetPort *v1alpha1.SubnetPort, nsxSubnet *model.VpcSubnet) error {

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -170,9 +170,6 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err != nil {
 			return common.ResultNormal, err
 		}
-		if staticIPAllocationType == "" {
-			staticIPAllocationType = subnetPort.Spec.StaticIPAllocationType
-		}
 		raDeactivated, err := r.VPCService.IsRADeactivatedByVPCPath(nsxSubnetPath)
 		if err != nil {
 			log.Error(err, "Failed to determine RA mode for SubnetPort's VPC", "SubnetPort", subnetPort, "nsxSubnetPath", nsxSubnetPath)
@@ -213,10 +210,12 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 			// In restore mode, we do not update the SubnetPort status to retian the status, so no need to check the realized bindings
 			// Check StaticIPAllocationType as mixed mode Subnet also have static ip allocation enabled but SubnetPort may be created in dhcp pool
-			if !r.restoreMode && util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) && staticIPAllocationType != v1alpha1.StaticIPAllocationTypeNone {
+			// Use subnetPort.Spec.StaticIPAllocationType, not the value resolved above: that one is empty on
+			// reconciles of an already-realized port, while updateSubnetPortIPType keeps Spec backfilled.
+			if !r.restoreMode && util.NSXSubnetStaticIPAllocationEnabled(nsxSubnet) && subnetPort.Spec.StaticIPAllocationType != v1alpha1.StaticIPAllocationTypeNone {
 				// Wait until every requested static family is realized, not just any binding,
 				// since mixed-mode Subnets can realize the DHCP family first.
-				if !realizedBindingsCoverStaticFamilies(nsxSubnetPortState.RealizedBindings, staticIPAllocationType) {
+				if !realizedBindingsCoverStaticFamilies(nsxSubnetPortState.RealizedBindings, subnetPort.Spec.StaticIPAllocationType) {
 					err = errors.New("IP and MAC are missing for SubnetPort")
 					r.StatusUpdater.UpdateFail(ctx, subnetPort, err, "IP and MAC are missing for SubnetPort", setSubnetPortReadyStatusFalse, r.SubnetPortService, r.restoreMode)
 					return common.ResultNormal, err
@@ -237,14 +236,14 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				DHCPv6DeactivatedOnSubnet: !util.NSXSubnetDHCPv6Enabled(nsxSubnet),
 				RADeactivated:             raDeactivated,
 			}
-			if staticIPAllocationType != v1alpha1.StaticIPAllocationTypeNone || len(subnetPort.Spec.AddressBindings) > 0 {
+			if subnetPort.Spec.StaticIPAllocationType != v1alpha1.StaticIPAllocationTypeNone || len(subnetPort.Spec.AddressBindings) > 0 {
 				if len(nsxSubnetPortState.RealizedBindings) > 0 {
 					realizedIPAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(nsxSubnetPortState.RealizedBindings)
-					if staticIPAllocationType != v1alpha1.StaticIPAllocationTypeNone && len(realizedIPAddresses) > 0 {
+					if subnetPort.Spec.StaticIPAllocationType != v1alpha1.StaticIPAllocationTypeNone && len(realizedIPAddresses) > 0 {
 						subnetPort.Status.NetworkInterfaceConfig.IPAddresses = realizedIPAddresses
 					}
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
-				} else if staticIPAllocationType == v1alpha1.StaticIPAllocationTypeNone && len(subnetPort.Spec.AddressBindings) > 0 {
+				} else if subnetPort.Spec.StaticIPAllocationType == v1alpha1.StaticIPAllocationTypeNone && len(subnetPort.Spec.AddressBindings) > 0 {
 					// StaticIPAllocation disabled: propagate MAC from spec since there's no realized binding yet.
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = subnetPort.Spec.AddressBindings[0].MACAddress
 				}
@@ -1064,6 +1063,10 @@ func realizedBindingsCoverStaticFamilies(realizedBindings []model.AddressBinding
 
 // networkInterfaceIPAddressesFromRealizedBindings builds one entry per realized
 // binding with an IP, plus the shared MAC address, independent of binding count.
+// On a mixed-mode Subnet, realizedBindings can legitimately contain addresses from
+// more than one family at once (e.g. a DHCP-realized IPv4 alongside a statically
+// realized IPv6) - all of them are returned, unfiltered, since this reflects the
+// port's actual interface state rather than being scoped to static addresses only.
 func networkInterfaceIPAddressesFromRealizedBindings(realizedBindings []model.AddressBindingEntry) ([]v1alpha1.NetworkInterfaceIPAddress, string) {
 	macAddress := ""
 	ipAddresses := make([]v1alpha1.NetworkInterfaceIPAddress, 0, len(realizedBindings))

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -238,8 +238,11 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 			if subnetPort.Spec.StaticIPAllocationType != v1alpha1.StaticIPAllocationTypeNone || len(subnetPort.Spec.AddressBindings) > 0 {
 				if len(nsxSubnetPortState.RealizedBindings) > 0 {
-					realizedIPAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(nsxSubnetPortState.RealizedBindings)
-					if subnetPort.Spec.StaticIPAllocationType != v1alpha1.StaticIPAllocationTypeNone && len(realizedIPAddresses) > 0 {
+					// networkInterfaceIPAddressesFromRealizedBindings already drops any
+					// address whose family isn't covered by StaticIPAllocationType, so a
+					// DHCP-realized address never lands in status here.
+					realizedIPAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(nsxSubnetPortState.RealizedBindings, subnetPort.Spec.StaticIPAllocationType)
+					if len(realizedIPAddresses) > 0 {
 						subnetPort.Status.NetworkInterfaceConfig.IPAddresses = realizedIPAddresses
 					}
 					subnetPort.Status.NetworkInterfaceConfig.MACAddress = macAddress
@@ -1062,18 +1065,28 @@ func realizedBindingsCoverStaticFamilies(realizedBindings []model.AddressBinding
 }
 
 // networkInterfaceIPAddressesFromRealizedBindings builds one entry per realized
-// binding with an IP, plus the shared MAC address, independent of binding count.
-// On a mixed-mode Subnet, realizedBindings can legitimately contain addresses from
-// more than one family at once (e.g. a DHCP-realized IPv4 alongside a statically
-// realized IPv6) - all of them are returned, unfiltered, since this reflects the
-// port's actual interface state rather than being scoped to static addresses only.
-func networkInterfaceIPAddressesFromRealizedBindings(realizedBindings []model.AddressBindingEntry) ([]v1alpha1.NetworkInterfaceIPAddress, string) {
+// binding whose family is covered by staticIPAllocationType, plus the shared MAC
+// address. DHCP-realized addresses of a family not covered by staticIPAllocationType
+// are dropped on purpose: SubnetPort only reconciles on CR events, but a DHCP lease
+// can change at any time, so showing it in status risks going stale until an
+// unrelated reconcile happens to refresh it. Statically allocated addresses don't
+// have that problem, since they only change via a CR spec change, which itself
+// triggers a reconcile.
+func networkInterfaceIPAddressesFromRealizedBindings(realizedBindings []model.AddressBindingEntry, staticIPAllocationType v1alpha1.StaticIPAllocationType) ([]v1alpha1.NetworkInterfaceIPAddress, string) {
 	macAddress := ""
 	ipAddresses := make([]v1alpha1.NetworkInterfaceIPAddress, 0, len(realizedBindings))
 	for _, binding := range realizedBindings {
 		if binding.Binding != nil && binding.Binding.IpAddress != nil {
 			if macAddress == "" && binding.Binding.MacAddress != nil {
 				macAddress = strings.Trim(*binding.Binding.MacAddress, "\"")
+			}
+			ip := net.ParseIP(*binding.Binding.IpAddress)
+			isIPv4 := ip != nil && ip.To4() != nil
+			if isIPv4 && !util.StaticIPAllocationTypeIncludesIPv4(staticIPAllocationType) {
+				continue
+			}
+			if !isIPv4 && !util.StaticIPAllocationTypeIncludesIPv6(staticIPAllocationType) {
+				continue
 			}
 			ipAddresses = append(ipAddresses, v1alpha1.NetworkInterfaceIPAddress{
 				Gateway:   "",

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -238,10 +238,12 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 			if subnetPort.Spec.StaticIPAllocationType != v1alpha1.StaticIPAllocationTypeNone || len(subnetPort.Spec.AddressBindings) > 0 {
 				if len(nsxSubnetPortState.RealizedBindings) > 0 {
-					// networkInterfaceIPAddressesFromRealizedBindings already drops any
-					// address whose family isn't covered by StaticIPAllocationType, so a
-					// DHCP-realized address never lands in status here.
-					realizedIPAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(nsxSubnetPortState.RealizedBindings, subnetPort.Spec.StaticIPAllocationType)
+					// A family is shown in status if it's either statically allocated or
+					// explicitly requested via addressBindings; otherwise it's an incidental
+					// DHCP lease and gets dropped. Checked per family, so a dual-stack port
+					// with an explicit binding for only one family still hides the other.
+					explicitIPv4Count, explicitIPv6Count := util.CountAddressBindingsByFamily(subnetPort.Spec.AddressBindings)
+					realizedIPAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(nsxSubnetPortState.RealizedBindings, subnetPort.Spec.StaticIPAllocationType, explicitIPv4Count > 0, explicitIPv6Count > 0)
 					if len(realizedIPAddresses) > 0 {
 						subnetPort.Status.NetworkInterfaceConfig.IPAddresses = realizedIPAddresses
 					}
@@ -1064,15 +1066,15 @@ func realizedBindingsCoverStaticFamilies(realizedBindings []model.AddressBinding
 	}
 }
 
-// networkInterfaceIPAddressesFromRealizedBindings builds one entry per realized
-// binding whose family is covered by staticIPAllocationType, plus the shared MAC
-// address. DHCP-realized addresses of a family not covered by staticIPAllocationType
-// are dropped on purpose: SubnetPort only reconciles on CR events, but a DHCP lease
-// can change at any time, so showing it in status risks going stale until an
-// unrelated reconcile happens to refresh it. Statically allocated addresses don't
-// have that problem, since they only change via a CR spec change, which itself
-// triggers a reconcile.
-func networkInterfaceIPAddressesFromRealizedBindings(realizedBindings []model.AddressBindingEntry, staticIPAllocationType v1alpha1.StaticIPAllocationType) ([]v1alpha1.NetworkInterfaceIPAddress, string) {
+// networkInterfaceIPAddressesFromRealizedBindings builds one status entry per
+// realized binding, plus the shared MAC address. A realized address is kept only
+// if its family is statically allocated (staticIPAllocationType) or explicitly
+// requested (hasExplicitIPv4/hasExplicitIPv6); otherwise it's an incidental DHCP
+// lease and is dropped, since SubnetPort doesn't reconcile on every DHCP renewal
+// and the address could go stale in status. This is checked per family, so e.g.
+// an explicit static IPv4 binding doesn't also expose an unrelated, DHCP-only
+// IPv6 address realized on the same dual-stack port.
+func networkInterfaceIPAddressesFromRealizedBindings(realizedBindings []model.AddressBindingEntry, staticIPAllocationType v1alpha1.StaticIPAllocationType, hasExplicitIPv4, hasExplicitIPv6 bool) ([]v1alpha1.NetworkInterfaceIPAddress, string) {
 	macAddress := ""
 	ipAddresses := make([]v1alpha1.NetworkInterfaceIPAddress, 0, len(realizedBindings))
 	for _, binding := range realizedBindings {
@@ -1082,10 +1084,10 @@ func networkInterfaceIPAddressesFromRealizedBindings(realizedBindings []model.Ad
 			}
 			ip := net.ParseIP(*binding.Binding.IpAddress)
 			isIPv4 := ip != nil && ip.To4() != nil
-			if isIPv4 && !util.StaticIPAllocationTypeIncludesIPv4(staticIPAllocationType) {
+			if isIPv4 && !util.StaticIPAllocationTypeIncludesIPv4(staticIPAllocationType) && !hasExplicitIPv4 {
 				continue
 			}
-			if !isIPv4 && !util.StaticIPAllocationTypeIncludesIPv6(staticIPAllocationType) {
+			if !isIPv4 && !util.StaticIPAllocationTypeIncludesIPv6(staticIPAllocationType) && !hasExplicitIPv6 {
 				continue
 			}
 			ipAddresses = append(ipAddresses, v1alpha1.NetworkInterfaceIPAddress{

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -1964,6 +1964,98 @@ func TestSubnetPortReconciler_updateSubnetStatusOnSubnetPort(t *testing.T) {
 	}
 }
 
+func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
+	tests := []struct {
+		name             string
+		realizedBindings []model.AddressBindingEntry
+		expectedIPs      []v1alpha1.NetworkInterfaceIPAddress
+		expectedMAC      string
+	}{
+		{
+			name:             "No realized bindings",
+			realizedBindings: nil,
+			expectedIPs:      []v1alpha1.NetworkInterfaceIPAddress{},
+			expectedMAC:      "",
+		},
+		{
+			name: "Single IPv4 binding",
+			realizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("10.0.0.2"),
+					MacAddress: servicecommon.String("aa:bb:cc:dd:ee:ff"),
+				}},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.2"},
+			},
+			expectedMAC: "aa:bb:cc:dd:ee:ff",
+		},
+		{
+			name: "Dual-stack: 1 IPv4 + 1 IPv6, one MAC",
+			realizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("10.0.0.2"),
+					MacAddress: servicecommon.String("aa:bb:cc:dd:ee:ff"),
+				}},
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("fe80::1"),
+					MacAddress: servicecommon.String("aa:bb:cc:dd:ee:ff"),
+				}},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.2"},
+				{IPAddress: "fe80::1"},
+			},
+			expectedMAC: "aa:bb:cc:dd:ee:ff",
+		},
+		{
+			name: "Multi-IP addressBindings sharing one MAC (spec 2.4.3): 3 same-family entries",
+			realizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("192.168.0.2"),
+					MacAddress: servicecommon.String("00:11:22:33:44:55"),
+				}},
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("192.168.0.3"),
+					MacAddress: servicecommon.String("00:11:22:33:44:55"),
+				}},
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("192.168.0.4"),
+					MacAddress: servicecommon.String("00:11:22:33:44:55"),
+				}},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "192.168.0.2"},
+				{IPAddress: "192.168.0.3"},
+				{IPAddress: "192.168.0.4"},
+			},
+			expectedMAC: "00:11:22:33:44:55",
+		},
+		{
+			name: "MAC taken from first binding that has one; only IP-bearing bindings produce entries",
+			realizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{IpAddress: nil}},
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("192.168.0.2"),
+					MacAddress: servicecommon.String("00:11:22:33:44:55"),
+				}},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "192.168.0.2"},
+			},
+			expectedMAC: "00:11:22:33:44:55",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(tt.realizedBindings)
+			assert.Equal(t, tt.expectedIPs, ipAddresses)
+			assert.Equal(t, tt.expectedMAC, macAddress)
+		})
+	}
+}
+
 func TestSubnetPortReconciler_getVirtualMachine(t *testing.T) {
 	mockCtl := gomock.NewController(t)
 	k8sClient := mock_client.NewMockClient(mockCtl)

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -413,11 +413,11 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 				v1sp.Spec.Subnet = "subnet1"
 				v1sp.Spec.AddressBindings = []v1alpha1.PortAddressBinding{
 					{
-						IPAddress: "1.2.3.5",
+						IPAddress:  "1.2.3.5",
 						MACAddress: "00:11:22:33:44:55",
 					},
 					{
-						IPAddress: "1.2.3.6",
+						IPAddress:  "1.2.3.6",
 						MACAddress: "00:11:22:33:44:55",
 					},
 				}
@@ -1068,7 +1068,6 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			return nil
 		})
 		defer patchesIPAllocDelete.Reset()
-
 
 		patches4 := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetByPath", func(_ *mock.MockSubnetServiceProvider, _ string, _ bool) (*model.VpcSubnet, error) {
 			return &model.VpcSubnet{
@@ -3566,7 +3565,6 @@ func TestSubnetPortReconciler_UpdateSubnetPortIPType(t *testing.T) {
 			},
 		}
 
-
 		subClient.EXPECT().Update(ctx, subnetPort).Return(nil)
 
 		err := r.updateSubnetPortIPType(ctx, subnetPort, v1alpha1.IPAddressTypeIPv4, &model.VpcSubnet{
@@ -3593,7 +3591,6 @@ func TestSubnetPortReconciler_UpdateSubnetPortIPType(t *testing.T) {
 				StaticIPAllocationType: "",
 			},
 		}
-
 
 		subClient.EXPECT().Update(ctx, subnetPort).Return(nil)
 

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -2332,6 +2332,8 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 		name                   string
 		realizedBindings       []model.AddressBindingEntry
 		staticIPAllocationType v1alpha1.StaticIPAllocationType
+		hasExplicitIPv4        bool
+		hasExplicitIPv6        bool
 		expectedIPs            []v1alpha1.NetworkInterfaceIPAddress
 		expectedMAC            string
 	}{
@@ -2400,10 +2402,11 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 			expectedMAC: "00:50:56:ba:d6:7a",
 		},
 		{
-			// Pure DHCP: StaticIPAllocationType=None. No family is statically requested,
-			// so the DHCP-realized IPv4 must be dropped entirely - status should show no
-			// IP at all, same as before this filtering was added.
-			name: "Pure DHCP: StaticIPAllocationType=None drops the DHCP-realized IPv4",
+			// Pure DHCP with no explicit addressBindings: StaticIPAllocationType=None. No
+			// family is statically requested, so the DHCP-realized IPv4 must be dropped
+			// entirely - status should show no IP at all, same as before this filtering
+			// was added.
+			name: "Pure DHCP, no addressBindings: StaticIPAllocationType=None drops the DHCP-realized IPv4",
 			realizedBindings: []model.AddressBindingEntry{
 				{Binding: &model.PacketAddressClassifier{
 					IpAddress:  servicecommon.String("172.26.0.165"),
@@ -2413,6 +2416,53 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
 			expectedIPs:            []v1alpha1.NetworkInterfaceIPAddress{},
 			expectedMAC:            "00:50:56:ba:d6:7a",
+		},
+		{
+			// DHCP Subnet with an explicit addressBindings entry (IP+MAC bound from the
+			// Subnet's MAC pool): StaticIPAllocationType resolves to None because the
+			// Subnet itself has no static allocation enabled, but the address was
+			// explicitly requested by the user, not an incidental DHCP lease - it must be
+			// shown in status. Regression test: this used to be dropped by the same
+			// filter that hides unrequested DHCP addresses on mixed-mode Subnets, which
+			// left status.NetworkInterfaceConfig.IPAddresses without an IP forever even
+			// though NSX had fully realized the port.
+			name: "DHCP Subnet with explicit addressBindings: StaticIPAllocationType=None must not drop the requested IP",
+			realizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("172.26.0.165"),
+					MacAddress: servicecommon.String("00:50:56:ba:d6:7a"),
+				}},
+			},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
+			hasExplicitIPv4:        true,
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "172.26.0.165"},
+			},
+			expectedMAC: "00:50:56:ba:d6:7a",
+		},
+		{
+			// Dual-stack mixed-mode Subnet: an explicit static IPv4 binding is requested,
+			// but IPv6 is not - it's realized independently via DHCP/SLAAC. The explicit
+			// IPv4 must be shown (hasExplicitIPv4), while the incidental, unrequested IPv6
+			// must still be dropped exactly as in the plain mixed-mode case above:
+			// per-family exemption must not become "any explicit binding shows everything".
+			name: "Dual-stack, explicit IPv4 only: incidental DHCP IPv6 is still dropped",
+			realizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("172.26.0.10"),
+					MacAddress: servicecommon.String("00:50:56:ba:d6:7a"),
+				}},
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("2001:db8::10"),
+					MacAddress: servicecommon.String("00:50:56:ba:d6:7a"),
+				}},
+			},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			hasExplicitIPv4:        true,
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "172.26.0.10"},
+			},
+			expectedMAC: "00:50:56:ba:d6:7a",
 		},
 		{
 			name: "Multi-IP addressBindings sharing one MAC (spec 2.4.3): 3 same-family entries",
@@ -2457,7 +2507,7 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ipAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(tt.realizedBindings, tt.staticIPAllocationType)
+			ipAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(tt.realizedBindings, tt.staticIPAllocationType, tt.hasExplicitIPv4, tt.hasExplicitIPv6)
 			assert.Equal(t, tt.expectedIPs, ipAddresses)
 			assert.Equal(t, tt.expectedMAC, macAddress)
 		})

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -1190,8 +1190,8 @@ func TestSubnetPortReconciler_Reconcile_RADeactivated(t *testing.T) {
 				}).Times(2)
 
 			patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-				func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-					return true, false, "/orgs/default/projects/default/vpcs/vpc1/subnets/subnet-1", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+				func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+					return true, false, "/orgs/default/projects/default/vpcs/vpc1/subnets/subnet-1", nil, nil, v1alpha1.IPAddressTypeIPv4, "", nil
 				})
 			defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -189,8 +189,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 	t.Run("failed with CheckAndGetSubnetPathForSubnetPort", func(t *testing.T) {
 		err := errors.New("CheckAndGetSubnetPathForSubnetPort failed")
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-				return false, false, "", nil, nil, "", err
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+				return false, false, "", nil, nil, "", "", err
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 
@@ -219,8 +219,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 	t.Run("failed with getVirtualMachine", func(t *testing.T) {
 		err := errors.New("getVirtualMachine failed")
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, "", nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetByUID := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
@@ -257,8 +257,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			})
 		defer patchesGetVirtualMachine.Reset()
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, "", nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetByUID := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
@@ -311,8 +311,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			})
 		defer patchesGetVirtualMachine.Reset()
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, "", nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetByUID := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
@@ -380,8 +380,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, "", nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesIsSharedSubnetPath := gomonkey.ApplyFunc(common.IsSharedSubnetPath, func(ctx context.Context, client client.Client, path string, ns string) (bool, error) {
@@ -404,6 +404,40 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		defer patchesUpdateSubnetStatusOnSubnetPort.Reset()
 		k8sClient.EXPECT().Status().Return(fakewriter)
 		_, ret := r.Reconcile(ctx, req)
+		assert.Equal(t, nil, ret)
+
+		// happy path - update addressbindings day 2
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
+			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+				v1sp := obj.(*v1alpha1.SubnetPort)
+				v1sp.Spec.Subnet = "subnet1"
+				v1sp.Spec.AddressBindings = []v1alpha1.PortAddressBinding{
+					{
+						IPAddress: "1.2.3.5",
+						MACAddress: "00:11:22:33:44:55",
+					},
+					{
+						IPAddress: "1.2.3.6",
+						MACAddress: "00:11:22:33:44:55",
+					},
+				}
+				return nil
+			}).Times(2)
+		portState3 := &model.SegmentPortState{
+			RealizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{IpAddress: ptr.To("1.2.3.5"), MacAddress: ptr.To("00:11:22:33:44:55")}},
+				{Binding: &model.PacketAddressClassifier{IpAddress: ptr.To("1.2.3.6"), MacAddress: ptr.To("00:11:22:33:44:55")}},
+			},
+			Attachment: &model.SegmentPortAttachmentState{
+				Id: &attachmentID,
+			},
+		}
+		patchesCreateOrUpdateSubnetPort.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
+			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+				return portState3, nil
+			})
+		k8sClient.EXPECT().Status().Return(fakewriter)
+		_, ret = r.Reconcile(ctx, req)
 		assert.Equal(t, nil, ret)
 
 		// happy path - dhcp subnetport with mac only
@@ -652,8 +686,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 				return nil
 			}).Times(2)
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, "", nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetSubnetByPath := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetByPath",
@@ -735,8 +769,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 				return nil
 			}).Times(2)
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, "", nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetSubnetByIP := gomonkey.ApplyFunc((*SubnetPortReconciler).getSubnetBySubnetPort, func(r *SubnetPortReconciler, subnetPort *v1alpha1.SubnetPort) (string, error) {
@@ -843,8 +877,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			}).Times(2)
 
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, "", nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetSubnetByIP := gomonkey.ApplyFunc((*SubnetPortReconciler).getSubnetBySubnetPort, func(r *SubnetPortReconciler, subnetPort *v1alpha1.SubnetPort) (string, error) {
@@ -937,8 +971,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 				return nil
 			}).Times(2)
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+				return true, false, "", nil, nil, v1alpha1.IPAddressTypeIPv4, "", nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesGetSubnetByIP := gomonkey.ApplyFunc((*SubnetPortReconciler).getSubnetBySubnetPort, func(r *SubnetPortReconciler, subnetPort *v1alpha1.SubnetPort) (string, error) {
@@ -1015,12 +1049,12 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			},
 		}
 
-		patches := gomonkey.ApplyMethod(reflect.TypeOf(&subnetport.SubnetPortService{}), "CreateOrUpdateSubnetPort", func(_ *subnetport.SubnetPortService, _ interface{}, _ *model.VpcSubnet, _ string, _ *map[string]string, _ bool, _ bool, _ v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+		patches := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort, func(_ *subnetport.SubnetPortService, _ interface{}, _ *model.VpcSubnet, _ string, _ *map[string]string, _ bool, _ bool, _ v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
 			return portStateLocal, nil
 		})
 		defer patches.Reset()
 
-		patches2 := gomonkey.ApplyMethod(reflect.TypeOf(&subnetport.SubnetPortService{}), "GetAddressBindingBySubnetPort", func(_ *subnetport.SubnetPortService, _ *v1alpha1.SubnetPort) *v1alpha1.AddressBinding {
+		patches2 := gomonkey.ApplyFunc((*subnetport.SubnetPortService).GetAddressBindingBySubnetPort, func(_ *subnetport.SubnetPortService, _ *v1alpha1.SubnetPort) *v1alpha1.AddressBinding {
 			return nil
 		})
 		defer patches2.Reset()
@@ -1035,13 +1069,15 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		})
 		defer patchesIPAllocDelete.Reset()
 
-		patches3 := gomonkey.ApplyFunc(pkgutil.NSXSubnetStaticIPAllocationEnabled, func(_ *model.VpcSubnet) bool {
-			return true
-		})
-		defer patches3.Reset()
 
-		patches4 := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "getSubnetBySubnetPort", func(_ *SubnetPortReconciler, _ *v1alpha1.SubnetPort) (*model.VpcSubnet, error) {
-			return &model.VpcSubnet{}, nil
+		patches4 := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetByPath", func(_ *mock.MockSubnetServiceProvider, _ string, _ bool) (*model.VpcSubnet, error) {
+			return &model.VpcSubnet{
+				AdvancedConfig: &model.SubnetAdvancedConfig{
+					StaticIpAllocation: &model.StaticIpAllocation{
+						Enabled: ptr.To(true),
+					},
+				},
+			}, nil
 		})
 		defer patches4.Reset()
 
@@ -1050,8 +1086,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		})
 		defer patches5.Reset()
 
-		patches6 := gomonkey.ApplyMethod(reflect.TypeOf(r), "CheckAndGetSubnetPathForSubnetPort", func(_ *SubnetPortReconciler, _ context.Context, _ *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-			return true, false, "/orgs/default/projects/default/vpcs/ns-1/subnets/subnet-1", nil, nil, "IPv4", nil
+		patches6 := gomonkey.ApplyMethod(reflect.TypeOf(r), "CheckAndGetSubnetPathForSubnetPort", func(_ *SubnetPortReconciler, _ context.Context, _ *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+			return true, false, "/orgs/default/projects/default/vpcs/ns-1/subnets/subnet-1", nil, nil, "IPv4", "", nil
 		})
 		defer patches6.Reset()
 
@@ -1059,6 +1095,12 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			return false, nil
 		})
 		defer patchesIsSharedSubnetPath.Reset()
+
+		patchesUpdateSubnetStatus := gomonkey.ApplyFunc((*SubnetPortReconciler).updateSubnetStatusOnSubnetPort,
+			func(r *SubnetPortReconciler, subnetPort *v1alpha1.SubnetPort, nsxSubnet *model.VpcSubnet) error {
+				return nil
+			})
+		defer patchesUpdateSubnetStatus.Reset()
 
 		patchesSetAddressBindingStatus := gomonkey.ApplyFunc(setAddressBindingStatusBySubnetPort,
 			func(client client.Client, ctx context.Context, subnetPort *v1alpha1.SubnetPort, subnetPortService *subnetport.SubnetPortService, transitionTime metav1.Time, e error) {
@@ -1852,8 +1894,8 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 							},
 						}, false, nil
 					})
-				patches.ApplyFunc((*subnet.SubnetService).GetSubnetsByIndex,
-					func(s *subnet.SubnetService, key string, value string) []*model.VpcSubnet {
+				patches.ApplyMethod(reflect.TypeOf(&subnet.SubnetStore{}), "GetByIndex",
+					func(s *subnet.SubnetStore, key string, value string) []*model.VpcSubnet {
 						return []*model.VpcSubnet{{
 							Path:           servicecommon.String("subnet-path-1"),
 							Ipv4SubnetSize: servicecommon.Int64(16),
@@ -1975,8 +2017,8 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 				})
 
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, *types.UID, *sync.RWMutex, error) {
-						return "subnet-path-1", nil, nil, nil
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, v1alpha1.StaticIPAllocationType, *types.UID, *sync.RWMutex, error) {
+						return "subnet-path-1", v1alpha1.StaticIPAllocationTypeIPv4, nil, nil, nil
 					})
 				return patches
 			},
@@ -2033,8 +2075,8 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 					})
 
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, *types.UID, *sync.RWMutex, error) {
-						return "subnet-path-1", nil, nil, nil
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, v1alpha1.StaticIPAllocationType, *types.UID, *sync.RWMutex, error) {
+						return "subnet-path-1", v1alpha1.StaticIPAllocationTypeIPv4, nil, nil, nil
 					})
 				return patches
 			},
@@ -2119,8 +2161,8 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 			patches := tt.prepareFunc(t, r)
 			defer patches.Reset()
 			r.restoreMode = tt.restoreMode
-			// Expanded to consume 7 returns values properly
-			isExisting, isStale, subnetPath, _, _, interfaceType, err := r.CheckAndGetSubnetPathForSubnetPort(ctx, tt.subnetport)
+			// Expanded to consume 8 return values properly
+			isExisting, isStale, subnetPath, _, _, interfaceType, _, err := r.CheckAndGetSubnetPathForSubnetPort(ctx, tt.subnetport)
 			assert.Equal(t, tt.expectedIsStale, isStale)
 			assert.Equal(t, tt.expectedIsExisting, isExisting)
 			if tt.expectedErr != "" {
@@ -3524,14 +3566,16 @@ func TestSubnetPortReconciler_UpdateSubnetPortIPType(t *testing.T) {
 			},
 		}
 
-		patchesStaticIPEnabled := gomonkey.ApplyFunc(pkgutil.NSXSubnetStaticIPAllocationEnabled, func(_ *model.VpcSubnet) bool {
-			return true
-		})
-		defer patchesStaticIPEnabled.Reset()
 
 		subClient.EXPECT().Update(ctx, subnetPort).Return(nil)
 
-		err := r.updateSubnetPortIPType(ctx, subnetPort, v1alpha1.IPAddressTypeIPv4, &model.VpcSubnet{})
+		err := r.updateSubnetPortIPType(ctx, subnetPort, v1alpha1.IPAddressTypeIPv4, &model.VpcSubnet{
+			AdvancedConfig: &model.SubnetAdvancedConfig{
+				StaticIpAllocation: &model.StaticIpAllocation{
+					Enabled: ptr.To(true),
+				},
+			},
+		})
 		assert.NoError(t, err)
 		assert.Equal(t, v1alpha1.StaticIPAllocationType(v1alpha1.IPAddressTypeIPv4), subnetPort.Spec.StaticIPAllocationType)
 	})
@@ -3550,10 +3594,6 @@ func TestSubnetPortReconciler_UpdateSubnetPortIPType(t *testing.T) {
 			},
 		}
 
-		patchesStaticIPEnabled := gomonkey.ApplyFunc(pkgutil.NSXSubnetStaticIPAllocationEnabled, func(_ *model.VpcSubnet) bool {
-			return false
-		})
-		defer patchesStaticIPEnabled.Reset()
 
 		subClient.EXPECT().Update(ctx, subnetPort).Return(nil)
 

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -2329,16 +2329,18 @@ func TestSubnetPortReconciler_updateSubnetStatusOnSubnetPort(t *testing.T) {
 
 func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 	tests := []struct {
-		name             string
-		realizedBindings []model.AddressBindingEntry
-		expectedIPs      []v1alpha1.NetworkInterfaceIPAddress
-		expectedMAC      string
+		name                   string
+		realizedBindings       []model.AddressBindingEntry
+		staticIPAllocationType v1alpha1.StaticIPAllocationType
+		expectedIPs            []v1alpha1.NetworkInterfaceIPAddress
+		expectedMAC            string
 	}{
 		{
-			name:             "No realized bindings",
-			realizedBindings: nil,
-			expectedIPs:      []v1alpha1.NetworkInterfaceIPAddress{},
-			expectedMAC:      "",
+			name:                   "No realized bindings",
+			realizedBindings:       nil,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			expectedIPs:            []v1alpha1.NetworkInterfaceIPAddress{},
+			expectedMAC:            "",
 		},
 		{
 			name: "Single IPv4 binding",
@@ -2348,6 +2350,7 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 					MacAddress: servicecommon.String("aa:bb:cc:dd:ee:ff"),
 				}},
 			},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
 				{IPAddress: "10.0.0.2"},
 			},
@@ -2365,6 +2368,7 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 					MacAddress: servicecommon.String("aa:bb:cc:dd:ee:ff"),
 				}},
 			},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4IPv6,
 			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
 				{IPAddress: "10.0.0.2"},
 				{IPAddress: "fe80::1"},
@@ -2372,13 +2376,13 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 			expectedMAC: "aa:bb:cc:dd:ee:ff",
 		},
 		{
-			// Mixed-mode Subnet: StaticIPAllocationType=IPv6 realizes the IPv6 binding, but
-			// DHCP independently keeps allocating the IPv4 family since it isn't statically
-			// pinned. Both are genuinely present on the port at once, so both must be
-			// reported here - this isn't scoped to "static addresses only", it reflects the
-			// real interface state. realizedBindingsCoverStaticFamilies already relies on
-			// this same assumption (see its "realized alongside DHCP IPv4" case).
-			name: "Mixed-mode: DHCP-realized IPv4 + static-realized IPv6 both reported",
+			// Mixed-mode Subnet: StaticIPAllocationType=IPv6 only. DHCP independently
+			// realizes an IPv4 address too, but it must NOT be shown in status: SubnetPort
+			// only reconciles on CR events, while a DHCP lease can change at any time, so
+			// showing it here would risk status going stale until an unrelated reconcile
+			// happens to refresh it. The static IPv6 address doesn't have that problem,
+			// since it only changes via a CR spec change, which itself triggers a reconcile.
+			name: "Mixed-mode: DHCP-realized IPv4 is dropped, only static-realized IPv6 is shown",
 			realizedBindings: []model.AddressBindingEntry{
 				{Binding: &model.PacketAddressClassifier{
 					IpAddress:  servicecommon.String("172.26.0.165"),
@@ -2389,11 +2393,26 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 					MacAddress: servicecommon.String("00:50:56:ba:d6:7a"),
 				}},
 			},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv6,
 			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
-				{IPAddress: "172.26.0.165"},
 				{IPAddress: "2001:db8::165"},
 			},
 			expectedMAC: "00:50:56:ba:d6:7a",
+		},
+		{
+			// Pure DHCP: StaticIPAllocationType=None. No family is statically requested,
+			// so the DHCP-realized IPv4 must be dropped entirely - status should show no
+			// IP at all, same as before this filtering was added.
+			name: "Pure DHCP: StaticIPAllocationType=None drops the DHCP-realized IPv4",
+			realizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("172.26.0.165"),
+					MacAddress: servicecommon.String("00:50:56:ba:d6:7a"),
+				}},
+			},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
+			expectedIPs:            []v1alpha1.NetworkInterfaceIPAddress{},
+			expectedMAC:            "00:50:56:ba:d6:7a",
 		},
 		{
 			name: "Multi-IP addressBindings sharing one MAC (spec 2.4.3): 3 same-family entries",
@@ -2411,6 +2430,7 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 					MacAddress: servicecommon.String("00:11:22:33:44:55"),
 				}},
 			},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
 				{IPAddress: "192.168.0.2"},
 				{IPAddress: "192.168.0.3"},
@@ -2427,6 +2447,7 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 					MacAddress: servicecommon.String("00:11:22:33:44:55"),
 				}},
 			},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
 				{IPAddress: "192.168.0.2"},
 			},
@@ -2436,7 +2457,7 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ipAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(tt.realizedBindings)
+			ipAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(tt.realizedBindings, tt.staticIPAllocationType)
 			assert.Equal(t, tt.expectedIPs, ipAddresses)
 			assert.Equal(t, tt.expectedMAC, macAddress)
 		})

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -495,8 +495,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
-			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
-				return true, false, "path1", nil, nil, "", nil
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, v1alpha1.StaticIPAllocationType, error) {
+				return true, false, "path1", nil, nil, "", "", nil
 			})
 		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
 		patchesIsSharedSubnetPath := gomonkey.ApplyFunc(common.IsSharedSubnetPath, func(ctx context.Context, client client.Client, path string, ns string) (bool, error) {

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -2372,6 +2372,30 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 			expectedMAC: "aa:bb:cc:dd:ee:ff",
 		},
 		{
+			// Mixed-mode Subnet: StaticIPAllocationType=IPv6 realizes the IPv6 binding, but
+			// DHCP independently keeps allocating the IPv4 family since it isn't statically
+			// pinned. Both are genuinely present on the port at once, so both must be
+			// reported here - this isn't scoped to "static addresses only", it reflects the
+			// real interface state. realizedBindingsCoverStaticFamilies already relies on
+			// this same assumption (see its "realized alongside DHCP IPv4" case).
+			name: "Mixed-mode: DHCP-realized IPv4 + static-realized IPv6 both reported",
+			realizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("172.26.0.165"),
+					MacAddress: servicecommon.String("00:50:56:ba:d6:7a"),
+				}},
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("2001:db8::165"),
+					MacAddress: servicecommon.String("00:50:56:ba:d6:7a"),
+				}},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "172.26.0.165"},
+				{IPAddress: "2001:db8::165"},
+			},
+			expectedMAC: "00:50:56:ba:d6:7a",
+		},
+		{
 			name: "Multi-IP addressBindings sharing one MAC (spec 2.4.3): 3 same-family entries",
 			realizedBindings: []model.AddressBindingEntry{
 				{Binding: &model.PacketAddressClassifier{

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -2286,6 +2286,98 @@ func TestSubnetPortReconciler_updateSubnetStatusOnSubnetPort(t *testing.T) {
 	}
 }
 
+func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
+	tests := []struct {
+		name             string
+		realizedBindings []model.AddressBindingEntry
+		expectedIPs      []v1alpha1.NetworkInterfaceIPAddress
+		expectedMAC      string
+	}{
+		{
+			name:             "No realized bindings",
+			realizedBindings: nil,
+			expectedIPs:      []v1alpha1.NetworkInterfaceIPAddress{},
+			expectedMAC:      "",
+		},
+		{
+			name: "Single IPv4 binding",
+			realizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("10.0.0.2"),
+					MacAddress: servicecommon.String("aa:bb:cc:dd:ee:ff"),
+				}},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.2"},
+			},
+			expectedMAC: "aa:bb:cc:dd:ee:ff",
+		},
+		{
+			name: "Dual-stack: 1 IPv4 + 1 IPv6, one MAC",
+			realizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("10.0.0.2"),
+					MacAddress: servicecommon.String("aa:bb:cc:dd:ee:ff"),
+				}},
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("fe80::1"),
+					MacAddress: servicecommon.String("aa:bb:cc:dd:ee:ff"),
+				}},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "10.0.0.2"},
+				{IPAddress: "fe80::1"},
+			},
+			expectedMAC: "aa:bb:cc:dd:ee:ff",
+		},
+		{
+			name: "Multi-IP addressBindings sharing one MAC (spec 2.4.3): 3 same-family entries",
+			realizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("192.168.0.2"),
+					MacAddress: servicecommon.String("00:11:22:33:44:55"),
+				}},
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("192.168.0.3"),
+					MacAddress: servicecommon.String("00:11:22:33:44:55"),
+				}},
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("192.168.0.4"),
+					MacAddress: servicecommon.String("00:11:22:33:44:55"),
+				}},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "192.168.0.2"},
+				{IPAddress: "192.168.0.3"},
+				{IPAddress: "192.168.0.4"},
+			},
+			expectedMAC: "00:11:22:33:44:55",
+		},
+		{
+			name: "MAC taken from first binding that has one; only IP-bearing bindings produce entries",
+			realizedBindings: []model.AddressBindingEntry{
+				{Binding: &model.PacketAddressClassifier{IpAddress: nil}},
+				{Binding: &model.PacketAddressClassifier{
+					IpAddress:  servicecommon.String("192.168.0.2"),
+					MacAddress: servicecommon.String("00:11:22:33:44:55"),
+				}},
+			},
+			expectedIPs: []v1alpha1.NetworkInterfaceIPAddress{
+				{IPAddress: "192.168.0.2"},
+			},
+			expectedMAC: "00:11:22:33:44:55",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipAddresses, macAddress := networkInterfaceIPAddressesFromRealizedBindings(tt.realizedBindings)
+			assert.Equal(t, tt.expectedIPs, ipAddresses)
+			assert.Equal(t, tt.expectedMAC, macAddress)
+		})
+	}
+}
+
 func TestSubnetPortReconciler_getVirtualMachine(t *testing.T) {
 	mockCtl := gomock.NewController(t)
 	k8sClient := mock_client.NewMockClient(mockCtl)

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -2419,6 +2419,66 @@ func TestNetworkInterfaceIPAddressesFromRealizedBindings(t *testing.T) {
 	}
 }
 
+func TestRealizedBindingsCoverStaticFamilies(t *testing.T) {
+	ipv4Binding := model.AddressBindingEntry{Binding: &model.PacketAddressClassifier{IpAddress: servicecommon.String("10.0.0.2")}}
+	ipv6Binding := model.AddressBindingEntry{Binding: &model.PacketAddressClassifier{IpAddress: servicecommon.String("fe80::1")}}
+
+	tests := []struct {
+		name                   string
+		realizedBindings       []model.AddressBindingEntry
+		staticIPAllocationType v1alpha1.StaticIPAllocationType
+		expected               bool
+	}{
+		{
+			name:                   "No realized bindings",
+			realizedBindings:       nil,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			expected:               false,
+		},
+		{
+			name:                   "IPv4 requested and realized",
+			realizedBindings:       []model.AddressBindingEntry{ipv4Binding},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			expected:               true,
+		},
+		{
+			name: "Mixed-mode Subnet: StaticIPAllocationType IPv6 but only the DHCP IPv4 is realized yet",
+			realizedBindings: []model.AddressBindingEntry{
+				ipv4Binding,
+			},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv6,
+			expected:               false,
+		},
+		{
+			name: "Mixed-mode Subnet: StaticIPAllocationType IPv6 and the static IPv6 binding is realized alongside DHCP IPv4",
+			realizedBindings: []model.AddressBindingEntry{
+				ipv4Binding,
+				ipv6Binding,
+			},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv6,
+			expected:               true,
+		},
+		{
+			name:                   "Dual-stack static: only IPv4 realized so far",
+			realizedBindings:       []model.AddressBindingEntry{ipv4Binding},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4IPv6,
+			expected:               false,
+		},
+		{
+			name:                   "Dual-stack static: both families realized",
+			realizedBindings:       []model.AddressBindingEntry{ipv4Binding, ipv6Binding},
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4IPv6,
+			expected:               true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, realizedBindingsCoverStaticFamilies(tt.realizedBindings, tt.staticIPAllocationType))
+		})
+	}
+}
+
 func TestSubnetPortReconciler_getVirtualMachine(t *testing.T) {
 	mockCtl := gomock.NewController(t)
 	k8sClient := mock_client.NewMockClient(mockCtl)

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -1861,7 +1861,7 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 						}}
 					})
 				patches.ApplyFunc((*subnetport.SubnetPortService).AllocatePortFromSubnet,
-					func(s *subnetport.SubnetPortService, nsxSubnet *model.VpcSubnet, sharedSubnet bool, interfaceType v1alpha1.IPAddressType) (bool, error) {
+					func(s *subnetport.SubnetPortService, nsxSubnet *model.VpcSubnet, sharedSubnet bool, interfaceType v1alpha1.IPAddressType, staticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (bool, error) {
 						return true, nil
 					})
 				return patches
@@ -1975,7 +1975,7 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 				})
 
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType) (string, *types.UID, *sync.RWMutex, error) {
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, *types.UID, *sync.RWMutex, error) {
 						return "subnet-path-1", nil, nil, nil
 					})
 				return patches
@@ -2033,7 +2033,7 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 					})
 
 				patches.ApplyFunc(common.AllocateSubnetFromSubnetSet,
-					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType) (string, *types.UID, *sync.RWMutex, error) {
+					func(client client.Client, apiReader client.Reader, subnetSet *v1alpha1.SubnetSet, vpcService servicecommon.VPCServiceProvider, subnetService servicecommon.SubnetServiceProvider, subnetPortService servicecommon.SubnetPortServiceProvider, interfaceType v1alpha1.IPAddressType, rawStaticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (string, *types.UID, *sync.RWMutex, error) {
 						return "subnet-path-1", nil, nil, nil
 					})
 				return patches

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -146,12 +146,12 @@ func (m *MockSubnetPortServiceProvider) GetPortsOfSubnet(subnetPath string) (por
 	return args.Get(0).([]*model.VpcSubnetPort)
 }
 
-func (m *MockSubnetPortServiceProvider) AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool, interfaceIPType v1alpha1.IPAddressType) (bool, error) {
-	args := m.Called(subnet, sharedSubnet, interfaceIPType)
+func (m *MockSubnetPortServiceProvider) AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool, interfaceIPType v1alpha1.IPAddressType, staticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (bool, error) {
+	args := m.Called(subnet, sharedSubnet, interfaceIPType, staticIPAllocationType, addressBindings)
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *MockSubnetPortServiceProvider) ReleasePortInSubnet(path string, interfaceIPType v1alpha1.IPAddressType) {
+func (m *MockSubnetPortServiceProvider) ReleasePortInSubnet(path string, interfaceIPType v1alpha1.IPAddressType, staticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) {
 }
 
 func (m *MockSubnetPortServiceProvider) IsEmptySubnet(path string) bool {

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -43,8 +43,8 @@ type SubnetServiceProvider interface {
 
 type SubnetPortServiceProvider interface {
 	GetPortsOfSubnet(subnetPath string) (ports []*model.VpcSubnetPort)
-	AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool, interfaceIPType v1alpha1.IPAddressType) (bool, error)
-	ReleasePortInSubnet(path string, interfaceIPType v1alpha1.IPAddressType)
+	AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool, interfaceIPType v1alpha1.IPAddressType, staticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (bool, error)
+	ReleasePortInSubnet(path string, interfaceIPType v1alpha1.IPAddressType, staticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding)
 	IsEmptySubnet(path string) bool
 	DeletePortCount(path string)
 	GetSubnetPathForSubnetPortFromStore(crUid types.UID) string

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -68,7 +68,8 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 				hasMacSpecified = true
 			}
 		} else if len(o.Spec.AddressBindings) > 0 {
-			// normal mode: process all address bindings (up to 2 for IPv4 and IPv6)
+			// normal mode: process all address bindings, any count. NSX validates MAC
+			// consistency across entries server-side, so no need to re-check it here.
 			for _, ab := range o.Spec.AddressBindings {
 				addressBinding := model.PortAddressBindingEntry{}
 				if len(ab.IPAddress) > 0 {

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -1659,3 +1659,77 @@ func TestBuildSubnetPortMACVersionGating(t *testing.T) {
 		assert.Equal(t, "aa:bb:cc:dd:ee:ff", *port.AddressBindings[0].MacAddress)
 	}
 }
+
+// TestBuildSubnetPortMultipleSameMACBindings verifies spec 2.4.3 (Blueprint VM
+// creation): a SubnetPort can carry more than 2 addressBindings entries sharing one
+// MAC address, with a mix of explicit and omitted IPs, and buildSubnetPort passes
+// all of them through to NSX unchanged (NSX itself enforces MAC consistency and
+// fills in omitted IPs from the pool).
+func TestBuildSubnetPortMultipleSameMACBindings(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	nsxClient := &nsx.Client{}
+	tr := true
+	service := &SubnetPortService{
+		Service: common.Service{
+			Client:    k8sClient,
+			NSXClient: nsxClient,
+			NSXConfig: &config.NSXOperatorConfig{
+				NsxConfig: &config.NsxConfig{
+					EnforcementPoint: "vmc-enforcementpoint",
+					VpcWcpEnhance:    &tr,
+				},
+				CoeConfig: &config.CoeConfig{Cluster: "fake_cluster"},
+			},
+		},
+		SubnetPortStore: setupStore(),
+	}
+
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion",
+		func(_ *nsx.Client, _ int) bool { return true })
+	defer patches.Reset()
+
+	ctx := context.Background()
+	namespace := &corev1.Namespace{}
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), namespace).Return(nil).Do(
+		func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+			return nil
+		}).AnyTimes()
+
+	staticEnabled := &tr
+	staticSubnet := &model.VpcSubnet{
+		AdvancedConfig: &model.SubnetAdvancedConfig{
+			StaticIpAllocation: &model.StaticIpAllocation{Enabled: staticEnabled},
+		},
+		Path: common.String("fake_path"),
+	}
+
+	sp := &v1alpha1.SubnetPort{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acd",
+			Name:      "fake_subnetport_multi",
+			Namespace: "fake_ns",
+		},
+		Spec: v1alpha1.SubnetPortSpec{
+			StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			AddressBindings: []v1alpha1.PortAddressBinding{
+				{IPAddress: "10.0.0.2", MACAddress: "00:11:22:33:44:55"},
+				{IPAddress: "10.0.0.3", MACAddress: "00:11:22:33:44:55"},
+				{MACAddress: "00:11:22:33:44:55"}, // IP omitted: allocated from pool by NSX
+			},
+		},
+	}
+
+	port, err := service.buildSubnetPort(sp, staticSubnet, "ctx", nil, false, false, v1alpha1.IPAddressTypeIPv4)
+	assert.Nil(t, err)
+	// staticIPAllocationType set + MAC specified -> IP_POOL (allocate omitted IPs, use specified MAC).
+	assert.Equal(t, "IP_POOL", *port.Attachment.AllocateAddresses)
+	if assert.Len(t, port.AddressBindings, 3) {
+		assert.Equal(t, "10.0.0.2", *port.AddressBindings[0].IpAddress)
+		assert.Equal(t, "00:11:22:33:44:55", *port.AddressBindings[0].MacAddress)
+		assert.Equal(t, "10.0.0.3", *port.AddressBindings[1].IpAddress)
+		assert.Equal(t, "00:11:22:33:44:55", *port.AddressBindings[1].MacAddress)
+		assert.Nil(t, port.AddressBindings[2].IpAddress)
+		assert.Equal(t, "00:11:22:33:44:55", *port.AddressBindings[2].MacAddress)
+	}
+}

--- a/pkg/nsx/services/subnetport/store.go
+++ b/pkg/nsx/services/subnetport/store.go
@@ -154,7 +154,10 @@ type CountInfo struct {
 	// pool and static IP pool respectively.
 	totalDhcpIP   int
 	totalStaticIP int
-	// totalDhcpIPv6/totalStaticIPv6 are the IPv6 equivalents of the above.
+	// totalDhcpIPv6/totalStaticIPv6 are the IPv6 equivalents of totalDhcpIP/totalStaticIP.
+	// totalDhcpIPv6 is only populated on NSX versions that expose DHCPv6 pool statistics
+	// via dhcp-server-config-stats (see checkIPv6Capacity); on older versions the
+	// DHCPv6-sourced capacity check is skipped and this field stays unused.
 	totalDhcpIPv6      int
 	totalStaticIPv6    int
 	exhaustedCheckTime time.Time

--- a/pkg/nsx/services/subnetport/store.go
+++ b/pkg/nsx/services/subnetport/store.go
@@ -141,15 +141,22 @@ type SubnetPortStore struct {
 }
 
 type CountInfo struct {
-	// dirtyCount defines the number of SubnetPorts under creation in the Subnet (IPv4)
-	dirtyCount int
-	// dirtyCountIPv6 defines the number of SubnetPorts under creation in the Subnet (IPv6)
-	dirtyCountIPv6 int
-	lock           sync.Mutex
-	// totalIP defines the number of available IPv4 in the Subnet
-	totalIP int
-	// totalIPv6 defines the number of available IPv6 in the Subnet
-	totalIPv6          int
+	// dirtyDhcpCount/dirtyStaticCount defines the number of IPv4 addresses requested by
+	// SubnetPorts under creation in the Subnet, split by the pool the address is allocated
+	// from. On a non-mixed-mode Subnet only one of the two pools exists and is used.
+	dirtyDhcpCount   int
+	dirtyStaticCount int
+	// dirtyDhcpCountIPv6/dirtyStaticCountIPv6 are the IPv6 equivalents of the above.
+	dirtyDhcpCountIPv6   int
+	dirtyStaticCountIPv6 int
+	lock                 sync.Mutex
+	// totalDhcpIP/totalStaticIP defines the number of available IPv4 in the Subnet's DHCP
+	// pool and static IP pool respectively.
+	totalDhcpIP   int
+	totalStaticIP int
+	// totalDhcpIPv6/totalStaticIPv6 are the IPv6 equivalents of the above.
+	totalDhcpIPv6      int
+	totalStaticIPv6    int
 	exhaustedCheckTime time.Time
 }
 

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -97,12 +97,32 @@ func setupStore() *SubnetPortStore {
 		}}
 }
 
+// allIPAddressesRealized reports whether every expected address has landed, not just the first.
+func allIPAddressesRealized(ipAddresses []v1alpha1.NetworkInterfaceIPAddress, expectedCount int) bool {
+	if len(ipAddresses) < expectedCount {
+		return false
+	}
+	for _, ipConfig := range ipAddresses {
+		if ipConfig.IPAddress == "" {
+			return false
+		}
+	}
+	return true
+}
+
 func (service *SubnetPortService) portAlreadyRealized(obj interface{}, nsxSubnetPort *model.VpcSubnetPort) bool {
 	switch o := obj.(type) {
 	case *v1alpha1.SubnetPort:
+		expectedIPCount := 1
+		if o.Spec.InterfaceIPType == v1alpha1.IPAddressTypeIPv4IPv6 {
+			expectedIPCount = 2
+		}
+		if len(o.Spec.AddressBindings) > expectedIPCount {
+			expectedIPCount = len(o.Spec.AddressBindings)
+		}
 		// In the scale case, the port's realized binding may not be set immediately after port creation, so need to check it.
 		if v := nsxSubnetPort.Attachment.AllocateAddresses; v != nil && (*v == "BOTH" || *v == "IP_POOL") {
-			if len(o.Status.NetworkInterfaceConfig.IPAddresses) == 0 || o.Status.NetworkInterfaceConfig.IPAddresses[0].IPAddress == "" {
+			if !allIPAddressesRealized(o.Status.NetworkInterfaceConfig.IPAddresses, expectedIPCount) {
 				return false
 			}
 		}

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -388,6 +388,33 @@ func (service *SubnetPortService) GetPortsOfSubnet(subnetPath string) (ports []*
 	return subnetPortList
 }
 
+// isPortStaticAllocated reports whether a realized port's addresses come from a static
+// IP pool (AllocateAddresses BOTH/IP_POOL) rather than a DHCP/MAC pool.
+func isPortStaticAllocated(port *model.VpcSubnetPort) bool {
+	if port.Attachment == nil || port.Attachment.AllocateAddresses == nil {
+		return false
+	}
+	switch *port.Attachment.AllocateAddresses {
+	case "BOTH", "IP_POOL":
+		return true
+	default:
+		return false
+	}
+}
+
+// countExistingPortsForPool counts only realized ports sourced from the pool being checked,
+// so a DHCP-sourced port on a mixed-mode Subnet doesn't count against static capacity (or
+// vice versa).
+func (service *SubnetPortService) countExistingPortsForPool(subnetPath string, useStaticPool bool) int {
+	count := 0
+	for _, port := range service.GetPortsOfSubnet(subnetPath) {
+		if isPortStaticAllocated(port) == useStaticPool {
+			count++
+		}
+	}
+	return count
+}
+
 func (service *SubnetPortService) ListSubnetPortIDsFromCRs(ctx context.Context) (sets.Set[string], error) {
 	subnetPortList := &v1alpha1.SubnetPortList{}
 	err := service.Client.List(ctx, subnetPortList)
@@ -483,13 +510,10 @@ func (service *SubnetPortService) ListSubnetPortByStsUid(ns string, stsUid strin
 	return result
 }
 
-// AllocatePortFromSubnet checks the number of IPs requested by the SubnetPort on the Subnet.
-// If the Subnet has capacity for the new SubnetPort, it will increase the number of IPs
-// under creation and return true.
-// For dual-stack subnets, both IPv4 and IPv6 capacity must be available. When addressBindings
-// requests multiple IPs for a family, all of them are accounted for. staticIPAllocationType
-// decides, per family, whether the IP is drawn from the Subnet's static IP pool or its DHCP
-// pool - this matters for mixed-mode Subnets where both pools exist simultaneously.
+// AllocatePortFromSubnet checks capacity for all IPs the SubnetPort requests (addressBindings
+// may ask for more than one per family) and reserves them if available. staticIPAllocationType
+// decides, per family, whether the IP is drawn from the static pool or the DHCP pool - needed
+// for mixed-mode Subnets where both exist at once.
 func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool, interfaceIPType v1alpha1.IPAddressType, staticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (bool, error) {
 	subnetInfo, _ := servicecommon.ParseVPCResourcePath(*subnet.Path)
 
@@ -549,9 +573,8 @@ func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet
 	return true, nil
 }
 
-// checkIPv4Capacity checks if the subnet has available IPv4 capacity for ipCount more addresses.
-// useStaticPool decides whether the static IP pool or the DHCP pool is checked, matching where
-// this SubnetPort's IPv4 address is actually allocated from.
+// checkIPv4Capacity checks for ipCount more IPv4 addresses in the static or DHCP pool,
+// per useStaticPool.
 func (service *SubnetPortService) checkIPv4Capacity(subnet *model.VpcSubnet, sharedSubnet bool, info *CountInfo, existedEntry bool, subnetInfo servicecommon.VPCResourceInfo, useStaticPool bool, ipCount int) (bool, error) {
 	dhcpMode := model.SubnetDhcpConfig_MODE_DEACTIVATED
 	if subnet.SubnetDhcpConfig != nil && subnet.SubnetDhcpConfig.Mode != nil {
@@ -620,7 +643,7 @@ func (service *SubnetPortService) checkIPv4Capacity(subnet *model.VpcSubnet, sha
 		return false, nil
 	}
 
-	existingPortCount := len(service.GetPortsOfSubnet(*subnet.Path))
+	existingPortCount := service.countExistingPortsForPool(*subnet.Path, useStaticPool)
 	// A shared Subnet can be used by other supervisors or other places where SubnetPort
 	// is created and not in operator cache.
 	// For DHCPServer Subnet, the allocated IP number wont change before the VM request IP
@@ -637,9 +660,8 @@ func (service *SubnetPortService) checkIPv4Capacity(subnet *model.VpcSubnet, sha
 	return info.dirtyDhcpCount+existingPortCount+ipCount <= info.totalDhcpIP, nil
 }
 
-// checkIPv6Capacity checks if the subnet has available IPv6 capacity for ipCount more addresses.
-// useStaticPool decides whether the static IP pool or the DHCP pool is checked, matching where
-// this SubnetPort's IPv6 address is actually allocated from.
+// checkIPv6Capacity checks for ipCount more IPv6 addresses in the static or DHCP pool,
+// per useStaticPool.
 func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sharedSubnet bool, info *CountInfo, isNewEntry bool, subnetInfo servicecommon.VPCResourceInfo, useStaticPool bool, ipCount int) (bool, error) {
 	dhcpv6Mode := model.SubnetDhcpv6Config_MODE_DEACTIVATED
 	if subnet.SubnetDhcpv6Config != nil && subnet.SubnetDhcpv6Config.Mode != nil {
@@ -657,10 +679,7 @@ func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sha
 
 	var allocatedIPNumberIPv6 int
 	if !useStaticPool {
-		// DHCPv6 pool statistics are only exposed by NSX versions with the VpcIpv6
-		// feature enabled - dhcp-server-config-stats returns a populated DhcpIpv6 field
-		// in that case. On older NSX versions, DhcpIpv6 stays nil and we allow the
-		// allocation unconditionally, same as before.
+		// DHCPv6 pool stats need NSX's VpcIpv6 feature; on older versions DhcpIpv6 stays nil.
 		if !service.NSXClient.NSXCheckVersion(nsx.IPv6) {
 			log.Info("DHCPv6 pool statistics unavailable on this NSX version; allowing allocation", "Subnet", *subnet.Path)
 			return true, nil
@@ -671,9 +690,6 @@ func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sha
 			return false, err
 		}
 		if dhcpServerStats.DhcpIpv6 == nil || len(dhcpServerStats.DhcpIpv6.IpPoolStats) == 0 {
-			// This NSX build doesn't populate DHCPv6 stats for this Subnet (e.g. IPv4-only
-			// Subnet, or VpcIpv6 feature switch off server-side despite the client-side
-			// version gate). Fall back to allowing the allocation unconditionally.
 			log.Info("DHCPv6 pool statistics not present in response; allowing allocation", "Subnet", *subnet.Path)
 			return true, nil
 		}
@@ -688,7 +704,7 @@ func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sha
 			return false, nil
 		}
 
-		existingPortCount := len(service.GetPortsOfSubnet(*subnet.Path))
+		existingPortCount := service.countExistingPortsForPool(*subnet.Path, false)
 		if sharedSubnet {
 			existingPortCount = max(existingPortCount, allocatedIPNumberIPv6)
 		}
@@ -714,7 +730,7 @@ func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sha
 		return false, nil
 	}
 
-	existingPortCount := len(service.GetPortsOfSubnet(*subnet.Path))
+	existingPortCount := service.countExistingPortsForPool(*subnet.Path, true)
 	if sharedSubnet {
 		existingPortCount = max(existingPortCount, allocatedIPNumberIPv6)
 	}
@@ -735,9 +751,8 @@ func (service *SubnetPortService) updateExhaustedSubnet(path string) {
 	info.exhaustedCheckTime = time.Now()
 }
 
-// ReleasePortInSubnet decreases the number of IPs under creation for a SubnetPort.
-// interfaceIPType, staticIPAllocationType and addressBindings must match the values passed to
-// the corresponding AllocatePortFromSubnet call, so the same pool counters are decremented.
+// ReleasePortInSubnet undoes AllocatePortFromSubnet's reservation. Params must match the
+// original Allocate call so the same pool counters are decremented.
 func (service *SubnetPortService) ReleasePortInSubnet(path string, interfaceIPType v1alpha1.IPAddressType, staticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) {
 	obj, ok := service.SubnetPortStore.PortCountInfo.Load(path)
 	if !ok {

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -434,11 +434,11 @@ func countNSXAddressBindingsByFamily(bindings []model.PortAddressBindingEntry) (
 	return ipv4Count, ipv6Count
 }
 
-// countExistingPortsForPool counts IPs (not ports) consumed from the pool being checked, for
+// countExistingIPsForPool counts IPs (not ports) consumed from the pool being checked, for
 // the given family. Only ports sourced from that pool are counted, so a DHCP-sourced port on
 // a mixed-mode Subnet doesn't count against static capacity (or vice versa). A port with
 // multiple bindings in the requested family counts for all of them, not just one.
-func (service *SubnetPortService) countExistingPortsForPool(subnetPath string, useStaticPool bool, useIPv6 bool) int {
+func (service *SubnetPortService) countExistingIPsForPool(subnetPath string, useStaticPool bool, useIPv6 bool) int {
 	count := 0
 	for _, port := range service.GetPortsOfSubnet(subnetPath) {
 		if isPortStaticAllocated(port) != useStaticPool {
@@ -687,7 +687,7 @@ func (service *SubnetPortService) checkIPv4Capacity(subnet *model.VpcSubnet, sha
 		return false, nil
 	}
 
-	existingPortCount := service.countExistingPortsForPool(*subnet.Path, useStaticPool, false)
+	existingIPCount := service.countExistingIPsForPool(*subnet.Path, useStaticPool, false)
 	// A shared Subnet can be used by other supervisors or other places where SubnetPort
 	// is created and not in operator cache.
 	// For DHCPServer Subnet, the allocated IP number wont change before the VM request IP
@@ -695,13 +695,13 @@ func (service *SubnetPortService) checkIPv4Capacity(subnet *model.VpcSubnet, sha
 	// Thus we use the max number of port record in store and allocated number from API to
 	// reduce the possibility to create SubnetPort on a Subnet without available IP
 	if sharedSubnet {
-		existingPortCount = max(existingPortCount, allocatedIPNumber)
+		existingIPCount = max(existingIPCount, allocatedIPNumber)
 	}
 
 	if useStaticPool {
-		return info.dirtyStaticCount+existingPortCount+ipCount <= info.totalStaticIP, nil
+		return info.dirtyStaticCount+existingIPCount+ipCount <= info.totalStaticIP, nil
 	}
-	return info.dirtyDhcpCount+existingPortCount+ipCount <= info.totalDhcpIP, nil
+	return info.dirtyDhcpCount+existingIPCount+ipCount <= info.totalDhcpIP, nil
 }
 
 // checkIPv6Capacity checks for ipCount more IPv6 addresses in the static or DHCP pool,
@@ -748,12 +748,12 @@ func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sha
 			return false, nil
 		}
 
-		existingPortCount := service.countExistingPortsForPool(*subnet.Path, false, true)
+		existingIPCount := service.countExistingIPsForPool(*subnet.Path, false, true)
 		if sharedSubnet {
-			existingPortCount = max(existingPortCount, allocatedIPNumberIPv6)
+			existingIPCount = max(existingIPCount, allocatedIPNumberIPv6)
 		}
 
-		return info.dirtyDhcpCountIPv6+existingPortCount+ipCount <= info.totalDhcpIPv6, nil
+		return info.dirtyDhcpCountIPv6+existingIPCount+ipCount <= info.totalDhcpIPv6, nil
 	}
 
 	if !isNewEntry || info.totalStaticIPv6 == 0 || sharedSubnet {
@@ -774,12 +774,12 @@ func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sha
 		return false, nil
 	}
 
-	existingPortCount := service.countExistingPortsForPool(*subnet.Path, true, true)
+	existingIPCount := service.countExistingIPsForPool(*subnet.Path, true, true)
 	if sharedSubnet {
-		existingPortCount = max(existingPortCount, allocatedIPNumberIPv6)
+		existingIPCount = max(existingIPCount, allocatedIPNumberIPv6)
 	}
 
-	return info.dirtyStaticCountIPv6+existingPortCount+ipCount <= info.totalStaticIPv6, nil
+	return info.dirtyStaticCountIPv6+existingIPCount+ipCount <= info.totalStaticIPv6, nil
 }
 
 func (service *SubnetPortService) updateExhaustedSubnet(path string) {

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -655,15 +655,47 @@ func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sha
 		return true, nil
 	}
 
+	var allocatedIPNumberIPv6 int
 	if !useStaticPool {
-		// TODO: Revisit when DHCPv6 is fully supported in NSX and DHCPv6 server statistics are available.
-		// For now, always allow allocation unconditionally for SubnetPorts sourcing their IPv6
-		// address from the DHCPv6 pool.
-		log.Info("DHCPv6 mode detected; allowing allocation (DHCPv6 support pending)", "Subnet", *subnet.Path)
-		return true, nil
+		// DHCPv6 pool statistics are only exposed by NSX versions with the VpcIpv6
+		// feature enabled - dhcp-server-config-stats returns a populated DhcpIpv6 field
+		// in that case. On older NSX versions, DhcpIpv6 stays nil and we allow the
+		// allocation unconditionally, same as before.
+		if !service.NSXClient.NSXCheckVersion(nsx.IPv6) {
+			log.Info("DHCPv6 pool statistics unavailable on this NSX version; allowing allocation", "Subnet", *subnet.Path)
+			return true, nil
+		}
+		dhcpServerStats, err := service.NSXClient.DhcpServerConfigStatsClient.Get(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, nil, nil, nil, nil, nil, nil, nil)
+		if err != nil {
+			log.Error(err, "Failed to get Subnet dhcp-server-config stats for IPv6", "Subnet", *subnet.Path)
+			return false, err
+		}
+		if dhcpServerStats.DhcpIpv6 == nil || len(dhcpServerStats.DhcpIpv6.IpPoolStats) == 0 {
+			// This NSX build doesn't populate DHCPv6 stats for this Subnet (e.g. IPv4-only
+			// Subnet, or VpcIpv6 feature switch off server-side despite the client-side
+			// version gate). Fall back to allowing the allocation unconditionally.
+			log.Info("DHCPv6 pool statistics not present in response; allowing allocation", "Subnet", *subnet.Path)
+			return true, nil
+		}
+		if dhcpServerStats.DhcpIpv6.IpPoolStats[0].PoolSize != nil {
+			info.totalDhcpIPv6 = int(*dhcpServerStats.DhcpIpv6.IpPoolStats[0].PoolSize)
+		}
+		if sharedSubnet && dhcpServerStats.DhcpIpv6.IpPoolStats[0].AllocatedNumber != nil {
+			allocatedIPNumberIPv6 = int(*dhcpServerStats.DhcpIpv6.IpPoolStats[0].AllocatedNumber)
+		}
+
+		if time.Since(info.exhaustedCheckTime) < IPReleaseTime {
+			return false, nil
+		}
+
+		existingPortCount := len(service.GetPortsOfSubnet(*subnet.Path))
+		if sharedSubnet {
+			existingPortCount = max(existingPortCount, allocatedIPNumberIPv6)
+		}
+
+		return info.dirtyDhcpCountIPv6+existingPortCount+ipCount <= info.totalDhcpIPv6, nil
 	}
 
-	var allocatedIPNumberIPv6 int
 	if !isNewEntry || info.totalStaticIPv6 == 0 || sharedSubnet {
 		staticIPPoolIPv6, err := service.NSXClient.IPPoolClient.Get(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, "static-ipv6-default")
 		if err != nil {

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -113,9 +114,22 @@ func allIPAddressesRealized(ipAddresses []v1alpha1.NetworkInterfaceIPAddress, ex
 func (service *SubnetPortService) portAlreadyRealized(obj interface{}, nsxSubnetPort *model.VpcSubnetPort) bool {
 	switch o := obj.(type) {
 	case *v1alpha1.SubnetPort:
+		// expectedIPCount is driven by StaticIPAllocationType, not InterfaceIPType: on a
+		// mixed-mode Subnet a dual-stack port (InterfaceIPType IPv4IPv6) may statically
+		// allocate only one family (e.g. StaticIPAllocationType IPv4), in which case only
+		// one IP is ever realized via AllocateAddresses BOTH/IP_POOL - the other family
+		// comes from DHCP/SLAAC and isn't tracked here.
 		expectedIPCount := 1
-		if o.Spec.InterfaceIPType == v1alpha1.IPAddressTypeIPv4IPv6 {
+		switch o.Spec.StaticIPAllocationType {
+		case v1alpha1.StaticIPAllocationTypeIPv4IPv6:
 			expectedIPCount = 2
+		case "", v1alpha1.StaticIPAllocationTypeNone:
+			// Not backfilled yet, or genuinely no static allocation (the AllocateAddresses
+			// check below already ensures we only reach here when static allocation is
+			// actually active) - fall back to InterfaceIPType as a best-effort default.
+			if o.Spec.InterfaceIPType == v1alpha1.IPAddressTypeIPv4IPv6 {
+				expectedIPCount = 2
+			}
 		}
 		if len(o.Spec.AddressBindings) > expectedIPCount {
 			expectedIPCount = len(o.Spec.AddressBindings)
@@ -402,14 +416,44 @@ func isPortStaticAllocated(port *model.VpcSubnetPort) bool {
 	}
 }
 
-// countExistingPortsForPool counts only realized ports sourced from the pool being checked,
-// so a DHCP-sourced port on a mixed-mode Subnet doesn't count against static capacity (or
-// vice versa).
-func (service *SubnetPortService) countExistingPortsForPool(subnetPath string, useStaticPool bool) int {
+// countNSXAddressBindingsByFamily is the NSX-model equivalent of
+// util.CountAddressBindingsByFamily, used for a realized port's AddressBindings.
+func countNSXAddressBindingsByFamily(bindings []model.PortAddressBindingEntry) (ipv4Count, ipv6Count int) {
+	for _, binding := range bindings {
+		if binding.IpAddress == nil || *binding.IpAddress == "" {
+			ipv4Count++
+			continue
+		}
+		ip := net.ParseIP(*binding.IpAddress)
+		if ip != nil && ip.To4() == nil {
+			ipv6Count++
+		} else {
+			ipv4Count++
+		}
+	}
+	return ipv4Count, ipv6Count
+}
+
+// countExistingPortsForPool counts IPs (not ports) consumed from the pool being checked, for
+// the given family. Only ports sourced from that pool are counted, so a DHCP-sourced port on
+// a mixed-mode Subnet doesn't count against static capacity (or vice versa). A port with
+// multiple bindings in the requested family counts for all of them, not just one.
+func (service *SubnetPortService) countExistingPortsForPool(subnetPath string, useStaticPool bool, useIPv6 bool) int {
 	count := 0
 	for _, port := range service.GetPortsOfSubnet(subnetPath) {
-		if isPortStaticAllocated(port) == useStaticPool {
+		if isPortStaticAllocated(port) != useStaticPool {
+			continue
+		}
+		if len(port.AddressBindings) == 0 {
+			// No explicit bindings recorded: assume the legacy single-IP-per-family shape.
 			count++
+			continue
+		}
+		ipv4Count, ipv6Count := countNSXAddressBindingsByFamily(port.AddressBindings)
+		if useIPv6 {
+			count += ipv6Count
+		} else {
+			count += ipv4Count
 		}
 	}
 	return count
@@ -643,7 +687,7 @@ func (service *SubnetPortService) checkIPv4Capacity(subnet *model.VpcSubnet, sha
 		return false, nil
 	}
 
-	existingPortCount := service.countExistingPortsForPool(*subnet.Path, useStaticPool)
+	existingPortCount := service.countExistingPortsForPool(*subnet.Path, useStaticPool, false)
 	// A shared Subnet can be used by other supervisors or other places where SubnetPort
 	// is created and not in operator cache.
 	// For DHCPServer Subnet, the allocated IP number wont change before the VM request IP
@@ -704,7 +748,7 @@ func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sha
 			return false, nil
 		}
 
-		existingPortCount := service.countExistingPortsForPool(*subnet.Path, false)
+		existingPortCount := service.countExistingPortsForPool(*subnet.Path, false, true)
 		if sharedSubnet {
 			existingPortCount = max(existingPortCount, allocatedIPNumberIPv6)
 		}
@@ -730,7 +774,7 @@ func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sha
 		return false, nil
 	}
 
-	existingPortCount := service.countExistingPortsForPool(*subnet.Path, true)
+	existingPortCount := service.countExistingPortsForPool(*subnet.Path, true, true)
 	if sharedSubnet {
 		existingPortCount = max(existingPortCount, allocatedIPNumberIPv6)
 	}

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -449,7 +449,8 @@ func (service *SubnetPortService) ResetSubnetTotalIP(path string) {
 	info := obj.(*CountInfo)
 	info.lock.Lock()
 	defer info.lock.Unlock()
-	info.totalIP = 0
+	info.totalStaticIP = 0
+	info.totalDhcpIP = 0
 }
 
 func (service *SubnetPortService) ListSubnetPortByStsName(ns string, stsName string) []*model.VpcSubnetPort {
@@ -482,11 +483,14 @@ func (service *SubnetPortService) ListSubnetPortByStsUid(ns string, stsUid strin
 	return result
 }
 
-// AllocatePortFromSubnet checks the number of SubnetPorts on the Subnet.
-// If the Subnet has capacity for the new SubnetPorts, it will increase
-// the number of SubnetPort under creation and return true.
-// For dual-stack subnets, both IPv4 and IPv6 capacity must be available.
-func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool, interfaceIPType v1alpha1.IPAddressType) (bool, error) {
+// AllocatePortFromSubnet checks the number of IPs requested by the SubnetPort on the Subnet.
+// If the Subnet has capacity for the new SubnetPort, it will increase the number of IPs
+// under creation and return true.
+// For dual-stack subnets, both IPv4 and IPv6 capacity must be available. When addressBindings
+// requests multiple IPs for a family, all of them are accounted for. staticIPAllocationType
+// decides, per family, whether the IP is drawn from the Subnet's static IP pool or its DHCP
+// pool - this matters for mixed-mode Subnets where both pools exist simultaneously.
+func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet, sharedSubnet bool, interfaceIPType v1alpha1.IPAddressType, staticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) (bool, error) {
 	subnetInfo, _ := servicecommon.ParseVPCResourcePath(*subnet.Path)
 
 	info := &CountInfo{}
@@ -496,9 +500,19 @@ func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet
 	info.lock.Lock()
 	defer info.lock.Unlock()
 
+	ipv4Count, ipv6Count := util.CountAddressBindingsByFamily(addressBindings)
+	if util.IPAddressTypeIncludesIPv4(interfaceIPType) && ipv4Count == 0 {
+		ipv4Count = 1
+	}
+	if util.IPAddressTypeIncludesIPv6(interfaceIPType) && ipv6Count == 0 {
+		ipv6Count = 1
+	}
+	useStaticIPv4 := util.StaticIPAllocationTypeIncludesIPv4(staticIPAllocationType)
+	useStaticIPv6 := util.StaticIPAllocationTypeIncludesIPv6(staticIPAllocationType)
+
 	// Handle IPv4 capacity check
 	if util.IPAddressTypeIncludesIPv4(interfaceIPType) {
-		hasCapacity, err := service.checkIPv4Capacity(subnet, sharedSubnet, info, ok, subnetInfo)
+		hasCapacity, err := service.checkIPv4Capacity(subnet, sharedSubnet, info, ok, subnetInfo, useStaticIPv4, ipv4Count)
 		if !hasCapacity {
 			return false, err
 		}
@@ -506,7 +520,7 @@ func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet
 
 	// Handle IPv6 capacity check
 	if util.IPAddressTypeIncludesIPv6(interfaceIPType) {
-		hasCapacity, err := service.checkIPv6Capacity(subnet, sharedSubnet, info, ok, subnetInfo)
+		hasCapacity, err := service.checkIPv6Capacity(subnet, sharedSubnet, info, ok, subnetInfo, useStaticIPv6, ipv6Count)
 		if !hasCapacity {
 			return false, err
 		}
@@ -514,77 +528,80 @@ func (service *SubnetPortService) AllocatePortFromSubnet(subnet *model.VpcSubnet
 
 	// Increment counters for successful allocation
 	if util.IPAddressTypeIncludesIPv4(interfaceIPType) {
-		info.dirtyCount += 1
-		log.Trace("Allocate Subnetport to IPv4 Subnet", "Subnet", *subnet.Path, "dirtyPortCount", info.dirtyCount)
+		if useStaticIPv4 {
+			info.dirtyStaticCount += ipv4Count
+			log.Trace("Allocate Subnetport to IPv4 static pool", "Subnet", *subnet.Path, "ipCount", ipv4Count, "dirtyStaticCount", info.dirtyStaticCount)
+		} else {
+			info.dirtyDhcpCount += ipv4Count
+			log.Trace("Allocate Subnetport to IPv4 dhcp pool", "Subnet", *subnet.Path, "ipCount", ipv4Count, "dirtyDhcpCount", info.dirtyDhcpCount)
+		}
 	}
 	if util.IPAddressTypeIncludesIPv6(interfaceIPType) {
-		info.dirtyCountIPv6 += 1
-		log.Trace("Allocate Subnetport to IPv6 Subnet", "Subnet", *subnet.Path, "dirtyPortCountIPv6", info.dirtyCountIPv6)
+		if useStaticIPv6 {
+			info.dirtyStaticCountIPv6 += ipv6Count
+			log.Trace("Allocate Subnetport to IPv6 static pool", "Subnet", *subnet.Path, "ipCount", ipv6Count, "dirtyStaticCountIPv6", info.dirtyStaticCountIPv6)
+		} else {
+			info.dirtyDhcpCountIPv6 += ipv6Count
+			log.Trace("Allocate Subnetport to IPv6 dhcp pool", "Subnet", *subnet.Path, "ipCount", ipv6Count, "dirtyDhcpCountIPv6", info.dirtyDhcpCountIPv6)
+		}
 	}
 
 	return true, nil
 }
 
-// checkIPv4Capacity checks if the subnet has available IPv4 capacity
-func (service *SubnetPortService) checkIPv4Capacity(subnet *model.VpcSubnet, sharedSubnet bool, info *CountInfo, existedEntry bool, subnetInfo servicecommon.VPCResourceInfo) (bool, error) {
+// checkIPv4Capacity checks if the subnet has available IPv4 capacity for ipCount more addresses.
+// useStaticPool decides whether the static IP pool or the DHCP pool is checked, matching where
+// this SubnetPort's IPv4 address is actually allocated from.
+func (service *SubnetPortService) checkIPv4Capacity(subnet *model.VpcSubnet, sharedSubnet bool, info *CountInfo, existedEntry bool, subnetInfo servicecommon.VPCResourceInfo, useStaticPool bool, ipCount int) (bool, error) {
 	dhcpMode := model.SubnetDhcpConfig_MODE_DEACTIVATED
 	if subnet.SubnetDhcpConfig != nil && subnet.SubnetDhcpConfig.Mode != nil {
 		dhcpMode = *subnet.SubnetDhcpConfig.Mode
 	}
 
+	staticIpAllocationEnabled := false
+	if subnet.AdvancedConfig != nil && subnet.AdvancedConfig.StaticIpAllocation != nil && subnet.AdvancedConfig.StaticIpAllocation.Enabled != nil {
+		staticIpAllocationEnabled = *subnet.AdvancedConfig.StaticIpAllocation.Enabled
+	}
 	// For DHCP Deactivated mode Subnet, if staticIpAllocation enable:false, skip check IP count
 	// and always return true
-	// TODO: The logic does not cover the case for mixed mode subnet where staticIpAllocation and dhcp can be enabled at the same time.
-	staticIpAllocationEnabled := false
-	if dhcpMode == model.SubnetDhcpConfig_MODE_DEACTIVATED {
-		if subnet.AdvancedConfig != nil && subnet.AdvancedConfig.StaticIpAllocation != nil && subnet.AdvancedConfig.StaticIpAllocation.Enabled != nil {
-			staticIpAllocationEnabled = *subnet.AdvancedConfig.StaticIpAllocation.Enabled
-		}
-		if !staticIpAllocationEnabled {
-			// for staticIpAllocation enable:false case, it can create SubnetPort and skip check the IP count
-			return true, nil
-		}
+	if dhcpMode == model.SubnetDhcpConfig_MODE_DEACTIVATED && !staticIpAllocationEnabled {
+		return true, nil
 	}
 
 	var allocatedIPNumber int
-	// For DHCP Server mode Subnet, get total IPs from DHCP IP Pool from NSX each time
-	// since user might update reservedIPRanges for the subnet and it impacts the DHCP Pool size
-	if dhcpMode == model.SubnetDhcpConfig_MODE_SERVER {
-		dhcpServerStats, err := service.NSXClient.DhcpServerConfigStatsClient.Get(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, nil, nil, nil, nil, nil, nil, nil)
-		if err != nil {
-			log.Error(err, "Failed to get Subnet dhcp-server-config stats", "Subnet", *subnet.Path)
-			return false, err
-		}
-		if len(dhcpServerStats.IpPoolStats) > 0 && dhcpServerStats.IpPoolStats[0].PoolSize != nil {
-			info.totalIP = int(*dhcpServerStats.IpPoolStats[0].PoolSize)
-		}
-		if sharedSubnet && len(dhcpServerStats.IpPoolStats) > 0 && dhcpServerStats.IpPoolStats[0].AllocatedNumber != nil {
-			allocatedIPNumber = int(*dhcpServerStats.IpPoolStats[0].AllocatedNumber)
-		}
-	}
-	// When SubnetIPReservation is created/deleted, we will reset the info.totalIP and
-	// expect the totalIP is updated from NSX ip pool API
-	// For shared Subnet, user can create IPReservation and SubnetPort from NSX side.
-	// We call NSX ip pool API to for latest total ip and requested ip.
-	if (!existedEntry || info.totalIP == 0 || sharedSubnet) && dhcpMode == model.SubnetDhcpConfig_MODE_DEACTIVATED {
-		// For DHCP Deactivated mode Subnet, get total IPs from IP pool static-ipv4-default
-		// only get Subnet total IPs from static IP Pool if staticIpAllocation enabled
-		if staticIpAllocationEnabled {
+	if useStaticPool {
+		// When SubnetIPReservation is created/deleted, we will reset the info.totalStaticIP and
+		// expect the totalStaticIP is updated from NSX ip pool API.
+		// For shared Subnet, user can create IPReservation and SubnetPort from NSX side.
+		// We call NSX ip pool API to for latest total ip and requested ip.
+		if !existedEntry || info.totalStaticIP == 0 || sharedSubnet {
 			staticIPPool, err := service.NSXClient.IPPoolClient.Get(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, "static-ipv4-default")
 			if err != nil {
 				log.Error(err, "Failed to get Subnet static IP Pool static-ipv4-default", "Subnet", *subnet.Path)
 				return false, err
 			}
 			if staticIPPool.PoolUsage != nil && staticIPPool.PoolUsage.TotalIps != nil {
-				info.totalIP = int(*staticIPPool.PoolUsage.TotalIps)
+				info.totalStaticIP = int(*staticIPPool.PoolUsage.TotalIps)
 			}
 			if sharedSubnet && staticIPPool.PoolUsage != nil && staticIPPool.PoolUsage.RequestedIpAllocations != nil {
 				allocatedIPNumber = int(*staticIPPool.PoolUsage.RequestedIpAllocations)
 			}
 		}
-	}
-
-	if !existedEntry && dhcpMode == model.SubnetDhcpConfig_MODE_RELAY {
+	} else if dhcpMode == model.SubnetDhcpConfig_MODE_SERVER {
+		// For DHCP Server mode Subnet, get total IPs from DHCP IP Pool from NSX each time
+		// since user might update reservedIPRanges for the subnet and it impacts the DHCP Pool size
+		dhcpServerStats, err := service.NSXClient.DhcpServerConfigStatsClient.Get(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, nil, nil, nil, nil, nil, nil, nil)
+		if err != nil {
+			log.Error(err, "Failed to get Subnet dhcp-server-config stats", "Subnet", *subnet.Path)
+			return false, err
+		}
+		if len(dhcpServerStats.IpPoolStats) > 0 && dhcpServerStats.IpPoolStats[0].PoolSize != nil {
+			info.totalDhcpIP = int(*dhcpServerStats.IpPoolStats[0].PoolSize)
+		}
+		if sharedSubnet && len(dhcpServerStats.IpPoolStats) > 0 && dhcpServerStats.IpPoolStats[0].AllocatedNumber != nil {
+			allocatedIPNumber = int(*dhcpServerStats.IpPoolStats[0].AllocatedNumber)
+		}
+	} else if !existedEntry && dhcpMode == model.SubnetDhcpConfig_MODE_RELAY {
 		// For DHCP Relay mode Subnet, assume 4 reserved IPs
 		var totalIP int
 		if subnet.Ipv4SubnetSize != nil {
@@ -596,7 +613,7 @@ func (service *SubnetPortService) checkIPv4Capacity(subnet *model.VpcSubnet, sha
 		}
 		// NSX reserves 4 ip addresses in each subnet for network address, gateway address,
 		// dhcp server address and broadcast address.
-		info.totalIP = totalIP - 4
+		info.totalDhcpIP = totalIP - 4
 	}
 
 	if time.Since(info.exhaustedCheckTime) < IPReleaseTime {
@@ -614,48 +631,50 @@ func (service *SubnetPortService) checkIPv4Capacity(subnet *model.VpcSubnet, sha
 		existingPortCount = max(existingPortCount, allocatedIPNumber)
 	}
 
-	return info.dirtyCount+existingPortCount < info.totalIP, nil
+	if useStaticPool {
+		return info.dirtyStaticCount+existingPortCount+ipCount <= info.totalStaticIP, nil
+	}
+	return info.dirtyDhcpCount+existingPortCount+ipCount <= info.totalDhcpIP, nil
 }
 
-// checkIPv6Capacity checks if the subnet has available IPv6 capacity
-func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sharedSubnet bool, info *CountInfo, isNewEntry bool, subnetInfo servicecommon.VPCResourceInfo) (bool, error) {
+// checkIPv6Capacity checks if the subnet has available IPv6 capacity for ipCount more addresses.
+// useStaticPool decides whether the static IP pool or the DHCP pool is checked, matching where
+// this SubnetPort's IPv6 address is actually allocated from.
+func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sharedSubnet bool, info *CountInfo, isNewEntry bool, subnetInfo servicecommon.VPCResourceInfo, useStaticPool bool, ipCount int) (bool, error) {
 	dhcpv6Mode := model.SubnetDhcpv6Config_MODE_DEACTIVATED
 	if subnet.SubnetDhcpv6Config != nil && subnet.SubnetDhcpv6Config.Mode != nil {
 		dhcpv6Mode = *subnet.SubnetDhcpv6Config.Mode
 	}
 
-	// For DHCP Deactivated mode Subnet, if staticIpAllocation enable:false, skip check IP count
 	staticIpAllocationEnabled := false
-	if dhcpv6Mode == model.SubnetDhcpv6Config_MODE_DEACTIVATED {
-		if subnet.AdvancedConfig != nil && subnet.AdvancedConfig.StaticIpAllocation != nil && subnet.AdvancedConfig.StaticIpAllocation.Enabled != nil {
-			staticIpAllocationEnabled = *subnet.AdvancedConfig.StaticIpAllocation.Enabled
-		}
-		if !staticIpAllocationEnabled {
-			return true, nil
-		}
+	if subnet.AdvancedConfig != nil && subnet.AdvancedConfig.StaticIpAllocation != nil && subnet.AdvancedConfig.StaticIpAllocation.Enabled != nil {
+		staticIpAllocationEnabled = *subnet.AdvancedConfig.StaticIpAllocation.Enabled
+	}
+	// For DHCP Deactivated mode Subnet, if staticIpAllocation enable:false, skip check IP count
+	if dhcpv6Mode == model.SubnetDhcpv6Config_MODE_DEACTIVATED && !staticIpAllocationEnabled {
+		return true, nil
 	}
 
-	var allocatedIPNumberIPv6 int
-	if dhcpv6Mode == model.SubnetDhcpv6Config_MODE_SERVER || dhcpv6Mode == model.SubnetDhcpv6Config_MODE_RELAY || dhcpv6Mode == model.SubnetDhcpv6Config_MODE_SERVER_STATELESS {
+	if !useStaticPool {
 		// TODO: Revisit when DHCPv6 is fully supported in NSX and DHCPv6 server statistics are available.
-		// For now, always allow allocation unconditionally for DHCPv6 mode.
+		// For now, always allow allocation unconditionally for SubnetPorts sourcing their IPv6
+		// address from the DHCPv6 pool.
 		log.Info("DHCPv6 mode detected; allowing allocation (DHCPv6 support pending)", "Subnet", *subnet.Path)
 		return true, nil
 	}
 
-	if (!isNewEntry || info.totalIPv6 == 0 || sharedSubnet) && dhcpv6Mode == model.SubnetDhcpv6Config_MODE_DEACTIVATED {
-		if staticIpAllocationEnabled {
-			staticIPPoolIPv6, err := service.NSXClient.IPPoolClient.Get(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, "static-ipv6-default")
-			if err != nil {
-				log.Error(err, "Failed to get Subnet static IP Pool static-ipv6-default", "Subnet", *subnet.Path)
-				return false, err
-			}
-			if staticIPPoolIPv6.PoolUsage != nil && staticIPPoolIPv6.PoolUsage.TotalIps != nil {
-				info.totalIPv6 = int(*staticIPPoolIPv6.PoolUsage.TotalIps)
-			}
-			if sharedSubnet && staticIPPoolIPv6.PoolUsage != nil && staticIPPoolIPv6.PoolUsage.RequestedIpAllocations != nil {
-				allocatedIPNumberIPv6 = int(*staticIPPoolIPv6.PoolUsage.RequestedIpAllocations)
-			}
+	var allocatedIPNumberIPv6 int
+	if !isNewEntry || info.totalStaticIPv6 == 0 || sharedSubnet {
+		staticIPPoolIPv6, err := service.NSXClient.IPPoolClient.Get(subnetInfo.OrgID, subnetInfo.ProjectID, subnetInfo.VPCID, subnetInfo.ID, "static-ipv6-default")
+		if err != nil {
+			log.Error(err, "Failed to get Subnet static IP Pool static-ipv6-default", "Subnet", *subnet.Path)
+			return false, err
+		}
+		if staticIPPoolIPv6.PoolUsage != nil && staticIPPoolIPv6.PoolUsage.TotalIps != nil {
+			info.totalStaticIPv6 = int(*staticIPPoolIPv6.PoolUsage.TotalIps)
+		}
+		if sharedSubnet && staticIPPoolIPv6.PoolUsage != nil && staticIPPoolIPv6.PoolUsage.RequestedIpAllocations != nil {
+			allocatedIPNumberIPv6 = int(*staticIPPoolIPv6.PoolUsage.RequestedIpAllocations)
 		}
 	}
 
@@ -668,7 +687,7 @@ func (service *SubnetPortService) checkIPv6Capacity(subnet *model.VpcSubnet, sha
 		existingPortCount = max(existingPortCount, allocatedIPNumberIPv6)
 	}
 
-	return info.dirtyCountIPv6+existingPortCount < info.totalIPv6, nil
+	return info.dirtyStaticCountIPv6+existingPortCount+ipCount <= info.totalStaticIPv6, nil
 }
 
 func (service *SubnetPortService) updateExhaustedSubnet(path string) {
@@ -684,8 +703,10 @@ func (service *SubnetPortService) updateExhaustedSubnet(path string) {
 	info.exhaustedCheckTime = time.Now()
 }
 
-// ReleasePortInSubnet decreases the number of SubnetPort under creation.
-func (service *SubnetPortService) ReleasePortInSubnet(path string, interfaceIPType v1alpha1.IPAddressType) {
+// ReleasePortInSubnet decreases the number of IPs under creation for a SubnetPort.
+// interfaceIPType, staticIPAllocationType and addressBindings must match the values passed to
+// the corresponding AllocatePortFromSubnet call, so the same pool counters are decremented.
+func (service *SubnetPortService) ReleasePortInSubnet(path string, interfaceIPType v1alpha1.IPAddressType, staticIPAllocationType v1alpha1.StaticIPAllocationType, addressBindings []v1alpha1.PortAddressBinding) {
 	obj, ok := service.SubnetPortStore.PortCountInfo.Load(path)
 	if !ok {
 		log.Error(nil, "Subnet does not have Subnetport to remove", "Subnet", path)
@@ -694,21 +715,48 @@ func (service *SubnetPortService) ReleasePortInSubnet(path string, interfaceIPTy
 	info := obj.(*CountInfo)
 	info.lock.Lock()
 	defer info.lock.Unlock()
+
+	ipv4Count, ipv6Count := util.CountAddressBindingsByFamily(addressBindings)
+	if util.IPAddressTypeIncludesIPv4(interfaceIPType) && ipv4Count == 0 {
+		ipv4Count = 1
+	}
+	if util.IPAddressTypeIncludesIPv6(interfaceIPType) && ipv6Count == 0 {
+		ipv6Count = 1
+	}
+
 	if util.IPAddressTypeIncludesIPv4(interfaceIPType) {
-		if info.dirtyCount < 1 {
-			log.Error(nil, "Subnet does not have IPv4 IP to remove for SubnetPort", "Subnet", path)
+		if util.StaticIPAllocationTypeIncludesIPv4(staticIPAllocationType) {
+			if info.dirtyStaticCount < ipv4Count {
+				log.Error(nil, "Subnet does not have IPv4 static IP to remove for SubnetPort", "Subnet", path)
+			} else {
+				info.dirtyStaticCount -= ipv4Count
+				log.Trace("Release Subnetport from Subnet", "Subnet", path, "dirtyStaticCount", info.dirtyStaticCount)
+			}
 		} else {
-			info.dirtyCount -= 1
-			log.Trace("Release Subnetport from Subnet", "Subnet", path, "dirtyPortCount", info.dirtyCount)
+			if info.dirtyDhcpCount < ipv4Count {
+				log.Error(nil, "Subnet does not have IPv4 dhcp IP to remove for SubnetPort", "Subnet", path)
+			} else {
+				info.dirtyDhcpCount -= ipv4Count
+				log.Trace("Release Subnetport from Subnet", "Subnet", path, "dirtyDhcpCount", info.dirtyDhcpCount)
+			}
 		}
 	}
 
 	if util.IPAddressTypeIncludesIPv6(interfaceIPType) {
-		if info.dirtyCountIPv6 < 1 {
-			log.Error(nil, "Subnet does not have IPv6 IP to remove for SubnetPort", "Subnet", path)
+		if util.StaticIPAllocationTypeIncludesIPv6(staticIPAllocationType) {
+			if info.dirtyStaticCountIPv6 < ipv6Count {
+				log.Error(nil, "Subnet does not have IPv6 static IP to remove for SubnetPort", "Subnet", path)
+			} else {
+				info.dirtyStaticCountIPv6 -= ipv6Count
+				log.Trace("Release Subnetport from Subnet", "Subnet", path, "dirtyStaticCountIPv6", info.dirtyStaticCountIPv6)
+			}
 		} else {
-			info.dirtyCountIPv6 -= 1
-			log.Trace("Release Subnetport from Subnet", "Subnet", path, "dirtyCountIPv6", info.dirtyCountIPv6)
+			if info.dirtyDhcpCountIPv6 < ipv6Count {
+				log.Error(nil, "Subnet does not have IPv6 dhcp IP to remove for SubnetPort", "Subnet", path)
+			} else {
+				info.dirtyDhcpCountIPv6 -= ipv6Count
+				log.Trace("Release Subnetport from Subnet", "Subnet", path, "dirtyDhcpCountIPv6", info.dirtyDhcpCountIPv6)
+			}
 		}
 	}
 }
@@ -719,7 +767,7 @@ func (service *SubnetPortService) IsEmptySubnet(path string) bool {
 	obj, ok := service.SubnetPortStore.PortCountInfo.Load(path)
 	if ok {
 		info := obj.(*CountInfo)
-		portCount += info.dirtyCount + info.dirtyCountIPv6
+		portCount += info.dirtyStaticCount + info.dirtyDhcpCount + info.dirtyStaticCountIPv6 + info.dirtyDhcpCountIPv6
 	}
 	return portCount < 1
 }

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -1639,6 +1639,55 @@ func TestSubnetPortService_portAlreadyRealized(t *testing.T) {
 	assert.False(t, service.portAlreadyRealized(subnetPortWrong, nsxSubnetPortWithNONE))
 	// SubnetPort: not realized (missing IP with AllocateAddresses=BOTH)
 
+	// SubnetPort: multi-IP addressBindings (3 entries, same MAC), only 2 of 3 IPs realized -> not realized
+	subnetPortMultiBindingPartial := &v1alpha1.SubnetPort{
+		Spec: v1alpha1.SubnetPortSpec{
+			AddressBindings: []v1alpha1.PortAddressBinding{
+				{IPAddress: "172.26.26.10", MACAddress: "04:50:56:00:b4:24"},
+				{IPAddress: "172.26.26.11", MACAddress: "04:50:56:00:b4:24"},
+				{IPAddress: "172.26.26.12", MACAddress: "04:50:56:00:b4:24"},
+			},
+		},
+		Status: v1alpha1.SubnetPortStatus{
+			Attachment: v1alpha1.PortAttachment{
+				ID: "some-id",
+			},
+			NetworkInterfaceConfig: v1alpha1.NetworkInterfaceConfig{
+				IPAddresses: []v1alpha1.NetworkInterfaceIPAddress{
+					{IPAddress: "172.26.26.10", Gateway: "some-gateway"},
+					{IPAddress: "172.26.26.11", Gateway: "some-gateway"},
+				},
+				MACAddress: "04:50:56:00:b4:24",
+			},
+		},
+	}
+	assert.False(t, service.portAlreadyRealized(subnetPortMultiBindingPartial, nsxSubnetPortWithBOTH))
+
+	// SubnetPort: multi-IP addressBindings (3 entries, same MAC), all 3 IPs realized -> realized
+	subnetPortMultiBindingFull := &v1alpha1.SubnetPort{
+		Spec: subnetPortMultiBindingPartial.Spec,
+		Status: v1alpha1.SubnetPortStatus{
+			Conditions: []v1alpha1.Condition{
+				{
+					Reason: "SubnetPortReady",
+					Status: corev1.ConditionTrue,
+				},
+			},
+			Attachment: v1alpha1.PortAttachment{
+				ID: "some-id",
+			},
+			NetworkInterfaceConfig: v1alpha1.NetworkInterfaceConfig{
+				IPAddresses: []v1alpha1.NetworkInterfaceIPAddress{
+					{IPAddress: "172.26.26.10", Gateway: "some-gateway"},
+					{IPAddress: "172.26.26.11", Gateway: "some-gateway"},
+					{IPAddress: "172.26.26.12", Gateway: "some-gateway"},
+				},
+				MACAddress: "04:50:56:00:b4:24",
+			},
+		},
+	}
+	assert.True(t, service.portAlreadyRealized(subnetPortMultiBindingFull, nsxSubnetPortWithBOTH))
+
 	// Pod: realized (annotation exists)
 	pod := &corev1.Pod{}
 	pod.Annotations = map[string]string{
@@ -1860,6 +1909,24 @@ func TestMergeSubnetPortAddressBinding(t *testing.T) {
 			},
 			expected: []model.PortAddressBindingEntry{
 				{IpAddress: common.String("10.0.0.1")},
+			},
+		},
+		{
+			name: "Multi-IP addressBindings sharing one MAC - merge each entry independently",
+			existing: []model.PortAddressBindingEntry{
+				{IpAddress: common.String("10.0.0.1"), MacAddress: common.String("aa:bb:cc:dd:ee:ff")},
+				{IpAddress: common.String("10.0.0.2"), MacAddress: common.String("aa:bb:cc:dd:ee:ff")},
+				{IpAddress: common.String("10.0.0.3"), MacAddress: common.String("aa:bb:cc:dd:ee:ff")},
+			},
+			desired: []model.PortAddressBindingEntry{
+				{IpAddress: common.String("10.0.0.1")},
+				{IpAddress: common.String("10.0.0.2")},
+				{IpAddress: common.String("10.0.0.3")},
+			},
+			expected: []model.PortAddressBindingEntry{
+				{IpAddress: common.String("10.0.0.1"), MacAddress: common.String("aa:bb:cc:dd:ee:ff")},
+				{IpAddress: common.String("10.0.0.2"), MacAddress: common.String("aa:bb:cc:dd:ee:ff")},
+				{IpAddress: common.String("10.0.0.3"), MacAddress: common.String("aa:bb:cc:dd:ee:ff")},
 			},
 		},
 	}

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -1169,20 +1169,20 @@ func TestSubnetPortService_AllocateAndReleasePortFromSubnet(t *testing.T) {
 	// Reset Subnet totalIP without SubnetPort does not influence the port count info
 	subnetPortService.ResetSubnetTotalIP(subnetPath)
 
-	ok, err := subnetPortService.AllocatePortFromSubnet(subnet1, false, v1alpha1.IPAddressTypeIPv4)
+	ok, err := subnetPortService.AllocatePortFromSubnet(subnet1, false, v1alpha1.IPAddressTypeIPv4, v1alpha1.StaticIPAllocationTypeNone, nil)
 	assert.True(t, ok)
 	require.NoError(t, err)
 
 	// Verify counter adjustments via internal Store check
 	if obj, existed := subnetPortService.SubnetPortStore.PortCountInfo.Load(subnetPath); existed {
 		info := obj.(*CountInfo)
-		assert.Equal(t, 1, info.dirtyCount)
-		assert.Equal(t, 0, info.dirtyCountIPv6)
+		assert.Equal(t, 1, info.dirtyDhcpCount)
+		assert.Equal(t, 0, info.dirtyDhcpCountIPv6)
 	}
 
 	empty := subnetPortService.IsEmptySubnet(subnetPath)
 	assert.False(t, empty)
-	subnetPortService.ReleasePortInSubnet(subnetPath, v1alpha1.IPAddressTypeIPv4)
+	subnetPortService.ReleasePortInSubnet(subnetPath, v1alpha1.IPAddressTypeIPv4, v1alpha1.StaticIPAllocationTypeNone, nil)
 	empty = subnetPortService.IsEmptySubnet(subnetPath)
 	assert.True(t, empty)
 
@@ -1190,7 +1190,7 @@ func TestSubnetPortService_AllocateAndReleasePortFromSubnet(t *testing.T) {
 	subnetPortService.updateExhaustedSubnet(subnetPath)
 	// Reset Subnet totalIP does not change other port count info
 	subnetPortService.ResetSubnetTotalIP(subnetPath)
-	ok, err = subnetPortService.AllocatePortFromSubnet(subnet1, false, v1alpha1.IPAddressTypeIPv4)
+	ok, err = subnetPortService.AllocatePortFromSubnet(subnet1, false, v1alpha1.IPAddressTypeIPv4, v1alpha1.StaticIPAllocationTypeNone, nil)
 	assert.False(t, ok)
 	assert.Nil(t, err)
 
@@ -1209,14 +1209,14 @@ func TestSubnetPortService_AllocateAndReleasePortFromSubnet(t *testing.T) {
 		Ipv4SubnetSize: common.Int64(16),
 	}
 
-	ok, err = subnetPortService.AllocatePortFromSubnet(dualStackSubnet, false, v1alpha1.IPAddressTypeIPv4IPv6)
+	ok, err = subnetPortService.AllocatePortFromSubnet(dualStackSubnet, false, v1alpha1.IPAddressTypeIPv4IPv6, v1alpha1.StaticIPAllocationTypeNone, nil)
 	assert.True(t, ok)
 	require.NoError(t, err)
 
 	if obj, existed := subnetPortService.SubnetPortStore.PortCountInfo.Load(subnetPath); existed {
 		info := obj.(*CountInfo)
-		assert.Equal(t, 1, info.dirtyCount)
-		assert.Equal(t, 1, info.dirtyCountIPv6)
+		assert.Equal(t, 1, info.dirtyDhcpCount)
+		assert.Equal(t, 1, info.dirtyDhcpCountIPv6)
 	}
 }
 
@@ -1293,19 +1293,36 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 		SubnetDhcpConfig: &model.SubnetDhcpConfig{Mode: common.String("DHCP_RELAY")},
 	}
 
+	// mixedModeSubnet has both DHCP and static IP allocation enabled at the same time
+	// (mixed mode): some SubnetPorts on it draw their IPv4 from the DHCP pool, others
+	// from the static pool, decided per-port by StaticIPAllocationType.
+	mixedModeSubnet := &model.VpcSubnet{
+		Ipv4SubnetSize: common.Int64(16),
+		IpAddresses:    []string{"10.0.0.1/28"},
+		Path:           &subnetPath,
+		Id:             &subnetId,
+		AdvancedConfig: &model.SubnetAdvancedConfig{
+			StaticIpAllocation: &model.StaticIpAllocation{Enabled: common.Bool(true)},
+		},
+		SubnetDhcpConfig: &model.SubnetDhcpConfig{Mode: common.String("DHCP_SERVER")},
+	}
+
 	tests := []struct {
-		name            string
-		subnet          *model.VpcSubnet
-		sharedSubnet    bool
-		interfaceIPType v1alpha1.IPAddressType // Added to test struct
-		prepareFunc     func(service *SubnetPortService) *gomonkey.Patches
-		expectedValue   bool
-		expectedErr     string
+		name                   string
+		subnet                 *model.VpcSubnet
+		sharedSubnet           bool
+		interfaceIPType        v1alpha1.IPAddressType // Added to test struct
+		staticIPAllocationType v1alpha1.StaticIPAllocationType
+		addressBindings        []v1alpha1.PortAddressBinding
+		prepareFunc            func(service *SubnetPortService) *gomonkey.Patches
+		expectedValue          bool
+		expectedErr            string
 	}{
 		{
-			name:            "Failed to get subnet static ip pool",
-			subnet:          staticSubnet,
-			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
+			name:                   "Failed to get subnet static ip pool",
+			subnet:                 staticSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
 					return model.IpAddressPool{}, fmt.Errorf("mock static error")
@@ -1327,9 +1344,10 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			expectedErr:   "mock dhcp error",
 		},
 		{
-			name:            "Allocate SubnetPort from static Subnet failed",
-			subnet:          staticSubnet,
-			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
+			name:                   "Allocate SubnetPort from static Subnet failed",
+			subnet:                 staticSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
 					return model.IpAddressPool{
@@ -1362,18 +1380,20 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			expectedValue: false,
 		},
 		{
-			name:            "Allocate SubnetPort from static subnet with staticIpAllocation disabled failed",
-			subnet:          staticSubnetWithStaticIPAllocationDisabled,
-			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
+			name:                   "Allocate SubnetPort from static subnet with staticIpAllocation disabled failed",
+			subnet:                 staticSubnetWithStaticIPAllocationDisabled,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				return nil
 			},
 			expectedValue: true,
 		},
 		{
-			name:            "Allocate SubnetPort from static Subnet",
-			subnet:          staticSubnet,
-			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
+			name:                   "Allocate SubnetPort from static Subnet",
+			subnet:                 staticSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
 					return model.IpAddressPool{
@@ -1384,9 +1404,10 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			expectedValue: true,
 		},
 		{
-			name:            "Allocate SubnetPort from static shared Subnet failed",
-			subnet:          staticSubnet,
-			interfaceIPType: v1alpha1.IPAddressTypeIPv4,
+			name:                   "Allocate SubnetPort from static shared Subnet failed",
+			subnet:                 staticSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
 					return model.IpAddressPool{
@@ -1420,9 +1441,10 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			expectedValue: true,
 		},
 		{
-			name:            "Failed to get static-ipv6-default pool",
-			subnet:          staticIPv6Subnet,
-			interfaceIPType: v1alpha1.IPAddressTypeIPv6,
+			name:                   "Failed to get static-ipv6-default pool",
+			subnet:                 staticIPv6Subnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv6,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv6,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, poolId string) (model.IpAddressPool, error) {
 					if poolId == "static-ipv6-default" {
@@ -1435,9 +1457,10 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			expectedErr:   "mock ipv6 static pool error",
 		},
 		{
-			name:            "Allocate SubnetPort from static IPv6 Subnet successful",
-			subnet:          staticIPv6Subnet,
-			interfaceIPType: v1alpha1.IPAddressTypeIPv6,
+			name:                   "Allocate SubnetPort from static IPv6 Subnet successful",
+			subnet:                 staticIPv6Subnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv6,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv6,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, poolId string) (model.IpAddressPool, error) {
 					if poolId == "static-ipv6-default" {
@@ -1451,9 +1474,10 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			expectedValue: true,
 		},
 		{
-			name:            "Allocate Dual-Stack SubnetPort failed due to IPv4 starvation",
-			subnet:          dualStackStaticSubnet,
-			interfaceIPType: v1alpha1.IPAddressTypeIPv4IPv6,
+			name:                   "Allocate Dual-Stack SubnetPort failed due to IPv4 starvation",
+			subnet:                 dualStackStaticSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4IPv6,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4IPv6,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, poolId string) (model.IpAddressPool, error) {
 					if poolId == "static-ipv4-default" {
@@ -1469,9 +1493,10 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			expectedValue: false,
 		},
 		{
-			name:            "Allocate Dual-Stack SubnetPort failed due to IPv6 starvation",
-			subnet:          dualStackStaticSubnet,
-			interfaceIPType: v1alpha1.IPAddressTypeIPv4IPv6,
+			name:                   "Allocate Dual-Stack SubnetPort failed due to IPv6 starvation",
+			subnet:                 dualStackStaticSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4IPv6,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4IPv6,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, poolId string) (model.IpAddressPool, error) {
 					if poolId == "static-ipv4-default" {
@@ -1489,6 +1514,138 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			},
 			expectedValue: false,
 		},
+		{
+			// Mixed mode: subnet has both DHCP_SERVER and static IP allocation enabled.
+			// A SubnetPort requesting a static IPv4 must be checked against the static
+			// pool, never the DHCP pool. We prove this by making the DHCP stats call
+			// error out - if the code wrongly consulted it, the test would fail.
+			name:                   "Mixed mode Subnet - static-sourced port checks static pool only",
+			subnet:                 mixedModeSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
+					return model.IpAddressPool{
+						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(5)},
+					}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(service.NSXClient.DhcpServerConfigStatsClient), "Get", func(_ *fakeStatsClient, _, _, _, _ string, _ *string, _ *string, _ *bool, _ *string, _ *int64, _ *bool, _ *string) (model.DhcpServerStatistics, error) {
+					return model.DhcpServerStatistics{}, fmt.Errorf("dhcp pool must not be checked for a static-sourced port")
+				})
+				return patches
+			},
+			expectedValue: true,
+		},
+		{
+			// Same mixed mode subnet, but this port has no static allocation (DHCP-sourced
+			// IPv4). It must be checked against the DHCP pool, never the static pool.
+			name:                   "Mixed mode Subnet - dhcp-sourced port checks dhcp pool only",
+			subnet:                 mixedModeSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.DhcpServerConfigStatsClient), "Get", func(_ *fakeStatsClient, _, _, _, _ string, _ *string, _ *string, _ *bool, _ *string, _ *int64, _ *bool, _ *string) (model.DhcpServerStatistics, error) {
+					return model.DhcpServerStatistics{
+						IpPoolStats: []model.DhcpIpPoolUsage{{PoolSize: common.Int64(5)}},
+					}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
+					return model.IpAddressPool{}, fmt.Errorf("static pool must not be checked for a dhcp-sourced port")
+				})
+				return patches
+			},
+			expectedValue: true,
+		},
+		{
+			// Mixed mode: the static pool is exhausted while the DHCP pool still has
+			// room. A static-sourced port must be rejected, not silently allowed
+			// through by looking at the (irrelevant) DHCP pool's capacity.
+			name:                   "Mixed mode Subnet - static pool exhausted, dhcp pool available",
+			subnet:                 mixedModeSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
+					return model.IpAddressPool{
+						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(0)},
+					}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(service.NSXClient.DhcpServerConfigStatsClient), "Get", func(_ *fakeStatsClient, _, _, _, _ string, _ *string, _ *string, _ *bool, _ *string, _ *int64, _ *bool, _ *string) (model.DhcpServerStatistics, error) {
+					return model.DhcpServerStatistics{
+						IpPoolStats: []model.DhcpIpPoolUsage{{PoolSize: common.Int64(100)}},
+					}, nil
+				})
+				return patches
+			},
+			expectedValue: false,
+		},
+		{
+			// Mixed mode: the DHCP pool is exhausted while the static pool still has
+			// room. A dhcp-sourced port must be rejected, not silently allowed through
+			// by looking at the (irrelevant) static pool's capacity.
+			name:                   "Mixed mode Subnet - dhcp pool exhausted, static pool available",
+			subnet:                 mixedModeSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.DhcpServerConfigStatsClient), "Get", func(_ *fakeStatsClient, _, _, _, _ string, _ *string, _ *string, _ *bool, _ *string, _ *int64, _ *bool, _ *string) (model.DhcpServerStatistics, error) {
+					return model.DhcpServerStatistics{
+						IpPoolStats: []model.DhcpIpPoolUsage{{PoolSize: common.Int64(0)}},
+					}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
+					return model.IpAddressPool{
+						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(100)},
+					}, nil
+				})
+				return patches
+			},
+			expectedValue: false,
+		},
+		{
+			// Multi-IP addressBindings: 2 IPv4 addresses requested on a static pool
+			// with room for two such allocations (the test harness below calls
+			// AllocatePortFromSubnet twice when expectedValue is true, so capacity
+			// must cover 2x the requested count).
+			name:                   "Multi-IP addressBindings fits in static pool capacity",
+			subnet:                 staticSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			addressBindings: []v1alpha1.PortAddressBinding{
+				{MACAddress: "00:11:22:33:44:55"},
+				{IPAddress: "10.0.0.2", MACAddress: "00:11:22:33:44:55"},
+			},
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
+					return model.IpAddressPool{
+						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(4)},
+					}, nil
+				})
+			},
+			expectedValue: true,
+		},
+		{
+			// Multi-IP addressBindings: 3 IPv4 addresses requested but the static pool
+			// only has room for 2 - must be rejected, not silently accepted as if only
+			// 1 IP were being requested.
+			name:                   "Multi-IP addressBindings exceeds static pool capacity",
+			subnet:                 staticSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			addressBindings: []v1alpha1.PortAddressBinding{
+				{MACAddress: "00:11:22:33:44:55"},
+				{IPAddress: "10.0.0.2", MACAddress: "00:11:22:33:44:55"},
+				{IPAddress: "10.0.0.3", MACAddress: "00:11:22:33:44:55"},
+			},
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
+					return model.IpAddressPool{
+						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(2)},
+					}, nil
+				})
+			},
+			expectedValue: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1499,7 +1656,7 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 				defer patches.Reset()
 			}
 
-			canAllocate, err := subnetPortService.AllocatePortFromSubnet(tt.subnet, tt.sharedSubnet, tt.interfaceIPType)
+			canAllocate, err := subnetPortService.AllocatePortFromSubnet(tt.subnet, tt.sharedSubnet, tt.interfaceIPType, tt.staticIPAllocationType, tt.addressBindings)
 			assert.Equal(t, tt.expectedValue, canAllocate)
 			if tt.expectedErr != "" {
 				assert.NotNil(t, err)
@@ -1509,7 +1666,7 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			}
 
 			if tt.expectedValue {
-				canAllocate, err = subnetPortService.AllocatePortFromSubnet(tt.subnet, tt.sharedSubnet, tt.interfaceIPType)
+				canAllocate, err = subnetPortService.AllocatePortFromSubnet(tt.subnet, tt.sharedSubnet, tt.interfaceIPType, tt.staticIPAllocationType, tt.addressBindings)
 				assert.Equal(t, tt.expectedValue, canAllocate)
 				if tt.expectedErr != "" {
 					assert.NotNil(t, err)

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -300,6 +300,75 @@ func TestSubnetPortService_CreateOrUpdateSubnetPort(t *testing.T) {
 			obj:       subnetPortCR,
 		},
 		{
+			name: "UpdateAddAddressBindings",
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+					namespaceCR := &corev1.Namespace{}
+					namespaceCR.UID = "ns1"
+					return nil
+				})
+				service.SubnetPortStore.Add(&nsxSubnetPort)
+				orgRootClient.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.PortStateClient), "Get", func(c *fakePortStateClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, portIdParam string, enforcementPointPathParam *string, sourceParam *string) (model.SegmentPortState, error) {
+					return model.SegmentPortState{
+						RealizedBindings: []model.AddressBindingEntry{{Binding: &model.PacketAddressClassifier{IpAddress: common.String("10.0.0.1")}}},
+					}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+					return false
+				})
+				return patches
+			},
+			wantErr:   false,
+			nsxSubnet: nsxSubnet2,
+			obj: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      subnetPortName,
+					Namespace: namespace,
+					UID:       "00000000-0000-0000-0000-000000000001",
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					AddressBindings: []v1alpha1.PortAddressBinding{
+						{IPAddress: "10.0.0.10", MACAddress: "00:11:22:33:44:55"},
+						{IPAddress: "10.0.0.11", MACAddress: "00:11:22:33:44:55"},
+					},
+				},
+			},
+		},
+		{
+			name: "UpdateRemoveAddressBindings",
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+					namespaceCR := &corev1.Namespace{}
+					namespaceCR.UID = "ns1"
+					return nil
+				})
+				service.SubnetPortStore.Add(&nsxSubnetPort)
+				orgRootClient.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.PortStateClient), "Get", func(c *fakePortStateClient, orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, portIdParam string, enforcementPointPathParam *string, sourceParam *string) (model.SegmentPortState, error) {
+					return model.SegmentPortState{
+						RealizedBindings: []model.AddressBindingEntry{{Binding: &model.PacketAddressClassifier{IpAddress: common.String("10.0.0.1")}}},
+					}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+					return false
+				})
+				return patches
+			},
+			wantErr:   false,
+			nsxSubnet: nsxSubnet2,
+			obj: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      subnetPortName,
+					Namespace: namespace,
+					UID:       "00000000-0000-0000-0000-000000000001",
+				},
+				Spec: v1alpha1.SubnetPortSpec{
+					AddressBindings: []v1alpha1.PortAddressBinding{},
+				},
+			},
+		},
+		{
 			name: "Update",
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
 				k8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
@@ -1884,6 +1953,102 @@ func TestSubnetPortService_portAlreadyRealized(t *testing.T) {
 		},
 	}
 	assert.True(t, service.portAlreadyRealized(subnetPortMultiBindingFull, nsxSubnetPortWithBOTH))
+
+	nsxSubnetPortWithMACPOOL := &model.VpcSubnetPort{
+		Attachment: &model.PortAttachment{
+			AllocateAddresses: common.String("MAC_POOL"),
+			Id:                common.String("attachment-id"),
+		},
+	}
+
+	// DHCP subnet, no addressBindings: realized as soon as MAC lands, IP count is irrelevant
+	// since AllocateAddresses is MAC_POOL, not BOTH/IP_POOL.
+	subnetPortDHCPNoBindings := &v1alpha1.SubnetPort{
+		Spec: v1alpha1.SubnetPortSpec{
+			StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
+		},
+		Status: v1alpha1.SubnetPortStatus{
+			Conditions: []v1alpha1.Condition{
+				{Reason: "SubnetPortReady", Status: corev1.ConditionTrue},
+			},
+			Attachment: v1alpha1.PortAttachment{ID: "some-id"},
+			NetworkInterfaceConfig: v1alpha1.NetworkInterfaceConfig{
+				IPAddresses: []v1alpha1.NetworkInterfaceIPAddress{{Gateway: "some-gateway"}},
+				MACAddress:  "04:50:56:00:b4:24",
+			},
+		},
+	}
+	assert.True(t, service.portAlreadyRealized(subnetPortDHCPNoBindings, nsxSubnetPortWithMACPOOL))
+
+	// DHCP subnet, multiple MAC-only addressBindings (pool-allocated, sharing one MAC):
+	// still realized as soon as MAC lands, regardless of how many bindings were requested.
+	subnetPortDHCPMultiBindings := &v1alpha1.SubnetPort{
+		Spec: v1alpha1.SubnetPortSpec{
+			StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
+			AddressBindings: []v1alpha1.PortAddressBinding{
+				{MACAddress: "04:50:56:00:b4:24"},
+				{MACAddress: "04:50:56:00:b4:24"},
+			},
+		},
+		Status: v1alpha1.SubnetPortStatus{
+			Conditions: []v1alpha1.Condition{
+				{Reason: "SubnetPortReady", Status: corev1.ConditionTrue},
+			},
+			Attachment: v1alpha1.PortAttachment{ID: "some-id"},
+			NetworkInterfaceConfig: v1alpha1.NetworkInterfaceConfig{
+				IPAddresses: []v1alpha1.NetworkInterfaceIPAddress{{Gateway: "some-gateway"}},
+				MACAddress:  "04:50:56:00:b4:24",
+			},
+		},
+	}
+	assert.True(t, service.portAlreadyRealized(subnetPortDHCPMultiBindings, nsxSubnetPortWithMACPOOL))
+
+	// Mixed-mode subnet, dual-stack interface but only IPv4 statically allocated, no explicit
+	// addressBindings: expect only 1 realized IP, not 2 - the IPv6 side comes from DHCP/SLAAC
+	// and is never reflected via AllocateAddresses BOTH/IP_POOL.
+	subnetPortMixedNoBindings := &v1alpha1.SubnetPort{
+		Spec: v1alpha1.SubnetPortSpec{
+			InterfaceIPType:        v1alpha1.IPAddressTypeIPv4IPv6,
+			StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+		},
+		Status: v1alpha1.SubnetPortStatus{
+			Conditions: []v1alpha1.Condition{
+				{Reason: "SubnetPortReady", Status: corev1.ConditionTrue},
+			},
+			Attachment: v1alpha1.PortAttachment{ID: "some-id"},
+			NetworkInterfaceConfig: v1alpha1.NetworkInterfaceConfig{
+				IPAddresses: []v1alpha1.NetworkInterfaceIPAddress{
+					{IPAddress: "172.26.26.10", Gateway: "some-gateway"},
+				},
+				MACAddress: "04:50:56:00:b4:24",
+			},
+		},
+	}
+	assert.True(t, service.portAlreadyRealized(subnetPortMixedNoBindings, nsxSubnetPortWithBOTH))
+
+	// Mixed-mode subnet, IPv4-only static allocation, 2 explicit addressBindings (multi-IP on
+	// the static side): expectedIPCount comes from len(AddressBindings), not StaticIPAllocationType.
+	subnetPortMixedMultiBindings := &v1alpha1.SubnetPort{
+		Spec: v1alpha1.SubnetPortSpec{
+			InterfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			AddressBindings: []v1alpha1.PortAddressBinding{
+				{IPAddress: "172.26.26.10", MACAddress: "04:50:56:00:b4:24"},
+				{IPAddress: "172.26.26.11", MACAddress: "04:50:56:00:b4:24"},
+			},
+		},
+		Status: v1alpha1.SubnetPortStatus{
+			Attachment: v1alpha1.PortAttachment{ID: "some-id"},
+			NetworkInterfaceConfig: v1alpha1.NetworkInterfaceConfig{
+				IPAddresses: []v1alpha1.NetworkInterfaceIPAddress{
+					{IPAddress: "172.26.26.10", Gateway: "some-gateway"},
+				},
+				MACAddress: "04:50:56:00:b4:24",
+			},
+		},
+	}
+	assert.False(t, service.portAlreadyRealized(subnetPortMixedMultiBindings, nsxSubnetPortWithBOTH),
+		"only 1 of 2 requested static IPs realized - must not be considered ready")
 
 	// Pod: realized (annotation exists)
 	pod := &corev1.Pod{}

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -1635,7 +1636,7 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 		{
 			// Regression test: an existing DHCP-sourced port already realized on the
 			// mixed-mode Subnet must not count against the static pool's capacity when
-			// checking a new static-sourced port. Before this fix, existingPortCount
+			// checking a new static-sourced port. Before this fix, existingIPCount
 			// counted every realized port on the Subnet regardless of which pool it
 			// drew from, so a lone DHCP-sourced port could falsely exhaust a small
 			// static pool it never actually touched.
@@ -2310,6 +2311,191 @@ func TestMergeSubnetPortAddressBinding(t *testing.T) {
 				} else {
 					assert.Nil(t, result[i].MacAddress)
 				}
+			}
+		})
+	}
+}
+
+func TestCountNSXAddressBindingsByFamily(t *testing.T) {
+	tests := []struct {
+		name     string
+		bindings []model.PortAddressBindingEntry
+		wantIPv4 int
+		wantIPv6 int
+	}{
+		{
+			name:     "Empty bindings",
+			bindings: []model.PortAddressBindingEntry{},
+			wantIPv4: 0,
+			wantIPv6: 0,
+		},
+		{
+			name: "Binding with nil IP",
+			bindings: []model.PortAddressBindingEntry{
+				{IpAddress: nil},
+			},
+			wantIPv4: 1,
+			wantIPv6: 0,
+		},
+		{
+			name: "Binding with empty IP string",
+			bindings: []model.PortAddressBindingEntry{
+				{IpAddress: common.String("")},
+			},
+			wantIPv4: 1,
+			wantIPv6: 0,
+		},
+		{
+			name: "IPv4 binding",
+			bindings: []model.PortAddressBindingEntry{
+				{IpAddress: common.String("192.168.1.1")},
+			},
+			wantIPv4: 1,
+			wantIPv6: 0,
+		},
+		{
+			name: "IPv6 binding",
+			bindings: []model.PortAddressBindingEntry{
+				{IpAddress: common.String("2001:db8::1")},
+			},
+			wantIPv4: 0,
+			wantIPv6: 1,
+		},
+		{
+			name: "Mixed bindings",
+			bindings: []model.PortAddressBindingEntry{
+				{IpAddress: common.String("192.168.1.1")},
+				{IpAddress: common.String("2001:db8::1")},
+				{IpAddress: nil},
+			},
+			wantIPv4: 2,
+			wantIPv6: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIPv4, gotIPv6 := countNSXAddressBindingsByFamily(tt.bindings)
+			if gotIPv4 != tt.wantIPv4 {
+				t.Errorf("countNSXAddressBindingsByFamily() gotIPv4 = %v, want %v", gotIPv4, tt.wantIPv4)
+			}
+			if gotIPv6 != tt.wantIPv6 {
+				t.Errorf("countNSXAddressBindingsByFamily() gotIPv6 = %v, want %v", gotIPv6, tt.wantIPv6)
+			}
+		})
+	}
+}
+
+func TestReleasePortInSubnet(t *testing.T) {
+	service := &SubnetPortService{
+		SubnetPortStore: &SubnetPortStore{
+			PortCountInfo: sync.Map{},
+		},
+	}
+
+	subnetPath := "test-subnet"
+
+	// Create CountInfo to put in store
+	info := &CountInfo{
+		dirtyDhcpCount:       5,
+		dirtyDhcpCountIPv6:   5,
+		dirtyStaticCount:     5,
+		dirtyStaticCountIPv6: 5,
+	}
+	service.SubnetPortStore.PortCountInfo.Store(subnetPath, info)
+
+	tests := []struct {
+		name                   string
+		path                   string
+		interfaceIPType        v1alpha1.IPAddressType
+		staticIPAllocationType v1alpha1.StaticIPAllocationType
+		addressBindings        []v1alpha1.PortAddressBinding
+		expectedDhcpCount      int
+		expectedDhcpV6Count    int
+		expectedStaticCount    int
+		expectedStaticV6Count  int
+	}{
+		{
+			name:                   "Subnet not found",
+			path:                   "non-existent-subnet",
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
+			addressBindings:        nil,
+			expectedDhcpCount:      5,
+		},
+		{
+			name:                   "Release DHCP IPv4 (no explicit bindings)",
+			path:                   subnetPath,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
+			addressBindings:        nil,
+			expectedDhcpCount:      4,
+			expectedDhcpV6Count:    5,
+			expectedStaticCount:    5,
+			expectedStaticV6Count:  5,
+		},
+		{
+			name:                   "Release Static IPv4 (single binding)",
+			path:                   subnetPath,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			addressBindings: []v1alpha1.PortAddressBinding{
+				{IPAddress: "192.168.1.1"},
+			},
+			expectedDhcpCount:     4,
+			expectedDhcpV6Count:   5,
+			expectedStaticCount:   4,
+			expectedStaticV6Count: 5,
+		},
+		{
+			name:                   "Release Static IPv6 (multiple bindings)",
+			path:                   subnetPath,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv6,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv6,
+			addressBindings: []v1alpha1.PortAddressBinding{
+				{IPAddress: "2001:db8::1"},
+				{IPAddress: "2001:db8::2"},
+			},
+			expectedDhcpCount:     4,
+			expectedDhcpV6Count:   5,
+			expectedStaticCount:   4,
+			expectedStaticV6Count: 3,
+		},
+		{
+			name:                   "Release DHCP IPv4IPv6 (no explicit bindings)",
+			path:                   subnetPath,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4IPv6,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
+			addressBindings:        nil,
+			expectedDhcpCount:      3,
+			expectedDhcpV6Count:    4,
+			expectedStaticCount:    4,
+			expectedStaticV6Count:  3,
+		},
+		{
+			name:                   "Underflow protection DHCP",
+			path:                   subnetPath,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
+			addressBindings: []v1alpha1.PortAddressBinding{
+				{}, {}, {}, {}, {}, {}, {}, // Try to release 7 when only 3 are left
+			},
+			expectedDhcpCount:     3, // Expected behavior: error logged, counter unchanged
+			expectedDhcpV6Count:   4,
+			expectedStaticCount:   4,
+			expectedStaticV6Count: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service.ReleasePortInSubnet(tt.path, tt.interfaceIPType, tt.staticIPAllocationType, tt.addressBindings)
+
+			if tt.path == subnetPath {
+				assert.Equal(t, tt.expectedDhcpCount, info.dirtyDhcpCount)
+				assert.Equal(t, tt.expectedDhcpV6Count, info.dirtyDhcpCountIPv6)
+				assert.Equal(t, tt.expectedStaticCount, info.dirtyStaticCount)
+				assert.Equal(t, tt.expectedStaticV6Count, info.dirtyStaticCountIPv6)
 			}
 		})
 	}

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -1564,6 +1564,39 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			expectedValue: true,
 		},
 		{
+			// Regression test: an existing DHCP-sourced port already realized on the
+			// mixed-mode Subnet must not count against the static pool's capacity when
+			// checking a new static-sourced port. Before this fix, existingPortCount
+			// counted every realized port on the Subnet regardless of which pool it
+			// drew from, so a lone DHCP-sourced port could falsely exhaust a small
+			// static pool it never actually touched.
+			name:                   "Mixed mode Subnet - existing dhcp-sourced port does not count against static pool",
+			subnet:                 mixedModeSubnet,
+			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
+			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
+				existingDhcpPort := &model.VpcSubnetPort{
+					Id:         common.String("existing-dhcp-port"),
+					Path:       common.String(subnetPath + "/ports/existing-dhcp-port"),
+					ParentPath: &subnetPath,
+					Attachment: &model.PortAttachment{
+						AllocateAddresses: common.String("NONE"),
+					},
+				}
+				service.SubnetPortStore.Add(existingDhcpPort)
+				// TotalIps is 2, not 1: the test harness below calls AllocatePortFromSubnet
+				// twice when expectedValue is true, so capacity must cover both calls
+				// (1 IP each). If the existing DHCP port were wrongly counted against the
+				// static pool, even a single call would fail here.
+				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
+					return model.IpAddressPool{
+						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(2)},
+					}, nil
+				})
+			},
+			expectedValue: true,
+		},
+		{
 			// Mixed mode: the static pool is exhausted while the DHCP pool still has
 			// room. A static-sourced port must be rejected, not silently allowed
 			// through by looking at the (irrelevant) DHCP pool's capacity.

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -1166,6 +1166,13 @@ func TestSubnetPortService_AllocateAndReleasePortFromSubnet(t *testing.T) {
 		},
 	}
 	subnetPortService := createSubnetPortService(t)
+	// This test doesn't exercise the DHCPv6-pool-statistics path; keep NSXCheckVersion(IPv6)
+	// false so checkIPv6Capacity's DHCP-sourced branch keeps its unconditional-allow fallback
+	// instead of calling the (unmocked) real Cluster.GetVersion().
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(subnetPortService.NSXClient), "NSXCheckVersion", func(_ *nsx.Client, _ int) bool {
+		return false
+	})
+	defer patches.Reset()
 	// Reset Subnet totalIP without SubnetPort does not influence the port count info
 	subnetPortService.ResetSubnetTotalIP(subnetPath)
 

--- a/pkg/util/ip.go
+++ b/pkg/util/ip.go
@@ -264,3 +264,34 @@ func IPAddressTypeIncludesIPv6(ipType v1alpha1.IPAddressType) bool {
 func IPAddressTypeIncludesIPv4(ipType v1alpha1.IPAddressType) bool {
 	return ipType != v1alpha1.IPAddressTypeIPv6
 }
+
+// StaticIPAllocationTypeIncludesIPv4 reports whether the given StaticIPAllocationType requests
+// static allocation of IPv4 addresses (i.e. IPv4-only or dual-stack).
+func StaticIPAllocationTypeIncludesIPv4(allocationType v1alpha1.StaticIPAllocationType) bool {
+	return allocationType == v1alpha1.StaticIPAllocationTypeIPv4 || allocationType == v1alpha1.StaticIPAllocationTypeIPv4IPv6
+}
+
+// StaticIPAllocationTypeIncludesIPv6 reports whether the given StaticIPAllocationType requests
+// static allocation of IPv6 addresses (i.e. IPv6-only or dual-stack).
+func StaticIPAllocationTypeIncludesIPv6(allocationType v1alpha1.StaticIPAllocationType) bool {
+	return allocationType == v1alpha1.StaticIPAllocationTypeIPv6 || allocationType == v1alpha1.StaticIPAllocationTypeIPv4IPv6
+}
+
+// CountAddressBindingsByFamily returns the number of IPv4 and IPv6 addresses requested by the
+// given PortAddressBindings. A binding with no IPAddress set (pool-allocated) is counted as
+// IPv4, matching NSX's behavior of always allocating pool-based bindings from the IPv4 pool.
+func CountAddressBindingsByFamily(addressBindings []v1alpha1.PortAddressBinding) (ipv4Count, ipv6Count int) {
+	for _, binding := range addressBindings {
+		if binding.IPAddress == "" {
+			ipv4Count++
+			continue
+		}
+		ip := net.ParseIP(binding.IPAddress)
+		if ip != nil && ip.To4() == nil {
+			ipv6Count++
+		} else {
+			ipv4Count++
+		}
+	}
+	return ipv4Count, ipv6Count
+}

--- a/test/e2e/nsx_subnet_test.go
+++ b/test/e2e/nsx_subnet_test.go
@@ -1072,6 +1072,62 @@ func SubnetMixedMode(t *testing.T) {
 	require.Equal(t, "BOTH", *(*nsxStaticPort.Attachment).AllocateAddresses,
 		"static SubnetPort in mixed mode should use BOTH allocation")
 
+	// Case 1a: a SubnetPort on the same mixed-mode Subnet that does NOT request
+	// static allocation must be sourced from the DHCP side, not the static pool.
+	// This exercises the capacity-check fix that resolves, per port, which pool
+	// (static vs DHCP) to check against on a mixed-mode Subnet - previously the
+	// static pool was checked exclusively, regardless of the port's actual source.
+	dhcpPort := &v1alpha1.SubnetPort{
+		ObjectMeta: v1.ObjectMeta{Name: "mixed-dhcp-port", Namespace: subnetTestNamespace},
+		Spec: v1alpha1.SubnetPortSpec{
+			Subnet:                 mixed.Name,
+			StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeNone,
+		},
+	}
+	dhcpPortCreated := createSubnetPortWithCheck(t, dhcpPort)
+	require.Equal(t, false, dhcpPortCreated.Status.NetworkInterfaceConfig.DHCPDeactivatedOnSubnet)
+	nsxDhcpPort := fetchSubnetPortBySubnetPortUID(t, string(dhcpPortCreated.GetUID()))
+	require.NotNil(t, nsxDhcpPort.Attachment)
+	require.NotEqual(t, "BOTH", *(*nsxDhcpPort.Attachment).AllocateAddresses,
+		"a non-static SubnetPort in mixed mode must not be allocated via the static (BOTH) pool")
+	require.NotEqual(t, "IP_POOL", *(*nsxDhcpPort.Attachment).AllocateAddresses,
+		"a non-static SubnetPort in mixed mode must not be allocated via the static (IP_POOL) pool")
+
+	// Case 1b: multi-IP addressBindings (2 explicit IPs sharing one MAC) drawn from
+	// the static pool of the mixed-mode Subnet. Exercises capacity accounting for
+	// N>1 addresses in a single AllocatePortFromSubnet call - previously only 1 IP
+	// per family was ever reserved/released regardless of how many bindings a
+	// SubnetPort actually requested.
+	multiIPAddr1 := make(net.IP, len(ip))
+	copy(multiIPAddr1, staticStart)
+	multiIPAddr1[3] += 2
+	multiIPAddr2 := make(net.IP, len(ip))
+	copy(multiIPAddr2, staticStart)
+	multiIPAddr2[3] += 3
+	sharedMultiIPMAC := "04:50:56:00:88:00"
+	multiIPPort := &v1alpha1.SubnetPort{
+		ObjectMeta: v1.ObjectMeta{Name: "mixed-multi-ip-port", Namespace: subnetTestNamespace},
+		Spec: v1alpha1.SubnetPortSpec{
+			Subnet:                 mixed.Name,
+			StaticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
+			AddressBindings: []v1alpha1.PortAddressBinding{
+				{IPAddress: multiIPAddr1.String(), MACAddress: sharedMultiIPMAC},
+				{IPAddress: multiIPAddr2.String(), MACAddress: sharedMultiIPMAC},
+			},
+		},
+	}
+	multiIPPortCreated := createSubnetPortWithCheck(t, multiIPPort, multiIPAddr1.String(), sharedMultiIPMAC)
+	require.Len(t, multiIPPortCreated.Status.NetworkInterfaceConfig.IPAddresses, 2,
+		"SubnetPort status must reflect both bound IPs, not just the first")
+	gotIPs := []string{
+		multiIPPortCreated.Status.NetworkInterfaceConfig.IPAddresses[0].IPAddress,
+		multiIPPortCreated.Status.NetworkInterfaceConfig.IPAddresses[1].IPAddress,
+	}
+	require.Contains(t, gotIPs[0]+" "+gotIPs[1], multiIPAddr1.String())
+	require.Contains(t, gotIPs[0]+" "+gotIPs[1], multiIPAddr2.String())
+	nsxMultiIPPort := fetchSubnetPortBySubnetPortUID(t, string(multiIPPortCreated.GetUID()))
+	require.Len(t, nsxMultiIPPort.AddressBindings, 2, "NSX port must realize both address bindings")
+
 	// Case 2: day-2 add a second poolRange; expect drift to reconcile.
 	// Re-fetch to obtain the latest ResourceVersion; using mixedCreated directly
 	// can cause HTTP 409 Conflict if the reconciler touched the object since we


### PR DESCRIPTION
 Support for multiple IP addresses sharing one MAC address on a single SubnetPort (needed for Blueprint VM scenarios where one VM interface needs several IPs).

1. SubnetPort status now correctly shows all the IPs NSX assigns to a port, no matter how many there are — before, the code only expected 1 IP (or 2 for dual-stack) and silently mishandled anything beyond that.
2. Double-checked that the existing logic deciding how NSX allocates IPs/MACs doesn't need any changes — it already works correctly regardless of how many bindings a port has.
3. Updated docs, regenerated the CRD, and added a sample YAML showing multiple IPs on one port.


### Setup — Subnet

```bash
kubectl apply -f - <<EOF
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  name: subnet-multi-ip-test
  namespace: subnetport-multi-ip-test
spec:
  accessMode: Private
  ipv4SubnetSize: 64
  subnetDHCPConfig:
    mode: DHCPDeactivated
  advancedConfig:
    staticIPAllocation:
      enabled: true
EOF
kubectl get subnet subnet-multi-ip-test -n subnetport-multi-ip-test -o yaml
```

```yaml
status:
  conditions:
  - message: 'NSX Subnet with DHCPv4: DHCPDeactivated has been successfully created/updated'
    reason: SubnetReady
    status: "True"
    type: Ready
  gatewayAddresses:
  - 172.26.0.1/26
  networkAddresses:
  - 172.26.0.0/26
```

---

**T1 — Multiple explicit IPs, one shared MAC: NSX realizes all 3, status reflects all 3**

```bash
kubectl apply -f - <<EOF
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: sp-multi-ip-test1
  namespace: subnetport-multi-ip-test
spec:
  subnet: subnet-multi-ip-test
  addressBindings:
  - ipAddress: 172.26.0.10
    macAddress: "00:11:22:33:44:55"
  - ipAddress: 172.26.0.11
    macAddress: "00:11:22:33:44:55"
  - ipAddress: 172.26.0.12
    macAddress: "00:11:22:33:44:55"
EOF
kubectl get subnetport sp-multi-ip-test1 -n subnetport-multi-ip-test -o yaml
```

```yaml
status:
  conditions:
  - message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    ipAddresses:
    - gateway: 172.26.0.1
      ipAddress: 172.26.0.10/26
    - gateway: 172.26.0.1
      ipAddress: 172.26.0.11/26
    - gateway: 172.26.0.1
      ipAddress: 172.26.0.12/26
    macAddress: "00:11:22:33:44:55"
```

```bash
curl -sk -u 'admin:<password>' \\
  "https://<nsx-manager>/policy/api/v1/orgs/default/projects/project-quality/vpcs/subnetport-multi-ip-test_jm54x/subnets/subnet-multi-ip-test_jm54x/ports" \\
  | python3 -m json.tool | grep -E '"display_name"|"allocate_addresses"|"ip_address"|"mac_address"'
```

```json
"display_name": "sp-multi-ip-test1",
"allocate_addresses": "IP_POOL",
"ip_address": "172.26.0.10",
"mac_address": "00:11:22:33:44:55",
"ip_address": "172.26.0.11",
"mac_address": "00:11:22:33:44:55",
"ip_address": "172.26.0.12",
"mac_address": "00:11:22:33:44:55",
```

---

**T2 — Multiple pool-allocated IPs (MAC-only bindings), one shared MAC: NSX allocates distinct IPs**

```bash
kubectl apply -f - <<EOF
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: sp-multi-ip-test3
  namespace: subnetport-multi-ip-test
spec:
  subnet: subnet-multi-ip-test
  addressBindings:
  - macAddress: "00:11:22:33:44:77"
  - macAddress: "00:11:22:33:44:77"
EOF
kubectl get subnetport sp-multi-ip-test3 -n subnetport-multi-ip-test -o yaml
```

```yaml
status:
  conditions:
  - message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    ipAddresses:
    - gateway: 172.26.0.1
      ipAddress: 172.26.0.34/26
    - gateway: 172.26.0.1
      ipAddress: 172.26.0.35/26
    macAddress: "00:11:22:33:44:77"
```

```bash
curl -sk -u 'admin:<password>' \\
  "https://<nsx-manager>/policy/api/v1/orgs/default/projects/project-quality/vpcs/subnetport-multi-ip-test_jm54x/subnets/subnet-multi-ip-test_jm54x/ports/sp-multi-ip-test3_jm54x/state"
```

```json
"realized_bindings" : [
  { "binding": { "ip_address": "172.26.0.34", "mac_address": "00:11:22:33:44:77" } },
  { "binding": { "ip_address": "172.26.0.35", "mac_address": "00:11:22:33:44:77" } }
]
```

---

**T3 — Dual-stack regression check: plain dual-stack SubnetPort still works, no `addressBindings`**

```bash
kubectl apply -f - <<EOF
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: sp-dualstack-plain
  namespace: subnetport-multi-ip-test
spec:
  subnet: subnet-dualstack-test
  interfaceIPType: IPv4IPv6
EOF
kubectl get subnetport sp-dualstack-plain -n subnetport-multi-ip-test -o yaml
```

```yaml
status:
  conditions:
  - message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    ipAddresses:
    - gateway: 172.26.0.65
      ipAddress: 172.26.0.66/26
    - gateway: fd12:1234::1
      ipAddress: fd12:1234::ffff:ffff:ffff:fc30/64
    macAddress: "04:50:56:00:80:00"
```

Confirmed unchanged dual-stack behavior — one IPv4 + one IPv6, correct per-family gateway, one shared MAC.

---

### Known limitations discovered during testing

**1. Mixing explicit-IP and pool-allocated bindings in one port fails — NSX platform defect, not fixable in nsx-operator**

```bash
kubectl apply -f - <<EOF
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: sp-multi-ip-test2
  namespace: subnetport-multi-ip-test
spec:
  subnet: subnet-multi-ip-test
  addressBindings:
  - macAddress: "00:11:22:33:44:66"
  - ipAddress: 172.26.0.20
    macAddress: "00:11:22:33:44:66"
  - macAddress: "00:11:22:33:44:66"
EOF
kubectl get subnetport sp-multi-ip-test2 -n subnetport-multi-ip-test -o yaml
```

```yaml
status:
  conditions:
  - message: 'error occurred while processing the SubnetPort CR. Error: .../ports/sp-multi-ip-test2_jm54x
      realized with errors: [IpAddressPool path=[.../ip-pools/static-ipv4-default]
      is exhausted, no free IPs available for allocation.]'
    reason: SubnetPortNotReady
    status: "False"
    type: Ready
```

Reproduced independently of nsx-operator via a direct `curl` PATCH to NSX with the identical binding shape — confirms NSX itself, not the operator, is the cause:

```bash
curl -sk -u 'admin:<password>' \\
  "https://<nsx-manager>/policy/api/v1/infra/realized-state/realized-entities?intent_path=.../ports/repro-mixed"
```

```json
"alarms": [{
  "message": "TX ABORT | ... | Conflict Stream = nsx$AllocationMarker | Cause = CONFLICT",
  "id": "PROVIDER_INVOCATION_FAILURE"
}]
```

The pool was not actually exhausted (`available_ips: 30` of 61 at the time). This is a false-exhaustion error from an internal NSX allocation-transaction conflict when a port mixes explicit-IP and auto-allocated bindings. Each failed attempt also leaks the pool's `allocated_ip_allocations` usage counter without releasing it (confirmed: `61 → 8` available across ~5 failed attempts, while real allocations stayed at 7).

**Workaround:** keep all `addressBindings` entries in a given SubnetPort uniformly explicit-IP or uniformly pool-allocated — don't mix within one port. Filed as an NSX platform issue separately.

**2. Dual-stack + multi-IP pool-allocated bindings always resolve to IPv4 only — NSX platform behavior, not a bug**

```bash
kubectl apply -f - <<EOF
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: sp-dualstack-multiip2
  namespace: subnetport-multi-ip-test
spec:
  subnet: subnet-dualstack-test
  interfaceIPType: IPv4IPv6
  addressBindings:
  - macAddress: "00:11:22:33:44:13"
  - macAddress: "00:11:22:33:44:13"
  - macAddress: "00:11:22:33:44:13"
EOF
kubectl get subnetport sp-dualstack-multiip2 -n subnetport-multi-ip-test -o yaml
```

```yaml
status:
  conditions:
  - message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    ipAddresses:
    - gateway: 172.26.0.65
      ipAddress: 172.26.0.67/26
    - gateway: 172.26.0.65
      ipAddress: 172.26.0.68/26
    - gateway: 172.26.0.65
      ipAddress: 172.26.0.69/26
    macAddress: "00:11:22:33:44:13"
```

Even with `interfaceIPType`/`staticIPAllocationType: IPv4IPv6`, all 3 bindings were allocated as IPv4 — no IPv6 address at all. Reproduced identically via a direct `curl` PATCH to NSX, confirming this is genuine NSX platform behavior, not caused by how nsx-operator builds the request:

```bash
curl -sk -u 'admin:<password>' \\
  "https://<nsx-manager>/policy/api/v1/orgs/default/projects/project-quality/vpcs/subnetport-multi-ip-test_jm54x/subnets/subnet-dualstack-test_jm54x/ports/repro-dualstack-pool/state"
```

```json
"realized_bindings": [
  {"ip_address": "172.26.0.72", "mac_address": "00:11:22:33:44:14"},
  {"ip_address": "172.26.0.70", "mac_address": "00:11:22:33:44:14"},
  {"ip_address": "172.26.0.71", "mac_address": "00:11:22:33:44:14"}
]
```

**Root cause:** NSX's `PortAddressBindingEntry` schema has no per-binding address-family field, so a pool-allocated (IP-omitted) binding gives NSX no way to know which family to allocate from — it defaults to IPv4 for all of them.

multi-IP `addressBindings` should be treated as effectively single-family when relying on pool allocation. To combine families in one port, every binding's IP must be given explicitly.
