### PR TITLE
Support RA mode status on SubnetPort.

### DIFF
--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -207,6 +207,11 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				DHCPDeactivatedOnSubnet:   !util.NSXSubnetDHCPEnabled(nsxSubnet),
 				DHCPv6DeactivatedOnSubnet: !util.NSXSubnetDHCPv6Enabled(nsxSubnet),
 			}
+			if raDeactivated, err := r.VPCService.IsRADeactivatedByVPCPath(nsxSubnetPath); err != nil {
+				log.Error(err, "Failed to determine RA mode for SubnetPort's VPC", "SubnetPort", subnetPort, "nsxSubnetPath", nsxSubnetPath)
+			} else {
+				subnetPort.Status.NetworkInterfaceConfig.RADeactivated = raDeactivated
+			}
 			// Append one more ipaddress for dual stack SubnetPort
 			if subnetPort.Spec.InterfaceIPType == v1alpha1.IPAddressTypeIPv4IPv6 {
 				subnetPort.Status.NetworkInterfaceConfig.IPAddresses = append(

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -160,7 +160,7 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err != nil {
 			log.Error(err, "Failed to determine RA mode for SubnetPort's VPC", "SubnetPort", subnetPort, "nsxSubnetPath", nsxSubnetPath)
 			r.StatusUpdater.UpdateFail(ctx, subnetPort, err, "Failed to determine RA mode for SubnetPort's VPC", setSubnetPortReadyStatusFalse, r.SubnetPortService, r.restoreMode)
-			return common.ResultRequeue, err
+			return common.ResultNormal, err
 		}
 
 		isVmSubnetPort := true

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -156,6 +156,12 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err != nil {
 			return common.ResultNormal, err
 		}
+		raDeactivated, err := r.VPCService.IsRADeactivatedByVPCPath(nsxSubnetPath)
+		if err != nil {
+			log.Error(err, "Failed to determine RA mode for SubnetPort's VPC", "SubnetPort", subnetPort, "nsxSubnetPath", nsxSubnetPath)
+			r.StatusUpdater.UpdateFail(ctx, subnetPort, err, "Failed to determine RA mode for SubnetPort's VPC", setSubnetPortReadyStatusFalse, r.SubnetPortService, r.restoreMode)
+			return common.ResultRequeue, err
+		}
 
 		isVmSubnetPort := true
 		if value, exists := subnetPort.Labels[servicecommon.LabelImageFetcher]; exists && value == "true" {
@@ -206,11 +212,7 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				},
 				DHCPDeactivatedOnSubnet:   !util.NSXSubnetDHCPEnabled(nsxSubnet),
 				DHCPv6DeactivatedOnSubnet: !util.NSXSubnetDHCPv6Enabled(nsxSubnet),
-			}
-			if raDeactivated, err := r.VPCService.IsRADeactivatedByVPCPath(nsxSubnetPath); err != nil {
-				log.Error(err, "Failed to determine RA mode for SubnetPort's VPC", "SubnetPort", subnetPort, "nsxSubnetPath", nsxSubnetPath)
-			} else {
-				subnetPort.Status.NetworkInterfaceConfig.RADeactivated = raDeactivated
+				RADeactivated:             raDeactivated,
 			}
 			// Append one more ipaddress for dual stack SubnetPort
 			if subnetPort.Spec.InterfaceIPType == v1alpha1.IPAddressTypeIPv4IPv6 {

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
+	testifymock "github.com/stretchr/testify/mock"
 	vmv1alpha1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
@@ -93,6 +94,8 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 	}
 	subnetService := &mock.MockSubnetServiceProvider{}
 	ipAllocationService := &mock.MockIPAddressAllocationProvider{}
+	vpcService := &mock.MockVPCServiceProvider{}
+	vpcService.On("IsRADeactivatedByVPCPath", testifymock.Anything).Return(false, nil)
 
 	r := &SubnetPortReconciler{
 		Client:                     k8sClient,
@@ -100,6 +103,7 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		Scheme:                     nil,
 		SubnetPortService:          service,
 		SubnetService:              subnetService,
+		VPCService:                 vpcService,
 		Recorder:                   fakeRecorder{},
 		IpAddressAllocationService: ipAllocationService,
 		restoreMode:                false,
@@ -971,6 +975,159 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Equal(t, "IP and MAC are missing for SubnetPort", err.Error())
 	})
