### PR TITLE
feat(hostname): filter duplicate annotation DNS between Service and Gateway

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/node"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/pod"
 	securitypolicycontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/securitypolicy"
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/service"
 	statefulsetcontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/statefulset"
 	staticroutecontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/staticroute"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/subnet"
@@ -57,7 +58,6 @@ import (
 	subnetportservice "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
 
 	nsxserviceaccountcontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/nsxserviceaccount"
-	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/service"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/metrics"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"

--- a/pkg/controllers/gateway/gateway_controller.go
+++ b/pkg/controllers/gateway/gateway_controller.go
@@ -123,6 +123,11 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return handleGatewayCleanup("Gateway is not in a valid management status (either unsupported GatewayClass, not programmed, or DNS is ignored), deleting DNS records")
 	}
 
+	if isGatewayOwnedByService(gw) {
+		log.Debug("Skipping annotated hostname DNS for Gateway owned by a Service", "Gateway", req.NamespacedName)
+		return handleGatewayCleanup("Gateway is owned by Service, skipping annotation DNS")
+	}
+
 	if !hasUsableGatewayIP(gw) {
 		return handleGatewayCleanup("Gateway has no valid address, DNS records should be deleted")
 	}
@@ -157,10 +162,8 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		log.Info("Reconciling Gateway failed", "Gateway", req.NamespacedName, "error", dnsErr)
 		return common.ResultRequeueAfter10sec, nil
 	}
-
 	r.StatusUpdater.UpdateSuccess(ctx, gw, nil)
 	log.Info("Reconciling Gateway", "Gateway", req.NamespacedName, "IPs", entry.IPs)
-
 	return common.ResultNormal, nil
 }
 

--- a/pkg/controllers/gateway/gateway_controller_test.go
+++ b/pkg/controllers/gateway/gateway_controller_test.go
@@ -520,6 +520,29 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 			wantRes: ctrl.Result{},
 		},
 		{
+			name: "managed gateway owned by service",
+			setupMock: func(c *mockclient.MockClient, d *mockdns.MockDNSRecordProvider, s *mockgateway.MockStatusUpdater) {
+				c.EXPECT().Get(gomock.Any(), gwReq.NamespacedName, gomock.Any()).DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					gw := obj.(*gatewayv1.Gateway)
+					gw.Spec.GatewayClassName = "avi-lb"
+					gw.Name = "gw1"
+					gw.Namespace = "default"
+					gw.OwnerReferences = []metav1.OwnerReference{{Kind: "Service", Name: "svc1"}}
+					hostname := gatewayv1.Hostname("a.com")
+					gw.Spec.Listeners = []gatewayv1.Listener{{Hostname: &hostname, Name: "l1"}}
+					gw.Status.Addresses = []gatewayv1.GatewayStatusAddress{{Type: ptrGatewayAddressType(gatewayv1.IPAddressType), Value: "1.1.1.1"}}
+					gw.Status.Conditions = []metav1.Condition{{Type: string(gatewayv1.GatewayConditionProgrammed), Status: metav1.ConditionTrue}}
+					return nil
+				}).AnyTimes()
+				d.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindGateway, "default", "gw1").Return(true, nil).Times(1)
+				c.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				s.EXPECT().IncreaseSyncTotal().AnyTimes()
+				s.EXPECT().IncreaseDeleteTotal().AnyTimes()
+				s.EXPECT().DeleteSuccess(gomock.Any(), gomock.Any()).AnyTimes()
+			},
+			wantRes: ctrl.Result{},
+		},
+		{
 			name: "client get error",
 			setupMock: func(c *mockclient.MockClient, d *mockdns.MockDNSRecordProvider, s *mockgateway.MockStatusUpdater) {
 				c.EXPECT().Get(gomock.Any(), gwReq.NamespacedName, gomock.Any()).Return(errors.New("get error"))

--- a/pkg/controllers/gateway/handlers.go
+++ b/pkg/controllers/gateway/handlers.go
@@ -145,8 +145,19 @@ func routeParentAcceptedByKey(routeNamespace string, parents []gatewayv1.RoutePa
 	return out
 }
 
-// routeDNSRequestsForListenerSet maps a ListenerSet to reconcile.Requests for Routes indexed on that LS.
+// isGatewayOwnedByService reports whether any ownerReference on the Gateway has Kind == "Service".
+// Such Gateways are created by a Service controller and their annotation DNS is managed by the
+// service reconciler, so the gateway reconciler should skip annotation DNS for them.
+func isGatewayOwnedByService(gw *gatewayv1.Gateway) bool {
+	for i := range gw.OwnerReferences {
+		if gw.OwnerReferences[i].Kind == "Service" {
+			return true
+		}
+	}
+	return false
+}
 
+// routeDNSRequestsForListenerSet maps a ListenerSet to reconcile.Requests for Routes indexed on that LS.
 func reconcileRequestsFromRouteList(list client.ObjectList) []reconcile.Request {
 	switch l := list.(type) {
 	case *gatewayv1.HTTPRouteList:
@@ -303,6 +314,10 @@ var predicateFuncsGateway = predicate.Funcs{
 		}
 
 		if !reflect.DeepEqual(oldObj.Status.Addresses, newObj.Status.Addresses) { // Gateway + Route ipCache
+			return true
+		}
+
+		if !reflect.DeepEqual(oldObj.OwnerReferences, newObj.OwnerReferences) {
 			return true
 		}
 

--- a/pkg/controllers/gateway/handlers_test.go
+++ b/pkg/controllers/gateway/handlers_test.go
@@ -486,3 +486,40 @@ func TestConvertToRouteObject(t *testing.T) {
 	_, ok = r1.convertToRouteObject(nil)
 	assert.False(t, ok)
 }
+
+func TestIsGatewayOwnedByService(t *testing.T) {
+	tests := []struct {
+		name string
+		gw   *gatewayv1.Gateway
+		want bool
+	}{
+		{
+			name: "no_owner_refs",
+			gw:   &gatewayv1.Gateway{},
+			want: false,
+		},
+		{
+			name: "owned_by_service",
+			gw: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: "parent"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "owned_by_deployment",
+			gw: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: "parent"}},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isGatewayOwnedByService(tt.gw))
+		})
+	}
+}

