### PR TITLE
Handle SubnetDHCPConfig.Mode or SubnetDHCPv6Config.Mode omitted case …

### DIFF
--- a/pkg/controllers/subnetset/subnetset_webhook.go
+++ b/pkg/controllers/subnetset/subnetset_webhook.go
@@ -329,6 +329,20 @@ func getEffectiveStaticIPAllocation(subnet *v1alpha1.Subnet) bool {
 	return util.GetDefaultStaticIPAllocation(subnet)
 }
 
+func getEffectiveDHCPMode(subnet *v1alpha1.Subnet) v1alpha1.DHCPConfigMode {
+	if subnet.Spec.SubnetDHCPConfig.Mode == "" {
+		return v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeDeactivated)
+	}
+	return subnet.Spec.SubnetDHCPConfig.Mode
+}
+
+func getEffectiveDHCPv6Mode(subnet *v1alpha1.Subnet) v1alpha1.DHCPv6ConfigMode {
+	if subnet.Spec.SubnetDHCPv6Config.Mode == "" {
+		return v1alpha1.DHCPv6ConfigModeDeactivated
+	}
+	return subnet.Spec.SubnetDHCPv6Config.Mode
+}
+
 func (v *SubnetSetValidator) validateSubnets(ctx context.Context, ns string, subnetNames *[]string, subnetSet string) (bool, error) {
 	var namespaceVpc string
 	var existingVPC string
@@ -346,27 +360,29 @@ func (v *SubnetSetValidator) validateSubnets(ctx context.Context, ns string, sub
 		if err != nil {
 			return false, fmt.Errorf("failed to get Subnet %s/%s: %v", ns, subnetName, err)
 		}
-		if crdSubnet.Spec.SubnetDHCPConfig.Mode == v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeRelay) {
+		dhcpMode := getEffectiveDHCPMode(crdSubnet)
+		if dhcpMode == v1alpha1.DHCPConfigMode(v1alpha1.DHCPConfigModeRelay) {
 			return true, fmt.Errorf("DHCPRelay Subnet %s/%s is not supported in SubnetSet", crdSubnet.Namespace, crdSubnet.Name)
 		}
-		if crdSubnet.Spec.SubnetDHCPv6Config.Mode == v1alpha1.DHCPv6ConfigMode(v1alpha1.DHCPv6ConfigModeRelay) {
+		dhcpv6Mode := getEffectiveDHCPv6Mode(crdSubnet)
+		if dhcpv6Mode == v1alpha1.DHCPv6ConfigModeRelay {
 			return true, fmt.Errorf("DHCPRelay Subnet %s/%s is not supported in SubnetSet", crdSubnet.Namespace, crdSubnet.Name)
 		}
 		if isFirstSubnet {
 			firstAccessMode = string(crdSubnet.Spec.AccessMode)
-			firstDHCPMode = string(crdSubnet.Spec.SubnetDHCPConfig.Mode)
-			firstDHCPv6Mode = string(crdSubnet.Spec.SubnetDHCPv6Config.Mode)
+			firstDHCPMode = string(dhcpMode)
+			firstDHCPv6Mode = string(dhcpv6Mode)
 			firstEffectiveStaticIPAllocation = getEffectiveStaticIPAllocation(crdSubnet)
 			isFirstSubnet = false
 		} else {
 			if firstAccessMode != string(crdSubnet.Spec.AccessMode) {
 				return true, fmt.Errorf("Subnets in SubnetSet %s/%s must have the same AccessMode, found different AccessModes: [%s, %s]", ns, subnetSet, firstAccessMode, crdSubnet.Spec.AccessMode)
 			}
-			if firstDHCPMode != string(crdSubnet.Spec.SubnetDHCPConfig.Mode) {
-				return true, fmt.Errorf("Subnets in SubnetSet %s/%s must have the same DHCPConfigMode, found different DHCPConfigModes: [%s, %s]", ns, subnetSet, firstDHCPMode, crdSubnet.Spec.SubnetDHCPConfig.Mode)
+			if firstDHCPMode != string(dhcpMode) {
+				return true, fmt.Errorf("Subnets in SubnetSet %s/%s must have the same DHCPConfigMode, found different DHCPConfigModes: [%s, %s]", ns, subnetSet, firstDHCPMode, dhcpMode)
 			}
-			if firstDHCPv6Mode != string(crdSubnet.Spec.SubnetDHCPv6Config.Mode) {
-				return true, fmt.Errorf("Subnets in SubnetSet %s/%s must have the same DHCPv6ConfigMode, found different DHCPv6ConfigModes: [%s, %s]", ns, subnetSet, firstDHCPv6Mode, crdSubnet.Spec.SubnetDHCPv6Config.Mode)
+			if firstDHCPv6Mode != string(dhcpv6Mode) {
+				return true, fmt.Errorf("Subnets in SubnetSet %s/%s must have the same DHCPv6ConfigMode, found different DHCPv6ConfigModes: [%s, %s]", ns, subnetSet, firstDHCPv6Mode, dhcpv6Mode)
 			}
 			currentEffectiveStaticIPAllocation := getEffectiveStaticIPAllocation(crdSubnet)
 			if firstEffectiveStaticIPAllocation != currentEffectiveStaticIPAllocation {

--- a/pkg/controllers/subnetset/subnetset_webhook_test.go
+++ b/pkg/controllers/subnetset/subnetset_webhook_test.go
@@ -217,6 +217,16 @@ func TestSubnetSetValidator(t *testing.T) {
 	})
 	fakeClient.Create(context.TODO(), &v1alpha1.Subnet{
 		ObjectMeta: metav1.ObjectMeta{
+			Name:        "subnet-dhcp-empty",
+			Namespace:   "ns-dhcp",
+			Annotations: map[string]string{common.AnnotationAssociatedResource: "default:ns-dhcp:subnet-dhcp-empty"},
+		},
+		Spec: v1alpha1.SubnetSpec{
+			SubnetDHCPConfig: v1alpha1.SubnetDHCPConfig{},
+		},
+	})
+	fakeClient.Create(context.TODO(), &v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:        "subnet-dhcp-2",
 			Namespace:   "ns-dhcp",
 			Annotations: map[string]string{common.AnnotationAssociatedResource: "default:ns-dhcp:subnet-dhcp-2"},
@@ -237,6 +247,16 @@ func TestSubnetSetValidator(t *testing.T) {
 			SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{
 				Mode: v1alpha1.DHCPv6ConfigModeDeactivated,
 			},
+		},
+	})
+	fakeClient.Create(context.TODO(), &v1alpha1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "subnet-dhcpv6-empty",
+			Namespace:   "ns-dhcp",
+			Annotations: map[string]string{common.AnnotationAssociatedResource: "default:ns-dhcp:subnet-dhcpv6-empty"},
+		},
+		Spec: v1alpha1.SubnetSpec{
+			SubnetDHCPv6Config: v1alpha1.SubnetDHCPv6Config{},
 		},
 	})
 	fakeClient.Create(context.TODO(), &v1alpha1.Subnet{
@@ -503,6 +523,22 @@ func TestSubnetSetValidator(t *testing.T) {
 			msg:       "Subnets in SubnetSet ns-dhcp/subnetset-dhcp must have the same DHCPConfigMode, found different DHCPConfigModes: [DHCPDeactivated, DHCPServer]",
 		},
 		{
+			name: "Create SubnetSet with empty and explicit DHCPDeactivated modes (should pass)",
+			op:   admissionv1.Create,
+			subnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subnetset-dhcp-empty-deactivated",
+					Namespace: "ns-dhcp",
+				},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames: &[]string{"subnet-dhcp-empty", "subnet-dhcp-1"},
+				},
+			},
+			user:            "fake-user",
+			isAllowed:       true,
+			accessModeCheck: true,
+		},
+		{
 			name: "Create SubnetSet with different DHCPv6Modes",
 			op:   admissionv1.Create,
 			subnetSet: &v1alpha1.SubnetSet{
@@ -517,6 +553,22 @@ func TestSubnetSetValidator(t *testing.T) {
 			user:      "fake-user",
 			isAllowed: false,
 			msg:       "Subnets in SubnetSet ns-dhcp/subnetset-dhcpv6 must have the same DHCPv6ConfigMode, found different DHCPv6ConfigModes: [DHCPDeactivated, DHCPServer]",
+		},
+		{
+			name: "Create SubnetSet with empty and explicit DHCPv6Deactivated modes (should pass)",
+			op:   admissionv1.Create,
+			subnetSet: &v1alpha1.SubnetSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subnetset-dhcpv6-empty-deactivated",
+					Namespace: "ns-dhcp",
+				},
+				Spec: v1alpha1.SubnetSetSpec{
+					SubnetNames: &[]string{"subnet-dhcpv6-empty", "subnet-dhcpv6-1"},
+				},
+			},
+			user:            "fake-user",
+			isAllowed:       true,
+			accessModeCheck: true,
 		},
 		{
 			name: "Create SubnetSet with different StaticIPAllocations",


### PR DESCRIPTION
…when in SubnetSet webhook

Root Cause
In pkg/controllers/subnetset/subnetset_webhook.go, method validateSubnets validates that all member Subnets in a SubnetSet have identical DHCPConfigMode and DHCPv6ConfigMode.

However, the webhook was reading raw strings directly from crdSubnet.Spec.SubnetDHCPConfig.Mode and crdSubnet.Spec.SubnetDHCPv6Config.Mode:

In Subnet CRD definition (pkg/apis/vpc/v1alpha1/subnet_types.go), DHCPDeactivated is the default behavior when subnet.Spec.SubnetDHCPConfig.Mode (or SubnetDHCPv6Config.Mode) is omitted / empty (""). subnet-01 did not explicitly specify subnetDHCPConfig.mode in its spec, so its mode string evaluated to "". vlan-subnet-2 explicitly specified subnetDHCPConfig.mode: DHCPDeactivated. validateSubnets compared string "" with "DHCPDeactivated" and failed validation even though both subnets effectively operate in DHCPDeactivated mode.

Fix Applied
1.Helper Functions: Added getEffectiveDHCPMode and getEffectiveDHCPv6Mode in pkg/controllers/subnetset/subnetset_webhook.go to return v1alpha1.DHCPConfigModeDeactivated / v1alpha1.DHCPv6ConfigModeDeactivated when the mode field is empty (""). 2.Webhook Validation: Updated validateSubnets to evaluate effective DHCP modes before checking relay constraints and mode equality across subnets in a SubnetSet. 3.Unit Tests: Added test cases in pkg/controllers/subnetset/subnetset_webhook_test.go to cover combinations of subnets with implicit (empty) and explicit DHCPDeactivated modes for IPv4 and IPv6.