+}
+
+type raCapturingStatusWriter struct {
+	captured *v1alpha1.SubnetPort
+}
+
+func (w *raCapturingStatusWriter) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	return nil
+}
+
+func (w *raCapturingStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	w.captured = obj.(*v1alpha1.SubnetPort).DeepCopy()
+	return nil
+}
+
+func (w *raCapturingStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	return nil
+}
+
+func (w *raCapturingStatusWriter) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	return nil
+}
+
+func TestSubnetPortReconciler_Reconcile_RADeactivated(t *testing.T) {
+	for _, tt := range []struct {
+		name                string
+		raDeactivated       bool
+		raErr               error
+		expectRADeactivated bool
+	}{
+		{name: "RA deactivated", raDeactivated: true, expectRADeactivated: true},
+		{name: "RA not deactivated", raDeactivated: false, expectRADeactivated: false},
+		{name: "RA lookup error does not fail reconcile", raErr: errors.New("lookup failed"), expectRADeactivated: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtl := gomock.NewController(t)
+			k8sClient := mock_client.NewMockClient(mockCtl)
+			defer mockCtl.Finish()
+
+			service := &subnetport.SubnetPortService{
+				Service: servicecommon.Service{
+					NSXClient: &nsx.Client{},
+					NSXConfig: &config.NSXOperatorConfig{
+						NsxConfig: &config.NsxConfig{
+							EnforcementPoint: "vmc-enforcementpoint",
+						},
+					},
+				},
+				SubnetPortStore: &subnetport.SubnetPortStore{},
+			}
+			subnetService := &mock.MockSubnetServiceProvider{}
+			ipAllocationService := &mock.MockIPAddressAllocationProvider{}
+			vpcService := &mock.MockVPCServiceProvider{}
+			vpcService.On("IsRADeactivatedByVPCPath", testifymock.Anything).Return(tt.raDeactivated, tt.raErr)
+
+			r := &SubnetPortReconciler{
+				Client:                     k8sClient,
+				APIReader:                  k8sClient,
+				SubnetPortService:          service,
+				SubnetService:              subnetService,
+				VPCService:                 vpcService,
+				Recorder:                   fakeRecorder{},
+				IpAddressAllocationService: ipAllocationService,
+			}
+			r.StatusUpdater = common.NewStatusUpdater(k8sClient, service.NSXConfig, r.Recorder, MetricResTypeSubnetPort, "SubnetPort", "SubnetPort")
+
+			ctx := context.Background()
+			req := controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "dummy", Name: "dummy"}}
+
+			// 1st Get: Reconciler fetching the CR. 2nd Get: updateSubnetPortStatusConditions
+			// re-fetching the latest CR before persisting the merged status.
+			k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
+				func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+					v1sp := obj.(*v1alpha1.SubnetPort)
+					v1sp.Spec.Subnet = "subnet1"
+					return nil
+				}).Times(2)
+
+			patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
+				func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+					return true, false, "/orgs/default/projects/default/vpcs/vpc1/subnets/subnet-1", nil, nil, v1alpha1.IPAddressTypeIPv4, nil
+				})
+			defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
+
+			patchesGetSubnetByPath := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetByPath",
+				func(s *mock.MockSubnetServiceProvider, nsxSubnetPath string, sharedSubnet bool) (*model.VpcSubnet, error) {
+					return &model.VpcSubnet{
+						Id:            ptr.To("subnet-1"),
+						RealizationId: ptr.To("realization-1"),
+					}, nil
+				})
+			defer patchesGetSubnetByPath.Reset()
+
+			patchesIsSharedSubnetPath := gomonkey.ApplyFunc(common.IsSharedSubnetPath, func(ctx context.Context, client client.Client, path string, ns string) (bool, error) {
+				return false, nil
+			})
+			defer patchesIsSharedSubnetPath.Reset()
+
+			patchesUpdateSubnetPortIPType := gomonkey.ApplyFunc((*SubnetPortReconciler).updateSubnetPortIPType,
+				func(_ *SubnetPortReconciler, _ context.Context, _ *v1alpha1.SubnetPort, _ v1alpha1.IPAddressType, _ *model.VpcSubnet) error {
+					return nil
+				})
+			defer patchesUpdateSubnetPortIPType.Reset()
+
+			patchesGetAddressBinding := gomonkey.ApplyMethod(reflect.TypeOf(&subnetport.SubnetPortService{}), "GetAddressBindingBySubnetPort", func(_ *subnetport.SubnetPortService, _ *v1alpha1.SubnetPort) *v1alpha1.AddressBinding {
+				return nil
+			})
+			defer patchesGetAddressBinding.Reset()
+
+			patchesIPAllocCreate := gomonkey.ApplyMethod(reflect.TypeOf(r.IpAddressAllocationService), "CreateIPAddressAllocationForAddressBinding", func(_ *mock.MockIPAddressAllocationProvider, _ *v1alpha1.AddressBinding, _ *v1alpha1.SubnetPort, _ bool) error {
+				return nil
+			})
+			defer patchesIPAllocCreate.Reset()
+
+			patchesIPAllocDelete := gomonkey.ApplyMethod(reflect.TypeOf(r.IpAddressAllocationService), "DeleteIPAddressAllocationForAddressBinding", func(_ *mock.MockIPAddressAllocationProvider, _ metav1.Object) error {
+				return nil
+			})
+			defer patchesIPAllocDelete.Reset()
+
+			attachmentID := "attachment-id"
+			portState := &model.SegmentPortState{
+				RealizedBindings: []model.AddressBindingEntry{},
+				Attachment: &model.SegmentPortAttachmentState{
+					Id: &attachmentID,
+				},
+			}
+			patchesCreateOrUpdateSubnetPort := gomonkey.ApplyMethod(reflect.TypeOf(&subnetport.SubnetPortService{}), "CreateOrUpdateSubnetPort",
+				func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+					return portState, nil
+				})
+			defer patchesCreateOrUpdateSubnetPort.Reset()
+
+			patchesUpdateSubnetStatusOnSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).updateSubnetStatusOnSubnetPort,
+				func(r *SubnetPortReconciler, subnetPort *v1alpha1.SubnetPort, nsxSubnet *model.VpcSubnet) error {
+					return nil
+				})
+			defer patchesUpdateSubnetStatusOnSubnetPort.Reset()
+
+			patchesSetAddressBindingStatus := gomonkey.ApplyFunc(setAddressBindingStatusBySubnetPort,
+				func(client client.Client, ctx context.Context, subnetPort *v1alpha1.SubnetPort, subnetPortService *subnetport.SubnetPortService, transitionTime metav1.Time, e error) {
+				})
+			defer patchesSetAddressBindingStatus.Reset()
+
+			statusWriter := &raCapturingStatusWriter{}
+			k8sClient.EXPECT().Status().Return(statusWriter).AnyTimes()
+
+			_, err := r.Reconcile(ctx, req)
+			assert.NoError(t, err)
+			if assert.NotNil(t, statusWriter.captured) {
+				assert.Equal(t, tt.expectRADeactivated, statusWriter.captured.Status.NetworkInterfaceConfig.RADeactivated)
+			}
+		})
+	}
 }
 
 func TestSubnetPortReconciler_GarbageCollector(t *testing.T) {

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -1004,10 +1004,11 @@ func TestSubnetPortReconciler_Reconcile_RADeactivated(t *testing.T) {
 		raDeactivated       bool
 		raErr               error
 		expectRADeactivated bool
+		expectReconcileErr  bool
 	}{
 		{name: "RA deactivated", raDeactivated: true, expectRADeactivated: true},
 		{name: "RA not deactivated", raDeactivated: false, expectRADeactivated: false},
-		{name: "RA lookup error does not fail reconcile", raErr: errors.New("lookup failed"), expectRADeactivated: false},
+		{name: "RA lookup error fails reconcile", raErr: errors.New("lookup failed"), expectReconcileErr: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			mockCtl := gomock.NewController(t)
@@ -1122,6 +1123,10 @@ func TestSubnetPortReconciler_Reconcile_RADeactivated(t *testing.T) {
 			k8sClient.EXPECT().Status().Return(statusWriter).AnyTimes()
 
 			_, err := r.Reconcile(ctx, req)
+			if tt.expectReconcileErr {
+				assert.Error(t, err)
+				return
+			}
 			assert.NoError(t, err)
 			if assert.NotNil(t, statusWriter.captured) {
 				assert.Equal(t, tt.expectRADeactivated, statusWriter.captured.Status.NetworkInterfaceConfig.RADeactivated)

--- a/pkg/mock/services_mock.go
+++ b/pkg/mock/services_mock.go
@@ -70,6 +70,11 @@ func (m *MockVPCServiceProvider) GetNetworkStackFromNC(nc *v1alpha1.VPCNetworkCo
 	return args.Get(0).(v1alpha1.NetworkStackType), args.Error(1)
 }
 
+func (m *MockVPCServiceProvider) IsRADeactivatedByVPCPath(vpcPath string) (bool, error) {
+	args := m.Called(vpcPath)
+	return args.Bool(0), args.Error(1)
+}
+
 type MockSubnetServiceProvider struct {
 	mock.Mock
 }

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -98,6 +98,8 @@ type Client struct {
 	VPCClient                         projects.VpcsClient
 	VPCStateClient                    vpcs.StateClient
 	VPCConnectivityProfilesClient     projects.VpcConnectivityProfilesClient
+	VpcServiceProfileClient           projects.VpcServiceProfilesClient
+	Ipv6NdraProfileClient             infra.Ipv6NdraProfilesClient
 	IPBlockClient                     project_infra.IpBlocksClient
 	StaticRouteClient                 vpcs.StaticRoutesClient
 	NATRuleClient                     nat.NatRulesClient
@@ -220,6 +222,8 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 	vpcClient := projects.NewVpcsClient(connector)
 	vpcStateClient := vpcs.NewStateClient(connector)
 	vpcConnectivityProfilesClient := projects.NewVpcConnectivityProfilesClient(connector)
+	vpcServiceProfileClient := projects.NewVpcServiceProfilesClient(connector)
+	ipv6NdraProfileClient := infra.NewIpv6NdraProfilesClient(connector)
 	ipBlockClient := project_infra.NewIpBlocksClient(connector)
 	staticRouteClient := vpcs.NewStaticRoutesClient(connector)
 	natRulesClient := nat.NewNatRulesClient(connector)
@@ -291,6 +295,8 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 		VPCClient:                         vpcClient,
 		VPCStateClient:                    vpcStateClient,
 		VPCConnectivityProfilesClient:     vpcConnectivityProfilesClient,
+		VpcServiceProfileClient:           vpcServiceProfileClient,
+		Ipv6NdraProfileClient:             ipv6NdraProfileClient,
 		IPBlockClient:                     ipBlockClient,
 		StaticRouteClient:                 staticRouteClient,
 		NATRuleClient:                     natRulesClient,

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -100,6 +100,7 @@ type Client struct {
 	VPCConnectivityProfilesClient     projects.VpcConnectivityProfilesClient
 	VpcServiceProfileClient           projects.VpcServiceProfilesClient
 	Ipv6NdraProfileClient             infra.Ipv6NdraProfilesClient
+	ProjectIpv6NdraProfileClient      project_infra.Ipv6NdraProfilesClient
 	IPBlockClient                     project_infra.IpBlocksClient
 	StaticRouteClient                 vpcs.StaticRoutesClient
 	NATRuleClient                     nat.NatRulesClient
@@ -224,6 +225,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 	vpcConnectivityProfilesClient := projects.NewVpcConnectivityProfilesClient(connector)
 	vpcServiceProfileClient := projects.NewVpcServiceProfilesClient(connector)
 	ipv6NdraProfileClient := infra.NewIpv6NdraProfilesClient(connector)
+	projectIpv6NdraProfileClient := project_infra.NewIpv6NdraProfilesClient(connector)
 	ipBlockClient := project_infra.NewIpBlocksClient(connector)
 	staticRouteClient := vpcs.NewStaticRoutesClient(connector)
 	natRulesClient := nat.NewNatRulesClient(connector)
@@ -297,6 +299,7 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 		VPCConnectivityProfilesClient:     vpcConnectivityProfilesClient,
 		VpcServiceProfileClient:           vpcServiceProfileClient,
 		Ipv6NdraProfileClient:             ipv6NdraProfileClient,
+		ProjectIpv6NdraProfileClient:      projectIpv6NdraProfileClient,
 		IPBlockClient:                     ipBlockClient,
 		StaticRouteClient:                 staticRouteClient,
 		NATRuleClient:                     natRulesClient,

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -24,6 +24,7 @@ type VPCServiceProvider interface {
 	GetNetworkconfigNameFromNS(ctx context.Context, ns string) (string, error)
 	IsDefaultNSXProject(orgID, projectID string) (bool, error)
 	GetNetworkStackFromNC(nc *v1alpha1.VPCNetworkConfiguration) (v1alpha1.NetworkStackType, error)
+	IsRADeactivatedByVPCPath(vpcPath string) (bool, error)
 }
 
 type SubnetServiceProvider interface {

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 	"strings"
 	"sync"
 
@@ -54,9 +55,10 @@ var (
 
 type VPCService struct {
 	common.Service
-	VpcStore            *VPCStore
-	LbsStore            *LBSStore
-	defaultProjectCache sync.Map // cache for IsDefaultNSXProject results, key: "orgID/projectID", value: bool
+	VpcStore             *VPCStore
+	LbsStore             *LBSStore
+	defaultProjectCache  sync.Map // cache for IsDefaultNSXProject results, key: "orgID/projectID", value: bool
+	raDeactivatedCache   sync.Map // cache for IsRADeactivatedByVPCPath results, key: VPC path, value: bool
 }
 
 func (s *VPCService) GetDefaultNetworkConfig() (*v1alpha1.VPCNetworkConfiguration, error) {
@@ -1211,6 +1213,78 @@ func (s *VPCService) GetVPCFromNSXByPath(vpcPath string) (*model.Vpc, error) {
 	}
 
 	return &vpc, nil
+}
+
+// IsRADeactivatedByVPCPath determines whether IPv6 Router Advertisement is deactivated for the
+// VPC that owns the given NSX path (a VPC path or any path nested under a VPC, e.g. a Subnet
+// path). It resolves the VPC's VpcServiceProfile, finds the referenced Ipv6NdraProfile, and
+// checks its RaMode. If no VpcServiceProfile or no Ipv6NdraProfile is configured, RA is
+// considered deactivated: NSX does not push any ra_config to the dataplane in that case, so no
+// Router Advertisements are actually sent on the wire, which is dataplane-equivalent to an
+// explicit ra_mode of DISABLED. Results are cached since RA configuration rarely changes at
+// runtime.
+func (s *VPCService) IsRADeactivatedByVPCPath(vpcPath string) (bool, error) {
+	vpcResInfo, err := common.ParseVPCResourcePath(vpcPath)
+	if err != nil {
+		log.Error(err, "Failed to parse VPCResourceInfo from the given VPC path", "VPC", vpcPath)
+		return false, err
+	}
+	cacheKey := vpcResInfo.GetVPCPath()
+	if val, ok := s.raDeactivatedCache.Load(cacheKey); ok {
+		return val.(bool), nil
+	}
+
+	raDeactivated, err := s.resolveRADeactivated(vpcResInfo)
+	if err != nil {
+		return false, err
+	}
+	s.raDeactivatedCache.Store(cacheKey, raDeactivated)
+	return raDeactivated, nil
+}
+
+// resolveRADeactivated resolves RA mode for a VPC without consulting or populating the cache.
+func (s *VPCService) resolveRADeactivated(vpcResInfo common.VPCResourceInfo) (bool, error) {
+	vpc, err := s.NSXClient.VPCClient.Get(vpcResInfo.OrgID, vpcResInfo.ProjectID, vpcResInfo.VPCID)
+	err = nsxutil.TransNSXApiError(err)
+	if err != nil {
+		log.Error(err, "Failed to read VPC object from NSX", "VPC", vpcResInfo.GetVPCPath())
+		return false, err
+	}
+	if vpc.VpcServiceProfile == nil {
+		return true, nil
+	}
+
+	profile, err := s.NSXClient.VpcServiceProfileClient.Get(vpcResInfo.OrgID, vpcResInfo.ProjectID, path.Base(*vpc.VpcServiceProfile))
+	err = nsxutil.TransNSXApiError(err)
+	if err != nil {
+		log.Error(err, "Failed to read VpcServiceProfile from NSX", "VpcServiceProfile", *vpc.VpcServiceProfile)
+		return false, err
+	}
+
+	ndraProfilePath := findIpv6NdraProfilePath(profile.Ipv6ProfilePaths)
+	if ndraProfilePath == "" {
+		return true, nil
+	}
+
+	ndraProfile, err := s.NSXClient.Ipv6NdraProfileClient.Get(path.Base(ndraProfilePath))
+	err = nsxutil.TransNSXApiError(err)
+	if err != nil {
+		log.Error(err, "Failed to read Ipv6NdraProfile from NSX", "Ipv6NdraProfile", ndraProfilePath)
+		return false, err
+	}
+
+	return ndraProfile.RaMode == nil || *ndraProfile.RaMode == model.Ipv6NdraProfile_RA_MODE_DISABLED, nil
+}
+
+// findIpv6NdraProfilePath returns the Ipv6NdraProfile path among the VpcServiceProfile's
+// Ipv6ProfilePaths (which may also contain an Ipv6DadProfile path), or "" if none is present.
+func findIpv6NdraProfilePath(ipv6ProfilePaths []string) string {
+	for _, p := range ipv6ProfilePaths {
+		if strings.Contains(p, "/ipv6-ndra-profiles/") {
+			return p
+		}
+	}
+	return ""
 }
 
 func (s *VPCService) GetLBSsFromNSXByVPC(vpcPath string) (string, error) {

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1238,8 +1238,8 @@ func (s *VPCService) resolveRADeactivated(vpcResInfo common.VPCResourceInfo) (bo
 		log.Error(err, "Failed to read VPC object from NSX", "VPC", vpcResInfo.GetVPCPath())
 		return false, err
 	}
-	if vpc.VpcServiceProfile == nil {
-		log.Debug("No VpcServiceProfile configured on VPC, treating RA as deactivated", "VPC", vpcResInfo.GetVPCPath())
+	if vpc.VpcServiceProfile == nil || *vpc.VpcServiceProfile == "" {
+		log.Info("No VpcServiceProfile configured on VPC, treating RA as deactivated", "VPC", vpcResInfo.GetVPCPath())
 		return true, nil
 	}
 

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -55,10 +55,9 @@ var (
 
 type VPCService struct {
 	common.Service
-	VpcStore             *VPCStore
-	LbsStore             *LBSStore
-	defaultProjectCache  sync.Map // cache for IsDefaultNSXProject results, key: "orgID/projectID", value: bool
-	raDeactivatedCache   sync.Map // cache for IsRADeactivatedByVPCPath results, key: VPC path, value: bool
+	VpcStore            *VPCStore
+	LbsStore            *LBSStore
+	defaultProjectCache sync.Map // cache for IsDefaultNSXProject results, key: "orgID/projectID", value: bool
 }
 
 func (s *VPCService) GetDefaultNetworkConfig() (*v1alpha1.VPCNetworkConfiguration, error) {
@@ -1221,28 +1220,17 @@ func (s *VPCService) GetVPCFromNSXByPath(vpcPath string) (*model.Vpc, error) {
 // checks its RaMode. If no VpcServiceProfile or no Ipv6NdraProfile is configured, RA is
 // considered deactivated: NSX does not push any ra_config to the dataplane in that case, so no
 // Router Advertisements are actually sent on the wire, which is dataplane-equivalent to an
-// explicit ra_mode of DISABLED. Results are cached since RA configuration rarely changes at
-// runtime.
+// explicit ra_mode of DISABLED. Not cached: an admin can change VPC RA config at any time, and a
+// stale positive would silently mislead every SubnetPort in the VPC until the operator restarts.
 func (s *VPCService) IsRADeactivatedByVPCPath(vpcPath string) (bool, error) {
 	vpcResInfo, err := common.ParseVPCResourcePath(vpcPath)
 	if err != nil {
 		log.Error(err, "Failed to parse VPCResourceInfo from the given VPC path", "VPC", vpcPath)
 		return false, err
 	}
-	cacheKey := vpcResInfo.GetVPCPath()
-	if val, ok := s.raDeactivatedCache.Load(cacheKey); ok {
-		return val.(bool), nil
-	}
-
-	raDeactivated, err := s.resolveRADeactivated(vpcResInfo)
-	if err != nil {
-		return false, err
-	}
-	s.raDeactivatedCache.Store(cacheKey, raDeactivated)
-	return raDeactivated, nil
+	return s.resolveRADeactivated(vpcResInfo)
 }
 
-// resolveRADeactivated resolves RA mode for a VPC without consulting or populating the cache.
 func (s *VPCService) resolveRADeactivated(vpcResInfo common.VPCResourceInfo) (bool, error) {
 	vpc, err := s.NSXClient.VPCClient.Get(vpcResInfo.OrgID, vpcResInfo.ProjectID, vpcResInfo.VPCID)
 	err = nsxutil.TransNSXApiError(err)
@@ -1251,6 +1239,7 @@ func (s *VPCService) resolveRADeactivated(vpcResInfo common.VPCResourceInfo) (bo
 		return false, err
 	}
 	if vpc.VpcServiceProfile == nil {
+		log.Debug("No VpcServiceProfile configured on VPC, treating RA as deactivated", "VPC", vpcResInfo.GetVPCPath())
 		return true, nil
 	}
 
@@ -1263,6 +1252,7 @@ func (s *VPCService) resolveRADeactivated(vpcResInfo common.VPCResourceInfo) (bo
 
 	ndraProfilePath := findIpv6NdraProfilePath(profile.Ipv6ProfilePaths)
 	if ndraProfilePath == "" {
+		log.Debug("No Ipv6NdraProfile referenced by VpcServiceProfile, treating RA as deactivated", "VpcServiceProfile", *vpc.VpcServiceProfile)
 		return true, nil
 	}
 
@@ -1273,7 +1263,9 @@ func (s *VPCService) resolveRADeactivated(vpcResInfo common.VPCResourceInfo) (bo
 		return false, err
 	}
 
-	return ndraProfile.RaMode == nil || *ndraProfile.RaMode == model.Ipv6NdraProfile_RA_MODE_DISABLED, nil
+	raDeactivated := ndraProfile.RaMode == nil || *ndraProfile.RaMode == model.Ipv6NdraProfile_RA_MODE_DISABLED
+	log.Debug("Resolved RA mode for VPC", "VPC", vpcResInfo.GetVPCPath(), "Ipv6NdraProfile", ndraProfilePath, "RaMode", ndraProfile.RaMode, "RADeactivated", raDeactivated)
+	return raDeactivated, nil
 }
 
 // findIpv6NdraProfilePath returns the Ipv6NdraProfile path among the VpcServiceProfile's

--- a/pkg/nsx/services/vpc/vpc.go
+++ b/pkg/nsx/services/vpc/vpc.go
@@ -1256,7 +1256,7 @@ func (s *VPCService) resolveRADeactivated(vpcResInfo common.VPCResourceInfo) (bo
 		return true, nil
 	}
 
-	ndraProfile, err := s.NSXClient.Ipv6NdraProfileClient.Get(path.Base(ndraProfilePath))
+	ndraProfile, err := s.getIpv6NdraProfile(vpcResInfo, ndraProfilePath)
 	err = nsxutil.TransNSXApiError(err)
 	if err != nil {
 		log.Error(err, "Failed to read Ipv6NdraProfile from NSX", "Ipv6NdraProfile", ndraProfilePath)
@@ -1266,6 +1266,17 @@ func (s *VPCService) resolveRADeactivated(vpcResInfo common.VPCResourceInfo) (bo
 	raDeactivated := ndraProfile.RaMode == nil || *ndraProfile.RaMode == model.Ipv6NdraProfile_RA_MODE_DISABLED
 	log.Debug("Resolved RA mode for VPC", "VPC", vpcResInfo.GetVPCPath(), "Ipv6NdraProfile", ndraProfilePath, "RaMode", ndraProfile.RaMode, "RADeactivated", raDeactivated)
 	return raDeactivated, nil
+}
+
+// getIpv6NdraProfile reads the Ipv6NdraProfile at the given path, which may either be an infra-level
+// profile (/infra/ipv6-ndra-profiles/<id>) or a project-level profile
+// (/orgs/<org>/projects/<project>/infra/ipv6-ndra-profiles/<id>).
+func (s *VPCService) getIpv6NdraProfile(vpcResInfo common.VPCResourceInfo, ndraProfilePath string) (model.Ipv6NdraProfile, error) {
+	ndraProfileID := path.Base(ndraProfilePath)
+	if strings.HasPrefix(ndraProfilePath, "/orgs/") {
+		return s.NSXClient.ProjectIpv6NdraProfileClient.Get(vpcResInfo.OrgID, vpcResInfo.ProjectID, ndraProfileID)
+	}
+	return s.NSXClient.Ipv6NdraProfileClient.Get(ndraProfileID)
 }
 
 // findIpv6NdraProfilePath returns the Ipv6NdraProfile path among the VpcServiceProfile's

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -201,6 +201,219 @@ func (c fakeVPCAttachmentsClient) Update(orgIdParam string, projectIdParam strin
 	return model.VpcAttachment{}, nil
 }
 
+type fakeVpcServiceProfilesClient struct{}
+
+func (c fakeVpcServiceProfilesClient) Delete(orgIdParam string, projectIdParam string, vpcServiceProfileIdParam string) error {
+	return nil
+}
+
+func (c fakeVpcServiceProfilesClient) Get(orgIdParam string, projectIdParam string, vpcServiceProfileIdParam string) (model.VpcServiceProfile, error) {
+	return model.VpcServiceProfile{}, nil
+}
+
+func (c fakeVpcServiceProfilesClient) List(orgIdParam string, projectIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.VpcServiceProfileListResult, error) {
+	return model.VpcServiceProfileListResult{}, nil
+}
+
+func (c fakeVpcServiceProfilesClient) Patch(orgIdParam string, projectIdParam string, vpcServiceProfileIdParam string, vpcServiceProfileParam model.VpcServiceProfile) error {
+	return nil
+}
+
+func (c fakeVpcServiceProfilesClient) Update(orgIdParam string, projectIdParam string, vpcServiceProfileIdParam string, vpcServiceProfileParam model.VpcServiceProfile) (model.VpcServiceProfile, error) {
+	return model.VpcServiceProfile{}, nil
+}
+
+type fakeIpv6NdraProfilesClient struct{}
+
+func (c fakeIpv6NdraProfilesClient) Delete(ndraProfileIdParam string, overrideParam *bool) error {
+	return nil
+}
+
+func (c fakeIpv6NdraProfilesClient) Get(ndraProfileIdParam string) (model.Ipv6NdraProfile, error) {
+	return model.Ipv6NdraProfile{}, nil
+}
+
+func (c fakeIpv6NdraProfilesClient) List(cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.Ipv6NdraProfileListResult, error) {
+	return model.Ipv6NdraProfileListResult{}, nil
+}
+
+func (c fakeIpv6NdraProfilesClient) Patch(ndraProfileIdParam string, ipv6NdraProfileParam model.Ipv6NdraProfile, overrideParam *bool) error {
+	return nil
+}
+
+func (c fakeIpv6NdraProfilesClient) Update(ndraProfileIdParam string, ipv6NdraProfileParam model.Ipv6NdraProfile, overrideParam *bool) (model.Ipv6NdraProfile, error) {
+	return model.Ipv6NdraProfile{}, nil
+}
+
+type fakeVpcsClientForRA struct{}
+
+func (c fakeVpcsClientForRA) Delete(orgIdParam string, projectIdParam string, vpcIdParam string, isRecursiveParam *bool) error {
+	return nil
+}
+
+func (c fakeVpcsClientForRA) Get(orgIdParam string, projectIdParam string, vpcIdParam string) (model.Vpc, error) {
+	return model.Vpc{}, nil
+}
+
+func (c fakeVpcsClientForRA) List(orgIdParam string, projectIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.VpcListResult, error) {
+	return model.VpcListResult{}, nil
+}
+
+func (c fakeVpcsClientForRA) Patch(orgIdParam string, projectIdParam string, vpcIdParam string, vpcParam model.Vpc) error {
+	return nil
+}
+
+func (c fakeVpcsClientForRA) Update(orgIdParam string, projectIdParam string, vpcIdParam string, vpcParam model.Vpc) (model.Vpc, error) {
+	return model.Vpc{}, nil
+}
+
+func TestIsRADeactivatedByVPCPath(t *testing.T) {
+	vpcPath := "/orgs/default/projects/p1/vpcs/vpc1"
+
+	newVpcService := func() *VPCService {
+		return &VPCService{
+			Service: common.Service{
+				NSXClient: &nsx.Client{
+					Cluster:                 &nsx.Cluster{},
+					VPCClient:               &fakeVpcsClientForRA{},
+					VpcServiceProfileClient: &fakeVpcServiceProfilesClient{},
+					Ipv6NdraProfileClient:   &fakeIpv6NdraProfilesClient{},
+				},
+			},
+		}
+	}
+
+	for _, tt := range []struct {
+		name              string
+		prepareFunc       func(*testing.T, *VPCService) *gomonkey.Patches
+		expectErr         bool
+		expectDeactivated bool
+	}{
+		{
+			name: "error when getting VPC",
+			prepareFunc: func(t *testing.T, service *VPCService) *gomonkey.Patches {
+				return gomonkey.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VPCClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.Vpc{}, errors.New("failed to get VPC")},
+					Times:  1,
+				}})
+			},
+			expectErr: true,
+		},
+		{
+			name: "no VpcServiceProfile configured on the VPC",
+			prepareFunc: func(t *testing.T, service *VPCService) *gomonkey.Patches {
+				return gomonkey.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VPCClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.Vpc{}, nil},
+					Times:  1,
+				}})
+			},
+			expectDeactivated: true,
+		},
+		{
+			name: "error when getting VpcServiceProfile",
+			prepareFunc: func(t *testing.T, service *VPCService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VPCClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.Vpc{VpcServiceProfile: common.String("/orgs/default/projects/p1/vpc-service-profiles/default")}, nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VpcServiceProfileClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.VpcServiceProfile{}, errors.New("failed to get VpcServiceProfile")},
+					Times:  1,
+				}})
+				return patches
+			},
+			expectErr: true,
+		},
+		{
+			name: "VpcServiceProfile has no ipv6-ndra-profiles path",
+			prepareFunc: func(t *testing.T, service *VPCService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VPCClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.Vpc{VpcServiceProfile: common.String("/orgs/default/projects/p1/vpc-service-profiles/default")}, nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VpcServiceProfileClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.VpcServiceProfile{Ipv6ProfilePaths: []string{"/infra/ipv6-dad-profiles/default"}}, nil},
+					Times:  1,
+				}})
+				return patches
+			},
+			expectDeactivated: true,
+		},
+		{
+			name: "error when getting Ipv6NdraProfile",
+			prepareFunc: func(t *testing.T, service *VPCService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VPCClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.Vpc{VpcServiceProfile: common.String("/orgs/default/projects/p1/vpc-service-profiles/default")}, nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VpcServiceProfileClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.VpcServiceProfile{Ipv6ProfilePaths: []string{"/infra/ipv6-ndra-profiles/default"}}, nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.Ipv6NdraProfileClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.Ipv6NdraProfile{}, errors.New("failed to get Ipv6NdraProfile")},
+					Times:  1,
+				}})
+				return patches
+			},
+			expectErr: true,
+		},
+		{
+			name: "RA mode is DISABLED",
+			prepareFunc: func(t *testing.T, service *VPCService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VPCClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.Vpc{VpcServiceProfile: common.String("/orgs/default/projects/p1/vpc-service-profiles/default")}, nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VpcServiceProfileClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.VpcServiceProfile{Ipv6ProfilePaths: []string{"/infra/ipv6-ndra-profiles/ra1"}}, nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.Ipv6NdraProfileClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.Ipv6NdraProfile{RaMode: common.String(model.Ipv6NdraProfile_RA_MODE_DISABLED)}, nil},
+					Times:  1,
+				}})
+				return patches
+			},
+			expectDeactivated: true,
+		},
+		{
+			name: "RA mode is SLAAC_DNS_THROUGH_RA",
+			prepareFunc: func(t *testing.T, service *VPCService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VPCClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.Vpc{VpcServiceProfile: common.String("/orgs/default/projects/p1/vpc-service-profiles/default")}, nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VpcServiceProfileClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.VpcServiceProfile{Ipv6ProfilePaths: []string{"/infra/ipv6-ndra-profiles/ra1"}}, nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.Ipv6NdraProfileClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.Ipv6NdraProfile{RaMode: common.String(model.Ipv6NdraProfile_RA_MODE_SLAAC_DNS_THROUGH_RA)}, nil},
+					Times:  1,
+				}})
+				return patches
+			},
+			expectDeactivated: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			vpcService := newVpcService()
+			if tt.prepareFunc != nil {
+				patches := tt.prepareFunc(t, vpcService)
+				defer patches.Reset()
+			}
+			deactivated, err := vpcService.IsRADeactivatedByVPCPath(vpcPath)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectDeactivated, deactivated)
+			}
+		})
+	}
+}
+
 type fakeIPAddressAllocationClient struct{}
 
 func (c fakeIPAddressAllocationClient) Delete(orgIdParam string, projectIdParam string, vpcIdParam string, ipAddressAllocationIdParam string) error {

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -414,6 +414,54 @@ func TestIsRADeactivatedByVPCPath(t *testing.T) {
 	}
 }
 