--- a/pkg/controllers/service/service_lb_controller_test.go
+++ b/pkg/controllers/service/service_lb_controller_test.go
@@ -289,9 +289,9 @@ func TestUpdateSuccess(t *testing.T) {
 		m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns", "lb-err-rec").Return(true, nil).Times(1)
 
 		r := &ServiceLbReconciler{Client: &fc, Service: testNSXServiceForLb(), Recorder: fakeRecorder{}, DNS: m}
-		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "lb-err-rec"}})
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "lb-err-rec"}})
 		assert.NoError(t, err)
-		assert.Equal(t, ctrlcommon.ResultRequeueAfter10sec, res)
+		assert.Equal(t, ctrlcommon.ResultRequeueAfter10sec, result)
 	})
 }
 

--- a/pkg/controllers/service/service_lb_dns.go
+++ b/pkg/controllers/service/service_lb_dns.go
@@ -63,9 +63,25 @@ func targetsFromLoadBalancerIngress(ingress []v1.LoadBalancerIngress) extdns.Tar
 	return extdns.NewTargets(vals...)
 }
 
+// isOwnedByGateway reports whether any ownerReference has the given Kind.
+func isOwnedByGateway(ownerRefs []metav1.OwnerReference) bool {
+	for i := range ownerRefs {
+		if ownerRefs[i].Kind == "Gateway" {
+			return true
+		}
+	}
+	return false
+}
+
 // buildLoadBalancerServiceDNSBatch builds owner-scoped DNS rows for a LoadBalancer Service: annotation hostnames,
 // targets from LB ingress, then ValidateEndpointsByZone for namespace VPC policy.
