### PR TITLE
Support InterfaceIPType backfilling after SubnetPort creation

### DIFF
--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -152,6 +152,16 @@ func (r *SubnetPortReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			r.StatusUpdater.UpdateFail(ctx, subnetPort, err, fmt.Sprintf("Failed to get Subnet by path: %s", nsxSubnetPath), setSubnetPortReadyStatusFalse, r.SubnetPortService, r.restoreMode)
 			return common.ResultRequeue, err
 		}
+		// If SubnetPort is created before VM creation, VM Operator will update the SubnetPort for owner references
+		// Under certain race conditions, the backfilled InterfaceIPType and StaticIPAllocationType in SubnetPort spec may be overwritten by the VM Operator
+		// If the NSX SubnetPort is created, interfaceIPType here will be empty. The correct interfaceIPType shall be generated based on NSX Subnet IPAddressType
+		if interfaceIPType == "" {
+			var parentIPAddressType v1alpha1.IPAddressType
+			if nsxSubnet != nil && nsxSubnet.IpAddressType != nil {
+				parentIPAddressType = common.ConvertNSXIPAddressTypeToCR(*nsxSubnet.IpAddressType)
+			}
+			interfaceIPType = subnetport.GetDefaultInterfaceIPType(interfaceIPType, parentIPAddressType)
+		}
 		err = r.updateSubnetPortIPType(ctx, subnetPort, interfaceIPType, nsxSubnet)
 		if err != nil {
 			return common.ResultNormal, err
@@ -944,6 +954,7 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 	if existingSubnetPort != nil && existingSubnetPort.ParentPath != nil && len(*existingSubnetPort.ParentPath) > 0 {
 		subnetPath = *existingSubnetPort.ParentPath
 		// If there is a SubnetPath in store, there is a subnetport in NSX, the subnetport is not created first time.
+		// For existing SubnetPort, interfaceIPType will be empty. It shall be calculated based on NSX Subnet IPAddressType in the caller.
 		log.Debug("NSX SubnetPort had been created, returning the existing NSX Subnet path", "subnetPort.UID", subnetPort.UID, "subnetPath", subnetPath)
 		existing = true
 		return

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -442,6 +442,99 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 		assert.Equal(t, nil, ret)
 	})
 