+// TestIsRADeactivatedByVPCPath_NoStaleCaching guards against a regression found during manual
+// testing: an earlier version of IsRADeactivatedByVPCPath cached its result forever, so an admin
+// enabling/disabling RA on a live VPC had no effect on already-cached SubnetPorts until the
+// operator restarted. This asserts back-to-back calls for the same VPC path always reflect the
+// latest NSX state.
+func TestIsRADeactivatedByVPCPath_NoStaleCaching(t *testing.T) {
+	vpcPath := "/orgs/default/projects/p1/vpcs/vpc1"
+	vpcService := &VPCService{
+		Service: common.Service{
+			NSXClient: &nsx.Client{
+				Cluster:                 &nsx.Cluster{},
+				VPCClient:               &fakeVpcsClientForRA{},
+				VpcServiceProfileClient: &fakeVpcServiceProfilesClient{},
+				Ipv6NdraProfileClient:   &fakeIpv6NdraProfilesClient{},
+			},
+		},
+	}
+
+	patches := gomonkey.ApplyMethodSeq(reflect.TypeOf(vpcService.NSXClient.VPCClient), "Get", []gomonkey.OutputCell{{
+		Values: gomonkey.Params{model.Vpc{}, nil},
+		Times:  1,
+	}})
+	defer patches.Reset()
+	firstResult, err := vpcService.IsRADeactivatedByVPCPath(vpcPath)
+	assert.NoError(t, err)
+	assert.True(t, firstResult, "no VpcServiceProfile configured should report RA deactivated")
+
+	// Simulate an admin attaching an active NDRA profile to the VPC's service profile after the
+	// first lookup.
+	patches.Reset()
+	patches = gomonkey.ApplyMethodSeq(reflect.TypeOf(vpcService.NSXClient.VPCClient), "Get", []gomonkey.OutputCell{{
+		Values: gomonkey.Params{model.Vpc{VpcServiceProfile: common.String("/orgs/default/projects/p1/vpc-service-profiles/default")}, nil},
+		Times:  1,
+	}})
+	patches.ApplyMethodSeq(reflect.TypeOf(vpcService.NSXClient.VpcServiceProfileClient), "Get", []gomonkey.OutputCell{{
+		Values: gomonkey.Params{model.VpcServiceProfile{Ipv6ProfilePaths: []string{"/infra/ipv6-ndra-profiles/ra1"}}, nil},
+		Times:  1,
+	}})
+	patches.ApplyMethodSeq(reflect.TypeOf(vpcService.NSXClient.Ipv6NdraProfileClient), "Get", []gomonkey.OutputCell{{
+		Values: gomonkey.Params{model.Ipv6NdraProfile{RaMode: common.String(model.Ipv6NdraProfile_RA_MODE_SLAAC_DNS_THROUGH_RA)}, nil},
+		Times:  1,
+	}})
+
+	secondResult, err := vpcService.IsRADeactivatedByVPCPath(vpcPath)
+	assert.NoError(t, err)
+	assert.False(t, secondResult, "second call must reflect the newly attached NDRA profile, not a cached stale value")
+}
+
 type fakeIPAddressAllocationClient struct{}
 
 func (c fakeIPAddressAllocationClient) Delete(orgIdParam string, projectIdParam string, vpcIdParam string, ipAddressAllocationIdParam string) error {

--- a/pkg/nsx/services/vpc/vpc_test.go
+++ b/pkg/nsx/services/vpc/vpc_test.go
@@ -14,6 +14,7 @@ import (
 	stderrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	project_infra "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/infra"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -245,6 +246,30 @@ func (c fakeIpv6NdraProfilesClient) Update(ndraProfileIdParam string, ipv6NdraPr
 	return model.Ipv6NdraProfile{}, nil
 }
 
+type fakeProjectIpv6NdraProfilesClient struct{}
+
+func (c fakeProjectIpv6NdraProfilesClient) Delete(orgIdParam string, projectIdParam string, ndraProfileIdParam string, overrideParam *bool) error {
+	return nil
+}
+
+func (c fakeProjectIpv6NdraProfilesClient) Get(orgIdParam string, projectIdParam string, ndraProfileIdParam string) (model.Ipv6NdraProfile, error) {
+	return model.Ipv6NdraProfile{}, nil
+}
+
+func (c fakeProjectIpv6NdraProfilesClient) List(orgIdParam string, projectIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.Ipv6NdraProfileListResult, error) {
+	return model.Ipv6NdraProfileListResult{}, nil
+}
+
+func (c fakeProjectIpv6NdraProfilesClient) Patch(orgIdParam string, projectIdParam string, ndraProfileIdParam string, ipv6NdraProfileParam model.Ipv6NdraProfile, overrideParam *bool) error {
+	return nil
+}
+
+func (c fakeProjectIpv6NdraProfilesClient) Update(orgIdParam string, projectIdParam string, ndraProfileIdParam string, ipv6NdraProfileParam model.Ipv6NdraProfile, overrideParam *bool) (model.Ipv6NdraProfile, error) {
+	return model.Ipv6NdraProfile{}, nil
+}
+
+var _ project_infra.Ipv6NdraProfilesClient = fakeProjectIpv6NdraProfilesClient{}
+
 type fakeVpcsClientForRA struct{}
 
 func (c fakeVpcsClientForRA) Delete(orgIdParam string, projectIdParam string, vpcIdParam string, isRecursiveParam *bool) error {
@@ -274,10 +299,11 @@ func TestIsRADeactivatedByVPCPath(t *testing.T) {
 		return &VPCService{
 			Service: common.Service{
 				NSXClient: &nsx.Client{
-					Cluster:                 &nsx.Cluster{},
-					VPCClient:               &fakeVpcsClientForRA{},
-					VpcServiceProfileClient: &fakeVpcServiceProfilesClient{},
-					Ipv6NdraProfileClient:   &fakeIpv6NdraProfilesClient{},
+					Cluster:                      &nsx.Cluster{},
+					VPCClient:                    &fakeVpcsClientForRA{},
+					VpcServiceProfileClient:      &fakeVpcServiceProfilesClient{},
+					Ipv6NdraProfileClient:        &fakeIpv6NdraProfilesClient{},
+					ProjectIpv6NdraProfileClient: &fakeProjectIpv6NdraProfilesClient{},
 				},
 			},
 		}
@@ -396,6 +422,25 @@ func TestIsRADeactivatedByVPCPath(t *testing.T) {
 			},
 			expectDeactivated: false,
 		},
+		{
+			name: "RA mode is DISABLED on a project-scoped Ipv6NdraProfile",
+			prepareFunc: func(t *testing.T, service *VPCService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VPCClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.Vpc{VpcServiceProfile: common.String("/orgs/default/projects/p1/vpc-service-profiles/default")}, nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.VpcServiceProfileClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.VpcServiceProfile{Ipv6ProfilePaths: []string{"/orgs/default/projects/p1/infra/ipv6-ndra-profiles/ra1"}}, nil},
+					Times:  1,
+				}})
+				patches.ApplyMethodSeq(reflect.TypeOf(service.NSXClient.ProjectIpv6NdraProfileClient), "Get", []gomonkey.OutputCell{{
+					Values: gomonkey.Params{model.Ipv6NdraProfile{RaMode: common.String(model.Ipv6NdraProfile_RA_MODE_DISABLED)}, nil},
+					Times:  1,
+				}})
+				return patches
+			},
+			expectDeactivated: true,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			vpcService := newVpcService()
@@ -433,16 +478,23 @@ func TestIsRADeactivatedByVPCPath_NoStaleCaching(t *testing.T) {
 	}
 
 	patches := gomonkey.ApplyMethodSeq(reflect.TypeOf(vpcService.NSXClient.VPCClient), "Get", []gomonkey.OutputCell{{
-		Values: gomonkey.Params{model.Vpc{}, nil},
+		Values: gomonkey.Params{model.Vpc{VpcServiceProfile: common.String("/orgs/default/projects/p1/vpc-service-profiles/default")}, nil},
+		Times:  1,
+	}})
+	patches.ApplyMethodSeq(reflect.TypeOf(vpcService.NSXClient.VpcServiceProfileClient), "Get", []gomonkey.OutputCell{{
+		Values: gomonkey.Params{model.VpcServiceProfile{Ipv6ProfilePaths: []string{"/infra/ipv6-ndra-profiles/ra1"}}, nil},
+		Times:  1,
+	}})
+	patches.ApplyMethodSeq(reflect.TypeOf(vpcService.NSXClient.Ipv6NdraProfileClient), "Get", []gomonkey.OutputCell{{
+		Values: gomonkey.Params{model.Ipv6NdraProfile{RaMode: common.String(model.Ipv6NdraProfile_RA_MODE_DISABLED)}, nil},
 		Times:  1,
 	}})
 	defer patches.Reset()
 	firstResult, err := vpcService.IsRADeactivatedByVPCPath(vpcPath)
 	assert.NoError(t, err)