+// Services whose ownerReference points to a K8s Gateway are skipped to avoid duplicate DNS records
+// with Gateway-direct annotation DNS managed by the gateway reconciler.
 func buildLoadBalancerServiceDNSBatch(svc *v1.Service, w dns.DNSRecordProvider) (*dns.AggregatedDNSEndpoints, error) {
+	if isOwnedByGateway(svc.GetOwnerReferences()) {
+		log.Debug("Skipping DNS batch for LB service owned by a Gateway", "namespace", svc.Namespace, "name", svc.Name)
+		return nil, nil
+	}
 	hostnames := parseDNSHostnamesFromAnnotation(svc.GetAnnotations())
 	if len(hostnames) == 0 {
 		return nil, nil
@@ -93,12 +109,14 @@ func buildLoadBalancerServiceDNSBatch(svc *v1.Service, w dns.DNSRecordProvider) 
 	}
 	owner := &dns.ResourceRef{Kind: dns.ResourceKindService, Object: svc.GetObjectMeta()}
 	rows, _, err := w.ValidateEndpointsByZone(svc.Namespace, owner, eps)
-
-	if len(rows) == 0 {
+	if err != nil {
 		return nil, err
 	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
 	log.Info("DNS batch built for LB service", "namespace", svc.Namespace, "name", svc.Name, "rows", len(rows))
-	return dns.NewOwnerScopedAggregatedRouteDNS(owner, rows), err
+	return dns.NewOwnerScopedAggregatedRouteDNS(owner, rows), nil
 }
 
 func buildServiceDNSReadyCondition(err error) metav1.Condition {

--- a/pkg/controllers/service/service_lb_dns_test.go
+++ b/pkg/controllers/service/service_lb_dns_test.go
@@ -122,6 +122,34 @@ func TestReconcileLoadBalancerServiceDNS(t *testing.T) {
 			},
 		},
 		{
+			name: "owned_by_gateway",
+			svc: func() *v1.Service {
+				s := makeLbSvc("ns1", "lb-gw", "u10", "app.example.com", "203.0.113.5")
+				s.OwnerReferences = []metav1.OwnerReference{{Kind: "Gateway", Name: "gw1"}}
+				return s
+			}(),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				// Should skip DNS batch and delete any existing records
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb-gw").Return(true, nil).Times(1)
+			},
+		},
+		{
+			name: "validate_endpoints_returns_zero_rows",
+			svc:  makeLbSvc("ns1", "lb-zero-rows", "u11", "app.example.com", "203.0.113.5"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil).Times(1)
+				m.EXPECT().DeleteRecordByOwnerNN(gomock.Any(), dns.ResourceKindService, "ns1", "lb-zero-rows").Return(true, nil).Times(1)
+			},
+		},
+		{
+			name: "validate_endpoints_returns_error",
+			svc:  makeLbSvc("ns1", "lb-val-err", "u12", "app.example.com", "203.0.113.5"),
+			setupMock: func(m *mockdns.MockDNSRecordProvider) {
+				m.EXPECT().ValidateEndpointsByZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, fmt.Errorf("some other error")).Times(1)
+			},
+			wantErr: true,
+		},
+		{
 			name: "empty_targets",
 			svc:  makeLbSvc("ns1", "lb-empty-targets", "u9", "app.example.com", ""),
 			setupMock: func(m *mockdns.MockDNSRecordProvider) {
@@ -416,4 +444,33 @@ func TestServiceLbReconciler_removeServiceDNSReadyCondition(t *testing.T) {
 	got := &v1.Service{}
 	require.NoError(t, r.Client.Get(ctx, nn, got))
 	assert.Nil(t, meta.FindStatusCondition(got.Status.Conditions, serviceDNSReadyConditionType))
+}
+
+func TestIsOwnedByGateway(t *testing.T) {
+	tests := []struct {
+		name      string
+		ownerRefs []metav1.OwnerReference
+		want      bool
+	}{
+		{
+			name:      "no_owner_refs",
+			ownerRefs: nil,
+			want:      false,
+		},
+		{
+			name:      "owned_by_gateway",
+			ownerRefs: []metav1.OwnerReference{{Kind: "Gateway", Name: "parent"}},
+			want:      true,
+		},
+		{
+			name:      "owned_by_deployment",
+			ownerRefs: []metav1.OwnerReference{{Kind: "Deployment", Name: "parent"}},
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isOwnedByGateway(tt.ownerRefs))
+		})
+	}
 }

