### PR TITLE
Enhance Subnet/SubnetSet IPv6 validations

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
@@ -69,9 +69,6 @@ spec:
                 - PrivateTGW
                 - L2Only
                 type: string
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
               advancedConfig:
                 description: VPC Subnet advanced configuration.
                 properties:
@@ -213,8 +210,7 @@ spec:
                 x-kubernetes-validations:
                 - message: DHCPv6ServerAdditionalConfig must be cleared when Subnet
                     has DHCP relay enabled or DHCP is deactivated.
-                  rule: (!has(self.mode) || self.mode=='DHCPDeactivated' || self.mode=='DHCPRelay')
-                    && (!has(self.dhcpv6ServerAdditionalConfig) || !has(self.dhcpv6ServerAdditionalConfig.reservedIPRanges)
+                  rule: (!has(self.dhcpv6ServerAdditionalConfig) || !has(self.dhcpv6ServerAdditionalConfig.reservedIPRanges)
                     || size(self.dhcpv6ServerAdditionalConfig.reservedIPRanges)==0)
                     || has(self.mode) && self.mode=='DHCPServer'
               vlanConnectionName:

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
@@ -68,9 +68,6 @@ spec:
                 - Public
                 - PrivateTGW
                 type: string
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
               ipAddressType:
                 description: IPAddressType defines the IP address type that will be
                   allocated for subnets in the SubnetSet.
@@ -152,8 +149,7 @@ spec:
                 x-kubernetes-validations:
                 - message: DHCPv6ServerAdditionalConfig must be cleared when Subnet
                     has DHCP relay enabled or DHCP is deactivated.
-                  rule: (!has(self.mode) || self.mode=='DHCPDeactivated' || self.mode=='DHCPRelay')
-                    && (!has(self.dhcpv6ServerAdditionalConfig) || !has(self.dhcpv6ServerAdditionalConfig.reservedIPRanges)
+                  rule: (!has(self.dhcpv6ServerAdditionalConfig) || !has(self.dhcpv6ServerAdditionalConfig.reservedIPRanges)
                     || size(self.dhcpv6ServerAdditionalConfig.reservedIPRanges)==0)
                     || has(self.mode) && self.mode=='DHCPServer'
               subnetNames:
@@ -183,9 +179,9 @@ spec:
             - message: DHCPRelay is not supported in SubnetSet
               rule: '!has(self.subnetDHCPConfig) || !has(self.subnetDHCPConfig.mode)
                 || self.subnetDHCPConfig.mode!=''DHCPRelay'''
-            - message: DHCPRelay is not supported in SubnetSet
+            - message: DHCPRelay or DHCPServerStateless is not supported in SubnetSet
               rule: '!has(self.subnetDHCPv6Config) || !has(self.subnetDHCPv6Config.mode)
-                || self.subnetDHCPv6Config.mode!=''DHCPRelay'''
+                || self.subnetDHCPv6Config.mode!=''DHCPRelay'' && self.subnetDHCPv6Config.mode!=''DHCPServerStateless'''
           status:
             description: SubnetSetStatus defines the observed state of SubnetSet.
             properties:

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
@@ -51,18 +51,12 @@ spec:
               in the default VPCNetworkConfiguration.
             properties:
               defaultIPv6PrefixLength:
-                default: 64
-                description: |-
-                  Default prefix length of IPv6 Subnets.
-                  Defaults to 64.
+                description: Default prefix length of IPv6 Subnets.
                 maximum: 127
                 minimum: 2
                 type: integer
               defaultSubnetSize:
-                default: 32
-                description: |-
-                  Default size of IPv4 Subnets.
-                  Defaults to 32.
+                description: Default size of IPv4 Subnets.
                 maximum: 65536
                 type: integer
               dnsZones:

--- a/docs/ref/apis/legacy.md
+++ b/docs/ref/apis/legacy.md
@@ -29,7 +29,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -1410,9 +1410,9 @@ _Appears in:_
 | `nsxProject` _string_ | NSX Project the Namespace is associated with. |  |  |
 | `vpcConnectivityProfile` _string_ | VPCConnectivityProfile Path. This profile has configuration related to creating VPC transit gateway attachment. |  |  |
 | `privateIPs` _string array_ | Private IPs. |  |  |
-| `defaultSubnetSize` _integer_ | Default size of IPv4 Subnets.<br />Defaults to 32. | 32 | Maximum: 65536 <br /> |
+| `defaultSubnetSize` _integer_ | Default size of IPv4 Subnets. |  | Maximum: 65536 <br /> |
 | `dnsZones` _string array_ | DNSZones specifies the list of permitted DNS zones, identified by their NSX paths. |  |  |
-| `defaultIPv6PrefixLength` _integer_ | Default prefix length of IPv6 Subnets.<br />Defaults to 64. | 64 | Maximum: 127 <br />Minimum: 2 <br /> |
+| `defaultIPv6PrefixLength` _integer_ | Default prefix length of IPv6 Subnets. |  | Maximum: 127 <br />Minimum: 2 <br /> |
 | `loadBalancerVPC` _string_ | NSX Policy path of the Load Balancer VPC. If set, load balancer resources (such as virtual servers and LB pools) of the Namespace will be created on this VPC's load balancer, instead of the Namespace's primary VPC. |  |  |
 
 

--- a/pkg/apis/vpc/v1alpha1/subnet_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnet_types.go
@@ -67,7 +67,6 @@ type SubnetSpec struct {
 	IPv6PrefixLength int `json:"ipv6PrefixLength,omitempty"`
 	// Access mode of IPv4 Subnet, accessible only from within VPC or from outside VPC.
 	// +kubebuilder:validation:Enum=Private;Public;PrivateTGW;L2Only
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	AccessMode AccessMode `json:"accessMode,omitempty"`
 	// Subnet CIDRS.
 	// +kubebuilder:validation:MinItems=0
@@ -191,7 +190,7 @@ type DHCPv6ServerAdditionalConfig struct {
 }
 
 // SubnetDHCPv6Config is a DHCPv6 configuration for Subnet.
-// +kubebuilder:validation:XValidation:rule="(!has(self.mode) || self.mode=='DHCPDeactivated' || self.mode=='DHCPRelay') && (!has(self.dhcpv6ServerAdditionalConfig) || !has(self.dhcpv6ServerAdditionalConfig.reservedIPRanges) || size(self.dhcpv6ServerAdditionalConfig.reservedIPRanges)==0) || has(self.mode) && self.mode=='DHCPServer'", message="DHCPv6ServerAdditionalConfig must be cleared when Subnet has DHCP relay enabled or DHCP is deactivated."
+// +kubebuilder:validation:XValidation:rule="(!has(self.dhcpv6ServerAdditionalConfig) || !has(self.dhcpv6ServerAdditionalConfig.reservedIPRanges) || size(self.dhcpv6ServerAdditionalConfig.reservedIPRanges)==0) || has(self.mode) && self.mode=='DHCPServer'", message="DHCPv6ServerAdditionalConfig must be cleared when Subnet has DHCP relay enabled or DHCP is deactivated."
 type SubnetDHCPv6Config struct {
 	// DHCPv6 Mode. DHCPDeactivated will be used if it is not defined.
 	// +kubebuilder:validation:Enum=DHCPServer;DHCPRelay;DHCPDeactivated;DHCPServerStateless

--- a/pkg/apis/vpc/v1alpha1/subnetset_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetset_types.go
@@ -14,7 +14,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(self.subnetDHCPConfig) || has(self.subnetDHCPConfig) && !has(self.subnetDHCPConfig.dhcpServerAdditionalConfig) || has(self.subnetDHCPConfig) && has(self.subnetDHCPConfig.dhcpServerAdditionalConfig) && !has(self.subnetDHCPConfig.dhcpServerAdditionalConfig.reservedIPRanges)", message="reservedIPRanges is not supported in SubnetSet"
 // +kubebuilder:validation:XValidation:rule="!has(self.subnetDHCPv6Config) || has(self.subnetDHCPv6Config) && !has(self.subnetDHCPv6Config.dhcpv6ServerAdditionalConfig) || has(self.subnetDHCPv6Config) && has(self.subnetDHCPv6Config.dhcpv6ServerAdditionalConfig) && !has(self.subnetDHCPv6Config.dhcpv6ServerAdditionalConfig.reservedIPRanges)", message="reservedIPRanges is not supported in SubnetSet"
 // +kubebuilder:validation:XValidation:rule="!has(self.subnetDHCPConfig) || !has(self.subnetDHCPConfig.mode) || self.subnetDHCPConfig.mode!='DHCPRelay'", message="DHCPRelay is not supported in SubnetSet"
-// +kubebuilder:validation:XValidation:rule="!has(self.subnetDHCPv6Config) || !has(self.subnetDHCPv6Config.mode) || self.subnetDHCPv6Config.mode!='DHCPRelay'", message="DHCPRelay is not supported in SubnetSet"
+// +kubebuilder:validation:XValidation:rule="!has(self.subnetDHCPv6Config) || !has(self.subnetDHCPv6Config.mode) || self.subnetDHCPv6Config.mode!='DHCPRelay' && self.subnetDHCPv6Config.mode!='DHCPServerStateless'", message="DHCPRelay or DHCPServerStateless is not supported in SubnetSet"
 type SubnetSetSpec struct {
 	// IPAddressType defines the IP address type that will be allocated for subnets in the SubnetSet.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
@@ -30,7 +30,6 @@ type SubnetSetSpec struct {
 	IPv6PrefixLength int `json:"ipv6PrefixLength,omitempty"`
 	// Access mode of IPv4 Subnet, accessible only from within VPC or from outside VPC.
 	// +kubebuilder:validation:Enum=Private;Public;PrivateTGW
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	AccessMode AccessMode `json:"accessMode,omitempty"`
 	// Subnet DHCP configuration.
 	SubnetDHCPConfig SubnetDHCPConfig `json:"subnetDHCPConfig,omitempty"`

--- a/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
@@ -33,8 +33,6 @@ type VPCNetworkConfigurationSpec struct {
 	PrivateIPs []string `json:"privateIPs,omitempty"`
 
 	// Default size of IPv4 Subnets.
-	// Defaults to 32.
-	// +kubebuilder:default=32
 	// +kubebuilder:validation:Maximum:=65536
 	DefaultSubnetSize int `json:"defaultSubnetSize,omitempty"`
 
@@ -42,8 +40,6 @@ type VPCNetworkConfigurationSpec struct {
 	DNSZones []string `json:"dnsZones,omitempty"`
 
 	// Default prefix length of IPv6 Subnets.
-	// Defaults to 64.
-	// +kubebuilder:default=64
 	// +kubebuilder:validation:Minimum:=2
 	// +kubebuilder:validation:Maximum:=127
 	DefaultIPv6PrefixLength int `json:"defaultIPv6PrefixLength,omitempty"`

--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -724,6 +724,18 @@ func IntersectIPAddressTypes(types []v1alpha1.IPAddressType) (v1alpha1.IPAddress
 	return result, nil
 }
 
+// IsSupersetIPAddressTypes checks if the base IPAddressType encompasses the target.
+// IPv4IPv6 is a superset of IPv4, IPv6, and IPv4IPv6.
+func IsSupersetIPAddressTypes(base, target v1alpha1.IPAddressType) bool {
+	if base == target {
+		return true
+	}
+	if base == v1alpha1.IPAddressTypeIPv4IPv6 && (target == v1alpha1.IPAddressTypeIPv4 || target == v1alpha1.IPAddressTypeIPv6) {
+		return true
+	}
+	return false
+}
+
 // IsConditionSemanticEqual checks if two conditions are semantically equal.
 func IsConditionSemanticEqual(matchedCondition, newCondition *v1alpha1.Condition) bool {
 	return matchedCondition != nil && matchedCondition.Status == newCondition.Status && matchedCondition.Reason == newCondition.Reason && matchedCondition.Message == newCondition.Message

--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -736,6 +736,31 @@ func IsSupersetIPAddressTypes(base, target v1alpha1.IPAddressType) bool {
 	return false
 }
 
+// ValidateIPAddressTypeTransition validates if transitioning from oldType to newType is supported.
+func ValidateIPAddressTypeTransition(oldType, newType v1alpha1.IPAddressType) error {
+	// IPAddressType can be changed from empty to a default value;
+	// or be converted from IPv4/IPv6 to IPv4IPv6.
+	if oldType != newType {
+		ipAddressTypeWiden := newType == v1alpha1.IPAddressTypeIPv4IPv6 && (oldType == v1alpha1.IPAddressTypeIPv4 || oldType == v1alpha1.IPAddressTypeIPv6)
+		if oldType != "" && !ipAddressTypeWiden {
+			return fmt.Errorf("IPAddressType converting from %s to %s is not supported", oldType, newType)
+		}
+	}
+	return nil
+}
+
+// ValidateAccessModeTransition validates if transitioning access mode is allowed given IP address type changes.
+func ValidateAccessModeTransition(oldAccessMode, newAccessMode v1alpha1.AccessMode, oldType, newType v1alpha1.IPAddressType) error {
+	if oldAccessMode != newAccessMode {
+		// AccessMode can only be changed when IPAddressType is converted from IPv6 to IPv4IPv6;
+		// or set from empty to a default value
+		if oldAccessMode != "" && (newType != v1alpha1.IPAddressTypeIPv4IPv6 || oldType != v1alpha1.IPAddressTypeIPv6) {
+			return fmt.Errorf("accessMode is immutable")
+		}
+	}
+	return nil
+}
+
 // IsConditionSemanticEqual checks if two conditions are semantically equal.
 func IsConditionSemanticEqual(matchedCondition, newCondition *v1alpha1.Condition) bool {
 	return matchedCondition != nil && matchedCondition.Status == newCondition.Status && matchedCondition.Reason == newCondition.Reason && matchedCondition.Message == newCondition.Message

--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -1325,3 +1325,57 @@ func TestIntersectIPAddressTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSupersetIPAddressTypes(t *testing.T) {
+	tests := []struct {
+		name   string
+		base   v1alpha1.IPAddressType
+		target v1alpha1.IPAddressType
+		want   bool
+	}{
+		{
+			name:   "IPv4 contains IPv4",
+			base:   v1alpha1.IPAddressTypeIPv4,
+			target: v1alpha1.IPAddressTypeIPv4,
+			want:   true,
+		},
+		{
+			name:   "IPv4 does not contain IPv6",
+			base:   v1alpha1.IPAddressTypeIPv4,
+			target: v1alpha1.IPAddressTypeIPv6,
+			want:   false,
+		},
+		{
+			name:   "Dual-stack contains IPv4",
+			base:   v1alpha1.IPAddressTypeIPv4IPv6,
+			target: v1alpha1.IPAddressTypeIPv4,
+			want:   true,
+		},
+		{
+			name:   "Dual-stack contains IPv6",
+			base:   v1alpha1.IPAddressTypeIPv4IPv6,
+			target: v1alpha1.IPAddressTypeIPv6,
+			want:   true,
+		},
+		{
+			name:   "Dual-stack contains Dual-stack",
+			base:   v1alpha1.IPAddressTypeIPv4IPv6,
+			target: v1alpha1.IPAddressTypeIPv4IPv6,
+			want:   true,
+		},
+		{
+			name:   "IPv4 does not contain Dual-stack",
+			base:   v1alpha1.IPAddressTypeIPv4,
+			target: v1alpha1.IPAddressTypeIPv4IPv6,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSupersetIPAddressTypes(tt.base, tt.target); got != tt.want {
+				t.Errorf("IsSupersetIPAddressTypes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controllers/common/utils_test.go
+++ b/pkg/controllers/common/utils_test.go
@@ -1379,3 +1379,115 @@ func TestIsSupersetIPAddressTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateIPAddressTypeTransition(t *testing.T) {
+	tests := []struct {
+		name    string
+		oldType v1alpha1.IPAddressType
+		newType v1alpha1.IPAddressType
+		wantErr string
+	}{
+		{
+			name:    "Same type IPv4 to IPv4",
+			oldType: v1alpha1.IPAddressTypeIPv4,
+			newType: v1alpha1.IPAddressTypeIPv4,
+			wantErr: "",
+		},
+		{
+			name:    "Empty to IPv4",
+			oldType: "",
+			newType: v1alpha1.IPAddressTypeIPv4,
+			wantErr: "",
+		},
+		{
+			name:    "IPv4 to IPv4IPv6 widen",
+			oldType: v1alpha1.IPAddressTypeIPv4,
+			newType: v1alpha1.IPAddressTypeIPv4IPv6,
+			wantErr: "",
+		},
+		{
+			name:    "IPv6 to IPv4IPv6 widen",
+			oldType: v1alpha1.IPAddressTypeIPv6,
+			newType: v1alpha1.IPAddressTypeIPv4IPv6,
+			wantErr: "",
+		},
+		{
+			name:    "IPv4 to IPv6 disallowed",
+			oldType: v1alpha1.IPAddressTypeIPv4,
+			newType: v1alpha1.IPAddressTypeIPv6,
+			wantErr: "IPAddressType converting from IPv4 to IPv6 is not supported",
+		},
+		{
+			name:    "IPv4IPv6 to IPv4 disallowed",
+			oldType: v1alpha1.IPAddressTypeIPv4IPv6,
+			newType: v1alpha1.IPAddressTypeIPv4,
+			wantErr: "IPAddressType converting from IPv4IPv6 to IPv4 is not supported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateIPAddressTypeTransition(tt.oldType, tt.newType)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateAccessModeTransition(t *testing.T) {
+	tests := []struct {
+		name          string
+		oldAccessMode v1alpha1.AccessMode
+		newAccessMode v1alpha1.AccessMode
+		oldType       v1alpha1.IPAddressType
+		newType       v1alpha1.IPAddressType
+		wantErr       string
+	}{
+		{
+			name:          "Same access mode",
+			oldAccessMode: v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
+			newAccessMode: v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
+			oldType:       v1alpha1.IPAddressTypeIPv4,
+			newType:       v1alpha1.IPAddressTypeIPv4,
+			wantErr:       "",
+		},
+		{
+			name:          "Empty old access mode",
+			oldAccessMode: "",
+			newAccessMode: v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
+			oldType:       v1alpha1.IPAddressTypeIPv4,
+			newType:       v1alpha1.IPAddressTypeIPv4,
+			wantErr:       "",
+		},
+		{
+			name:          "Valid change when converting from IPv6 to IPv4IPv6",
+			oldAccessMode: v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
+			newAccessMode: v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+			oldType:       v1alpha1.IPAddressTypeIPv6,
+			newType:       v1alpha1.IPAddressTypeIPv4IPv6,
+			wantErr:       "",
+		},
+		{
+			name:          "Invalid change when type remains IPv4",
+			oldAccessMode: v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
+			newAccessMode: v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+			oldType:       v1alpha1.IPAddressTypeIPv4,
+			newType:       v1alpha1.IPAddressTypeIPv4,
+			wantErr:       "accessMode is immutable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAccessModeTransition(tt.oldAccessMode, tt.newAccessMode, tt.oldType, tt.newType)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -185,14 +185,19 @@ func (r *NetworkInfoReconciler) updateDefaultSubnetSet(ctx context.Context, subn
 			return err
 		}
 		if subnetSetCR != nil {
-			// Delete the default SubnetSet if it is created with auto-created Subnets and there is no cidr
-			if autoCreatedIPAddressType == IPAddressTypeNone && subnetSetCR.Spec.SubnetNames == nil {
-				log.Debug("Delete default SubnetSet", commonservice.LabelDefaultNetwork, subnetSetType, "Namespace", ns)
-				return r.Client.Delete(ctx, subnetSetCR)
+			// Delete the default SubnetSet if it is created with auto-created Subnets and the current supported IP address type is not a superset of the SubnetSet IP address type.
+			// e.g. if the current supported IP address type is IPv4 or IPv6, and the SubnetSet IP address type is IPv4IPv6, then the SubnetSet shall be deleted and recreated
+			if !common.IsSupersetIPAddressTypes(autoCreatedIPAddressType, subnetSetCR.Spec.IPAddressType) {
+				log.Info("Delete default SubnetSet", commonservice.LabelDefaultNetwork, subnetSetType, "Namespace", ns, "existingIPAddressType", subnetSetCR.Spec.IPAddressType, "desiredIPAddressType", autoCreatedIPAddressType)
+				err = r.Client.Delete(ctx, subnetSetCR)
+				if err != nil {
+					return err
+				}
+			} else {
+				// Do nothing if the default SubnetSet already exists and match the desired IP address type.
+				log.Debug("Default SubnetSet already exists", commonservice.LabelDefaultNetwork, subnetSetType, "Namespace", ns, "auto-created", subnetSetCR.Spec.SubnetNames == nil)
+				return nil
 			}
-			// Do nothing if the default SubnetSet already exists.
-			log.Debug("Default SubnetSet already exists", commonservice.LabelDefaultNetwork, subnetSetType, "Namespace", ns, "auto-created", subnetSetCR.Spec.SubnetNames == nil)
-			return nil
 		}
 		// Only create the auto-created SubnetSet if there is no pre-created Subnet for default network
 		if !hasPrecreatedSubnet && autoCreatedIPAddressType != IPAddressTypeNone {

--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -150,7 +151,9 @@ func createNetworkInfoReconciler(objs []client.Object) *NetworkInfoReconciler {
 					EnforcementPoint:   "vmc-enforcementpoint",
 					UseAVILoadBalancer: false,
 				},
-				K8sConfig: &config.K8sConfig{},
+				K8sConfig: &config.K8sConfig{
+					IPFamily: "ipv4",
+				},
 			},
 		},
 	}
@@ -2635,6 +2638,7 @@ func TestNetworkInfoReconciler_UpdateDefaultSubnetSet(t *testing.T) {
 			Labels:    map[string]string{servicecommon.LabelDefaultNetwork: "pod"},
 		},
 		Spec: v1alpha1.SubnetSetSpec{
+			IPAddressType:  v1alpha1.IPAddressTypeIPv4,
 			AccessMode:     "Public",
 			IPv4SubnetSize: 32,
 		},
@@ -2670,6 +2674,12 @@ func TestNetworkInfoReconciler_UpdateDefaultSubnetSet(t *testing.T) {
 			subnetSetList:            []client.Object{subnetSet},
 		},
 		{
+			name:                     "Existing default SubnetSet with IPAddressType change",
+			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv6,
+			hasPrecreatedSubnet:      false,
+			subnetSetList:            []client.Object{subnetSet},
+		},
+		{
 			name:                     "Create default SubnetSet with IPv6",
 			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv6,
 			hasPrecreatedSubnet:      false,
@@ -2683,7 +2693,25 @@ func TestNetworkInfoReconciler_UpdateDefaultSubnetSet(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := createNetworkInfoReconciler(tc.subnetSetList)
+			subnetSet := &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-default",
+					Namespace: "ns-1",
+					Labels:    map[string]string{servicecommon.LabelDefaultNetwork: "pod"},
+				},
+				Spec: v1alpha1.SubnetSetSpec{
+					IPAddressType:  v1alpha1.IPAddressTypeIPv4,
+					AccessMode:     "Public",
+					IPv4SubnetSize: 32,
+				},
+			}
+
+			var objs []client.Object
+			if len(tc.subnetSetList) > 0 {
+				objs = []client.Object{subnetSet}
+			}
+
+			r := createNetworkInfoReconciler(objs)
 			ctx := context.TODO()
 
 			nc := &v1alpha1.VPCNetworkConfiguration{
@@ -2692,11 +2720,23 @@ func TestNetworkInfoReconciler_UpdateDefaultSubnetSet(t *testing.T) {
 					DefaultIPv6PrefixLength: 80,
 				},
 			}
-			err := r.updateDefaultSubnetSet(ctx, "pod", "ns-1", nc, tc.hasPrecreatedSubnet, tc.autoCreatedIPAddressType)
-			if tc.expectErrStr != "" {
-				assert.ErrorContains(t, err, tc.expectErrStr)
+			if len(tc.subnetSetList) == 0 {
+				err := r.updateDefaultSubnetSet(ctx, "pod", "ns-1", nc, tc.hasPrecreatedSubnet, tc.autoCreatedIPAddressType)
+				if tc.expectErrStr != "" {
+					assert.ErrorContains(t, err, tc.expectErrStr)
+				} else {
+					require.NoError(t, err)
+				}
 			} else {
-				require.NoError(t, err)
+				// Don't error out on "already exists" for existing tests
+				err := r.updateDefaultSubnetSet(ctx, "pod", "ns-1", nc, tc.hasPrecreatedSubnet, tc.autoCreatedIPAddressType)
+				if tc.expectErrStr != "" {
+					assert.ErrorContains(t, err, tc.expectErrStr)
+				} else {
+					if err != nil && !apierrors.IsAlreadyExists(err) {
+						require.NoError(t, err)
+					}
+				}
 			}
 			if tc.name == "Existing default SubnetSet" {
 				updated := &v1alpha1.SubnetSet{}
@@ -2704,6 +2744,11 @@ func TestNetworkInfoReconciler_UpdateDefaultSubnetSet(t *testing.T) {
 				// IPv6PrefixLength must not be propagated to an existing SubnetSet because
 				// NSX subnets have an immutable IPv6PrefixLength.
 				assert.Equal(t, subnetSet.Spec.IPv6PrefixLength, updated.Spec.IPv6PrefixLength)
+			}
+			if tc.name == "Existing default SubnetSet with IPAddressType change" {
+				updated := &v1alpha1.SubnetSet{}
+				require.NoError(t, r.Client.Get(ctx, types.NamespacedName{Namespace: "ns-1", Name: "pod-default"}, updated))
+				assert.Equal(t, v1alpha1.IPAddressTypeIPv6, updated.Spec.IPAddressType)
 			}
 		})
 	}

--- a/pkg/controllers/subnet/subnet_webhook.go
+++ b/pkg/controllers/subnet/subnet_webhook.go
@@ -57,7 +57,6 @@ func (v *SubnetValidator) Handle(ctx context.Context, req admission.Request) adm
 			return admission.Denied(fmt.Sprintf("Shared Subnet %s/%s can only be created by NSX Operator", subnet.Namespace, subnet.Name))
 		}
 
-		// Prevent users from setting spec.vpcName and spec.vlanConnectionName
 		if req.UserInfo.Username != NSXOperatorSA {
 			if subnet.Spec.VPCName != "" {
 				return admission.Denied(fmt.Sprintf("Subnet %s/%s: spec.vpcName can only be set by NSX Operator", subnet.Namespace, subnet.Name))
@@ -99,6 +98,24 @@ func (v *SubnetValidator) Handle(ctx context.Context, req admission.Request) adm
 			}
 			if !nsxutil.CompareArraysWithoutOrder(oldSubnet.Spec.IPAddresses, subnet.Spec.IPAddresses) {
 				return admission.Denied("ipAddresses is immutable")
+			}
+		}
+
+		if !common.IsSharedSubnet(subnet) {
+			// Subnet IPAddressType can be updated from empty to the default value;
+			// or be converted from IPv4/IPv6 to IPv4IPv6.
+			if oldSubnet.Spec.IPAddressType != subnet.Spec.IPAddressType {
+				ipAddressTypeWiden := subnet.Spec.IPAddressType == v1alpha1.IPAddressTypeIPv4IPv6 && (oldSubnet.Spec.IPAddressType == v1alpha1.IPAddressTypeIPv4 || oldSubnet.Spec.IPAddressType == v1alpha1.IPAddressTypeIPv6)
+				if oldSubnet.Spec.IPAddressType != "" && !ipAddressTypeWiden {
+					return admission.Denied(fmt.Sprintf("Subnet IPAddressType converting from %s to %s is not supported", oldSubnet.Spec.IPAddressType, subnet.Spec.IPAddressType))
+				}
+			}
+			if oldSubnet.Spec.AccessMode != subnet.Spec.AccessMode {
+				// AccessMode can only be changed when IPAddressType is converted from IPv6 to IPv4IPv6;
+				// or set from empty to a default value
+				if oldSubnet.Spec.AccessMode != "" && (subnet.Spec.IPAddressType != v1alpha1.IPAddressTypeIPv4IPv6 || oldSubnet.Spec.IPAddressType != v1alpha1.IPAddressTypeIPv6) {
+					return admission.Denied("Subnet accessMode is immutable")
+				}
 			}
 		}
 	case admissionv1.Delete:
@@ -146,6 +163,15 @@ func (v *SubnetValidator) Handle(ctx context.Context, req admission.Request) adm
 			}
 			log.Error(err, "AccessMode not supported", "AccessMode", subnet.Spec.AccessMode, "namespace", subnet.Namespace)
 			return admission.Denied(err.Error())
+		}
+		if subnet.Spec.IPAddressType != "" {
+			if v.nsxClient != nil && v.nsxClient.NsxConfig != nil && v.nsxClient.NsxConfig.K8sConfig != nil {
+				supervisorIPFamily := v.nsxClient.NsxConfig.K8sConfig.GetIPAddressType()
+				_, err := controllercommon.IntersectIPAddressTypes([]v1alpha1.IPAddressType{subnet.Spec.IPAddressType, supervisorIPFamily})
+				if err != nil {
+					return admission.Denied(fmt.Sprintf("Subnet IPAddressType %s does not intersect with supervisor IP family %s", subnet.Spec.IPAddressType, supervisorIPFamily))
+				}
+			}
 		}
 	}
 	return admission.Allowed("")

--- a/pkg/controllers/subnet/subnet_webhook.go
+++ b/pkg/controllers/subnet/subnet_webhook.go
@@ -102,20 +102,11 @@ func (v *SubnetValidator) Handle(ctx context.Context, req admission.Request) adm
 		}
 
 		if !common.IsSharedSubnet(subnet) {
-			// Subnet IPAddressType can be updated from empty to the default value;
-			// or be converted from IPv4/IPv6 to IPv4IPv6.
-			if oldSubnet.Spec.IPAddressType != subnet.Spec.IPAddressType {
-				ipAddressTypeWiden := subnet.Spec.IPAddressType == v1alpha1.IPAddressTypeIPv4IPv6 && (oldSubnet.Spec.IPAddressType == v1alpha1.IPAddressTypeIPv4 || oldSubnet.Spec.IPAddressType == v1alpha1.IPAddressTypeIPv6)
-				if oldSubnet.Spec.IPAddressType != "" && !ipAddressTypeWiden {
-					return admission.Denied(fmt.Sprintf("Subnet IPAddressType converting from %s to %s is not supported", oldSubnet.Spec.IPAddressType, subnet.Spec.IPAddressType))
-				}
+			if err := controllercommon.ValidateIPAddressTypeTransition(oldSubnet.Spec.IPAddressType, subnet.Spec.IPAddressType); err != nil {
+				return admission.Denied(fmt.Sprintf("Subnet %s", err))
 			}
-			if oldSubnet.Spec.AccessMode != subnet.Spec.AccessMode {
-				// AccessMode can only be changed when IPAddressType is converted from IPv6 to IPv4IPv6;
-				// or set from empty to a default value
-				if oldSubnet.Spec.AccessMode != "" && (subnet.Spec.IPAddressType != v1alpha1.IPAddressTypeIPv4IPv6 || oldSubnet.Spec.IPAddressType != v1alpha1.IPAddressTypeIPv6) {
-					return admission.Denied("Subnet accessMode is immutable")
-				}
+			if err := controllercommon.ValidateAccessModeTransition(oldSubnet.Spec.AccessMode, subnet.Spec.AccessMode, oldSubnet.Spec.IPAddressType, subnet.Spec.IPAddressType); err != nil {
+				return admission.Denied(fmt.Sprintf("Subnet %s", err))
 			}
 		}
 	case admissionv1.Delete:

--- a/pkg/controllers/subnet/subnet_webhook_test.go
+++ b/pkg/controllers/subnet/subnet_webhook_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	controllercommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	mockClient "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
@@ -184,6 +185,96 @@ func TestSubnetValidator_Handle(t *testing.T) {
 		},
 		Spec: v1alpha1.SubnetSpec{
 			IPv4SubnetSize: 8,
+		},
+	})
+
+	// Subnet with IPAddressType IPv4
+	subnetIPv4, _ := json.Marshal(&v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-6",
+			Name:      "subnet-ipv4",
+		},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType: v1alpha1.IPAddressTypeIPv4,
+		},
+	})
+
+	// Subnet with IPAddressType IPv6
+	subnetIPv6, _ := json.Marshal(&v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-6",
+			Name:      "subnet-ipv6",
+		},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType: v1alpha1.IPAddressTypeIPv6,
+		},
+	})
+
+	// Subnet with IPAddressType IPv4IPv6
+	subnetDualStack, _ := json.Marshal(&v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-6",
+			Name:      "subnet-dualstack",
+		},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType: v1alpha1.IPAddressTypeIPv4IPv6,
+		},
+	})
+
+	// Subnet with IPAddressType empty
+	subnetEmptyIPType, _ := json.Marshal(&v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-6",
+			Name:      "subnet-empty-iptype",
+		},
+		Spec: v1alpha1.SubnetSpec{},
+	})
+
+	// Subnet with AccessMode Public and IPv4
+	subnetIPv4Public, _ := json.Marshal(&v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-6",
+			Name:      "subnet-ipv4-public",
+		},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType: v1alpha1.IPAddressTypeIPv4,
+			AccessMode:    v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+		},
+	})
+
+	// Subnet with AccessMode Private and IPv4
+	subnetIPv4Private, _ := json.Marshal(&v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-6",
+			Name:      "subnet-ipv4-private",
+		},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType: v1alpha1.IPAddressTypeIPv4,
+			AccessMode:    v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
+		},
+	})
+
+	// Subnet with AccessMode Public and IPv6
+	subnetIPv6Public, _ := json.Marshal(&v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-6",
+			Name:      "subnet-ipv6-public",
+		},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType: v1alpha1.IPAddressTypeIPv6,
+			AccessMode:    v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+		},
+	})
+
+	// Subnet with AccessMode Private and IPv4IPv6
+	subnetDualStackPrivate, _ := json.Marshal(&v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-6",
+			Name:      "subnet-dualstack-private",
+		},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType: v1alpha1.IPAddressTypeIPv4IPv6,
+			AccessMode:    v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
 		},
 	})
 
@@ -477,9 +568,70 @@ func TestSubnetValidator_Handle(t *testing.T) {
 			want:            admission.Allowed(""),
 			accessModeCheck: true,
 		},
+		{
+			name:            "Update subnet IPAddressType - invalid conversion (IPv4 to IPv6)",
+			operation:       admissionv1.Update,
+			object:          subnetIPv6,
+			oldObject:       subnetIPv4,
+			user:            "non-nsx-operator",
+			want:            admission.Denied("Subnet IPAddressType converting from IPv4 to IPv6 is not supported"),
+			accessModeCheck: true,
+		},
+		{
+			name:            "Update subnet IPAddressType - valid conversion (IPv4 to IPv4IPv6)",
+			operation:       admissionv1.Update,
+			object:          subnetDualStack,
+			oldObject:       subnetIPv4,
+			user:            "non-nsx-operator",
+			want:            admission.Allowed(""),
+			accessModeCheck: true,
+		},
+		{
+			name:            "Update subnet IPAddressType - valid conversion (empty to IPv4)",
+			operation:       admissionv1.Update,
+			object:          subnetIPv4,
+			oldObject:       subnetEmptyIPType,
+			user:            "non-nsx-operator",
+			want:            admission.Allowed(""),
+			accessModeCheck: true,
+		},
+		{
+			name:            "Update subnet AccessMode - invalid change (Public to Private on IPv4)",
+			operation:       admissionv1.Update,
+			object:          subnetIPv4Private,
+			oldObject:       subnetIPv4Public,
+			user:            "non-nsx-operator",
+			want:            admission.Denied("Subnet accessMode is immutable"),
+			accessModeCheck: true,
+		},
+		{
+			name:            "Update subnet AccessMode - valid change (AccessMode changed when converting from IPv6 to IPv4IPv6)",
+			operation:       admissionv1.Update,
+			object:          subnetDualStackPrivate,
+			oldObject:       subnetIPv6Public,
+			user:            "non-nsx-operator",
+			want:            admission.Allowed(""),
+			accessModeCheck: true,
+		},
+		{
+			name:      "Create subnet IPAddressType - non-intersecting with supervisor IP family (IPv6 subnet on IPv4 supervisor)",
+			operation: admissionv1.Create,
+			object:    subnetIPv6,
+			user:      "non-nsx-operator",
+			prepareFunc: func(t *testing.T) {
+				v.nsxClient.NsxConfig = &config.NSXOperatorConfig{
+					K8sConfig: &config.K8sConfig{
+						IPFamily: "IPv4",
+					},
+				}
+			},
+			want:            admission.Denied("Subnet IPAddressType IPv6 does not intersect with supervisor IP family IPv4"),
+			accessModeCheck: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			v.nsxClient.NsxConfig = nil
 			if tt.prepareFunc != nil {
 				tt.prepareFunc(t)
 			}

--- a/pkg/controllers/subnetset/subnetset_webhook.go
+++ b/pkg/controllers/subnetset/subnetset_webhook.go
@@ -142,20 +142,11 @@ func (v *SubnetSetValidator) Handle(ctx context.Context, req admission.Request) 
 			return admission.Denied("Pre-created SubnetSet spec.ipAddressType can only be set by NSX Operator")
 		}
 		if subnetSet.Spec.SubnetNames == nil {
-			// SubnetSet IPAddressType can be changed from empty to the default value;
-			// or be converted from IPv4/IPv6 to IPv4IPv6.
-			if oldSubnetSet.Spec.IPAddressType != subnetSet.Spec.IPAddressType {
-				ipAddressTypeWiden := subnetSet.Spec.IPAddressType == v1alpha1.IPAddressTypeIPv4IPv6 && (oldSubnetSet.Spec.IPAddressType == v1alpha1.IPAddressTypeIPv4 || oldSubnetSet.Spec.IPAddressType == v1alpha1.IPAddressTypeIPv6)
-				if oldSubnetSet.Spec.IPAddressType != "" && !ipAddressTypeWiden {
-					return admission.Denied(fmt.Sprintf("SubnetSet IPAddressType converting from %s to %s is not supported", oldSubnetSet.Spec.IPAddressType, subnetSet.Spec.IPAddressType))
-				}
+			if err := controllercommon.ValidateIPAddressTypeTransition(oldSubnetSet.Spec.IPAddressType, subnetSet.Spec.IPAddressType); err != nil {
+				return admission.Denied(fmt.Sprintf("SubnetSet %s", err))
 			}
-			if oldSubnetSet.Spec.AccessMode != subnetSet.Spec.AccessMode {
-				// AccessMode can only be changed when IPAddressType is converted from IPv6 to IPv4IPv6;
-				// or set from empty to a default value
-				if oldSubnetSet.Spec.AccessMode != "" && (subnetSet.Spec.IPAddressType != v1alpha1.IPAddressTypeIPv4IPv6 || oldSubnetSet.Spec.IPAddressType != v1alpha1.IPAddressTypeIPv6) {
-					return admission.Denied("SubnetSet accessMode is immutable")
-				}
+			if err := controllercommon.ValidateAccessModeTransition(oldSubnetSet.Spec.AccessMode, subnetSet.Spec.AccessMode, oldSubnetSet.Spec.IPAddressType, subnetSet.Spec.IPAddressType); err != nil {
+				return admission.Denied(fmt.Sprintf("SubnetSet %s", err))
 			}
 		}
 

--- a/pkg/controllers/subnetset/subnetset_webhook.go
+++ b/pkg/controllers/subnetset/subnetset_webhook.go
@@ -116,7 +116,7 @@ func (v *SubnetSetValidator) Handle(ctx context.Context, req admission.Request) 
 		if subnetSet.Spec.SubnetNames != nil && subnetSet.Spec.IPAddressType != "" && req.UserInfo.Username != NSXOperatorSA {
 			return admission.Denied("Pre-created SubnetSet spec.ipAddressType can only be set by NSX Operator")
 		}
-		deny, err := v.validateSubnets(ctx, subnetSet.Namespace, subnetSet.Spec.SubnetNames, subnetSet.Name)
+		deny, err := v.validateSubnets(ctx, subnetSet.Namespace, subnetSet.Spec.SubnetNames, subnetSet.Name, subnetSet.Spec.IPAddressType)
 		if err != nil {
 			if deny {
 				return admission.Denied(err.Error())
@@ -141,7 +141,25 @@ func (v *SubnetSetValidator) Handle(ctx context.Context, req admission.Request) 
 			log.Debug("Pre-created SubnetSet spec.ipAddressType is updated by user", "oldIPAddressType", oldSubnetSet.Spec.IPAddressType, "newIPAddressType", subnetSet.Spec.IPAddressType, "username", req.UserInfo.Username)
 			return admission.Denied("Pre-created SubnetSet spec.ipAddressType can only be set by NSX Operator")
 		}
-		deny, err := v.validateSubnets(ctx, subnetSet.Namespace, subnetSet.Spec.SubnetNames, subnetSet.Name)
+		if subnetSet.Spec.SubnetNames == nil {
+			// SubnetSet IPAddressType can be changed from empty to the default value;
+			// or be converted from IPv4/IPv6 to IPv4IPv6.
+			if oldSubnetSet.Spec.IPAddressType != subnetSet.Spec.IPAddressType {
+				ipAddressTypeWiden := subnetSet.Spec.IPAddressType == v1alpha1.IPAddressTypeIPv4IPv6 && (oldSubnetSet.Spec.IPAddressType == v1alpha1.IPAddressTypeIPv4 || oldSubnetSet.Spec.IPAddressType == v1alpha1.IPAddressTypeIPv6)
+				if oldSubnetSet.Spec.IPAddressType != "" && !ipAddressTypeWiden {
+					return admission.Denied(fmt.Sprintf("SubnetSet IPAddressType converting from %s to %s is not supported", oldSubnetSet.Spec.IPAddressType, subnetSet.Spec.IPAddressType))
+				}
+			}
+			if oldSubnetSet.Spec.AccessMode != subnetSet.Spec.AccessMode {
+				// AccessMode can only be changed when IPAddressType is converted from IPv6 to IPv4IPv6;
+				// or set from empty to a default value
+				if oldSubnetSet.Spec.AccessMode != "" && (subnetSet.Spec.IPAddressType != v1alpha1.IPAddressTypeIPv4IPv6 || oldSubnetSet.Spec.IPAddressType != v1alpha1.IPAddressTypeIPv6) {
+					return admission.Denied("SubnetSet accessMode is immutable")
+				}
+			}
+		}
+
+		deny, err := v.validateSubnets(ctx, subnetSet.Namespace, subnetSet.Spec.SubnetNames, subnetSet.Name, subnetSet.Spec.IPAddressType)
 		if err != nil {
 			if deny {
 				return admission.Denied(err.Error())
@@ -191,6 +209,15 @@ func (v *SubnetSetValidator) Handle(ctx context.Context, req admission.Request) 
 			}
 			log.Error(err, "AccessMode not supported", "AccessMode", subnetSet.Spec.AccessMode, "namespace", subnetSet.Namespace)
 			return admission.Denied(err.Error())
+		}
+		if subnetSet.Spec.IPAddressType != "" {
+			if v.nsxClient != nil && v.nsxClient.NsxConfig != nil && v.nsxClient.NsxConfig.K8sConfig != nil {
+				supervisorIPFamily := v.nsxClient.NsxConfig.K8sConfig.GetIPAddressType()
+				_, err := controllercommon.IntersectIPAddressTypes([]v1alpha1.IPAddressType{subnetSet.Spec.IPAddressType, supervisorIPFamily})
+				if err != nil {
+					return admission.Denied(fmt.Sprintf("SubnetSet IPAddressType %s does not intersect with supervisor IP family %s", subnetSet.Spec.IPAddressType, supervisorIPFamily))
+				}
+			}
 		}
 	}
 
@@ -343,7 +370,7 @@ func getEffectiveDHCPv6Mode(subnet *v1alpha1.Subnet) v1alpha1.DHCPv6ConfigMode {
 	return subnet.Spec.SubnetDHCPv6Config.Mode
 }
 
-func (v *SubnetSetValidator) validateSubnets(ctx context.Context, ns string, subnetNames *[]string, subnetSet string) (bool, error) {
+func (v *SubnetSetValidator) validateSubnets(ctx context.Context, ns string, subnetNames *[]string, subnetSet string, subnetSetIPAddressType v1alpha1.IPAddressType) (bool, error) {
 	var namespaceVpc string
 	var existingVPC string
 	firstAccessMode := ""
@@ -367,6 +394,17 @@ func (v *SubnetSetValidator) validateSubnets(ctx context.Context, ns string, sub
 		dhcpv6Mode := getEffectiveDHCPv6Mode(crdSubnet)
 		if dhcpv6Mode == v1alpha1.DHCPv6ConfigModeRelay {
 			return true, fmt.Errorf("DHCPRelay Subnet %s/%s is not supported in SubnetSet", crdSubnet.Namespace, crdSubnet.Name)
+		}
+		if subnetSetIPAddressType != "" {
+			if !controllercommon.IsSupersetIPAddressTypes(crdSubnet.Spec.IPAddressType, subnetSetIPAddressType) {
+				return true, fmt.Errorf("Subnet %s with IPAddressType %s cannot be added to SubnetSet of IPAddressType %s", crdSubnet.Name, crdSubnet.Spec.IPAddressType, subnetSetIPAddressType)
+			}
+		}
+		if crdSubnet.Spec.SubnetDHCPConfig.Mode == v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeRelay) {
+			return true, fmt.Errorf("DHCPRelay Subnet %s/%s is not supported in SubnetSet", crdSubnet.Namespace, crdSubnet.Name)
+		}
+		if crdSubnet.Spec.SubnetDHCPv6Config.Mode == v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeRelay) || crdSubnet.Spec.SubnetDHCPv6Config.Mode == v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeServerStateless) {
+			return true, fmt.Errorf("DHCPRelay or DHCPServerStateless Subnet %s/%s is not supported in SubnetSet", crdSubnet.Namespace, crdSubnet.Name)
 		}
 		if isFirstSubnet {
 			firstAccessMode = string(crdSubnet.Spec.AccessMode)

--- a/pkg/controllers/subnetset/subnetset_webhook_test.go
+++ b/pkg/controllers/subnetset/subnetset_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	controllercommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	pkgmock "github.com/vmware-tanzu/nsx-operator/pkg/mock"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
@@ -271,6 +272,38 @@ func TestSubnetSetValidator(t *testing.T) {
 			},
 		},
 	})
+	fakeClient.Create(context.TODO(), &v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "subnet-dhcpv6-stateless",
+			Namespace:   "ns-dhcp",
+			Annotations: map[string]string{common.AnnotationAssociatedResource: "default:ns-dhcp:subnet-dhcpv6-stateless"},
+		},
+		Spec: v1alpha1.SubnetSpec{
+			SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+				Mode: v1alpha1.DHCPv6ConfigModeServerStateless,
+			},
+		},
+	})
+	fakeClient.Create(context.TODO(), &v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "subnet-ipv4-only",
+			Namespace:   "ns-ipaddress-type",
+			Annotations: map[string]string{common.AnnotationAssociatedResource: "default:ns-ipaddress-type:subnet-ipv4-only"},
+		},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType: v1alpha1.IPAddressTypeIPv4,
+		},
+	})
+	fakeClient.Create(context.TODO(), &v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "subnet-ipv6-only",
+			Namespace:   "ns-ipaddress-type",
+			Annotations: map[string]string{common.AnnotationAssociatedResource: "default:ns-ipaddress-type:subnet-ipv6-only"},
+		},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType: v1alpha1.IPAddressTypeIPv6,
+		},
+	})
 	trueVal := true
 	falseVal := false
 	fakeClient.Create(context.TODO(), &v1alpha1.Subnet{
@@ -489,6 +522,56 @@ func TestSubnetSetValidator(t *testing.T) {
 			},
 			user:      "fake-user",
 			isAllowed: false,
+		},
+		{
+			name: "Create SubnetSet with DHCPServerStateless Subnets",
+			op:   admissionv1.Create,
+			subnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subnetset-1",
+					Namespace: "ns-dhcp",
+				},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames: &[]string{"subnet-dhcpv6-stateless"},
+				},
+			},
+			user:      "fake-user",
+			isAllowed: false,
+			msg:       "DHCPRelay or DHCPServerStateless Subnet ns-dhcp/subnet-dhcpv6-stateless is not supported in SubnetSet",
+		},
+		{
+			name: "Create SubnetSet of IPAddressType IPv4IPv6 with Subnet of IPAddressType IPv4",
+			op:   admissionv1.Create,
+			subnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subnetset-1",
+					Namespace: "ns-ipaddress-type",
+				},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames:   &[]string{"subnet-ipv4-only"},
+					IPAddressType: v1alpha1.IPAddressTypeIPv4IPv6,
+				},
+			},
+			user:      NSXOperatorSA,
+			isAllowed: false,
+			msg:       "Subnet subnet-ipv4-only with IPAddressType IPv4 cannot be added to SubnetSet of IPAddressType IPv4IPv6",
+		},
+		{
+			name: "Create SubnetSet of IPAddressType IPv4 with Subnet of IPAddressType IPv4",
+			op:   admissionv1.Create,
+			subnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subnetset-1",
+					Namespace: "ns-ipaddress-type",
+				},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames:   &[]string{"subnet-ipv4-only"},
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
+				},
+			},
+			user:            NSXOperatorSA,
+			isAllowed:       true,
+			accessModeCheck: true,
 		},
 		{
 			name: "Create SubnetSet with different AccessModes",
@@ -1446,10 +1529,109 @@ func TestSubnetSetValidator_IPAddressTypeValidation(t *testing.T) {
 			},
 			isAllowed: true,
 		},
+		{
+			name:      "Update - IPAddressType conversion from IPv4 to IPv6 is not supported",
+			username:  "user-1",
+			operation: admissionv1.Update,
+			oldSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
+				},
+			},
+			newSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					IPAddressType: v1alpha1.IPAddressTypeIPv6,
+				},
+			},
+			isAllowed: false,
+			msg:       "SubnetSet IPAddressType converting from IPv4 to IPv6 is not supported",
+		},
+		{
+			name:      "Update - IPAddressType conversion from IPv4 to IPv4IPv6 is supported",
+			username:  "user-1",
+			operation: admissionv1.Update,
+			oldSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
+				},
+			},
+			newSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					IPAddressType: v1alpha1.IPAddressTypeIPv4IPv6,
+				},
+			},
+			isAllowed: true,
+		},
+		{
+			name:      "Update - AccessMode change on IPv4 SubnetSet is not supported",
+			username:  "user-1",
+			operation: admissionv1.Update,
+			oldSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
+					AccessMode:    v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+				},
+			},
+			newSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					IPAddressType: v1alpha1.IPAddressTypeIPv4,
+					AccessMode:    v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
+				},
+			},
+			isAllowed: false,
+			msg:       "SubnetSet accessMode is immutable",
+		},
+		{
+			name:      "Update - AccessMode change when converting from IPv6 to IPv4IPv6 is supported",
+			username:  "user-1",
+			operation: admissionv1.Update,
+			oldSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					IPAddressType: v1alpha1.IPAddressTypeIPv6,
+					AccessMode:    v1alpha1.AccessMode(v1alpha1.AccessModePublic),
+				},
+			},
+			newSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					IPAddressType: v1alpha1.IPAddressTypeIPv4IPv6,
+					AccessMode:    v1alpha1.AccessMode(v1alpha1.AccessModePrivate),
+				},
+			},
+			isAllowed: true,
+		},
+		{
+			name:      "Create - IPAddressType non-intersecting with supervisor IP family (IPv6 subnetset on IPv4 supervisor)",
+			username:  "user-1",
+			operation: admissionv1.Create,
+			newSubnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-set", Namespace: "ns-1"},
+				Spec: v1alpha1.SubnetSetSpec{
+					IPAddressType: v1alpha1.IPAddressTypeIPv6,
+				},
+			},
+			isAllowed: false,
+			msg:       "SubnetSet IPAddressType IPv6 does not intersect with supervisor IP family IPv4",
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			validator.nsxClient.NsxConfig = nil
+			if testCase.name == "Create - IPAddressType non-intersecting with supervisor IP family (IPv6 subnetset on IPv4 supervisor)" {
+				validator.nsxClient.NsxConfig = &config.NSXOperatorConfig{
+					K8sConfig: &config.K8sConfig{
+						IPFamily: "IPv4",
+					},
+				}
+			}
 			req := admission.Request{}
 			jsonData, err := json.Marshal(testCase.newSubnetSet)
 			assert.NoError(t, err)

--- a/pkg/nsx/services/subnet/builder.go
+++ b/pkg/nsx/services/subnet/builder.go
@@ -189,7 +189,7 @@ func (service *SubnetService) buildSubnet(obj client.Object, tags []model.Tag, i
 		// Support custom DHCP server addresses whenever DHCP mode is DHCPServer,
 		// regardless of staticIPAllocation. In mixed mode (Static + DHCPServer),
 		// the operator still needs to forward user-provided DHCP server IPs.
-		if string(o.Spec.SubnetDHCPConfig.Mode) == v1alpha1.DHCPConfigModeServer && len(o.Spec.AdvancedConfig.DHCPServerAddresses) > 0 {
+		if (string(o.Spec.SubnetDHCPConfig.Mode) == v1alpha1.DHCPConfigModeServer || string(o.Spec.SubnetDHCPv6Config.Mode) == string(v1alpha1.DHCPv6ConfigModeServer)) && len(o.Spec.AdvancedConfig.DHCPServerAddresses) > 0 {
 			nsxSubnet.AdvancedConfig.DhcpServerAddresses = o.Spec.AdvancedConfig.DHCPServerAddresses
 		}
 	case *v1alpha1.SubnetSet:

--- a/pkg/nsx/services/subnet/builder_test.go
+++ b/pkg/nsx/services/subnet/builder_test.go
@@ -703,6 +703,31 @@ func TestBuildSubnetWithCustomDHCPServerAddresses(t *testing.T) {
 		},
 	}
 
+	// Test case 1: DHCPv6 Server active + custom DHCP server addresses (should be set)
+	subnet1 := &v1alpha1.Subnet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "subnet-dhcpv6-custom",
+			Namespace: "ns-1",
+		},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddresses: []string{"fd00:1234:5678:9abc::/64"},
+			SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
+				Mode: v1alpha1.DHCPv6ConfigModeServer,
+			},
+			AdvancedConfig: v1alpha1.SubnetAdvancedConfig{
+				DHCPServerAddresses: []string{"fd00:1234:5678:9abc::3"},
+				StaticIPAllocation: v1alpha1.StaticIPAllocation{
+					Enabled: common.Bool(false),
+				},
+			},
+		},
+	}
+
+	nsxSubnet1, err := service.buildSubnet(subnet1, tags, []string{})
+	assert.Nil(t, err)
+	assert.NotNil(t, nsxSubnet1.AdvancedConfig)
+	assert.Equal(t, []string{"fd00:1234:5678:9abc::3"}, nsxSubnet1.AdvancedConfig.DhcpServerAddresses)
+
 	// Test case 2: Static IP allocation enabled + custom DHCP server addresses (should NOT be set) - this should work without nil pointer issues
 	subnet2 := &v1alpha1.Subnet{
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -190,6 +190,8 @@ func (service *SubnetService) CreateOrUpdateSubnet(obj client.Object, vpcInfo co
 				updatedSubnet.SubnetDhcpConfig = nsxSubnet.SubnetDhcpConfig
 				updatedSubnet.SubnetDhcpv6Config = nsxSubnet.SubnetDhcpv6Config
 				updatedSubnet.IpAddressType = nsxSubnet.IpAddressType
+				// AccessMode can be updated when IPAddressType is updated from IPv6 to IPv4IPv6
+				updatedSubnet.AccessMode = nsxSubnet.AccessMode
 				// Only update gateway_addresses, dhcp_server_address, connectivity_state
 				// and static_ip_allocation (enabled + pool_ranges) from AdvancedConfig.
 				if nsxSubnet.AdvancedConfig != nil {
@@ -561,6 +563,8 @@ func (service *SubnetService) UpdateSubnetSet(ns string, vpcSubnets []*model.Vpc
 		// is only updated after the updating succeeds.
 		updatedSubnet := *vpcSubnets[i] // #nosec G602
 		updatedSubnet.Tags = newTags
+		// AccessMode can be updated when IPAddressType is updated from IPv6 to IPv4IPv6
+		updatedSubnet.AccessMode = String(convertAccessMode(string(subnetsetCR.Spec.AccessMode)))
 		if service.Service.NSXClient.NSXCheckVersion(nsx.IPv6) {
 			updatedSubnet.IpAddressType = String(controllercommon.ConvertCRIPAddressTypeToNSX(subnetsetCR.Spec.IPAddressType))
 		}

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -149,7 +149,11 @@ func (s *VPCService) ValidateNetworkConfig(nc *v1alpha1.VPCNetworkConfiguration)
 	if networkStack == v1alpha1.VLANBackedVPC {
 		return nil
 	}
-
+	// skip the check on PrivateIPs if ipFamily is IPv6
+	ipFamily := s.NSXConfig.K8sConfig.GetIPAddressType()
+	if ipFamily == v1alpha1.IPAddressTypeIPv6 {
+		return nil
+	}
 	if len(nc.Spec.PrivateIPs) != 0 {
 		return nil
 	}

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -150,8 +150,7 @@ func (s *VPCService) ValidateNetworkConfig(nc *v1alpha1.VPCNetworkConfiguration)
 		return nil
 	}
 	// skip the check on PrivateIPs if ipFamily is IPv6
-	ipFamily := s.NSXConfig.K8sConfig.GetIPAddressType()
-	if ipFamily == v1alpha1.IPAddressTypeIPv6 {
+	if s.NSXConfig != nil && s.NSXConfig.K8sConfig != nil && s.NSXConfig.K8sConfig.GetIPAddressType() == v1alpha1.IPAddressTypeIPv6 {
 		return nil
 	}
 	if len(nc.Spec.PrivateIPs) != 0 {

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -1419,11 +1419,13 @@ func TestGetLBSsFromNSXByVPC(t *testing.T) {
 
 func TestVPCService_ValidateNetworkConfig(t *testing.T) {
 	service, _, _, _, _ := createService(t)
+	service.NSXConfig.K8sConfig = &config.K8sConfig{}
 	tests := []struct {
 		name          string
 		nc            v1alpha1.VPCNetworkConfiguration
 		expectedError string
 		networkStack  v1alpha1.NetworkStackType
+		ipFamily      string
 	}{
 		{
 			name:          "is pre-created vpc",
@@ -1467,9 +1469,19 @@ func TestVPCService_ValidateNetworkConfig(t *testing.T) {
 			expectedError: "",
 			networkStack:  v1alpha1.FullStackVPC,
 		},
+		{
+			name:          "auto-created vpc with empty private ips and ipv6",
+			nc:            v1alpha1.VPCNetworkConfiguration{Spec: v1alpha1.VPCNetworkConfigurationSpec{NSXProject: "/orgs/org/projects/project", VPC: "", PrivateIPs: []string{}}},
+			expectedError: "",
+			networkStack:  v1alpha1.FullStackVPC,
+			ipFamily:      "IPv6",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.ipFamily != "" {
+				service.NSXConfig.K8sConfig.IPFamily = tt.ipFamily
+			}
 			patches := gomonkey.ApplyFunc((*VPCService).GetNetworkStackFromNC, func(s *VPCService, nc *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error) {
 				return tt.networkStack, nil
 			})


### PR DESCRIPTION
This PR includes some IPv6 validations and enhancement
Validations
- Subnet/SubnetSet IPAddressType should have intersection with supervisor ipFamily
- Only Subnet with ipAddressType as superset of the SubnetSet ipAddressType can be added into this SubnetSet
- DHCPServerStateless is not supported in SubnetSet
- Not check vpc private cidr for IPv6 single stack
- Allow dhcpserveraddress to be set for dhcpv6

Enhancements:
- Support to upgrade Subnet/SubnetSet from IPv4/IPv6 to IPv4IPv6
- For pre-created VPC, the default SubnetSet will be deleted if the IPBlock needed by the SubnetSet is removed from the VPC

Testing done:

Create ipv6 subnet/subnetset on ipv4 supervisor should be blocked
```shell
    kubectl apply -f subnet.yaml -n ns-1   
    Error from server (Forbidden): error when creating "subnet.yaml": admission webhook "subnet.validating.crd.nsx.vmware.com" denied the request: Subnet IPAddressType IPv6 does not intersect with supervisor IP family IPv4

    kubectl apply -f subnetset.yaml -n ns-1
    Error from server (Forbidden): error when creating "subnetset.yaml": admission webhook "subnetset.validating.crd.nsx.vmware.com" denied the request: SubnetSet IPAddressType IPv6 does not intersect with supervisor IP family IPv4
```

Add ipv6 subnet to ipv4 pre-created subnetset should be blocked

```shell
    Error from server (Forbidden): error when applying patch:
    {"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"crd.nsx.vmware.com/v1alpha1\",\"kind\":\"SubnetSet\",\"metadata\":{\"annotations\":{},\"name\":\"subnetset-1\",\"namespace\":\"ns-1\"},\"spec\":{\"subnetNames\":[\"subnet-1\",\"subnet-2\",\"subnet-3\"]}}\n"}},"spec":{"subnetNames":["subnet-1","subnet-2","subnet-3"]}}
    to:
    Resource: "crd.nsx.vmware.com/v1alpha1, Resource=subnetsets", GroupVersionKind: "crd.nsx.vmware.com/v1alpha1, Kind=SubnetSet"
    Name: "subnetset-1", Namespace: "ns-1"
    for: "subnet.yaml": admission webhook "subnetset.validating.crd.nsx.vmware.com" denied the request: Subnet subnet-3 with IPAddressType IPv6 cannot be added to SubnetSet of IPAddressType IPv4
```

Update subnet/subnetset ipfamily from ipv4 to ipv6 is not supported

```
    Error from server (Forbidden): error when applying patch:
    {"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"crd.nsx.vmware.com/v1alpha1\",\"kind\":\"Subnet\",\"metadata\":{\"annotations\":{},\"name\":\"subnet-1\",\"namespace\":\"ns-1\"},\"spec\":{\"accessMode\":\"Public\",\"ipAddressType\":\"IPv6\"}}\n"}},"spec":{"ipAddressType":"IPv6"}}
    to:
    Resource: "crd.nsx.vmware.com/v1alpha1, Resource=subnets", GroupVersionKind: "crd.nsx.vmware.com/v1alpha1, Kind=Subnet"
    Name: "subnet-1", Namespace: "ns-1"
    for: "subnet.yaml": admission webhook "subnet.validating.crd.nsx.vmware.com" denied the request: Subnet IPAddressType converting from IPv4 to IPv6 is not supported

    Error from server (Forbidden): error when applying patch:
    {"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"crd.nsx.vmware.com/v1alpha1\",\"kind\":\"SubnetSet\",\"metadata\":{\"annotations\":{},\"name\":\"subnetset-2\",\"namespace\":\"ns-1\"},\"spec\":{\"accessMode\":\"Public\",\"ipAddressType\":\"IPv6\"}}\n"}},"spec":{"ipAddressType":"IPv6"}}
    to:
    Resource: "crd.nsx.vmware.com/v1alpha1, Resource=subnetsets", GroupVersionKind: "crd.nsx.vmware.com/v1alpha1, Kind=SubnetSet"
    Name: "subnetset-2", Namespace: "ns-1"
    for: "subnet.yaml": admission webhook "subnetset.validating.crd.nsx.vmware.com" denied the request: SubnetSet IPAddressType converting from IPv4 to IPv6 is not supported
```

Update subnet subnet-3 from IPv6 to IPv4IPv6 and access mode from Public to Private. It succeeds.

 ```yaml
  kubectl get subnet -n ns-1 -o yaml subnet-3
  apiVersion: crd.nsx.vmware.com/v1alpha1
  kind: Subnet
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"Subnet","metadata":{"annotations":{},"name":"subnet-3","namespace":"ns-1"},"spec":{"accessMode":"Private","ipAddressType":"IPv4IPv6"}}
    creationTimestamp: "2026-07-02T08:12:17Z"
    generation: 4
    name: subnet-3
    namespace: ns-1
    resourceVersion: "47030"
    uid: df913211-9835-4033-a87f-fcd0fb240c75
  spec:
    accessMode: Private
    advancedConfig:
      connectivityState: Connected
      staticIPAllocation:
        enabled: true
    ipAddressType: IPv4IPv6
    ipv4SubnetSize: 32
    ipv6PrefixLength: 64
    subnetDHCPConfig:
      dhcpServerAdditionalConfig: {}
    subnetDHCPv6Config:
      dhcpv6ServerAdditionalConfig: {}
    vpcName: project-quality:ns-1_8mbmo
  status:
    conditions:
    - lastTransitionTime: "2026-07-02T08:14:15Z"
      message: 'NSX Subnet with DHCPv4: DHCPDeactivated, DHCPv6: DHCPDeactivated has
        been successfully created/updated'
      reason: SubnetReady
      status: "True"
      type: Ready
    gatewayAddresses:
    - 172.26.0.65/26
    - 2001:db8:0:6::1/64
    networkAddresses:
    - 172.26.0.64/26
    - 2001:db8:0:6::/64
    shared: false
    vlanExtension: {}
  ```

Create a subnetport on subnetset-3 and update subnetset subnetset-3 from IPv6 to IPv4IPv6 and access mode from Public to Private. It succeeds.

  ```yaml
  kubectl get subnetset -n ns-1 -o yaml subnetset-3
  apiVersion: crd.nsx.vmware.com/v1alpha1
  kind: SubnetSet
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetSet","metadata":{"annotations":{},"name":"subnetset-3","namespace":"ns-1"},"spec":{"accessMode":"Private","ipAddressType":"IPv4IPv6"}}
    creationTimestamp: "2026-07-02T08:12:17Z"
    generation: 4
    name: subnetset-3
    namespace: ns-1
    resourceVersion: "47020"
    uid: 73695db8-3961-4c60-b7d9-351331ffc1d5
  spec:
    accessMode: Private
    ipAddressType: IPv4IPv6
    ipv4SubnetSize: 32
    ipv6PrefixLength: 64
    subnetDHCPConfig:
      dhcpServerAdditionalConfig: {}
    subnetDHCPv6Config:
      dhcpv6ServerAdditionalConfig: {}
  status:
    conditions:
    - lastTransitionTime: "2026-07-02T08:12:17Z"
      message: SubnetSet CR has been successfully created/updated
      reason: SubnetSetReady
      status: "True"
      type: Ready
    subnets:
    - gatewayAddresses:
      - 172.26.0.1/26
      - 2001:db8:0:9::1/64
      networkAddresses:
      - 172.26.0.0/26
      - 2001:db8:0:9::/64
  ```

Auto created subnetset of DHCPv6ConfigModeServerStateless is not supported
```shell
Error from server (Invalid): error when creating "subnet.yaml": SubnetSet.crd.nsx.vmware.com "subnetset-4" is invalid: spec: Invalid value: "object": DHCPRelay or DHCPServerStateless is not supported in SubnetSet
```

Create subnet with dhcpv6 and dhcpserveraddress is allowed
```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: Subnet
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"Subnet","metadata":{"annotations":{},"name":"subnet-4","namespace":"ns-1"},"spec":{"accessMode":"Private","advancedConfig":{"dhcpServerAddresses":["2001:db8:0:a::10/64"]},"ipAddressType":"IPv6","ipAddresses":["2001:db8:0:a::/64"],"subnetDHCPv6Config":{"dhcpv6ServerAdditionalConfig":{"reservedIPRanges":["2001:db8:0:a::ff"]},"mode":"DHCPServer"}}}
  creationTimestamp: "2026-07-03T08:40:31Z"
  generation: 2
  name: subnet-4
  namespace: ns-1
  resourceVersion: "895966"
  uid: 53e02bfe-b268-470b-90f0-c31a817e412f
spec:
  accessMode: Private
  advancedConfig:
    connectivityState: Connected
    dhcpServerAddresses:
    - 2001:db8:0:a::10/64
    staticIPAllocation:
      enabled: false
  ipAddressType: IPv6
  ipAddresses:
  - 2001:db8:0:a::/64
  subnetDHCPConfig:
    dhcpServerAdditionalConfig: {}
  subnetDHCPv6Config:
    dhcpv6ServerAdditionalConfig:
      reservedIPRanges:
      - 2001:db8:0:a::ff
    mode: DHCPServer
  vpcName: project-quality:ns-1_8mbmo
status:
  DHCPServerAddresses:
  - 2001:db8:0:a::10/64
  conditions:
  - lastTransitionTime: "2026-07-03T08:40:33Z"
    message: 'NSX Subnet with DHCPv6: DHCPServer has been successfully created/updated'
    reason: SubnetReady
    status: "True"
    type: Ready
  gatewayAddresses:
  - 2001:db8:0:a::1/64
  networkAddresses:
  - 2001:db8:0:a::/64
  shared: false
  vlanExtension: {}
```

Create a pre-create vpc with v4+v6 blocks, observed dual stack default subnetset is created
```          
NAME          ACCESSMODE   IPADDRESSTYPE   IPV4SUBNETSIZE   IPV6PREFIXLENGTH   NETWORKADDRESSES
pod-default   PrivateTGW   IPv4IPv6        32               64                 
vm-default    Private      IPv4IPv6        32               64      
```

Remove the IPv6 block from the profile, observed the subnetset becomes ipv4
```
NAME          ACCESSMODE   IPADDRESSTYPE   IPV4SUBNETSIZE   IPV6PREFIXLENGTH   NETWORKADDRESSES
pod-default   PrivateTGW   IPv4            32                                  
vm-default    Private      IPv4            32       
```

Add back the IPv6 block and remove the privatetgw ipv4 block, observed the pod-default SubnetSet is updated
```
NAME          ACCESSMODE   IPADDRESSTYPE   IPV4SUBNETSIZE   IPV6PREFIXLENGTH   NETWORKADDRESSES
pod-default   PrivateTGW   IPv6                             64                 
vm-default    Private      IPv4            32     
```

Remove private ipv4 cidr, observed the pod-default SubnetSet is updated
```yaml
kubectl get subnetset -n test
NAME          ACCESSMODE   IPADDRESSTYPE   IPV4SUBNETSIZE   IPV6PREFIXLENGTH   NETWORKADDRESSES
pod-default   PrivateTGW   IPv6                             64                 
vm-default    Private      IPv6                             64      
```