-	assert.True(t, firstResult, "no VpcServiceProfile configured should report RA deactivated")
+	assert.True(t, firstResult, "explicit ra_mode DISABLED should report RA deactivated")
 
-	// Simulate an admin attaching an active NDRA profile to the VPC's service profile after the
-	// first lookup.
+	// Simulate an admin re-enabling RA on the attached NDRA profile after the first lookup.
 	patches.Reset()
 	patches = gomonkey.ApplyMethodSeq(reflect.TypeOf(vpcService.NSXClient.VPCClient), "Get", []gomonkey.OutputCell{{
 		Values: gomonkey.Params{model.Vpc{VpcServiceProfile: common.String("/orgs/default/projects/p1/vpc-service-profiles/default")}, nil},
@@ -459,7 +511,7 @@ func TestIsRADeactivatedByVPCPath_NoStaleCaching(t *testing.T) {
 
 	secondResult, err := vpcService.IsRADeactivatedByVPCPath(vpcPath)
 	assert.NoError(t, err)
-	assert.False(t, secondResult, "second call must reflect the newly attached NDRA profile, not a cached stale value")
+	assert.False(t, secondResult, "second call must reflect the newly re-enabled NDRA profile, not a cached stale value")
 }
 
 type fakeIPAddressAllocationClient struct{}


### PR DESCRIPTION

SubnetPort.status.networkInterfaceConfig.raDeactivated now correctly reflects whether IPv6 RA is deactivated on the port's VPC — the CRD field already existed but was never populated.

To figure out whether RA is on or off, the operator looks up the SubnetPort's Subnet, finds its VPC, checks which service profile that VPC uses, and reads the ra_mode from the IPv6 NDRA profile attached to it. If the VPC has no service profile, or that profile doesn't have an NDRA profile attached, RA is treated as deactivated.

**Setup — Subnet**
```bash
kubectl get subnet subnet-dualstack-test -n subnetport-multi-ip-test -o yaml

status:
  conditions:
  - message: 'NSX Subnet with DHCPv4: DHCPDeactivated has been successfully created/updated'
    reason: SubnetReady
    status: "True"
    type: Ready
  gatewayAddresses:
  - 172.26.0.65/26
  - fd12:1234::1/64
  networkAddresses:
  - 172.26.0.64/26
  - fd12:1234::/64
```
**T1 — No NDRA profile attached to the VPC's VpcServiceProfile: RA reported as deactivated**

```bash
curl -sk -u 'admin:<password>' \
  "https://<nsx-manager>/policy/api/v1/orgs/default/projects/project-quality/vpc-service-profiles/default--46bd56af-40f2-4730-a127-baa70f304477" \
  | python3 -c "import json,sys; d=json.load(sys.stdin); print('ipv6_profile_paths:', d.get('ipv6_profile_paths'))"

ipv6_profile_paths: None
```
```bash
kubectl apply -f - <<EOF
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: sp-ra-test
  namespace: subnetport-multi-ip-test
spec:
  subnet: subnet-dualstack-test
  interfaceIPType: IPv4IPv6
EOF
kubectl get subnetport sp-ra-test -n subnetport-multi-ip-test -o yaml
------------
status:
  conditions:
  - message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    ipAddresses:
    - gateway: 172.26.0.65
      ipAddress: 172.26.0.70/26
    - gateway: fd12:1234::1
      ipAddress: fd12:1234::ffff:ffff:ffff:f830/64
    macAddress: "04:50:56:00:20:00"
    raDeactivated: true
  ```
  
  **T2 — Active NDRA profile attached (ra_mode: SLAAC_DNS_THROUGH_RA): RA reported as not deactivated**
  
  ```bash
  curl -sk -u 'admin:<password>' -X PUT \
  "https://<nsx-manager>/policy/api/v1/orgs/default/projects/project-quality/vpc-service-profiles/default--46bd56af-40f2-4730-a127-baa70f304477" \
  -H "Content-Type: application/json" \
  -d @vsp-with-default-ndra.json

"ipv6_profile_paths" : [ "/infra/ipv6-ndra-profiles/default" ]
```
```bash
kubectl apply -f - <<EOF
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: sp-ra-test-round2
  namespace: subnetport-multi-ip-test
spec:
  subnet: subnet-dualstack-test
  interfaceIPType: IPv4IPv6
EOF
kubectl get subnetport sp-ra-test-round2 -n subnetport-multi-ip-test -o jsonpath='{.status.networkInterfaceConfig}'
----------
{"dhcpDeactivatedOnSubnet":true,"dhcpv6DeactivatedOnSubnet":true,"ipAddresses":[...],"logicalSwitchUUID":"...","macAddress":"04:50:56:00:bc:00"}
```

```bash
raDeactivated is correctly false here, but is omitted from the object entirely — the field has omitempty and false is the Go zero value, so it's indistinguishable from "never set" in kubectl output by design (same as dhcpDeactivatedOnSubnet/dhcpv6DeactivatedOnSubnet would be). Confirmed directly via the operator's debug log instead:


DEBUG vpc.go:1267 Resolved RA mode for VPC Ipv6NdraProfile=/infra/ipv6-ndra-profiles/default RADeactivated=false RaMode=SLAAC_DNS_THROUGH_RA VPC=/orgs/default/projects/project-quality/vpcs/subnetport-multi-ip-test_jm54x
```
**T3 — Explicit ra_mode: DISABLED NDRA profile attached: RA reported as deactivated**

```bash
curl -sk -u 'admin:<password>' -X PUT \
  "https://<nsx-manager>/policy/api/v1/infra/ipv6-ndra-profiles/default" \
  -H "Content-Type: application/json" \
  -d @ndra-disabled.json

"ra_mode" : "DISABLED"
```
```bash
kubectl apply -f - <<EOF
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: sp-ra-test-round3
  namespace: subnetport-multi-ip-test
spec:
  subnet: subnet-dualstack-test
  interfaceIPType: IPv4IPv6
EOF
-------
kubectl get subnetport sp-ra-test-round3 -n subnetport-multi-ip-test -o jsonpath='{.status.networkInterfaceConfig}'
------------
{"dhcpDeactivatedOnSubnet":true,"dhcpv6DeactivatedOnSubnet":true,"ipAddresses":[...],"logicalSwitchUUID":"...","macAddress":"04:50:56:00:10:00","raDeactivated":true}

```