--- a/pkg/mock/gateway/mock_status_updater.go
+++ b/pkg/mock/gateway/mock_status_updater.go
@@ -8,10 +8,11 @@ import (
 	context "context"
 	reflect "reflect"
 
-	common "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 	gomock "go.uber.org/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	common "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
 )
 
 // MockStatusUpdater is a mock of StatusUpdater interface.


### PR DESCRIPTION
Prevent duplicate DNS records when a Gateway owns a Service or a Service
owns a Gateway, both carrying the same hostname annotation:

- In buildLoadBalancerServiceDNSBatch: skip Services whose ownerRef Kind is "Gateway" (managed Gateway creates the Service; DNS is the Gateway reconciler's responsibility).
- In GatewayReconciler.Reconcile: skip annotation-hostname DNS for Gateways whose ownerRef Kind is "Service" (Service creates the Gateway; DNS annotation is the service reconciler's responsibility).
- In predicateFuncsGateway.UpdateFunc: add check for Gateway's ownerReferences to ensure reconcile is triggered when ownerReferences are modified.
- Add isOwnedByGateway helper (service) and isGatewayOwnedByService helper (gateway) for the ownership check.

Test Done:
1. Deploy Gateway and HTTPRoute manifests, and annotate Gateway resource
```
root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# kubectl get gateway,httproute -n test1 -owide
NAME                                        CLASS   ADDRESS       PROGRAMMED   AGE
gateway.gateway.networking.k8s.io/gateway   istio   192.168.0.7   True         3d

NAME                                         HOSTNAMES                 AGE
httproute.gateway.networking.k8s.io/http-1   ["httpbin.example.com"]   3d

root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# kubectl annotate gateway -n test1 gateway nsx.vmware.com/hostname="my-gw.example.com"
gateway.gateway.networking.k8s.io/gateway annotated
```
2. Check the `DNSRecordReady` condition status in Gateway resource, and check the NSX DNSRecord resource creation
```
root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# kubectl get gateway -n test1 gateway -o jsonpath='{.status.conditions[?(@.type=="DNSRecordReady")].status}'
True

root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# curl -s -k -u ${cred} https://10.192.49.176/policy/api/v1/orgs/default/projects/project-quality/dns-records | jq '[.results[] | select(.record_name == "my-gw") | {zone_path, record_name, record_type, record_values, tags}]'
[
  {
    "zone_path": "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
    "record_name": "my-gw",
    "record_type": "A",
    "record_values": [
      "192.168.0.7"
    ],
    "tags": [
      {
        "scope": "nsx-op/cluster",
        "tag": "6edf5c92-2967-41a3-9b7c-a3d50fca857b"
      },
      {
        "scope": "nsx-op/version",
        "tag": "1.0.0"
      },
      {
        "scope": "nsx-op/namespace_uid",
        "tag": "c54019ac-89cf-4877-a3df-feadbd4049bd"
      },
      {
        "scope": "nsx-op/dns_for",
        "tag": "gateway"
      },
      {
        "scope": "nsx-op/dns_owner_namespace",
        "tag": "test1"
      },
      {
        "scope": "nsx-op/dns_owner_name",
        "tag": "gateway"
      },
      {
        "scope": "nsx-op/dns_contributing_owners",
        "tag": "service/test1/gateway-istio"
      }
    ]
  }
]
```
3. Check the corresponsing LB Service provisioned by the Gateway resource, a "Ready" condition is added before applying this change.
```
root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# kubectl get service -n test1 gateway-istio -o jsonpath='{.status.conditions[?(@.type=="Ready")]}'
{"lastTransitionTime":"2026-08-10T07:38:09Z","message":"","reason":"DNSRecordConfigured","status":"True","type":"Ready"}
```
4. Apply this change, it is observed that the condition property is removed from the corresponding Service; the condition still exists in the Gateway CR; the NSX DNSRecord still exists
```
root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# kubectl get service -n test1 gateway-istio -oyaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    nsx.vmware.com/hostname: my-gw.example.com
  creationTimestamp: "2026-08-07T07:30:04Z"
  finalizers:
  - netoperator.vmware.com/service
  labels:
    gateway.istio.io/managed: istio.io-gateway-controller
    gateway.networking.k8s.io/gateway-class-name: istio
    gateway.networking.k8s.io/gateway-name: gateway
    service.route.lbapi.run.tanzu.vmware.com/gateway-name: gateway-istio
    service.route.lbapi.run.tanzu.vmware.com/gateway-namespace: test1
    service.route.lbapi.run.tanzu.vmware.com/type: direct
  name: gateway-istio
  namespace: test1
  ownerReferences:
  - apiVersion: gateway.networking.k8s.io/v1
    kind: Gateway
    name: gateway
    uid: 65b274b9-44b8-4611-9e8a-c238efff2dbc
  resourceVersion: "3028297"
  uid: 116e05ab-ceca-4bcf-89f0-6b2b38e772cd
spec:
  allocateLoadBalancerNodePorts: true
  clusterIP: 172.24.67.94
  clusterIPs:
  - 172.24.67.94
  externalTrafficPolicy: Cluster
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  ipFamilyPolicy: PreferDualStack
  ports:
  - appProtocol: tcp
    name: status-port
    nodePort: 31153
    port: 15021
    protocol: TCP
    targetPort: 15021
  - appProtocol: http
    name: default
    nodePort: 30451
    port: 80
    protocol: TCP
    targetPort: 80
  selector:
    gateway.networking.k8s.io/gateway-name: gateway
  sessionAffinity: None
  type: LoadBalancer
status:
  loadBalancer:
    ingress:
    - ip: 192.168.0.7
      ipMode: Proxy

root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# kubectl get gateway -n test1 gateway -o jsonpath='{.status.conditions[?(@.type=="DNSRecordReady")]}'
{"lastTransitionTime":"2026-08-10T07:38:08Z","message":"","observedGeneration":1,"reason":"DNSRecordConfigured","status":"True","type":"DNSRecordReady"}
      
root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# curl -s -k -u ${cred} https://10.192.49.176/policy/api/v1/orgs/default/projects/project-quality/dns-records | jq '[.results[] | select(.record_name == "my-gw") | {zone_path, record_name, record_type, record_values, tags}]'
[
  {
    "zone_path": "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
    "record_name": "my-gw",
    "record_type": "A",
    "record_values": [
      "192.168.0.7"
    ],
    "tags": [
      {
        "scope": "nsx-op/cluster",
        "tag": "6edf5c92-2967-41a3-9b7c-a3d50fca857b"
      },
      {
        "scope": "nsx-op/version",
        "tag": "1.0.0"
      },
      {
        "scope": "nsx-op/namespace_uid",
        "tag": "c54019ac-89cf-4877-a3df-feadbd4049bd"
      },
      {
        "scope": "nsx-op/dns_for",
        "tag": "gateway"
      },
      {
        "scope": "nsx-op/dns_owner_namespace",
        "tag": "test1"
      },
      {
        "scope": "nsx-op/dns_owner_name",
        "tag": "gateway"
      }
    ]
  }
]
```
5. Annotate the Gateway resource to skip the FQDNs, and check that all related DNSRecords (including on Gateway and HTTPRoute) are removed automatically
```
root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# kubectl annotate gateway -n test1 gateway nsx.vmware.com/skip="true"
gateway.gateway.networking.k8s.io/gateway annotated

root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# kubectl get gateway -n test1 gateway -o jsonpath='{.status.conditions[]}'
{"lastTransitionTime":"2026-08-07T07:30:03Z","message":"Resource accepted","observedGeneration":1,"reason":"Accepted","status":"True","type":"Accepted"}

root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# kubectl get httproute -n test1 http-1 -o jsonpath='{.status.parents[*].conditions}'
[{"lastTransitionTime":"2026-08-07T07:30:03Z","message":"Route was valid","observedGeneration":1,"reason":"Accepted","status":"True","type":"Accepted"},{"lastTransitionTime":"2026-08-07T07:30:03Z","message":"All references resolved","observedGeneration":1,"reason":"ResolvedRefs","status":"True","type":"ResolvedRefs"}]

root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# curl -s -k -u ${cred} https://10.192.49.176/policy/api/v1/orgs/default/projects/project-quality/dns-records
{
  "results" : [ ],
  "result_count" : 0,
  "sort_by" : "display_name",
  "sort_ascending" : true
}
```