+	// happy path - empty interfaceIPType for existing SubnetPort
+	t.Run("succeeded with empty interfaceIPType for existing SubnetPort", func(t *testing.T) {
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
+			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+				v1sp := obj.(*v1alpha1.SubnetPort)
+				v1sp.Spec.Subnet = "subnet1"
+				return nil
+			}).Times(2)
+		portState := &model.SegmentPortState{
+			Attachment: &model.SegmentPortAttachmentState{
+				Id: &attachmentID,
+			},
+		}
+		patchesCheckAndGetSubnetPathForSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).CheckAndGetSubnetPathForSubnetPort,
+			func(r *SubnetPortReconciler, ctx context.Context, subnetPort *v1alpha1.SubnetPort) (bool, bool, string, *types.UID, *sync.RWMutex, v1alpha1.IPAddressType, error) {
+				return true, false, "path1", nil, nil, "", nil
+			})
+		defer patchesCheckAndGetSubnetPathForSubnetPort.Reset()
+		patchesIsSharedSubnetPath := gomonkey.ApplyFunc(common.IsSharedSubnetPath, func(ctx context.Context, client client.Client, path string, ns string) (bool, error) {
+			return false, nil
+		})
+		defer patchesIsSharedSubnetPath.Reset()
+
+		ipTypeIPv6 := "IPV6"
+		pGetSubnetByPath := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetByPath",
+			func(s *mock.MockSubnetServiceProvider, nsxSubnetPath string, sharedSubnet bool) (*model.VpcSubnet, error) {
+				nsxSubnet := &model.VpcSubnet{
+					Id:            ptr.To("subnet-1"),
+					RealizationId: ptr.To("realization-1"),
+					IpAddressType: &ipTypeIPv6,
+				}
+				return nsxSubnet, nil
+			})
+		defer pGetSubnetByPath.Reset()
+
+		var capturedIPTypeInUpdate v1alpha1.IPAddressType
+		pUpdateSubnetPortIPType := gomonkey.ApplyFunc((*SubnetPortReconciler).updateSubnetPortIPType,
+			func(_ *SubnetPortReconciler, _ context.Context, _ *v1alpha1.SubnetPort, interfaceIPType v1alpha1.IPAddressType, _ *model.VpcSubnet) error {
+				capturedIPTypeInUpdate = interfaceIPType
+				return nil
+			})
+		defer pUpdateSubnetPortIPType.Reset()
+
+		var capturedIPTypeInCreate v1alpha1.IPAddressType
+		patchesCreateOrUpdateSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
+			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
+				capturedIPTypeInCreate = interfaceIPType
+				return portState, nil
+			})
+		defer patchesCreateOrUpdateSubnetPort.Reset()
+
+		patchesSetAddressBindingStatus := gomonkey.ApplyFunc(setAddressBindingStatusBySubnetPort,
+			func(client client.Client, ctx context.Context, subnetPort *v1alpha1.SubnetPort, subnetPortService *subnetport.SubnetPortService) {
+			})
+		defer patchesSetAddressBindingStatus.Reset()
+		patchesUpdateSubnetStatusOnSubnetPort := gomonkey.ApplyFunc((*SubnetPortReconciler).updateSubnetStatusOnSubnetPort,
+			func(r *SubnetPortReconciler, subnetPort *v1alpha1.SubnetPort, nsxSubnet *model.VpcSubnet) error {
+				return nil
+			})
+		defer patchesUpdateSubnetStatusOnSubnetPort.Reset()
+		k8sClient.EXPECT().Status().Return(fakewriter)
+
+		_, ret := r.Reconcile(ctx, req)
+		assert.Equal(t, nil, ret)
+		assert.Equal(t, v1alpha1.IPAddressTypeIPv6, capturedIPTypeInUpdate)
+		assert.Equal(t, v1alpha1.IPAddressTypeIPv6, capturedIPTypeInCreate)
+
+		// Test IPv4_IPV6 defaulting
+		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(
+			func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+				v1sp := obj.(*v1alpha1.SubnetPort)
+				v1sp.Spec.Subnet = "subnet1"
+				return nil
+			}).Times(2)
+		ipTypeDual := "IPV4_IPV6"
+		pGetSubnetByPathDual := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService), "GetSubnetByPath",
+			func(s *mock.MockSubnetServiceProvider, nsxSubnetPath string, sharedSubnet bool) (*model.VpcSubnet, error) {
+				nsxSubnet := &model.VpcSubnet{
+					Id:            ptr.To("subnet-1"),
+					RealizationId: ptr.To("realization-1"),
+					IpAddressType: &ipTypeDual,
+				}
+				return nsxSubnet, nil
+			})
+		defer pGetSubnetByPathDual.Reset()
+		k8sClient.EXPECT().Status().Return(fakewriter)
+
+		_, ret = r.Reconcile(ctx, req)
+		assert.Equal(t, nil, ret)
+		assert.Equal(t, v1alpha1.IPAddressTypeIPv4, capturedIPTypeInUpdate)
+		assert.Equal(t, v1alpha1.IPAddressTypeIPv4, capturedIPTypeInCreate)
+	})
+
 	// handle deletion event - delete NSX subnet port failed
 	t.Run("failed to delete NSX VpcSubnetPort", func(t *testing.T) {
 		sp := &v1alpha1.SubnetPort{}


### PR DESCRIPTION
If SubnetPort is created before VM creation, VM Operator will update the SubnetPort for owner references.
In some race condition, the backfilled InterfaceIPType and StaticIPAllocationType in SubnetPort spec set
by NSX Operator may be overwritten by the VM Operator.

Previous implementation does not compute InterfaceIPType for existing NSX SubnetPort.
This results that InterfaceIPType will not be backfilled, StaticIPAllocationType will be updated to None,
and SubnetPort IP will be removed in status.

This PR computes the InterfaceIPType for existing NSX SubnetPort based on NSX Subnet IPAddressType.

Testing done:

Create 2 SubnetPort

```yaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: subnetport-1
spec:
---
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  name: subnetport-2
spec:
  addressBindings:
  - macAddress: 04:50:56:00:a4:a1
```

Observed the SubnetPorts are realized

```yaml
# kubectl get subnetport -n ns-1 -o yaml subnetport-1
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetPort","metadata":{"annotations":{},"name":"subnetport-1","namespace":"ns-1"},"spec":null}
  creationTimestamp: "2026-07-28T08:26:32Z"
  generation: 4
  name: subnetport-1
  namespace: ns-1
  resourceVersion: "921783"
  uid: 6704b353-5823-4d8a-95bd-3df23678aba7
spec:
  interfaceIPType: IPv4
  staticIPAllocationType: IPv4
status:
  attachment:
    id: 36373034-6233-4533-ad35-3832332d3464
  conditions:
  - lastTransitionTime: "2026-07-28T08:26:33Z"
    message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    dhcpDeactivatedOnSubnet: true
    dhcpv6DeactivatedOnSubnet: true
    ipAddresses:
    - gateway: 172.26.0.1
      ipAddress: 172.26.0.4/27
    logicalSwitchUUID: 0d3abdaa-6838-427e-92f6-a800b84a528c
    macAddress: 04:50:56:00:e4:00
# kubectl get subnetport -n ns-1 -o yaml subnetport-2
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetPort
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetPort","metadata":{"annotations":{},"name":"subnetport-2","namespace":"ns-1"},"spec":{"addressBindings":[{"macAddress":"04:50:56:00:a4:a1"}]}}
  creationTimestamp: "2026-07-28T08:26:33Z"
  generation: 4
  name: subnetport-2
  namespace: ns-1
  resourceVersion: "921854"
  uid: bc8b88e3-d10c-44d3-8bf8-18977b8bea97
spec:
  addressBindings:
  - macAddress: 04:50:56:00:a4:a1
  interfaceIPType: IPv4
  staticIPAllocationType: IPv4
status:
  attachment:
    id: 62633862-3838-4533-ad64-3130632d3434
  conditions:
  - lastTransitionTime: "2026-07-28T08:26:34Z"
    message: NSX subnet port has been successfully created/updated
    reason: SubnetPortReady
    status: "True"
    type: Ready
  networkInterfaceConfig:
    dhcpDeactivatedOnSubnet: true
    dhcpv6DeactivatedOnSubnet: true
    ipAddresses:
    - gateway: 172.26.0.1
      ipAddress: 172.26.0.5/27
    logicalSwitchUUID: 0d3abdaa-6838-427e-92f6-a800b84a528c
    macAddress: 04:50:56:00:a4:a1
```

Removed the `spec.interfaceIPType` and `spec.staticIPAllocationType` and observed the SubnetPort are still realized with IP.