### PR TITLE
feat(dns): handle contributing owners tag overflow issue and the race condition when sharing a  single FQDN

### DIFF
--- a/pkg/nsx/services/common/policy_tree.go
+++ b/pkg/nsx/services/common/policy_tree.go
@@ -551,7 +551,7 @@ func (b *PolicyTreeBuilder[T]) UpdateMultipleResourcesOnNSX(objects []T, nsxClie
 				if resPath != nil {
 					path = *resPath
 				}
-				log.Error(err, "Failed to delete resource", "resourceType", b.leafType, "resourceID", id, "resourceName", name, "resourcePath", path)
+				log.Error(err, "Failed to apply resource", "resourceType", b.leafType, "resourceID", id, "resourceName", name, "resourcePath", path)
 			}
 			return err
 		}
@@ -566,7 +566,7 @@ func (b *PolicyTreeBuilder[T]) UpdateMultipleResourcesOnNSX(objects []T, nsxClie
 			if resName != nil {
 				name = *resName
 			}
-			log.Info("Successfully deleted resource", "resourceType", b.leafType, "resourceID", id, "resourceName", name)
+			log.Info("Successfully applied resource", "resourceType", b.leafType, "resourceID", id, "resourceName", name)
 		}
 		return nil
 	}
@@ -593,7 +593,7 @@ func (b *PolicyTreeBuilder[T]) UpdateMultipleResourcesOnNSX(objects []T, nsxClie
 			if resPath != nil {
 				path = *resPath
 			}
-			log.Error(err, "Failed to delete resource", "resourceType", b.leafType, "resourceID", id, "resourceName", name, "resourcePath", path)
+			log.Error(err, "Failed to apply resource", "resourceType", b.leafType, "resourceID", id, "resourceName", name, "resourcePath", path)
 		}
 		return err
 	}
@@ -608,7 +608,7 @@ func (b *PolicyTreeBuilder[T]) UpdateMultipleResourcesOnNSX(objects []T, nsxClie
 		if resName != nil {
 			name = *resName
 		}
-		log.Info("Successfully deleted resource", "resourceType", b.leafType, "resourceID", id, "resourceName", name)
+		log.Info("Successfully applied resource", "resourceType", b.leafType, "resourceID", id, "resourceName", name)
 	}
 
 	return nil
@@ -659,7 +659,7 @@ func (builder *PolicyTreeBuilder[T]) PagingUpdateResources(ctx context.Context, 
 	pagedObjs := PagingNSXResources(objs, pageSize)
 	totalBatches := len(pagedObjs)
 
-	log.Info("Starting batch deletion", "resourceType", builder.leafType, "totalResources", totalCount, "totalBatches", totalBatches, "batchSize", pageSize)
+	log.Info("Starting batch apply", "resourceType", builder.leafType, "totalResources", totalCount, "totalBatches", totalBatches, "batchSize", pageSize)
 
 	var nsxErr error
 	successCount := 0
@@ -671,7 +671,7 @@ func (builder *PolicyTreeBuilder[T]) PagingUpdateResources(ctx context.Context, 
 
 		select {
 		case <-ctx.Done():
-			log.Info("Batch deletion interrupted by context", "resourceType", builder.leafType, "processedBatches", currentBatch-1, "totalBatches", totalBatches, "successCount", successCount, "failedCount", failedCount)
+			log.Info("Batch apply interrupted by context", "resourceType", builder.leafType, "processedBatches", currentBatch-1, "totalBatches", totalBatches, "successCount", successCount, "failedCount", failedCount)
 			return errors.Join(util.TimeoutFailed, ctx.Err())
 		default:
 			updateErr := builder.UpdateMultipleResourcesOnNSX(partialObjs, nsxClient)
@@ -684,11 +684,11 @@ func (builder *PolicyTreeBuilder[T]) PagingUpdateResources(ctx context.Context, 
 				continue
 			}
 			failedCount += len(partialObjs)
-			log.Error(updateErr, "Batch update failed", "resourceType", builder.leafType, "batch", fmt.Sprintf("%d/%d", currentBatch, totalBatches), "batchResourceCount", len(partialObjs), "cumulativeFailed", failedCount)
+			log.Error(updateErr, "Batch apply failed", "resourceType", builder.leafType, "batch", fmt.Sprintf("%d/%d", currentBatch, totalBatches), "batchResourceCount", len(partialObjs), "cumulativeFailed", failedCount)
 			nsxErr = updateErr
 		}
 	}
 
-	log.Info("Batch deletion completed", "resourceType", builder.leafType, "totalResources", totalCount, "successCount", successCount, "failedCount", failedCount)
+	log.Info("Batch apply completed", "resourceType", builder.leafType, "totalResources", totalCount, "successCount", successCount, "failedCount", failedCount)
 	return nsxErr
 }

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -108,19 +108,20 @@ const (
 	TagScopeStatefulSetUID             string = "nsx-op/sts_uid"
 
 	// Tags and annotations for DNS record use case.
-	TagScopeDNSRecordFor                string = "nsx-op/dns_for" // value: gateway, service, xxroutes
-	TagScopeDNSRecordGatewayIndexList   string = "nsx-op/dns_gateway_index_list"
-	TagScopeDNSRecordOwnerNamespace     string = "nsx-op/dns_owner_namespace"
-	TagScopeDNSRecordOwnerName          string = "nsx-op/dns_owner_name"
-	TagScopeDNSRecordContributingOwners string = "nsx-op/dns_contributing_owners"
-	TagValueDNSRecordForGateway         string = "gateway"
-	TagValueDNSRecordForHTTPRoute       string = "httproute"
-	TagValueDNSRecordForGRPCRoute       string = "grpcroute"
-	TagValueDNSRecordForTLSRoute        string = "tlsroute"
-	TagValueDNSRecordForService         string = "service"
-	AnnotationDNSHostnameKey            string = "external-dns.alpha.kubernetes.io/hostname"
-	AnnotationDNSHostnameSourceKey      string = "external-dns.alpha.kubernetes.io/gateway-hostname-source"
-	AnnotationsDNSSkip                  string = "dns.nsx.vmware.com/skip"
+	TagScopeDNSRecordFor                          string = "nsx-op/dns_for" // value: gateway, service, xxroutes
+	TagScopeDNSRecordGatewayIndexList             string = "nsx-op/dns_gateway_index_list"
+	TagScopeDNSRecordOwnerNamespace               string = "nsx-op/dns_owner_namespace"
+	TagScopeDNSRecordOwnerName                    string = "nsx-op/dns_owner_name"
+	TagScopeDNSRecordContributingOwners           string = "nsx-op/dns_contributing_owners"
+	TagScopeDNSRecordAdditionalContributingOwners string = "nsx-op/dns_contributing_owners_ext"
+	TagValueDNSRecordForGateway                   string = "gateway"
+	TagValueDNSRecordForHTTPRoute                 string = "httproute"
+	TagValueDNSRecordForGRPCRoute                 string = "grpcroute"
+	TagValueDNSRecordForTLSRoute                  string = "tlsroute"
+	TagValueDNSRecordForService                   string = "service"
+	AnnotationDNSHostnameKey                      string = "external-dns.alpha.kubernetes.io/hostname"
+	AnnotationDNSHostnameSourceKey                string = "external-dns.alpha.kubernetes.io/gateway-hostname-source"
+	AnnotationsDNSSkip                            string = "dns.nsx.vmware.com/skip"
 
 	// TagScopePodIndex is the NSX tag scope for Pod label apps.kubernetes.io/pod-index when synced onto the port (not set in BuildBasicTags).
 	TagScopePodIndex   string = "apps.kubernetes.io/pod-index"

--- a/pkg/nsx/services/dns/builder.go
+++ b/pkg/nsx/services/dns/builder.go
@@ -103,7 +103,7 @@ func (r *EndpointRow) appendRowOwnershipTags(ownerTags []model.Tag) []model.Tag 
 	if r.Endpoint != nil && r.Endpoint.Labels != nil {
 		gwKeys := strings.TrimSpace(r.Endpoint.Labels[EndpointLabelParentGateway])
 		if len(gwKeys) > 0 {
-			gwKey = compressString(gwKeys)
+			gwKey, _ = joinAndPackStrings(strings.Split(gwKeys, ","))
 		}
 	}
 	return appendGatewayAndContributionTags(tags, gwKey, r.contributingOwnerKeys)

--- a/pkg/nsx/services/dns/builder.go
+++ b/pkg/nsx/services/dns/builder.go
@@ -17,7 +17,7 @@ const (
 )
 
 // BuildDnsRecord builds one *model.DnsRecord for row using batchOwner or row.effectiveOwner.
-func (s *DNSRecordService) BuildDnsRecord(batchOwner *ResourceRef, row EndpointRow) *model.DnsRecord {
+func (s *DNSRecordService) BuildDnsRecord(batchOwner *ResourceRef, row EndpointRow) (*model.DnsRecord, error) {
 	owner := batchOwner
 	if row.effectiveOwner != nil {
 		owner = row.effectiveOwner
@@ -54,9 +54,12 @@ func getRecordIDAndPathAndType(recordName, endpointRecordType, zonePath string) 
 	return recID, recordPath, nsxRecordType
 }
 
-func (r *EndpointRow) buildDNSRecord(basicTags []model.Tag) *model.DnsRecord {
+func (r *EndpointRow) buildDNSRecord(basicTags []model.Tag) (*model.DnsRecord, error) {
 	// Append the tags according to the Endpoint labels, e.g., the parent gateway settings for a Route.
-	tags := r.appendRowOwnershipTags(basicTags)
+	tags, err := r.appendRowOwnershipTags(basicTags)
+	if err != nil {
+		return nil, err
+	}
 	recID, path, rt := getRecordIDAndPathAndType(r.nsxRecordName, r.RecordType, r.zonePath)
 	ttl := int64(DefaultRecordTtL)
 	if r.Endpoint.RecordTTL.IsConfigured() {
@@ -76,7 +79,7 @@ func (r *EndpointRow) buildDNSRecord(basicTags []model.Tag) *model.DnsRecord {
 		// Mirror logical FQDN for store indexing / conflict detection; stripped before Policy PATCH (see WrapDnsRecord).
 		Fqdn: common.String(strings.ToLower(r.Endpoint.DNSName)),
 	}
-	return rec
+	return rec, nil
 }
 
 func getNSXDnsRecordType(recType string) string {
@@ -97,13 +100,18 @@ func getNSXDnsRecordType(recType string) string {
 	}
 }
 
-func (r *EndpointRow) appendRowOwnershipTags(ownerTags []model.Tag) []model.Tag {
+func (r *EndpointRow) appendRowOwnershipTags(ownerTags []model.Tag) ([]model.Tag, error) {
 	tags := append([]model.Tag{}, ownerTags...)
 	gwKey := ""
 	if r.Endpoint != nil && r.Endpoint.Labels != nil {
 		gwKeys := strings.TrimSpace(r.Endpoint.Labels[EndpointLabelParentGateway])
 		if len(gwKeys) > 0 {
-			gwKey, _ = joinAndPackStrings(strings.Split(gwKeys, ","))
+			var overflow string
+			var truncated bool
+			gwKey, overflow, truncated = joinAndPackStrings(strings.Split(gwKeys, ","))
+			if truncated || overflow != "" {
+				return nil, fmt.Errorf("gateway index list exceeds maximum tag capacity")
+			}
 		}
 	}
 	return appendGatewayAndContributionTags(tags, gwKey, r.contributingOwnerKeys)

--- a/pkg/nsx/services/dns/compare_contributing_test.go
+++ b/pkg/nsx/services/dns/compare_contributing_test.go
@@ -144,7 +144,7 @@ func TestResourceRefFromDNSRecord_table(t *testing.T) {
 	}
 }
 
-func TestPrimaryOwnerNNIndexKeyFromRecord_table(t *testing.T) {
+func TestGetDNSRecordOwnerNamespacedName(t *testing.T) {
 	tests := []struct {
 		name    string
 		rec     *model.DnsRecord
@@ -176,7 +176,7 @@ func TestPrimaryOwnerNNIndexKeyFromRecord_table(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.wantKey, primaryOwnerNNIndexKeyFromRecord(tc.rec))
+			require.Equal(t, tc.wantKey, getDNSRecordOwnerNamespacedName(tc.rec))
 		})
 	}
 }

--- a/pkg/nsx/services/dns/contributing.go
+++ b/pkg/nsx/services/dns/contributing.go
@@ -4,10 +4,7 @@
 package dns
 
 import (
-	"bytes"
-	"compress/zlib"
-	"encoding/base64"
-	"io"
+	"slices"
 	"strings"
 
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
@@ -18,7 +15,18 @@ import (
 )
 
 func parseContributingOwnersFromRecord(rec *model.DnsRecord) []string {
-	return parseContributingOwnersTag(decompressContributingTags(rec))
+	tagKeys := parseContributingOwnersTag(decompressContributingTags(rec))
+
+	var allKeys []string
+	allKeys = append(allKeys, tagKeys...)
+
+	additionalTag := firstTagValue(rec.Tags, common.TagScopeDNSRecordAdditionalContributingOwners)
+	if additionalTag != "" {
+		additionalKeys := parseContributingOwnersTag(additionalTag)
+		allKeys = append(allKeys, additionalKeys...)
+	}
+
+	return sortedCopyStrings(allKeys)
 }
 
 func decompressContributingTags(rec *model.DnsRecord) string {
@@ -26,7 +34,7 @@ func decompressContributingTags(rec *model.DnsRecord) string {
 	if encodedContributingKeys == "" {
 		return ""
 	}
-	return decompressString(encodedContributingKeys)
+	return encodedContributingKeys
 }
 
 func parseContributingOwnersTag(raw string) []string {
@@ -45,30 +53,31 @@ func parseContributingOwnersTag(raw string) []string {
 	return out
 }
 
-func formatContributingOwnersTag(keys []string) string {
+func formatContributingOwnersTag(keys []string) (string, string) {
 	if len(keys) == 0 {
-		return ""
+		return "", ""
 	}
-	cp := sortedCopyStrings(keys)
-	plainText := strings.Join(cp, ",")
-	// Compress the consolidated plain text into a tight string under 255 characters.
-	return compressString(plainText)
+	contributionTag, extraTag := joinAndPackStrings(keys)
+	if len(extraTag) > 0 {
+		log.Info("Tag length exceeds dns_contributing_owners limit (255), putting remaining in dns_contributing_owners_ext")
+	}
+	return contributionTag, extraTag
 }
 
 // mergeContributingOwnerKeys returns sorted unique contributing keys (excludes primaryNNKey).
-func mergeContributingOwnerKeys(existing string, add string, primaryNNKey string) string {
-	raw := strings.Join([]string{existing, add}, ",")
+func mergeContributingOwnerKeys(existing []string, add string, primaryNNKey string) []string {
 	seen := sets.New[string]()
-	for _, p := range strings.Split(raw, ",") {
-		k := strings.TrimSpace(p)
-		if k == "" || k == primaryNNKey {
-			continue
-		}
-		if k != "" {
+	for _, k := range existing {
+		k = strings.TrimSpace(k)
+		if k != "" && k != primaryNNKey {
 			seen.Insert(k)
 		}
 	}
-	return formatContributingOwnersTag(seen.UnsortedList())
+	k := strings.TrimSpace(add)
+	if k != "" && k != primaryNNKey {
+		seen.Insert(k)
+	}
+	return sortedCopyStrings(seen.UnsortedList())
 }
 
 func resourceRefFromDNSRecord(rec *model.DnsRecord) (*ResourceRef, bool) {
@@ -111,19 +120,21 @@ func ownerNNIndexKeyForResourceRef(owner *ResourceRef) string {
 	return dnsRecordOwnerKey(createdFor, dnsRecordOwnerNamespacedNameKey(owner.GetNamespace(), owner.GetName()))
 }
 
-func primaryOwnerNNIndexKeyFromRecord(rec *model.DnsRecord) string {
-	return getDNSRecordOwnerNamespacedName(rec)
-}
-
 // appendGatewayAndContributionTags appends the optional GatewayIndexList and ContributingOwners tags
 // onto tags when their values are non-empty, returning the extended slice. The caller is
 // responsible for passing a slice it owns so this function may append to it directly.
-func appendGatewayAndContributionTags(tags []model.Tag, gwKey string, ctag string) []model.Tag {
+func appendGatewayAndContributionTags(tags []model.Tag, gwKey string, contribKeys []string) []model.Tag {
 	if gwKey = strings.TrimSpace(gwKey); gwKey != "" {
 		tags = append(tags, modelTag(common.TagScopeDNSRecordGatewayIndexList, gwKey))
 	}
-	if ctag != "" {
-		tags = append(tags, modelTag(common.TagScopeDNSRecordContributingOwners, ctag))
+	if len(contribKeys) > 0 {
+		plain, overflow := formatContributingOwnersTag(contribKeys)
+		if plain != "" {
+			tags = append(tags, modelTag(common.TagScopeDNSRecordContributingOwners, plain))
+		}
+		if overflow != "" {
+			tags = append(tags, modelTag(common.TagScopeDNSRecordAdditionalContributingOwners, overflow))
+		}
 	}
 	return tags
 }
@@ -134,56 +145,72 @@ func replaceContributingOwnersInTags(tags []model.Tag, newContribKeys []string) 
 		if t.Scope == nil {
 			continue
 		}
-		if *t.Scope != common.TagScopeDNSRecordContributingOwners {
-			out = append(out, t)
+		if *t.Scope == common.TagScopeDNSRecordContributingOwners || *t.Scope == common.TagScopeDNSRecordAdditionalContributingOwners {
 			continue
 		}
-		if len(newContribKeys) > 0 {
-			out = append(out, modelTag(common.TagScopeDNSRecordContributingOwners, formatContributingOwnersTag(newContribKeys)))
+		out = append(out, t)
+	}
+	if len(newContribKeys) > 0 {
+		plain, overflow := formatContributingOwnersTag(newContribKeys)
+		if plain != "" {
+			out = append(out, modelTag(common.TagScopeDNSRecordContributingOwners, plain))
+		}
+		if overflow != "" {
+			out = append(out, modelTag(common.TagScopeDNSRecordAdditionalContributingOwners, overflow))
 		}
 	}
 	return out
 }
 
-// compressString compresses plain-text keys using zlib and encodes the result into RawURLEncoding Base64.
-func compressString(src string) string {
-	if src == "" {
-		return ""
-	}
-	var b bytes.Buffer
-	w := zlib.NewWriter(&b)
-	_, _ = w.Write([]byte(src))
-	_ = w.Close()
-
-	// RawURLEncoding is used to strip trailing padding characters ('='), saving extra bytes.
-	return base64.RawURLEncoding.EncodeToString(b.Bytes())
-}
-
-// decompressString decodes the Base64 payload and inflates the zlib stream back to plain text.
-func decompressString(compressed string) string {
-	if compressed == "" || !strings.HasPrefix(compressed, "eJ") {
-		return compressed
+// joinAndPackStrings sorts and joins src strings into two comma-separated
+// chunks (primary and overflow), each strictly bounded to 255 bytes.
+func joinAndPackStrings(src []string) (string, string) {
+	if len(src) == 0 {
+		return "", ""
 	}
 
-	data, err := base64.RawURLEncoding.DecodeString(compressed)
-	if err != nil {
-		return compressed // Fallback to raw string if Base64 decoding fails.
+	sorted := slices.Clone(src)
+	slices.Sort(sorted)
+
+	var sb, overflowSB strings.Builder
+	sb.Grow(255)
+	overflowSB.Grow(255)
+
+	// push attempts to append an item to the specified builder (truncating single oversized items).
+	// It returns true if the item was successfully appended within the 255-byte limit.
+	push := func(b *strings.Builder, item string) bool {
+		if len(item) > 255 {
+			item = item[:255]
+		}
+		needComma := b.Len() > 0
+		addedLen := len(item)
+		if needComma {
+			addedLen++
+		}
+
+		if b.Len()+addedLen > 255 {
+			return false
+		}
+		if needComma {
+			b.WriteString(",")
+		}
+		b.WriteString(item)
+		return true
 	}
 
-	b := bytes.NewReader(data)
-	r, err := zlib.NewReader(b)
-	if err != nil {
-		return compressed // Fallback to raw string if zlib reader initialization fails.
+	truncated := false
+	for _, item := range sorted {
+		if push(&sb, item) {
+			continue
+		}
+		if !push(&overflowSB, item) {
+			truncated = true
+		}
 	}
-	defer r.Close()
 
-	var out bytes.Buffer
-	maxDecompressedSize := int64(1024 * 1024)
-	limitedReader := io.LimitReader(r, maxDecompressedSize+1)
-	_, err = io.Copy(&out, limitedReader)
-	if err != nil {
-		log.Error(err, "Failed to decompress the string, returning the compressed value", "value", compressed)
-		return compressed
+	if truncated {
+		log.Info("Tag length exceeds the extra tag's limit (255), truncating additional inputs")
 	}
-	return out.String()
+
+	return sb.String(), overflowSB.String()
 }

--- a/pkg/nsx/services/dns/contributing.go
+++ b/pkg/nsx/services/dns/contributing.go
@@ -4,6 +4,7 @@
 package dns
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
@@ -53,15 +54,18 @@ func parseContributingOwnersTag(raw string) []string {
 	return out
 }
 
-func formatContributingOwnersTag(keys []string) (string, string) {
+func formatContributingOwnersTag(keys []string) (string, string, error) {
 	if len(keys) == 0 {
-		return "", ""
+		return "", "", nil
 	}
-	contributionTag, extraTag := joinAndPackStrings(keys)
+	contributionTag, extraTag, truncated := joinAndPackStrings(keys)
+	if truncated {
+		return "", "", fmt.Errorf("contributing owners count exceeds maximum tag capacity")
+	}
 	if len(extraTag) > 0 {
 		log.Info("Tag length exceeds dns_contributing_owners limit (255), putting remaining in dns_contributing_owners_ext")
 	}
-	return contributionTag, extraTag
+	return contributionTag, extraTag, nil
 }
 
 // mergeContributingOwnerKeys returns sorted unique contributing keys (excludes primaryNNKey).
@@ -123,12 +127,15 @@ func ownerNNIndexKeyForResourceRef(owner *ResourceRef) string {
 // appendGatewayAndContributionTags appends the optional GatewayIndexList and ContributingOwners tags
 // onto tags when their values are non-empty, returning the extended slice. The caller is
 // responsible for passing a slice it owns so this function may append to it directly.
-func appendGatewayAndContributionTags(tags []model.Tag, gwKey string, contribKeys []string) []model.Tag {
+func appendGatewayAndContributionTags(tags []model.Tag, gwKey string, contribKeys []string) ([]model.Tag, error) {
 	if gwKey = strings.TrimSpace(gwKey); gwKey != "" {
 		tags = append(tags, modelTag(common.TagScopeDNSRecordGatewayIndexList, gwKey))
 	}
 	if len(contribKeys) > 0 {
-		plain, overflow := formatContributingOwnersTag(contribKeys)
+		plain, overflow, err := formatContributingOwnersTag(contribKeys)
+		if err != nil {
+			return nil, err
+		}
 		if plain != "" {
 			tags = append(tags, modelTag(common.TagScopeDNSRecordContributingOwners, plain))
 		}
@@ -136,10 +143,10 @@ func appendGatewayAndContributionTags(tags []model.Tag, gwKey string, contribKey
 			tags = append(tags, modelTag(common.TagScopeDNSRecordAdditionalContributingOwners, overflow))
 		}
 	}
-	return tags
+	return tags, nil
 }
 
-func replaceContributingOwnersInTags(tags []model.Tag, newContribKeys []string) []model.Tag {
+func replaceContributingOwnersInTags(tags []model.Tag, newContribKeys []string) ([]model.Tag, error) {
 	out := make([]model.Tag, 0)
 	for _, t := range tags {
 		if t.Scope == nil {
@@ -151,7 +158,10 @@ func replaceContributingOwnersInTags(tags []model.Tag, newContribKeys []string) 
 		out = append(out, t)
 	}
 	if len(newContribKeys) > 0 {
-		plain, overflow := formatContributingOwnersTag(newContribKeys)
+		plain, overflow, err := formatContributingOwnersTag(newContribKeys)
+		if err != nil {
+			return nil, err
+		}
 		if plain != "" {
 			out = append(out, modelTag(common.TagScopeDNSRecordContributingOwners, plain))
 		}
@@ -159,14 +169,14 @@ func replaceContributingOwnersInTags(tags []model.Tag, newContribKeys []string) 
 			out = append(out, modelTag(common.TagScopeDNSRecordAdditionalContributingOwners, overflow))
 		}
 	}
-	return out
+	return out, nil
 }
 
 // joinAndPackStrings sorts and joins src strings into two comma-separated
 // chunks (primary and overflow), each strictly bounded to 255 bytes.
-func joinAndPackStrings(src []string) (string, string) {
+func joinAndPackStrings(src []string) (string, string, bool) {
 	if len(src) == 0 {
-		return "", ""
+		return "", "", false
 	}
 
 	sorted := slices.Clone(src)
@@ -176,11 +186,11 @@ func joinAndPackStrings(src []string) (string, string) {
 	sb.Grow(255)
 	overflowSB.Grow(255)
 
-	// push attempts to append an item to the specified builder (truncating single oversized items).
+	// push attempts to append an item to the specified builder.
 	// It returns true if the item was successfully appended within the 255-byte limit.
 	push := func(b *strings.Builder, item string) bool {
 		if len(item) > 255 {
-			item = item[:255]
+			return false
 		}
 		needComma := b.Len() > 0
 		addedLen := len(item)
@@ -212,5 +222,5 @@ func joinAndPackStrings(src []string) (string, string) {
 		log.Info("Tag length exceeds the extra tag's limit (255), truncating additional inputs")
 	}
 
-	return sb.String(), overflowSB.String()
+	return sb.String(), overflowSB.String(), truncated
 }

--- a/pkg/nsx/services/dns/contributing_test.go
+++ b/pkg/nsx/services/dns/contributing_test.go
@@ -1,0 +1,159 @@
+/* Copyright © 2026 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package dns
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+func TestJoinAndPackStrings(t *testing.T) {
+	// Generate a list of keys that will exceed 255 characters when joined
+	var keys []string
+	for i := 0; i < 50; i++ {
+		keys = append(keys, fmt.Sprintf("http_route/namespace-%d/name-%d", i, i))
+	}
+
+	plain, overflow := joinAndPackStrings(keys)
+
+	// Plain string should not exceed 255 characters
+	require.LessOrEqual(t, len(plain), 255)
+
+	// Overflow should not exceed 255 characters
+	require.LessOrEqual(t, len(overflow), 255)
+	require.NotEmpty(t, overflow)
+
+	// Verify that the overflow string contains valid keys
+	// It might be truncated, so we just check if the first few overflow keys are present
+	overflowKeys := strings.Split(overflow, ",")
+	require.True(t, len(overflowKeys) > 0)
+
+	// Ensure no corrupted partial keys are present (they should start with "http_route")
+	for _, k := range overflowKeys {
+		require.True(t, strings.HasPrefix(k, "http_route/"))
+	}
+}
+
+func TestJoinAndPackStrings_EdgeCases(t *testing.T) {
+	// Empty slice
+	plain, overflow := joinAndPackStrings(nil)
+	require.Empty(t, plain)
+	require.Empty(t, overflow)
+
+	// Small slice (no overflow)
+	keys := []string{"http_route/ns1/name1", "http_route/ns2/name2"}
+	plain, overflow = joinAndPackStrings(keys)
+	require.Equal(t, "http_route/ns1/name1,http_route/ns2/name2", plain)
+	require.Empty(t, overflow)
+}
+
+func TestParseContributingOwnersTag(t *testing.T) {
+	require.Empty(t, parseContributingOwnersTag(""))
+	require.Empty(t, parseContributingOwnersTag("   "))
+
+	parsed := parseContributingOwnersTag("key1, key2 ,key3,  key1 ")
+	require.ElementsMatch(t, []string{"key1", "key2", "key3"}, parsed)
+}
+
+func TestMergeContributingOwnerKeys(t *testing.T) {
+	existing := []string{"key1", "key2"}
+
+	// Normal merge
+	merged := mergeContributingOwnerKeys(existing, "key3", "primaryKey")
+	require.Equal(t, []string{"key1", "key2", "key3"}, merged)
+
+	// Deduplication and exclude primaryNNKey
+	merged = mergeContributingOwnerKeys(existing, "key2", "key1")
+	require.Equal(t, []string{"key2"}, merged)
+
+	// Add primaryNNKey (should be excluded)
+	merged = mergeContributingOwnerKeys(existing, "primaryKey", "primaryKey")
+	require.Equal(t, []string{"key1", "key2"}, merged)
+}
+
+func TestAppendGatewayAndContributionTags(t *testing.T) {
+	tags := []model.Tag{{Scope: common.String("existing"), Tag: common.String("value")}}
+
+	// Empty gateway, empty contrib
+	out := appendGatewayAndContributionTags(tags, "", nil)
+	require.Len(t, out, 1)
+
+	// With gateway, empty contrib
+	out = appendGatewayAndContributionTags(tags, "gw-key", nil)
+	require.Len(t, out, 2)
+	require.Equal(t, common.TagScopeDNSRecordGatewayIndexList, *out[1].Scope)
+	require.Equal(t, "gw-key", *out[1].Tag)
+
+	// With contrib (small)
+	contribKeys := []string{"key1", "key2"}
+	out = appendGatewayAndContributionTags(tags, "", contribKeys)
+	require.Len(t, out, 2)
+	require.Equal(t, common.TagScopeDNSRecordContributingOwners, *out[1].Scope)
+	require.Equal(t, "key1,key2", *out[1].Tag)
+}
+
+func TestParseContributingOwnersFromRecord(t *testing.T) {
+	var keys []string
+	for i := 0; i < 50; i++ {
+		keys = append(keys, fmt.Sprintf("http_route/namespace-%d/name-%d", i, i))
+	}
+
+	plain, overflow := joinAndPackStrings(keys)
+
+	rec := &model.DnsRecord{
+		Tags: []model.Tag{
+			{Scope: common.String(common.TagScopeDNSRecordContributingOwners), Tag: common.String(plain)},
+			{Scope: common.String(common.TagScopeDNSRecordAdditionalContributingOwners), Tag: common.String(overflow)},
+		},
+	}
+
+	parsedKeys := parseContributingOwnersFromRecord(rec)
+
+	// We might lose some keys due to truncation, but we should definitely have more than what fits in the plain tag
+	plainKeys := strings.Split(plain, ",")
+	require.Greater(t, len(parsedKeys), len(plainKeys))
+
+	// All parsed keys should be valid
+	for _, k := range parsedKeys {
+		require.True(t, strings.HasPrefix(k, "http_route/"))
+	}
+}
+
+func TestReplaceContributingOwnersInTagsWithOverflow(t *testing.T) {
+	var keys []string
+	for i := 0; i < 50; i++ {
+		keys = append(keys, fmt.Sprintf("http_route/namespace-%d/name-%d", i, i))
+	}
+
+	tags := []model.Tag{
+		{Scope: common.String(common.TagScopeCluster), Tag: common.String("c1")},
+	}
+
+	out := replaceContributingOwnersInTags(tags, keys)
+
+	// Should have Cluster, ContributingOwners, and AdditionalContributingOwners tags
+	require.Len(t, out, 3)
+
+	hasPlain := false
+	hasOverflow := false
+	for _, tag := range out {
+		if *tag.Scope == common.TagScopeDNSRecordContributingOwners {
+			hasPlain = true
+			require.LessOrEqual(t, len(*tag.Tag), 255)
+		}
+		if *tag.Scope == common.TagScopeDNSRecordAdditionalContributingOwners {
+			hasOverflow = true
+			require.LessOrEqual(t, len(*tag.Tag), 255)
+		}
+	}
+
+	require.True(t, hasPlain)
+	require.True(t, hasOverflow)
+}

--- a/pkg/nsx/services/dns/contributing_test.go
+++ b/pkg/nsx/services/dns/contributing_test.go
@@ -21,7 +21,7 @@ func TestJoinAndPackStrings(t *testing.T) {
 		keys = append(keys, fmt.Sprintf("http_route/namespace-%d/name-%d", i, i))
 	}
 
-	plain, overflow := joinAndPackStrings(keys)
+	plain, overflow, truncated := joinAndPackStrings(keys)
 
 	// Plain string should not exceed 255 characters
 	require.LessOrEqual(t, len(plain), 255)
@@ -39,19 +39,55 @@ func TestJoinAndPackStrings(t *testing.T) {
 	for _, k := range overflowKeys {
 		require.True(t, strings.HasPrefix(k, "http_route/"))
 	}
+
+	// Since we generated 50 keys and each is ~30 chars, total is ~1500 chars.
+	// Two 255-char buffers can only hold ~510 chars, so it MUST be truncated.
+	require.True(t, truncated)
 }
 
 func TestJoinAndPackStrings_EdgeCases(t *testing.T) {
 	// Empty slice
-	plain, overflow := joinAndPackStrings(nil)
+	plain, overflow, truncated := joinAndPackStrings(nil)
 	require.Empty(t, plain)
 	require.Empty(t, overflow)
+	require.False(t, truncated)
 
 	// Small slice (no overflow)
 	keys := []string{"http_route/ns1/name1", "http_route/ns2/name2"}
-	plain, overflow = joinAndPackStrings(keys)
+	plain, overflow, truncated = joinAndPackStrings(keys)
 	require.Equal(t, "http_route/ns1/name1,http_route/ns2/name2", plain)
 	require.Empty(t, overflow)
+	require.False(t, truncated)
+
+	// Single item exceeding 255 bytes (must not be truncated silently, must mark truncated=true)
+	longKey := "http_route/ns/" + strings.Repeat("a", 260)
+	plain, overflow, truncated = joinAndPackStrings([]string{longKey})
+	require.Empty(t, plain)
+	require.Empty(t, overflow)
+	require.True(t, truncated)
+}
+
+func TestFormatContributingOwnersTag(t *testing.T) {
+	// Empty keys
+	tag1, tag2, err := formatContributingOwnersTag(nil)
+	require.NoError(t, err)
+	require.Empty(t, tag1)
+	require.Empty(t, tag2)
+
+	// Small keys
+	tag1, tag2, err = formatContributingOwnersTag([]string{"key1", "key2"})
+	require.NoError(t, err)
+	require.Equal(t, "key1,key2", tag1)
+	require.Empty(t, tag2)
+
+	// Large keys that cause truncation
+	var keys []string
+	for i := 0; i < 50; i++ {
+		keys = append(keys, fmt.Sprintf("http_route/namespace-%d/name-%d", i, i))
+	}
+	_, _, err = formatContributingOwnersTag(keys)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "contributing owners count exceeds maximum tag capacity")
 }
 
 func TestParseContributingOwnersTag(t *testing.T) {
@@ -82,18 +118,21 @@ func TestAppendGatewayAndContributionTags(t *testing.T) {
 	tags := []model.Tag{{Scope: common.String("existing"), Tag: common.String("value")}}
 
 	// Empty gateway, empty contrib
-	out := appendGatewayAndContributionTags(tags, "", nil)
+	out, err := appendGatewayAndContributionTags(tags, "", nil)
+	require.NoError(t, err)
 	require.Len(t, out, 1)
 
 	// With gateway, empty contrib
-	out = appendGatewayAndContributionTags(tags, "gw-key", nil)
+	out, err = appendGatewayAndContributionTags(tags, "gw-key", nil)
+	require.NoError(t, err)
 	require.Len(t, out, 2)
 	require.Equal(t, common.TagScopeDNSRecordGatewayIndexList, *out[1].Scope)
 	require.Equal(t, "gw-key", *out[1].Tag)
 
 	// With contrib (small)
 	contribKeys := []string{"key1", "key2"}
-	out = appendGatewayAndContributionTags(tags, "", contribKeys)
+	out, err = appendGatewayAndContributionTags(tags, "", contribKeys)
+	require.NoError(t, err)
 	require.Len(t, out, 2)
 	require.Equal(t, common.TagScopeDNSRecordContributingOwners, *out[1].Scope)
 	require.Equal(t, "key1,key2", *out[1].Tag)
@@ -105,7 +144,7 @@ func TestParseContributingOwnersFromRecord(t *testing.T) {
 		keys = append(keys, fmt.Sprintf("http_route/namespace-%d/name-%d", i, i))
 	}
 
-	plain, overflow := joinAndPackStrings(keys)
+	plain, overflow, _ := joinAndPackStrings(keys)
 
 	rec := &model.DnsRecord{
 		Tags: []model.Tag{
@@ -126,34 +165,71 @@ func TestParseContributingOwnersFromRecord(t *testing.T) {
 	}
 }
 
-func TestReplaceContributingOwnersInTagsWithOverflow(t *testing.T) {
-	var keys []string
-	for i := 0; i < 50; i++ {
-		keys = append(keys, fmt.Sprintf("http_route/namespace-%d/name-%d", i, i))
-	}
-
+func TestReplaceContributingOwnersInTags(t *testing.T) {
 	tags := []model.Tag{
 		{Scope: common.String(common.TagScopeCluster), Tag: common.String("c1")},
+		{Scope: common.String(common.TagScopeDNSRecordContributingOwners), Tag: common.String("old_plain")},
+		{Scope: common.String(common.TagScopeDNSRecordAdditionalContributingOwners), Tag: common.String("old_overflow")},
 	}
 
-	out := replaceContributingOwnersInTags(tags, keys)
+	t.Run("normal replacement without overflow", func(t *testing.T) {
+		keys := []string{"http_route/ns1/name1"}
+		out, err := replaceContributingOwnersInTags(tags, keys)
+		require.NoError(t, err)
+		require.Len(t, out, 2)
+		require.Equal(t, common.TagScopeCluster, *out[0].Scope)
+		require.Equal(t, common.TagScopeDNSRecordContributingOwners, *out[1].Scope)
+		require.Equal(t, "http_route/ns1/name1", *out[1].Tag)
+	})
 
-	// Should have Cluster, ContributingOwners, and AdditionalContributingOwners tags
-	require.Len(t, out, 3)
-
-	hasPlain := false
-	hasOverflow := false
-	for _, tag := range out {
-		if *tag.Scope == common.TagScopeDNSRecordContributingOwners {
-			hasPlain = true
-			require.LessOrEqual(t, len(*tag.Tag), 255)
+	t.Run("replacement with overflow but no truncation", func(t *testing.T) {
+		// Generate enough keys to spill into the second tag, but not exceed both 255-byte limits.
+		// 10 keys of ~30 chars = ~300 chars.
+		var keys []string
+		for i := 0; i < 10; i++ {
+			keys = append(keys, fmt.Sprintf("http_route/namespace-%d/name-%d", i, i))
 		}
-		if *tag.Scope == common.TagScopeDNSRecordAdditionalContributingOwners {
-			hasOverflow = true
-			require.LessOrEqual(t, len(*tag.Tag), 255)
-		}
-	}
+		out, err := replaceContributingOwnersInTags(tags, keys)
+		require.NoError(t, err)
+		require.Len(t, out, 3)
 
-	require.True(t, hasPlain)
-	require.True(t, hasOverflow)
+		hasPlain := false
+		hasOverflow := false
+		for _, tag := range out {
+			if *tag.Scope == common.TagScopeDNSRecordContributingOwners {
+				hasPlain = true
+				require.LessOrEqual(t, len(*tag.Tag), 255)
+			}
+			if *tag.Scope == common.TagScopeDNSRecordAdditionalContributingOwners {
+				hasOverflow = true
+				require.LessOrEqual(t, len(*tag.Tag), 255)
+			}
+		}
+		require.True(t, hasPlain)
+		require.True(t, hasOverflow)
+	})
+
+	t.Run("replacement with truncation returns error", func(t *testing.T) {
+		// Generate huge number of keys to force truncation
+		var keys []string
+		for i := 0; i < 50; i++ {
+			keys = append(keys, fmt.Sprintf("http_route/namespace-%d/name-%d", i, i))
+		}
+		out, err := replaceContributingOwnersInTags(tags, keys)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "contributing owners count exceeds maximum tag capacity")
+		require.Nil(t, out)
+	})
+}
+
+func TestParseOwnerNNIndexKey(t *testing.T) {
+	cf, ns, n, ok := parseOwnerNNIndexKey("httproute/ns1/r1")
+	require.True(t, ok)
+	require.Equal(t, common.TagValueDNSRecordForHTTPRoute, cf)
+	require.Equal(t, "ns1", ns)
+	require.Equal(t, "r1", n)
+
+	// Invalid format
+	_, _, _, ok = parseOwnerNNIndexKey("invalid")
+	require.False(t, ok)
 }

--- a/pkg/nsx/services/dns/initialize.go
+++ b/pkg/nsx/services/dns/initialize.go
@@ -14,6 +14,10 @@ import (
 )
 
 // InitializeDNSRecordService constructs a DNSRecordService and hydrates DNSRecordStore from NSX Policy search.
+// Note: NSX Search API currently does not support searching DNSRecord and DNSZone types.
+// Thus, this initial population will result in an empty store, and resources will be read on-demand
+// (via direct GETs) or created afresh.
+// TODO: Remove this Note once NSX Search API supports DNSRecord.
 func InitializeDNSRecordService(commonService common.Service, vpcService common.VPCServiceProvider) (*DNSRecordService, error) {
 	builder, err := common.PolicyPathDnsRecord.NewPolicyTreeBuilder()
 	if err != nil {

--- a/pkg/nsx/services/dns/recordservice.go
+++ b/pkg/nsx/services/dns/recordservice.go
@@ -16,11 +16,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	extdns "github.com/vmware-tanzu/nsx-operator/pkg/third_party/externaldns/endpoint"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
 var (
@@ -30,6 +32,43 @@ var (
 
 // NSX Policy path: /orgs/{org}/projects/{project}/dns-records/{record-id}
 var dnsRecordPathRe = regexp.MustCompile(`^/orgs/([^/]+)/projects/([^/]+)/dns-records/([^/]+)$`)
+
+// recordAccessArbitrator ensures that concurrent goroutines cannot perform operations
+// on the same record ID within a zone simultaneously. It avoids the memory leaks associated with
+// storing a sync.Mutex per record ID indefinitely.
+type recordAccessArbitrator struct {
+	mutex       sync.Mutex
+	cond        *sync.Cond
+	busyRecords map[string]bool
+}
+
+var recordArbitrator = func() *recordAccessArbitrator {
+	a := &recordAccessArbitrator{
+		busyRecords: make(map[string]bool),
+	}
+	a.cond = sync.NewCond(&a.mutex)
+	return a
+}()
+
+func getLockKey(zonePath, recordID, recType string) string {
+	return zonePath + "/" + recordID + "/" + recType
+}
+
+func (a *recordAccessArbitrator) lock(lockKey string) {
+	a.cond.L.Lock()
+	defer a.cond.L.Unlock()
+	for a.busyRecords[lockKey] {
+		a.cond.Wait()
+	}
+	a.busyRecords[lockKey] = true
+}
+
+func (a *recordAccessArbitrator) unlock(lockKey string) {
+	a.cond.L.Lock()
+	defer a.cond.L.Unlock()
+	delete(a.busyRecords, lockKey)
+	a.cond.Broadcast()
+}
 
 // dnsZoneCache is a thread-safe zone path → DNS domain name cache.
 type dnsZoneCache struct {
@@ -72,16 +111,58 @@ type DNSRecordService struct {
 	DnsRecordBuilder *common.PolicyTreeBuilder[*model.DnsRecord]
 }
 
+// getInvolvedRecordLockKeys returns the unique policy paths and lock keys for all records involved in this batch.
+// This includes the records the batch *wants* to manage, as well as the records the owner *currently* owns.
+func (s *DNSRecordService) getInvolvedRecordLockKeys(batch *AggregatedDNSEndpoints) (lockKeys []string) {
+	involvedLockKeys := make(map[string]struct{})
+
+	if batch.Owner != nil {
+		for _, row := range batch.Rows {
+			recID, _, recType := getRecordIDAndPathAndType(row.nsxRecordName, row.RecordType, row.zonePath)
+			involvedLockKeys[getLockKey(row.zonePath, recID, recType)] = struct{}{}
+		}
+
+		_, ownedRecs := s.collectRecordsByOwner(batch.Owner.Kind, batch.Owner.GetNamespace(), batch.Owner.GetName())
+		for _, rec := range ownedRecs {
+			if rec.Id != nil && rec.ZonePath != nil && rec.RecordType != nil {
+				involvedLockKeys[getLockKey(*rec.ZonePath, *rec.Id, *rec.RecordType)] = struct{}{}
+			}
+		}
+	}
+
+	for k := range involvedLockKeys {
+		lockKeys = append(lockKeys, k)
+	}
+	slices.Sort(lockKeys)
+
+	return lockKeys
+}
+
 // CreateOrUpdateRecords upserts batch rows into the store and NSX placeholder. Returns (storeMutated, err).
 func (s *DNSRecordService) CreateOrUpdateRecords(ctx context.Context, batch *AggregatedDNSEndpoints) (bool, error) {
+	sortedRecordIDs := s.getInvolvedRecordLockKeys(batch)
+
+	for _, id := range sortedRecordIDs {
+		recordArbitrator.lock(id)
+	}
+	defer func() {
+		// unlock in reverse order
+		for i := len(sortedRecordIDs) - 1; i >= 0; i-- {
+			recordArbitrator.unlock(sortedRecordIDs[i])
+		}
+	}()
+
 	toUpsert, toRemove, err := s.applyDNSUpsertRows(batch)
 	if err != nil {
 		return false, err
 	}
+
 	if len(toUpsert) == 0 && len(toRemove) == 0 {
 		return false, nil
 	}
+
 	toApply, syncErr := s.syncDnsRecordsInNSX(ctx, toUpsert, toRemove)
+
 	// Apply whichever records were successfully processed to keep the local store in sync even on
 	// partial realization failures; this prevents re-sending already-realized records next reconcile.
 	if len(toApply) > 0 {
@@ -103,7 +184,9 @@ func (s *DNSRecordService) syncDnsRecordsInNSX(ctx context.Context, toUpsert, to
 		removeOps = append(removeOps, &cp)
 	}
 
+	// Merge ops, ensuring deletes process first or aren't duplicated if upserting same path
 	batch := append(append([]*model.DnsRecord(nil), toUpsert...), removeOps...)
+	batch = dedupeRecordsByPath(batch) // In case of overlap, the last one in batch wins
 
 	if len(batch) == 0 {
 		return nil, nil
@@ -124,11 +207,31 @@ func (s *DNSRecordService) syncDnsRecordsInNSX(ctx context.Context, toUpsert, to
 			realizeErrs = append(realizeErrs, perr)
 			continue
 		}
-		live, gerr := s.NSXClient.DnsRecordsClient.Get(orgID, projectID, recordID)
-		gerr = nsxutil.TransNSXApiError(gerr)
-		if gerr != nil {
-			log.Error(gerr, "Failed to get realized DnsRecord from NSX", "Id", recordID)
-			realizeErrs = append(realizeErrs, fmt.Errorf("failed to get record %s from NSX after realization: %w", recordID, gerr))
+
+		var live model.DnsRecord
+		var gerr error
+		err := retry.OnError(util.NSXTRealizeRetry, func(err error) bool {
+			if err == nil {
+				return false
+			}
+			// 500087 is checked and handled at the top level retry loop
+			if nsxApiErr, ok := err.(*nsxutil.NSXApiError); ok {
+				if nsxApiErr.ErrorCode != nil && *nsxApiErr.ErrorCode == 500090 {
+					// 500090 is returned when the object is requested before it is fully indexed/available
+					return true
+				}
+			}
+			return false
+		}, func() error {
+			live, gerr = s.NSXClient.DnsRecordsClient.Get(orgID, projectID, recordID)
+			gerr = nsxutil.TransNSXApiError(gerr)
+			// Return immediately if it's 500090 so the retry catches it
+			return gerr
+		})
+
+		if err != nil {
+			log.Error(err, "Failed to get realized DnsRecord from NSX", "Id", recordID)
+			realizeErrs = append(realizeErrs, fmt.Errorf("failed to get record %s from NSX after realization: %w", recordID, err))
 			continue
 		}
 		log.Debug("DnsRecord realized and refreshed", "Id", recordID)
@@ -156,36 +259,45 @@ func (s *DNSRecordService) validateEndpointRowConflict(zonePath string, ep *extd
 	recs := s.DNSRecordStore.GetByIndex(indexKeyDNSRecordZonePathRecordName, idxKey)
 	log.Debug("Checking DNS record conflict", "fqdn", fqdn, "zone", zonePath, "type", recTypeForIdx, "existingCount", len(recs))
 	currentNNKey := ownerNNIndexKeyForResourceRef(owner)
-	for _, rec := range recs {
-		if getDNSRecordOwnerNamespacedName(rec) == currentNNKey {
-			return NewEndpointRow(ep, zonePath, recordName), nil
+	if len(recs) == 0 {
+		return NewEndpointRow(ep, zonePath, recordName), nil
+	}
+
+	// Always prefer the newest record for the index key if multiple exist somehow (which shouldn't happen)
+	rec := recs[0]
+	for _, r := range recs {
+		if r.MarkedForDelete == nil || !*r.MarkedForDelete {
+			rec = r
+			break
 		}
-		if *rec.RecordType != ep.RecordType {
-			continue
-		}
-		extRecValues := sortedCopyStrings(rec.RecordValues)
-		newRecValues := sortedCopyStrings(ep.Targets)
-		if !slices.Equal(extRecValues, newRecValues) {
-			err := fmt.Errorf("FQDN %s is configured with different values in DNS zone %s", fqdn, zonePath)
-			log.Error(err, "FQDN targets conflict with existing record", "resource", getDNSRecordOwnerNamespacedName(rec))
-			return nil, err
-		}
-		effectiveOwner, ok := resourceRefFromDNSRecord(rec)
-		if !ok {
-			err := fmt.Errorf("FQDN %s has an existing DNS record with incomplete owner metadata in DNS zone %s", fqdn, zonePath)
-			log.Error(err, "cannot adopt shared DNS record")
-			return nil, err
-		}
-		log.Info("Adopting shared DNS record", "fqdn", fqdn, "zone", zonePath,
-			"effectiveOwner", getDNSRecordOwnerNamespacedName(rec), "currentOwner", currentNNKey)
+	}
+
+	if getDNSRecordOwnerNamespacedName(rec) == currentNNKey {
 		row := NewEndpointRow(ep, zonePath, recordName)
-		primaryNN := primaryOwnerNNIndexKeyFromRecord(rec)
-		row.effectiveOwner = effectiveOwner
-		existingContributions := decompressContributingTags(rec)
-		row.contributingOwnerKeys = mergeContributingOwnerKeys(existingContributions, currentNNKey, primaryNN)
+		row.contributingOwnerKeys = parseContributingOwnersFromRecord(rec)
 		return row, nil
 	}
-	return NewEndpointRow(ep, zonePath, recordName), nil
+	extRecValues := sortedCopyStrings(rec.RecordValues)
+	newRecValues := sortedCopyStrings(ep.Targets)
+	if !slices.Equal(extRecValues, newRecValues) {
+		err := fmt.Errorf("FQDN %s is configured with different values in DNS zone %s", fqdn, zonePath)
+		log.Error(err, "FQDN targets conflict with existing record", "resource", getDNSRecordOwnerNamespacedName(rec))
+		return nil, err
+	}
+	effectiveOwner, ok := resourceRefFromDNSRecord(rec)
+	if !ok {
+		err := fmt.Errorf("FQDN %s has an existing DNS record with incomplete owner metadata in DNS zone %s", fqdn, zonePath)
+		log.Error(err, "cannot adopt shared DNS record")
+		return nil, err
+	}
+	primaryNN := getDNSRecordOwnerNamespacedName(rec)
+	log.Info("Adopting shared DNS record", "fqdn", fqdn, "zone", zonePath,
+		"effectiveOwner", primaryNN, "currentOwner", currentNNKey)
+	row := NewEndpointRow(ep, zonePath, recordName)
+	row.effectiveOwner = effectiveOwner
+	existingContributions := parseContributingOwnersFromRecord(rec)
+	row.contributingOwnerKeys = mergeContributingOwnerKeys(existingContributions, currentNNKey, primaryNN)
+	return row, nil
 }
 
 // classifyOwnerRemoval handles the three-way decision for a record that references deletedOwnerKey
@@ -231,7 +343,14 @@ func (s *DNSRecordService) applyDNSUpsertRows(batch *AggregatedDNSEndpoints) ([]
 
 	desiredRecs := make([]*model.DnsRecord, 0, len(batch.Rows))
 	for _, row := range batch.Rows {
-		if rec := s.BuildDnsRecord(batch.Owner, row); rec != nil {
+		// Re-evaluate the row against the current store state while under the local lock
+		// to prevent overwriting existing shared records if the initial validation used a stale cache.
+		freshRow, err := s.validateEndpointRowConflict(row.zonePath, row.Endpoint, row.nsxRecordName, batch.Owner)
+		if err != nil {
+			log.Error(err, "conflict detected during upsert, skipping row", "fqdn", row.Endpoint.DNSName)
+			return nil, nil, &DNSZoneValidationError{Msg: "DNS endpoint validation failed for FQDN is taken by other resource", Cause: err}
+		}
+		if rec := s.BuildDnsRecord(batch.Owner, *freshRow); rec != nil {
 			desiredRecs = append(desiredRecs, rec)
 		}
 	}
@@ -249,6 +368,7 @@ func (s *DNSRecordService) applyDNSUpsertRows(batch *AggregatedDNSEndpoints) ([]
 			return nil, nil, err
 		}
 	}
+
 	log.Debug("DNS record diff ready", "owner", ownerNNKey, "toUpsert", len(toUpsert), "toRemove", len(toRemove))
 	return toUpsert, toRemove, nil
 }
@@ -266,6 +386,32 @@ func (s *DNSRecordService) collectRecordsByOwner(ownerKind, ownerNamespace, owne
 
 // DeleteRecordByOwnerNN deletes or retags rows for kind/ns/name. Returns (storeMutated, err).
 func (s *DNSRecordService) DeleteRecordByOwnerNN(ctx context.Context, kind, namespace, name string) (bool, error) {
+	// calculate distinct record IDs to lock to prevent overlapping calculations and patches
+	recordIDsToLock := make(map[string]struct{})
+	_, ownedRecs := s.collectRecordsByOwner(kind, namespace, name)
+	for _, rec := range ownedRecs {
+		if rec.Id != nil && rec.ZonePath != nil && rec.RecordType != nil {
+			recordIDsToLock[getLockKey(*rec.ZonePath, *rec.Id, *rec.RecordType)] = struct{}{}
+		}
+	}
+
+	// acquire locks in a deterministic order to prevent deadlocks
+	var sortedRecordIDs []string
+	for id := range recordIDsToLock {
+		sortedRecordIDs = append(sortedRecordIDs, id)
+	}
+	slices.Sort(sortedRecordIDs)
+
+	for _, id := range sortedRecordIDs {
+		recordArbitrator.lock(id)
+	}
+	defer func() {
+		// unlock in reverse order
+		for i := len(sortedRecordIDs) - 1; i >= 0; i-- {
+			recordArbitrator.unlock(sortedRecordIDs[i])
+		}
+	}()
+
 	toUpdate, toDelete, err := s.calculateRecordsForDeletion(kind, namespace, name)
 	if err != nil {
 		return false, err
@@ -277,7 +423,9 @@ func (s *DNSRecordService) DeleteRecordByOwnerNN(ctx context.Context, kind, name
 	if !cacheChanged {
 		return false, nil
 	}
+
 	toApply, syncErr := s.syncDnsRecordsInNSX(ctx, toUpdate, toDelete)
+
 	if len(toApply) > 0 {
 		if applyErr := s.DNSRecordStore.Apply(toApply); applyErr != nil {
 			return false, applyErr
@@ -299,6 +447,7 @@ func (s *DNSRecordService) calculateRecordsForDeletion(kind, namespace, name str
 			return nil, nil, err
 		}
 	}
+
 	return toUpdate, toDelete, nil
 }
 
@@ -309,7 +458,6 @@ func gatewayIndexTagFromRecord(rec *model.DnsRecord) string {
 // recordAfterPrimaryDeletePromotion returns the updated record when the primary owner is removed but contributors remain.
 func (s *DNSRecordService) recordAfterPrimaryDeletePromotion(rec *model.DnsRecord, sortedContribNNKeys []string) (*model.DnsRecord, error) {
 	promotedNN := sortedContribNNKeys[0]
-	remaining := append([]string(nil), sortedContribNNKeys[1:]...)
 	createdFor, ns, name, ok := parseOwnerNNIndexKey(promotedNN)
 	if !ok {
 		return nil, fmt.Errorf("invalid contributing owner key %q", promotedNN)
@@ -318,9 +466,14 @@ func (s *DNSRecordService) recordAfterPrimaryDeletePromotion(rec *model.DnsRecor
 	if kind == "" {
 		return nil, fmt.Errorf("unknown created-for tag in contributing owner key %q", promotedNN)
 	}
+
 	newOwner := &ResourceRef{Kind: kind, Object: &metav1.ObjectMeta{Namespace: ns, Name: name}}
 	out := *rec
-	out.Tags = appendGatewayAndContributionTags(s.tagsForOwner(newOwner), gatewayIndexTagFromRecord(rec), formatContributingOwnersTag(remaining))
+	var remaining []string
+	if len(sortedContribNNKeys) > 1 {
+		remaining = append(remaining, sortedContribNNKeys[1:]...)
+	}
+	out.Tags = appendGatewayAndContributionTags(s.tagsForOwner(newOwner), gatewayIndexTagFromRecord(rec), remaining)
 	out.MarkedForDelete = nil
 	return &out, nil
 }

--- a/pkg/nsx/services/dns/recordservice.go
+++ b/pkg/nsx/services/dns/recordservice.go
@@ -26,8 +26,9 @@ import (
 )
 
 var (
-	log                   = logger.Log
-	_   DNSRecordProvider = (*DNSRecordService)(nil)
+	log                               = logger.Log
+	_               DNSRecordProvider = (*DNSRecordService)(nil)
+	k8sRouteKindSet                   = sets.New(ResourceKindHTTPRoute, ResourceKindGRPCRoute, ResourceKindTLSRoute)
 )
 
 // NSX Policy path: /orgs/{org}/projects/{project}/dns-records/{record-id}
@@ -140,8 +141,15 @@ func (s *DNSRecordService) getInvolvedRecordLockKeys(batch *AggregatedDNSEndpoin
 
 // CreateOrUpdateRecords upserts batch rows into the store and NSX placeholder. Returns (storeMutated, err).
 func (s *DNSRecordService) CreateOrUpdateRecords(ctx context.Context, batch *AggregatedDNSEndpoints) (bool, error) {
+	if batch.Owner != nil {
+		ownerKey := "owner/" + batch.Owner.Kind + "/" + batch.Owner.GetNamespace() + "/" + batch.Owner.GetName()
+		recordArbitrator.lock(ownerKey)
+		defer recordArbitrator.unlock(ownerKey)
+	}
+
 	sortedRecordIDs := s.getInvolvedRecordLockKeys(batch)
 
+	// Acquire locks in a deterministic order to prevent deadlocks
 	for _, id := range sortedRecordIDs {
 		recordArbitrator.lock(id)
 	}
@@ -247,7 +255,48 @@ func (s *DNSRecordService) syncDnsRecordsInNSX(ctx context.Context, toUpsert, to
 	return toApply, nil
 }
 
-// validateEndpointRowConflict returns a row for ep in zone, or an error on FQDN conflict.
+func isRouteKind(kind string) bool {
+	return k8sRouteKindSet.Has(kind)
+}
+
+// isRouteKindCompatible checks if both kind1 and kind2 belong to the route kind group (HTTPRoute, GRPCRoute, TLSRoute).
+func isRouteKindCompatible(kind1, kind2 string) bool {
+	return kind1 == kind2 || (k8sRouteKindSet.Has(kind1) && k8sRouteKindSet.Has(kind2))
+}
+
+// isRecordSharableWithContributors checks if existing rec is owned by a route kind that supports the contributor mechanism.
+func isRecordSharableWithContributors(rec *model.DnsRecord) bool {
+	owner, ok := resourceRefFromDNSRecord(rec)
+	if !ok {
+		return false
+	}
+	return isRouteKind(owner.Kind)
+}
+
+// isRouteTargetConsistent checks if incoming ep and owner match the parent gateway values of existing rec for adoption.
+func isRouteTargetConsistent(rec *model.DnsRecord, ep *extdns.Endpoint, owner *ResourceRef, zonePath string) error {
+	fqdn := strings.ToLower(ep.DNSName)
+	recGw := gatewayIndexTagFromRecord(rec)
+	epGw := strings.TrimSpace(ep.Labels[EndpointLabelParentGateway])
+	if recGw != epGw {
+		err := fmt.Errorf("FQDN %s parent gateway %s conflicts with existing record parent gateway %s in DNS zone %s", fqdn, epGw, recGw, zonePath)
+		return err
+	}
+	return nil
+}
+
+// validateEndpointRowConflict checks whether an incoming endpoint can create or adopt a DNS record,
+// or if it conflicts with an existing record in the store.
+//
+// Validation rules for shared DNS records:
+//  1. Primary owner reconciliation (current owner == record primary owner):
+//     - If the record has active contributors, changing the parent gateway is forbidden to prevent
+//     gateway mismatch for contributors. Target IP changes (e.g. gateway IP updates) are allowed.
+//  2. Contributor adoption flow (current owner != record primary owner):
+//     - Contributor sharing is only supported for route resources (HTTPRoute, GRPCRoute, TLSRoute).
+//     - The incoming resource and existing primary owner must be compatible route kinds.
+//     - Both resources must be associated with the exact same parent Gateway.
+//     - When valid, the incoming resource adopts the existing record as a contributor.
 func (s *DNSRecordService) validateEndpointRowConflict(zonePath string, ep *extdns.Endpoint, recordName string, owner *ResourceRef) (*EndpointRow, error) {
 	createdFor := resourceKindToCreatedFor(owner.Kind)
 	if createdFor == "" {
@@ -272,25 +321,61 @@ func (s *DNSRecordService) validateEndpointRowConflict(zonePath string, ep *extd
 		}
 	}
 
-	if getDNSRecordOwnerNamespacedName(rec) == currentNNKey {
-		row := NewEndpointRow(ep, zonePath, recordName)
-		row.contributingOwnerKeys = parseContributingOwnersFromRecord(rec)
-		return row, nil
-	}
 	extRecValues := sortedCopyStrings(rec.RecordValues)
 	newRecValues := sortedCopyStrings(ep.Targets)
-	if !slices.Equal(extRecValues, newRecValues) {
-		err := fmt.Errorf("FQDN %s is configured with different values in DNS zone %s", fqdn, zonePath)
-		log.Error(err, "FQDN targets conflict with existing record", "resource", getDNSRecordOwnerNamespacedName(rec))
-		return nil, err
+
+	// Case 1: Reconciling resource is the primary owner of the existing record.
+	if getDNSRecordOwnerNamespacedName(rec) == currentNNKey {
+		row := NewEndpointRow(ep, zonePath, recordName)
+		if isRecordSharableWithContributors(rec) {
+			existingContribs := parseContributingOwnersFromRecord(rec)
+			if len(existingContribs) > 0 {
+				recGw := gatewayIndexTagFromRecord(rec)
+				epGw := strings.TrimSpace(ep.Labels[EndpointLabelParentGateway])
+				// Prevent gateway changes while other contributors are attached to this record.
+				if recGw != epGw {
+					err := fmt.Errorf("FQDN %s in DNS zone %s is taken by other resources: parent gateway changed from %s to %s", fqdn, zonePath, recGw, epGw)
+					log.Error(err, "parent gateway changed during primary owner reconcile", "resource", currentNNKey)
+					return nil, err
+				}
+				row.contributingOwnerKeys = existingContribs
+			}
+		}
+		if !slices.Equal(extRecValues, newRecValues) {
+			log.Info("DNS record targets changed", "fqdn", fqdn, "zone", zonePath, "resource", currentNNKey, "oldTargets", extRecValues, "newTargets", newRecValues)
+		}
+		return row, nil
 	}
+
+	// Case 2: Incoming resource is trying to adopt an existing record owned by another resource.
 	effectiveOwner, ok := resourceRefFromDNSRecord(rec)
 	if !ok {
 		err := fmt.Errorf("FQDN %s has an existing DNS record with incomplete owner metadata in DNS zone %s", fqdn, zonePath)
 		log.Error(err, "cannot adopt shared DNS record")
 		return nil, err
 	}
+
 	primaryNN := getDNSRecordOwnerNamespacedName(rec)
+	// Contributor sharing is restricted to route resources (non-route kinds like Service cannot be shared).
+	if !isRecordSharableWithContributors(rec) {
+		err := fmt.Errorf("contributor mechanism is only supported for route resources; FQDN %s is already owned by %s (%s) in DNS zone %s", fqdn, effectiveOwner.Kind, primaryNN, zonePath)
+		log.Error(err, "cannot adopt DNS record for non-route kind")
+		return nil, err
+	}
+
+	// Incoming resource and primary owner must be compatible route kinds.
+	if !isRouteKindCompatible(owner.Kind, effectiveOwner.Kind) {
+		err := fmt.Errorf("FQDN %s is not sharable between resources %s and %s in DNS zone %s", fqdn, effectiveOwner.Kind, owner.Kind, zonePath)
+		log.Error(err, "cannot adopt DNS record between incompatible kinds")
+		return nil, err
+	}
+
+	// Incoming resource and primary owner must belong to the exact same parent Gateway.
+	if err := isRouteTargetConsistent(rec, ep, owner, zonePath); err != nil {
+		log.Error(err, "parent gateway conflict for shared DNS record", "currentOwner", currentNNKey, "existingOwner", getDNSRecordOwnerNamespacedName(rec))
+		return nil, err
+	}
+
 	log.Info("Adopting shared DNS record", "fqdn", fqdn, "zone", zonePath,
 		"effectiveOwner", primaryNN, "currentOwner", currentNNKey)
 	row := NewEndpointRow(ep, zonePath, recordName)
@@ -321,7 +406,11 @@ func (s *DNSRecordService) classifyOwnerRemoval(rec *model.DnsRecord, deletedOwn
 		*toUpdate = append(*toUpdate, upd)
 		return nil
 	}
-	if upd, ok := recordAfterContributingRemoval(rec, deletedOwnerKey); ok {
+	upd, ok, err := recordAfterContributingRemoval(rec, deletedOwnerKey)
+	if err != nil {
+		return err
+	}
+	if ok {
 		*toUpdate = append(*toUpdate, upd)
 	}
 	return nil
@@ -347,10 +436,15 @@ func (s *DNSRecordService) applyDNSUpsertRows(batch *AggregatedDNSEndpoints) ([]
 		// to prevent overwriting existing shared records if the initial validation used a stale cache.
 		freshRow, err := s.validateEndpointRowConflict(row.zonePath, row.Endpoint, row.nsxRecordName, batch.Owner)
 		if err != nil {
-			log.Error(err, "conflict detected during upsert, skipping row", "fqdn", row.Endpoint.DNSName)
+			log.Error(err, "conflict detected during upsert, aborting batch", "fqdn", row.Endpoint.DNSName)
 			return nil, nil, &DNSZoneValidationError{Msg: "DNS endpoint validation failed for FQDN is taken by other resource", Cause: err}
 		}
-		if rec := s.BuildDnsRecord(batch.Owner, *freshRow); rec != nil {
+		rec, err := s.BuildDnsRecord(batch.Owner, *freshRow)
+		if err != nil {
+			log.Error(err, "failed to build DNS record, aborting batch", "fqdn", row.Endpoint.DNSName)
+			return nil, nil, &DNSZoneValidationError{Msg: "DNS endpoint validation failed during record build", Cause: err}
+		}
+		if rec != nil {
 			desiredRecs = append(desiredRecs, rec)
 		}
 	}
@@ -384,9 +478,7 @@ func (s *DNSRecordService) collectRecordsByOwner(ownerKind, ownerNamespace, owne
 	return ownerNNKey, dedupeRecordsByPath(slices.Concat(primRecs, contribRecs))
 }
 
-// DeleteRecordByOwnerNN deletes or retags rows for kind/ns/name. Returns (storeMutated, err).
-func (s *DNSRecordService) DeleteRecordByOwnerNN(ctx context.Context, kind, namespace, name string) (bool, error) {
-	// calculate distinct record IDs to lock to prevent overlapping calculations and patches
+func (s *DNSRecordService) getInvolvedRecordLockKeysForOwner(kind, namespace, name string) []string {
 	recordIDsToLock := make(map[string]struct{})
 	_, ownedRecs := s.collectRecordsByOwner(kind, namespace, name)
 	for _, rec := range ownedRecs {
@@ -395,13 +487,25 @@ func (s *DNSRecordService) DeleteRecordByOwnerNN(ctx context.Context, kind, name
 		}
 	}
 
-	// acquire locks in a deterministic order to prevent deadlocks
 	var sortedRecordIDs []string
 	for id := range recordIDsToLock {
 		sortedRecordIDs = append(sortedRecordIDs, id)
 	}
 	slices.Sort(sortedRecordIDs)
 
+	return sortedRecordIDs
+}
+
+// DeleteRecordByOwnerNN deletes or retags rows for kind/ns/name. Returns (storeMutated, err).
+func (s *DNSRecordService) DeleteRecordByOwnerNN(ctx context.Context, kind, namespace, name string) (bool, error) {
+	ownerKey := "owner/" + kind + "/" + namespace + "/" + name
+	recordArbitrator.lock(ownerKey)
+	defer recordArbitrator.unlock(ownerKey)
+
+	// calculate distinct record IDs to lock to prevent overlapping calculations and patches
+	sortedRecordIDs := s.getInvolvedRecordLockKeysForOwner(kind, namespace, name)
+
+	// Acquire locks in a deterministic order to prevent deadlocks
 	for _, id := range sortedRecordIDs {
 		recordArbitrator.lock(id)
 	}
@@ -473,22 +577,30 @@ func (s *DNSRecordService) recordAfterPrimaryDeletePromotion(rec *model.DnsRecor
 	if len(sortedContribNNKeys) > 1 {
 		remaining = append(remaining, sortedContribNNKeys[1:]...)
 	}
-	out.Tags = appendGatewayAndContributionTags(s.tagsForOwner(newOwner), gatewayIndexTagFromRecord(rec), remaining)
+	tags, err := appendGatewayAndContributionTags(s.tagsForOwner(newOwner), gatewayIndexTagFromRecord(rec), remaining)
+	if err != nil {
+		return nil, err
+	}
+	out.Tags = tags
 	out.MarkedForDelete = nil
 	return &out, nil
 }
 
-// recordAfterContributingRemoval removes deletedNNKey from the contributing tag; returns (updatedRecord, changed).
-func recordAfterContributingRemoval(rec *model.DnsRecord, deletedNNKey string) (*model.DnsRecord, bool) {
+// recordAfterContributingRemoval removes deletedNNKey from the contributing tag; returns (updatedRecord, changed, error).
+func recordAfterContributingRemoval(rec *model.DnsRecord, deletedNNKey string) (*model.DnsRecord, bool, error) {
 	keys := parseContributingOwnersFromRecord(rec)
 	if !slices.Contains(keys, deletedNNKey) {
-		return nil, false
+		return nil, false, nil
 	}
 	newContribKeys := slices.DeleteFunc(keys, func(k string) bool { return k == deletedNNKey })
 	out := *rec
-	out.Tags = replaceContributingOwnersInTags(rec.Tags, newContribKeys)
+	tags, err := replaceContributingOwnersInTags(rec.Tags, newContribKeys)
+	if err != nil {
+		return nil, false, err
+	}
+	out.Tags = tags
 	out.MarkedForDelete = nil
-	return &out, true
+	return &out, true, nil
 }
 
 func dedupeRecordsByPath(recs []*model.DnsRecord) []*model.DnsRecord {

--- a/pkg/nsx/services/dns/recordservice_test.go
+++ b/pkg/nsx/services/dns/recordservice_test.go
@@ -91,7 +91,7 @@ func registerBodiesForBatch(t *testing.T, env *testDNSSvc, batch *AggregatedDNSE
 		return
 	}
 	for _, row := range batch.Rows {
-		rec := env.BuildDnsRecord(batch.Owner, row)
+		rec, _ := env.BuildDnsRecord(batch.Owner, row)
 		if rec == nil || rec.Id == nil {
 			continue
 		}
@@ -350,7 +350,8 @@ func TestDNSRecordService_deletesAndQueries_table(t *testing.T) {
 				ep := extdns.NewEndpoint("gw.example.com", extdns.RecordTypeA, "10.0.0.1")
 				ep.WithLabel(EndpointLabelParentGateway, "app/gw1")
 				row := EndpointRow{Endpoint: ep, zonePath: z, nsxRecordName: "gw.example.com"}
-				require.NotNil(t, env.BuildDnsRecord(owner, row))
+				rec, _ := env.BuildDnsRecord(owner, row)
+				require.NotNil(t, rec)
 				requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(owner, []EndpointRow{row}))
 				key := recordStoreKey(row.zonePath, row.nsxRecordName, row.Endpoint.RecordType)
 				require.NotNil(t, env.DNSRecordStore.GetByKey(key))
@@ -369,7 +370,8 @@ func TestDNSRecordService_deletesAndQueries_table(t *testing.T) {
 				epG := extdns.NewEndpoint("gw.example.com", extdns.RecordTypeA, "10.0.0.1")
 				epG.WithLabel(EndpointLabelParentGateway, "app/gw1")
 				rowG := EndpointRow{Endpoint: epG, zonePath: z, nsxRecordName: "gw.example.com"}
-				require.NotNil(t, env.BuildDnsRecord(gwOwner, rowG))
+				rec, _ := env.BuildDnsRecord(gwOwner, rowG)
+				require.NotNil(t, rec)
 				requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(gwOwner, []EndpointRow{rowG}))
 				hrEp := extdns.NewEndpoint("r.example.com", extdns.RecordTypeA, "10.0.0.2")
 				hrEp.WithLabel(EndpointLabelParentGateway, "app/gw1")
@@ -378,7 +380,9 @@ func TestDNSRecordService_deletesAndQueries_table(t *testing.T) {
 					Kind:   ResourceKindHTTPRoute,
 					Object: &metav1.ObjectMeta{Namespace: "app", Name: "hr1", UID: types.UID("u-hr")},
 				}
-				require.NotNil(t, env.BuildDnsRecord(hrOwner, *hrRow))
+				rec, err := env.BuildDnsRecord(hrOwner, *hrRow)
+				require.NoError(t, err)
+				require.NotNil(t, rec)
 				requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(hrOwner, []EndpointRow{*hrRow}))
 				requireNoErrDeleteDNS(ctx, t, env, ResourceKindGateway, "app", "gw1")
 				require.Nil(t, env.DNSRecordStore.GetByKey(recordStoreKey(rowG.zonePath, rowG.nsxRecordName, rowG.Endpoint.RecordType)))
@@ -396,7 +400,8 @@ func TestDNSRecordService_deletesAndQueries_table(t *testing.T) {
 					Kind:   ResourceKindHTTPRoute,
 					Object: &metav1.ObjectMeta{Namespace: ns, Name: "hr1", UID: types.UID("uid-hr1")},
 				}
-				require.NotNil(t, env.BuildDnsRecord(hrOwner, *row))
+				rec, _ := env.BuildDnsRecord(hrOwner, *row)
+				require.NotNil(t, rec)
 				requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(hrOwner, []EndpointRow{*row}))
 				require.True(t, env.ListReferredGatewayNN().Has(types.NamespacedName{Namespace: "demo", Name: "gw1"}))
 				groups := env.ListRecordOwnerResource()
@@ -586,14 +591,15 @@ func TestCreateOrUpdateRecords_ownerScoped_mergeUpdatesTargets(t *testing.T) {
 	recordName := "x.example.com"
 	ep0 := extdns.NewEndpoint("x.example.com", extdns.RecordTypeA, "10.0.0.1")
 	ep0.WithLabel(EndpointLabelParentGateway, "ns/gw")
-	require.NotNil(t, env.BuildDnsRecord(owner, EndpointRow{Endpoint: ep0, zonePath: z, nsxRecordName: recordName}))
+	rec, _ := env.BuildDnsRecord(owner, EndpointRow{Endpoint: ep0, zonePath: z, nsxRecordName: recordName})
+	require.NotNil(t, rec)
 	for _, targets := range [][]string{{"10.0.0.1"}, {"10.0.0.2"}} {
 		ep := extdns.NewEndpoint("x.example.com", extdns.RecordTypeA, targets...)
 		ep.WithLabel(EndpointLabelParentGateway, "ns/gw")
 		row := EndpointRow{Endpoint: ep, zonePath: z, nsxRecordName: recordName}
 		requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(owner, []EndpointRow{row}))
 	}
-	rec := store.GetByKey(recordStoreKey(testDNSZonePathZ, recordName, extdns.RecordTypeA))
+	rec = store.GetByKey(recordStoreKey(testDNSZonePathZ, recordName, extdns.RecordTypeA))
 	require.NotNil(t, rec)
 	vals := append([]string(nil), rec.RecordValues...)
 	require.Equal(t, []string{"10.0.0.2"}, vals)
@@ -609,7 +615,8 @@ func Test_CreateOrUpdateRecords_Service_DeleteByOwnerNN(t *testing.T) {
 	ep := extdns.NewEndpoint("x.example.com", extdns.RecordTypeA, "10.0.0.1")
 	ep.WithLabel(EndpointLabelParentGateway, "ns1/lbsvc")
 	row := EndpointRow{Endpoint: ep, zonePath: z, nsxRecordName: "x.example.com"}
-	require.NotNil(t, env.BuildDnsRecord(owner, row))
+	rec, _ := env.BuildDnsRecord(owner, row)
+	require.NotNil(t, rec)
 	requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(owner, []EndpointRow{row}))
 	require.Len(t, env.DNSRecordStore.GetByOwnerResourceNamespacedName(ResourceKindService, "ns1", "lbsvc"), 1)
 	requireNoErrDeleteDNS(ctx, t, env, ResourceKindService, "ns1", "lbsvc")
@@ -688,40 +695,6 @@ func TestDeleteDnsRecordOnNSX(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestContributingHelpers_table(t *testing.T) {
-	t.Run("parseContributingOwnersTag", func(t *testing.T) {
-		require.Nil(t, parseContributingOwnersTag(""))
-		got := parseContributingOwnersTag(" b/a/x , a/b/y ")
-		require.Equal(t, []string{"a/b/y", "b/a/x"}, got)
-	})
-	t.Run("mergeContributingOwnerKeys", func(t *testing.T) {
-		primary := "p"
-		got := mergeContributingOwnerKeys([]string{"x", primary, "y"}, "z", primary)
-		require.Equal(t, []string{"x", "y", "z"}, got)
-	})
-	t.Run("parseOwnerNNIndexKey", func(t *testing.T) {
-		cf, ns, n, ok := parseOwnerNNIndexKey("httproute/ns1/r1")
-		require.True(t, ok)
-		require.Equal(t, servicecommon.TagValueDNSRecordForHTTPRoute, cf)
-		require.Equal(t, "ns1", ns)
-		require.Equal(t, "r1", n)
-	})
-	t.Run("replaceContributingOwnersInTags", func(t *testing.T) {
-		oldStr, _ := joinAndPackStrings([]string{"old"})
-		tags := []model.Tag{
-			modelTag(servicecommon.TagScopeDNSRecordContributingOwners, oldStr),
-			modelTag(servicecommon.TagScopeCluster, "c"),
-		}
-		out := replaceContributingOwnersInTags(tags, []string{"k1", "k2"})
-		require.Len(t, out, 2)
-		k1k2Str, _ := joinAndPackStrings([]string{"k1", "k2"})
-		require.ElementsMatch(t, []model.Tag{
-			modelTag(servicecommon.TagScopeCluster, "c"),
-			modelTag(servicecommon.TagScopeDNSRecordContributingOwners, k1k2Str),
-		}, out)
-	})
-}
-
 func TestAppendRecordOwnershipTags_table(t *testing.T) {
 	clusterTag := modelTag(servicecommon.TagScopeCluster, "cls")
 	baseTags := []model.Tag{clusterTag}
@@ -766,7 +739,8 @@ func TestAppendRecordOwnershipTags_table(t *testing.T) {
 			if tc.contributingKeys != "" {
 				keys = strings.Split(tc.contributingKeys, ",")
 			}
-			got := appendGatewayAndContributionTags(in, tc.gwKey, keys)
+			got, err := appendGatewayAndContributionTags(in, tc.gwKey, keys)
+			require.NoError(t, err)
 			gotScopes := make([]string, 0, len(got))
 			for _, tg := range got {
 				if tg.Scope != nil {
@@ -966,7 +940,8 @@ func TestClassifyOwnerRemoval_table(t *testing.T) {
 			modelTag(servicecommon.TagScopeDNSRecordOwnerName, name),
 		}
 		if len(contribs) > 0 {
-			plain, overflow := formatContributingOwnersTag(contribs)
+			plain, overflow, err := formatContributingOwnersTag(contribs)
+			require.NoError(t, err)
 			tags = append(tags, modelTag(servicecommon.TagScopeDNSRecordContributingOwners, plain))
 			if overflow != "" {
 				tags = append(tags, modelTag(servicecommon.TagScopeDNSRecordAdditionalContributingOwners, overflow))
@@ -1095,7 +1070,8 @@ func TestCleanupInfraResources(t *testing.T) {
 	ep := extdns.NewEndpoint("cl.example.com", extdns.RecordTypeA, "192.0.2.1")
 	ep.WithLabel(EndpointLabelParentGateway, "ns/gw")
 	row := EndpointRow{Endpoint: ep, zonePath: z, nsxRecordName: "cl.example.com"}
-	require.NotNil(t, env.BuildDnsRecord(owner, row))
+	rec, _ := env.BuildDnsRecord(owner, row)
+	require.NotNil(t, rec)
 	requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(owner, []EndpointRow{row}))
 	require.NotEmpty(t, store.ListDNSRecords())
 
@@ -1108,8 +1084,9 @@ func TestValidateEndpointRowConflict_table(t *testing.T) {
 	const fqdn = "svc.example.com"
 	zonePath := testDNSZonePathT
 
-	ownerA := &ResourceRef{Kind: ResourceKindService, Object: &metav1.ObjectMeta{Namespace: "ns", Name: "svcA"}}
-	ownerB := &ResourceRef{Kind: ResourceKindService, Object: &metav1.ObjectMeta{Namespace: "ns", Name: "svcB"}}
+	ownerA := &ResourceRef{Kind: ResourceKindHTTPRoute, Object: &metav1.ObjectMeta{Namespace: "ns", Name: "svcA"}}
+	ownerB := &ResourceRef{Kind: ResourceKindHTTPRoute, Object: &metav1.ObjectMeta{Namespace: "ns", Name: "svcB"}}
+	ownerSvc := &ResourceRef{Kind: ResourceKindService, Object: &metav1.ObjectMeta{Namespace: "ns", Name: "svcC"}}
 	epA := extdns.NewEndpoint(fqdn, extdns.RecordTypeA, "10.0.0.1")
 
 	makeStoreRec := func(owner *ResourceRef, path string, values []string) *model.DnsRecord {
@@ -1133,6 +1110,7 @@ func TestValidateEndpointRowConflict_table(t *testing.T) {
 		name       string
 		storeRecs  []*model.DnsRecord
 		owner      *ResourceRef
+		ep         *extdns.Endpoint
 		wantErr    bool
 		errSub     string
 		wantShared bool
@@ -1147,17 +1125,39 @@ func TestValidateEndpointRowConflict_table(t *testing.T) {
 			owner:     ownerA,
 		},
 		{
-			name:      "FQDN conflict: different target values for different owner",
-			storeRecs: []*model.DnsRecord{makeStoreRec(ownerB, "/orgs/org1/projects/proj1/dns-records/r-svcB", []string{"10.0.0.99"})},
-			owner:     ownerA,
-			wantErr:   true,
-			errSub:    "configured with different values",
+			name:       "adoption: target values from different owner without gateway conflict",
+			storeRecs:  []*model.DnsRecord{makeStoreRec(ownerB, "/orgs/org1/projects/proj1/dns-records/r-svcB", []string{"10.0.0.99"})},
+			owner:      ownerA,
+			wantShared: true,
 		},
 		{
 			name:       "adoption: same values from different owner",
 			storeRecs:  []*model.DnsRecord{makeStoreRec(ownerB, "/orgs/org1/projects/proj1/dns-records/r-svcB", []string{"10.0.0.1"})},
 			owner:      ownerA,
 			wantShared: true,
+		},
+		{
+			name:      "adoption fails: non-route kind",
+			storeRecs: []*model.DnsRecord{makeStoreRec(ownerSvc, "/orgs/org1/projects/proj1/dns-records/r-svcC", []string{"10.0.0.1"})},
+			owner:     ownerA,
+			wantErr:   true,
+			errSub:    "contributor mechanism is only supported for route resources",
+		},
+		{
+			name: "adoption fails: parent gateway conflict",
+			storeRecs: []*model.DnsRecord{func() *model.DnsRecord {
+				rec := makeStoreRec(ownerB, "/orgs/org1/projects/proj1/dns-records/r-svcB", []string{"10.0.0.1"})
+				rec.Tags = append(rec.Tags, modelTag(servicecommon.TagScopeDNSRecordGatewayIndexList, "ns/gw1"))
+				return rec
+			}()},
+			owner: ownerA,
+			ep: func() *extdns.Endpoint {
+				ep := extdns.NewEndpoint(fqdn, extdns.RecordTypeA, "10.0.0.1")
+				ep.WithLabel(EndpointLabelParentGateway, "ns/gw2")
+				return ep
+			}(),
+			wantErr: true,
+			errSub:  "parent gateway ns/gw2 conflicts with existing record parent gateway ns/gw1",
 		},
 		{
 			name: "adoption fails: same values but incomplete owner metadata",
@@ -1181,7 +1181,11 @@ func TestValidateEndpointRowConflict_table(t *testing.T) {
 			for _, r := range tc.storeRecs {
 				require.NoError(t, env.DNSRecordStore.Add(r))
 			}
-			row, err := env.validateEndpointRowConflict(zonePath, epA, "svc", tc.owner)
+			targetEP := epA
+			if tc.ep != nil {
+				targetEP = tc.ep
+			}
+			row, err := env.validateEndpointRowConflict(zonePath, targetEP, "svc", tc.owner)
 			if tc.wantErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errSub)
@@ -1195,6 +1199,130 @@ func TestValidateEndpointRowConflict_table(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateEndpointRowConflict_PrimaryTargetChange(t *testing.T) {
+	const fqdn = "svc.example.com"
+	zonePath := testDNSZonePathT
+
+	ownerA := &ResourceRef{Kind: ResourceKindHTTPRoute, Object: &metav1.ObjectMeta{Namespace: "ns", Name: "svcA"}}
+	createdForA := resourceKindToCreatedFor(ownerA.Kind)
+
+	recWithContribs := &model.DnsRecord{
+		Path:         servicecommon.String("/orgs/org1/projects/proj1/dns-records/r-svcA"),
+		ZonePath:     servicecommon.String(zonePath),
+		RecordType:   servicecommon.String(model.DnsRecord_RECORD_TYPE_A),
+		RecordName:   servicecommon.String("svc"),
+		Fqdn:         servicecommon.String(fqdn),
+		RecordValues: []string{"10.0.0.1"},
+		Tags: []model.Tag{
+			modelTag(servicecommon.TagScopeDNSRecordFor, createdForA),
+			modelTag(servicecommon.TagScopeDNSRecordOwnerNamespace, ownerA.GetNamespace()),
+			modelTag(servicecommon.TagScopeDNSRecordOwnerName, ownerA.GetName()),
+			modelTag(servicecommon.TagScopeDNSRecordGatewayIndexList, "ns/gw1"),
+			modelTag(servicecommon.TagScopeDNSRecordContributingOwners, "httproute/ns/svcB"),
+		},
+	}
+
+	t.Run("same targets preserves contributing owners", func(t *testing.T) {
+		env := newTestDNSRecordService(t, BuildDNSRecordStore())
+		require.NoError(t, env.DNSRecordStore.Add(recWithContribs))
+
+		epSame := extdns.NewEndpoint(fqdn, extdns.RecordTypeA, "10.0.0.1")
+		epSame.WithLabel(EndpointLabelParentGateway, "ns/gw1")
+		row, err := env.validateEndpointRowConflict(zonePath, epSame, "svc", ownerA)
+		require.NoError(t, err)
+		require.NotNil(t, row)
+		require.Equal(t, []string{"httproute/ns/svcB"}, row.contributingOwnerKeys)
+	})
+
+	t.Run("changed targets on same parent gateway (gateway IP updated)", func(t *testing.T) {
+		env := newTestDNSRecordService(t, BuildDNSRecordStore())
+		require.NoError(t, env.DNSRecordStore.Add(recWithContribs))
+
+		epChanged := extdns.NewEndpoint(fqdn, extdns.RecordTypeA, "10.0.0.2")
+		epChanged.WithLabel(EndpointLabelParentGateway, "ns/gw1")
+		row, err := env.validateEndpointRowConflict(zonePath, epChanged, "svc", ownerA)
+		require.NoError(t, err)
+		require.NotNil(t, row)
+		require.Equal(t, []string{"httproute/ns/svcB"}, row.contributingOwnerKeys)
+	})
+
+	t.Run("changed targets on different parent gateway returns error", func(t *testing.T) {
+		env := newTestDNSRecordService(t, BuildDNSRecordStore())
+		require.NoError(t, env.DNSRecordStore.Add(recWithContribs))
+
+		epChanged := extdns.NewEndpoint(fqdn, extdns.RecordTypeA, "10.0.0.2")
+		epChanged.WithLabel(EndpointLabelParentGateway, "ns/gw2")
+		row, err := env.validateEndpointRowConflict(zonePath, epChanged, "svc", ownerA)
+		require.Error(t, err)
+		require.Nil(t, row)
+		require.Contains(t, err.Error(), "is taken by other resources")
+		require.Contains(t, err.Error(), "parent gateway changed from ns/gw1 to ns/gw2")
+	})
+
+	t.Run("same targets on different parent gateway returns error", func(t *testing.T) {
+		env := newTestDNSRecordService(t, BuildDNSRecordStore())
+		require.NoError(t, env.DNSRecordStore.Add(recWithContribs))
+
+		epSameIPDifferentGW := extdns.NewEndpoint(fqdn, extdns.RecordTypeA, "10.0.0.1")
+		epSameIPDifferentGW.WithLabel(EndpointLabelParentGateway, "ns/gw2")
+		row, err := env.validateEndpointRowConflict(zonePath, epSameIPDifferentGW, "svc", ownerA)
+		require.Error(t, err)
+		require.Nil(t, row)
+		require.Contains(t, err.Error(), "is taken by other resources")
+		require.Contains(t, err.Error(), "parent gateway changed from ns/gw1 to ns/gw2")
+	})
+
+	t.Run("single owner without contributors changing parent gateway is allowed", func(t *testing.T) {
+		env := newTestDNSRecordService(t, BuildDNSRecordStore())
+		recSingleOwner := &model.DnsRecord{
+			Path:         servicecommon.String("/orgs/org1/projects/proj1/dns-records/r-svcA"),
+			ZonePath:     servicecommon.String(zonePath),
+			RecordType:   servicecommon.String(model.DnsRecord_RECORD_TYPE_A),
+			RecordName:   servicecommon.String("svc"),
+			Fqdn:         servicecommon.String(fqdn),
+			RecordValues: []string{"10.0.0.1"},
+			Tags: []model.Tag{
+				modelTag(servicecommon.TagScopeDNSRecordFor, createdForA),
+				modelTag(servicecommon.TagScopeDNSRecordOwnerNamespace, ownerA.GetNamespace()),
+				modelTag(servicecommon.TagScopeDNSRecordOwnerName, ownerA.GetName()),
+				modelTag(servicecommon.TagScopeDNSRecordGatewayIndexList, "ns/gw1"),
+			},
+		}
+		require.NoError(t, env.DNSRecordStore.Add(recSingleOwner))
+
+		epNewGW := extdns.NewEndpoint(fqdn, extdns.RecordTypeA, "10.0.0.2")
+		epNewGW.WithLabel(EndpointLabelParentGateway, "ns/gw2")
+		row, err := env.validateEndpointRowConflict(zonePath, epNewGW, "svc", ownerA)
+		require.NoError(t, err)
+		require.NotNil(t, row)
+		require.Empty(t, row.contributingOwnerKeys)
+	})
+
+	t.Run("changed targets for single owner without contributors", func(t *testing.T) {
+		env := newTestDNSRecordService(t, BuildDNSRecordStore())
+		recSingleOwner := &model.DnsRecord{
+			Path:         servicecommon.String("/orgs/org1/projects/proj1/dns-records/r-svcA"),
+			ZonePath:     servicecommon.String(zonePath),
+			RecordType:   servicecommon.String(model.DnsRecord_RECORD_TYPE_A),
+			RecordName:   servicecommon.String("svc"),
+			Fqdn:         servicecommon.String(fqdn),
+			RecordValues: []string{"10.0.0.1"},
+			Tags: []model.Tag{
+				modelTag(servicecommon.TagScopeDNSRecordFor, createdForA),
+				modelTag(servicecommon.TagScopeDNSRecordOwnerNamespace, ownerA.GetNamespace()),
+				modelTag(servicecommon.TagScopeDNSRecordOwnerName, ownerA.GetName()),
+			},
+		}
+		require.NoError(t, env.DNSRecordStore.Add(recSingleOwner))
+
+		epNewTarget := extdns.NewEndpoint(fqdn, extdns.RecordTypeA, "10.0.0.99")
+		row, err := env.validateEndpointRowConflict(zonePath, epNewTarget, "svc", ownerA)
+		require.NoError(t, err)
+		require.NotNil(t, row)
+		require.Empty(t, row.contributingOwnerKeys)
+	})
 }
 
 func TestCreateOrUpdateRecords_errorPaths_table(t *testing.T) {
@@ -1216,6 +1344,35 @@ func TestCreateOrUpdateRecords_errorPaths_table(t *testing.T) {
 		mut, err := env.CreateOrUpdateRecords(ctx, NewOwnerScopedAggregatedRouteDNS(owner, nil))
 		require.NoError(t, err)
 		require.False(t, mut)
+	})
+
+	t.Run("gateway tags exceed maximum tag capacity", func(t *testing.T) {
+		env := newTestDNSRecordService(t, BuildDNSRecordStore())
+		owner := &ResourceRef{Kind: ResourceKindGateway, Object: &metav1.ObjectMeta{Namespace: "ns", Name: "gw"}}
+
+		// Generate a huge gateway keys list that will cause truncation
+		var gwKeys []string
+		for i := 0; i < 50; i++ {
+			gwKeys = append(gwKeys, fmt.Sprintf("gateway/namespace-%d/name-%d", i, i))
+		}
+		hugeGwKeysStr := strings.Join(gwKeys, ",")
+
+		ep := extdns.NewEndpoint("x.example.com", extdns.RecordTypeA, "1.1.1.1")
+		ep.Labels = map[string]string{
+			EndpointLabelParentGateway: hugeGwKeysStr,
+		}
+
+		batch := &AggregatedDNSEndpoints{
+			Owner: owner,
+			Rows: []EndpointRow{{
+				Endpoint: ep,
+				zonePath: "zone",
+			}},
+		}
+
+		_, err := env.CreateOrUpdateRecords(ctx, batch)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "gateway index list exceeds maximum tag capacity")
 	})
 }
 

--- a/pkg/nsx/services/dns/recordservice_test.go
+++ b/pkg/nsx/services/dns/recordservice_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -285,20 +286,6 @@ func TestValidateEndpointsByZone_table(t *testing.T) {
 			wantN:    intPtr(1),
 		},
 		{
-			name: "unsupported_owner_kind_returns_validation_error",
-			nc:   testVPCNetworkConfiguration(),
-			buildOwner: func(ns string) *ResourceRef {
-				return &ResourceRef{Kind: "UnknownKind", Object: &metav1.ObjectMeta{Namespace: ns, Name: "x"}}
-			},
-			ns:               "tenant",
-			eps:              []*extdns.Endpoint{ep},
-			errSub:           "unsupported resource kind",
-			wantZoneValErr:   true,
-			wantAllowedOnErr: map[string]string{testDNSZonePathT: "example.com"},
-			wantN:            intPtr(0),
-		},
-		{
-			// hostname does not lie under any allowed zone → must be *DNSZoneValidationError
 			// and allowedZones must still be returned so the controller can clean up stale records.
 			name:             "hostname_not_in_zone_is_DNSZoneValidationError_with_allowedZones",
 			nc:               testVPCNetworkConfiguration(), // zone = example.com
@@ -674,10 +661,24 @@ func TestParseDnsRecordPolicyPath_table(t *testing.T) {
 
 func TestDedupeRecordsByPath(t *testing.T) {
 	p := "/orgs/o/projects/p/dns-records/a"
-	a := &model.DnsRecord{Path: servicecommon.String(p), Id: servicecommon.String("a")}
+	a := &model.DnsRecord{Path: servicecommon.String(p), Id: servicecommon.String("a"), MarkedForDelete: servicecommon.Bool(true)}
 	b := &model.DnsRecord{Path: servicecommon.String(p), Id: servicecommon.String("b")}
+	// In the simplified dedupeRecordsByPath, it just takes the last one it sees
 	out := dedupeRecordsByPath([]*model.DnsRecord{a, b})
 	require.Len(t, out, 1)
+	require.Equal(t, "b", *out[0].Id)
+
+	out2 := dedupeRecordsByPath([]*model.DnsRecord{b, a})
+	require.Len(t, out2, 1)
+	require.Equal(t, "a", *out2[0].Id)
+
+	// nil/empty path cases
+	c := &model.DnsRecord{Id: servicecommon.String("c")}
+	d := &model.DnsRecord{Path: servicecommon.String("  "), Id: servicecommon.String("d")}
+	var e *model.DnsRecord
+	out3 := dedupeRecordsByPath([]*model.DnsRecord{a, c, d, e})
+	require.Len(t, out3, 1)
+	require.Equal(t, "a", *out3[0].Id)
 }
 
 func TestDeleteDnsRecordOnNSX(t *testing.T) {
@@ -695,8 +696,8 @@ func TestContributingHelpers_table(t *testing.T) {
 	})
 	t.Run("mergeContributingOwnerKeys", func(t *testing.T) {
 		primary := "p"
-		got := mergeContributingOwnerKeys(fmt.Sprintf("x,%s,y", primary), "z", primary)
-		require.Equal(t, compressString("x,y,z"), got)
+		got := mergeContributingOwnerKeys([]string{"x", primary, "y"}, "z", primary)
+		require.Equal(t, []string{"x", "y", "z"}, got)
 	})
 	t.Run("parseOwnerNNIndexKey", func(t *testing.T) {
 		cf, ns, n, ok := parseOwnerNNIndexKey("httproute/ns1/r1")
@@ -706,15 +707,17 @@ func TestContributingHelpers_table(t *testing.T) {
 		require.Equal(t, "r1", n)
 	})
 	t.Run("replaceContributingOwnersInTags", func(t *testing.T) {
+		oldStr, _ := joinAndPackStrings([]string{"old"})
 		tags := []model.Tag{
-			modelTag(servicecommon.TagScopeDNSRecordContributingOwners, compressString("old")),
+			modelTag(servicecommon.TagScopeDNSRecordContributingOwners, oldStr),
 			modelTag(servicecommon.TagScopeCluster, "c"),
 		}
 		out := replaceContributingOwnersInTags(tags, []string{"k1", "k2"})
 		require.Len(t, out, 2)
+		k1k2Str, _ := joinAndPackStrings([]string{"k1", "k2"})
 		require.ElementsMatch(t, []model.Tag{
 			modelTag(servicecommon.TagScopeCluster, "c"),
-			modelTag(servicecommon.TagScopeDNSRecordContributingOwners, compressString("k1,k2")),
+			modelTag(servicecommon.TagScopeDNSRecordContributingOwners, k1k2Str),
 		}, out)
 	})
 }
@@ -759,7 +762,11 @@ func TestAppendRecordOwnershipTags_table(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// pass a copy so we can verify the original is not mutated
 			in := append([]model.Tag{}, baseTags...)
-			got := appendGatewayAndContributionTags(in, tc.gwKey, tc.contributingKeys)
+			var keys []string
+			if tc.contributingKeys != "" {
+				keys = strings.Split(tc.contributingKeys, ",")
+			}
+			got := appendGatewayAndContributionTags(in, tc.gwKey, keys)
 			gotScopes := make([]string, 0, len(got))
 			for _, tg := range got {
 				if tg.Scope != nil {
@@ -959,7 +966,11 @@ func TestClassifyOwnerRemoval_table(t *testing.T) {
 			modelTag(servicecommon.TagScopeDNSRecordOwnerName, name),
 		}
 		if len(contribs) > 0 {
-			tags = append(tags, modelTag(servicecommon.TagScopeDNSRecordContributingOwners, formatContributingOwnersTag(contribs)))
+			plain, overflow := formatContributingOwnersTag(contribs)
+			tags = append(tags, modelTag(servicecommon.TagScopeDNSRecordContributingOwners, plain))
+			if overflow != "" {
+				tags = append(tags, modelTag(servicecommon.TagScopeDNSRecordAdditionalContributingOwners, overflow))
+			}
 		}
 		return &model.DnsRecord{Path: servicecommon.String(path), Tags: tags}
 	}
@@ -1234,7 +1245,7 @@ func TestApplyDNSUpsertRows_unsupportedOwnerKind(t *testing.T) {
 	// collectRecordsByOwner returns ("", nil) for unknown kind, so ownerNNKey="" → toUpsert is non-empty
 	// but syncDnsRecordsInNSX will be called. The important thing is no panic.
 	_, _, err := env.applyDNSUpsertRows(batch)
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "unsupported resource kind")
 }
 
 func TestSyncDNSZonesByVpcNetworkConfig_table(t *testing.T) {
@@ -1323,7 +1334,7 @@ func TestRouteRecordWithGatewayAndContributions(t *testing.T) {
 		Object: &metav1.ObjectMeta{Namespace: "app", Name: "route3", UID: types.UID("r3")},
 	}
 	owner3NNKey := ownerNNIndexKeyForResourceRef(owner3)
-	row3 := EndpointRow{Endpoint: ep2, zonePath: z, nsxRecordName: "rec2", effectiveOwner: owner2, contributingOwnerKeys: compressString(owner3NNKey)}
+	row3 := EndpointRow{Endpoint: ep2, zonePath: z, nsxRecordName: "rec2", effectiveOwner: owner2, contributingOwnerKeys: []string{owner3NNKey}}
 	requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(owner3, []EndpointRow{row3}))
 	recByOwner2 := store.GetByOwnerResourceNamespacedName(ResourceKindHTTPRoute, "app", "route2")
 	require.Len(t, recByOwner2, 1)
@@ -1338,4 +1349,109 @@ func TestRouteRecordWithGatewayAndContributions(t *testing.T) {
 	recByOwner3 = store.GetByOwnerResourceNamespacedName(ResourceKindGRPCRoute, "app", "route3")
 	require.Len(t, recByOwner3, 1)
 	require.Empty(t, store.ListRecordsReferencingContributingOwner(owner3NNKey))
+}
+
+func TestRouteRecordWithContributingOwnersOverflow(t *testing.T) {
+	store := BuildDNSRecordStore()
+	env := newTestDNSRecordService(t, store)
+	ctx := context.Background()
+	z := testDNSZonePathZ
+	ep := extdns.NewEndpoint("shared.example.com", extdns.RecordTypeA, "10.0.0.10")
+
+	// 1. Create primary owner
+	primaryOwner := &ResourceRef{
+		Kind:   ResourceKindHTTPRoute,
+		Object: &metav1.ObjectMeta{Namespace: "app", Name: "route-primary", UID: types.UID("r-primary")},
+	}
+	rowPrimary := EndpointRow{Endpoint: ep, zonePath: z, nsxRecordName: "shared"}
+	requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(primaryOwner, []EndpointRow{rowPrimary}))
+
+	recs := store.GetByOwnerResourceNamespacedName(ResourceKindHTTPRoute, "app", "route-primary")
+	require.Len(t, recs, 1)
+
+	// 2. Create many contributing owners to exceed 255 chars
+	var contribOwners []*ResourceRef
+	for i := 0; i < 15; i++ {
+		owner := &ResourceRef{
+			Kind:   ResourceKindHTTPRoute,
+			Object: &metav1.ObjectMeta{Namespace: "app", Name: fmt.Sprintf("route-contrib-%d", i), UID: types.UID(fmt.Sprintf("r-contrib-%d", i))},
+		}
+		contribOwners = append(contribOwners, owner)
+	}
+
+	// Apply each contributing owner
+	for _, owner := range contribOwners {
+		// simulate the conflict validation that populates effectiveOwner and contributingOwnerKeys
+		row, err := env.validateEndpointRowConflict(z, ep, "shared", owner)
+		require.NoError(t, err)
+		requireNoErrCreateDNS(ctx, t, env, NewOwnerScopedAggregatedRouteDNS(owner, []EndpointRow{*row}))
+	}
+
+	// 3. Verify that the DNS record in the store has both tags
+	recs = store.GetByOwnerResourceNamespacedName(ResourceKindHTTPRoute, "app", "route-primary")
+	require.Len(t, recs, 1)
+	rec := recs[0]
+
+	hasPlain := false
+	hasOverflow := false
+	for _, tag := range rec.Tags {
+		if tag.Scope != nil && *tag.Scope == servicecommon.TagScopeDNSRecordContributingOwners {
+			hasPlain = true
+			require.LessOrEqual(t, len(*tag.Tag), 255)
+		}
+		if tag.Scope != nil && *tag.Scope == servicecommon.TagScopeDNSRecordAdditionalContributingOwners {
+			hasOverflow = true
+			require.LessOrEqual(t, len(*tag.Tag), 255)
+		}
+	}
+	require.True(t, hasPlain)
+	require.True(t, hasOverflow)
+
+	// 4. Verify that parseContributingOwnersFromRecord returns all the contributing owners
+	parsedKeys := parseContributingOwnersFromRecord(rec)
+	require.Len(t, parsedKeys, 15)
+
+	// 5. Delete the primary owner
+	requireNoErrDeleteDNS(ctx, t, env, ResourceKindHTTPRoute, "app", "route-primary")
+
+	// 6. Verify that one of the contributing owners is promoted
+	recs = store.GetByOwnerResourceNamespacedName(ResourceKindHTTPRoute, "app", "route-primary")
+	require.Empty(t, recs)
+
+	// The first contributing owner should be promoted
+	promotedOwner := contribOwners[0]
+	recs = store.GetByOwnerResourceNamespacedName(ResourceKindHTTPRoute, "app", promotedOwner.GetName())
+	require.Len(t, recs, 1)
+
+	// The remaining contributing owners should still be there
+	parsedKeysAfterPromotion := parseContributingOwnersFromRecord(recs[0])
+	require.Len(t, parsedKeysAfterPromotion, 14)
+}
+
+func TestSyncDnsRecordsInNSX(t *testing.T) {
+	env := newTestDNSRecordService(t, BuildDNSRecordStore())
+
+	p := "/orgs/org1/projects/proj1/dns-records/rec1"
+	rec1 := &model.DnsRecord{Path: &p, Id: servicecommon.String("rec1")}
+
+	// empty batch
+	out, err := env.syncDnsRecordsInNSX(context.TODO(), nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, out)
+
+	// only removes
+	out, err = env.syncDnsRecordsInNSX(context.TODO(), nil, []*model.DnsRecord{rec1})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.True(t, *out[0].MarkedForDelete)
+
+	// upserts
+	rec2 := &model.DnsRecord{Path: servicecommon.String("/orgs/org1/projects/proj1/dns-records/rec2"), Id: servicecommon.String("rec2")}
+	out, err = env.syncDnsRecordsInNSX(context.TODO(), []*model.DnsRecord{rec2}, nil)
+	t.Logf("err: %v, out: %v", err, out)
+
+	// parse err
+	rec3 := &model.DnsRecord{Path: servicecommon.String("invalid-path"), Id: servicecommon.String("rec3")}
+	out, err = env.syncDnsRecordsInNSX(context.TODO(), []*model.DnsRecord{rec3}, nil)
+	t.Logf("err: %v, out: %v", err, out)
 }

--- a/pkg/nsx/services/dns/store.go
+++ b/pkg/nsx/services/dns/store.go
@@ -125,7 +125,7 @@ func gatewayIndexKeysFromDNSRecord(v *model.DnsRecord) []string {
 }
 
 func parseGateways(raw string) []string {
-	plainGws := decompressString(raw)
+	plainGws := raw
 	seen := sets.New[string]()
 	for _, part := range strings.Split(plainGws, ",") {
 		k := strings.TrimSpace(part)

--- a/pkg/nsx/services/dns/types.go
+++ b/pkg/nsx/services/dns/types.go
@@ -48,7 +48,7 @@ type EndpointRow struct {
 	// the zone domain is "example.com", nsxRecordName is "foo".
 	nsxRecordName         string
 	effectiveOwner        *ResourceRef // primary for shared FQDN row when adopting
-	contributingOwnerKeys string       // sorted, comma-separated contributing owner index keys; matches TagScopeDNSRecordContributingOwners tag value
+	contributingOwnerKeys []string     // sorted contributing owner index keys
 }
 
 func NewEndpointRow(ep *extdns.Endpoint, zonePath string, recordName string) *EndpointRow {

--- a/pkg/nsx/services/dns/zones.go
+++ b/pkg/nsx/services/dns/zones.go
@@ -109,13 +109,7 @@ func (s *DNSRecordService) ValidateEndpointsByZone(namespace string, owner *Reso
 			continue
 		}
 		log.Debug("Mapped DNS endpoint to zone", "dnsName", ep.DNSName, "zonePath", zonePath, "recordName", recName)
-		row, validErr := s.validateEndpointRowConflict(zonePath, ep, recName, owner)
-		if validErr != nil {
-			if validationErr == nil {
-				validationErr = &DNSZoneValidationError{Msg: "DNS endpoint validation failed for DNS zone policy", Cause: validErr}
-			}
-			continue
-		}
+		row := NewEndpointRow(ep, zonePath, recName)
 		validRows = append(validRows, *row)
 	}
 	return validRows, allowedZones, validationErr


### PR DESCRIPTION
This PR stabilizes shared DNS record reconciliation (used by Gateway API) by fixing concurrency issues that caused NSX updates to overwrite each other, and by handling NSX tag length limits for heavily shared records.

**Key Changes**
1. Fix TOCTOU Race Conditions: 
1.1 Implemented a local lock (recordAccessArbitrator) to serialize concurrent updates to the same DNS record.
1.2 Moved conflict validation inside the lock to ensure reads aren't stale.
1.3 Fixed a bug where the primary owner would mistakenly drop existing contributing_owners during its own reconciliation.
2. Fix Tag Overflow: 
2.1 Introduced an extension tag (nsx-op/dns_contributing_owners_ext) to handle cases where the joined dns_contributing_owners string exceeds the NSX 255-character limit.
3. Corrected misleading "delete resource" logs for PATCH operations.

**Test Done**
1. Prepare 1 gateway and 10 HTTPRoutes, all HTTPRoutes are configured with the same FQDN and refer to the same gateway. Each HTTPRoute.spec.rule is configured with a unique path

2. Apply the manifest and check the status 
```
root@420aec474057587e08ae81c7f6ce8984 [ ~/wenying ]# kubectl -n test1 apply -f gateway-multiple-routes.yaml 
gateway.gateway.networking.k8s.io/gateway created
httproute.gateway.networking.k8s.io/http-1 created
httproute.gateway.networking.k8s.io/http-2 created
httproute.gateway.networking.k8s.io/http-3 created
httproute.gateway.networking.k8s.io/http-4 created
httproute.gateway.networking.k8s.io/http-5 created
httproute.gateway.networking.k8s.io/http-6 created
httproute.gateway.networking.k8s.io/http-7 created
httproute.gateway.networking.k8s.io/http-8 created
httproute.gateway.networking.k8s.io/http-9 created
httproute.gateway.networking.k8s.io/http-10 created

root@420aec474057587e08ae81c7f6ce8984 [ ~/wenying ]# kubectl get gateway,httproute -n test1 -owide
NAME                                        CLASS   ADDRESS       PROGRAMMED   AGE
gateway.gateway.networking.k8s.io/gateway   istio   192.168.0.7   True         32s

NAME                                          HOSTNAMES                 AGE
httproute.gateway.networking.k8s.io/http-1    ["httpbin.example.com"]   32s
httproute.gateway.networking.k8s.io/http-10   ["httpbin.example.com"]   31s
httproute.gateway.networking.k8s.io/http-2    ["httpbin.example.com"]   32s
httproute.gateway.networking.k8s.io/http-3    ["httpbin.example.com"]   31s
httproute.gateway.networking.k8s.io/http-4    ["httpbin.example.com"]   31s
httproute.gateway.networking.k8s.io/http-5    ["httpbin.example.com"]   31s
httproute.gateway.networking.k8s.io/http-6    ["httpbin.example.com"]   31s
httproute.gateway.networking.k8s.io/http-7    ["httpbin.example.com"]   31s
httproute.gateway.networking.k8s.io/http-8    ["httpbin.example.com"]   31s
httproute.gateway.networking.k8s.io/http-9    ["httpbin.example.com"]   31s
```
3. Check all HTTPRoutes are configured with DNSRecordReady==True condition
```
root@420aec474057587e08ae81c7f6ce8984 [ ~/wenying ]# for i in {1..10}; do
  status=$(kubectl get httproute -n test1 "http-$i" -o jsonpath='{.status.parents[*].conditions[?(@.type=="DNSRecordReady")].status}' 2>/dev/null)
  echo "http-$i: ${status:-Not Found / No Status}"
done
http-1: True
http-2: True
http-3: True
http-4: True
http-5: True
http-6: True
http-7: True
http-8: True
http-9: True
http-10: True
```
4. Check NSX DNSRecord before applying this change, a single DNS Record is created, and tags for  `dns_gateway_index_list` and `dns_contributing_owners` are encoded.
```
root@420aec474057587e08ae81c7f6ce8984 [ ~/wenying ]# curl -s -k -u ${cred} https://10.192.49.176/policy/api/v1/orgs/default/projects/project-quality/dns-records | jq '{
  result_count,
  results: [.results[] | {zone_path, record_name, record_type, record_values, tags}]
}'
{
  "result_count": 1,
  "results": [
    {
      "zone_path": "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
      "record_name": "httpbin",
      "record_type": "A",
      "record_values": [
        "192.168.0.7"
      ],
      "tags": [
        {
          "scope": "nsx-op/cluster",
          "tag": "6edf5c92-2967-41a3-9b7c-a3d50fca857b"
        },
        {
          "scope": "nsx-op/version",
          "tag": "1.0.0"
        },
        {
          "scope": "nsx-op/namespace_uid",
          "tag": "c54019ac-89cf-4877-a3df-feadbd4049bd"
        },
        {
          "scope": "nsx-op/dns_for",
          "tag": "httproute"
        },
        {
          "scope": "nsx-op/dns_owner_namespace",
          "tag": "test1"
        },
        {
          "scope": "nsx-op/dns_owner_name",
          "tag": "http-3"
        },
        {
          "scope": "nsx-op/dns_gateway_index_list",
          "tag": "eJwqSS0uMdRPTyxJLU-sBAQAAP__IuYFEw"
        },
        {
          "scope": "nsx-op/dns_contributing_owners",
          "tag": "eJzKKCkpKMovLUnVL0ktLjHUB_F1DQ10sIqbYRc2xy5sAQgAAP__TBgiNw"
        }
      ]
    }
  ]
}
```
5. After applying this change, all HTTPRoutes are shown in the scope "dns_contributing_owners" with the plaintext, and the dns_gateway_index_list is also shown as plaintext
```
root@420aec474057587e08ae81c7f6ce8984 [ ~ ]# curl -s -k -u ${cred} https://10.192.49.176/policy/api/v1/orgs/default/projects/project-quality/dns-records | jq '{
  result_count,
  results: [.results[] | {zone_path, record_name, record_type, record_values, tags}]
}'
{
  "result_count": 1,
  "results": [
    {
      "zone_path": "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
      "record_name": "httpbin",
      "record_type": "A",
      "record_values": [
        "192.168.0.7"
      ],
      "tags": [
        {
          "scope": "nsx-op/cluster",
          "tag": "6edf5c92-2967-41a3-9b7c-a3d50fca857b"
        },
        {
          "scope": "nsx-op/version",
          "tag": "1.0.0"
        },
        {
          "scope": "nsx-op/namespace_uid",
          "tag": "c54019ac-89cf-4877-a3df-feadbd4049bd"
        },
        {
          "scope": "nsx-op/dns_for",
          "tag": "httproute"
        },
        {
          "scope": "nsx-op/dns_owner_namespace",
          "tag": "test1"
        },
        {
          "scope": "nsx-op/dns_owner_name",
          "tag": "http-7"
        },
        {
          "scope": "nsx-op/dns_gateway_index_list",
          "tag": "test1/gateway"
        },
        {
          "scope": "nsx-op/dns_contributing_owners",
          "tag": "httproute/test1/http-1,httproute/test1/http-10,httproute/test1/http-2,httproute/test1/http-3,httproute/test1/http-4,httproute/test1/http-5,httproute/test1/http-6,httproute/test1/http-8,httproute/test1/http-9"
        }
      ]
    }
  ]
}
```
6. Add another 10 HTTPRoutes with the same FQDN and referring to the same parent Gateway,
```
root@420aec474057587e08ae81c7f6ce8984 [ ~/wenying ]# kubectl get gateway,httproute -n test1 -owide
NAME                                        CLASS   ADDRESS       PROGRAMMED   AGE
gateway.gateway.networking.k8s.io/gateway   istio   192.168.0.7   True         3h57m

NAME                                          HOSTNAMES                 AGE
httproute.gateway.networking.k8s.io/http-1    ["httpbin.example.com"]   3h57m
httproute.gateway.networking.k8s.io/http-10   ["httpbin.example.com"]   3h57m
httproute.gateway.networking.k8s.io/http-11   ["httpbin.example.com"]   33s
httproute.gateway.networking.k8s.io/http-12   ["httpbin.example.com"]   33s
httproute.gateway.networking.k8s.io/http-13   ["httpbin.example.com"]   33s
httproute.gateway.networking.k8s.io/http-14   ["httpbin.example.com"]   33s
httproute.gateway.networking.k8s.io/http-15   ["httpbin.example.com"]   33s
httproute.gateway.networking.k8s.io/http-16   ["httpbin.example.com"]   32s
httproute.gateway.networking.k8s.io/http-17   ["httpbin.example.com"]   32s
httproute.gateway.networking.k8s.io/http-18   ["httpbin.example.com"]   32s
httproute.gateway.networking.k8s.io/http-19   ["httpbin.example.com"]   32s
httproute.gateway.networking.k8s.io/http-2    ["httpbin.example.com"]   3h57m
httproute.gateway.networking.k8s.io/http-20   ["httpbin.example.com"]   32s
httproute.gateway.networking.k8s.io/http-3    ["httpbin.example.com"]   3h57m
httproute.gateway.networking.k8s.io/http-4    ["httpbin.example.com"]   3h57m
httproute.gateway.networking.k8s.io/http-5    ["httpbin.example.com"]   3h57m
httproute.gateway.networking.k8s.io/http-6    ["httpbin.example.com"]   3h57m
httproute.gateway.networking.k8s.io/http-7    ["httpbin.example.com"]   3h57m
httproute.gateway.networking.k8s.io/http-8    ["httpbin.example.com"]   3h57m
httproute.gateway.networking.k8s.io/http-9    ["httpbin.example.com"]   3h57m

root@420aec474057587e08ae81c7f6ce8984 [ ~/wenying ]# for i in {1..20}; do
  status=$(kubectl get httproute -n test1 "http-$i" -o jsonpath='{.status.parents[*].conditions[?(@.type=="DNSRecordReady")].status}' 2>/dev/null)
  echo "http-$i: ${status:-Not Found / No Status}"
done
http-1: True
http-2: True
http-3: True
http-4: True
http-5: True
http-6: True
http-7: True
http-8: True
http-9: True
http-10: True
http-11: True
http-12: True
http-13: True
http-14: True
http-15: True
http-16: True
http-17: True
http-18: True
http-19: True
http-20: True
```
7. Check the NSX DNSRecord resource, a single resource exists, and tag "dns_contributing_owners_ext" is updated.
```
root@420aec474057587e08ae81c7f6ce8984 [ ~/wenying ]#  curl -s -k -u ${cred} https://10.192.49.176/policy/api/v1/orgs/default/projects/project-quality/dns-records | jq '{
  result_count,
  results: [.results[] | {zone_path, record_name, record_type, record_values, tags}]
}'
{
  "result_count": 1,
  "results": [
    {
      "zone_path": "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
      "record_name": "httpbin",
      "record_type": "A",
      "record_values": [
        "192.168.0.7"
      ],
      "tags": [
        {
          "scope": "nsx-op/cluster",
          "tag": "6edf5c92-2967-41a3-9b7c-a3d50fca857b"
        },
        {
          "scope": "nsx-op/version",
          "tag": "1.0.0"
        },
        {
          "scope": "nsx-op/namespace_uid",
          "tag": "c54019ac-89cf-4877-a3df-feadbd4049bd"
        },
        {
          "scope": "nsx-op/dns_for",
          "tag": "httproute"
        },
        {
          "scope": "nsx-op/dns_owner_namespace",
          "tag": "test1"
        },
        {
          "scope": "nsx-op/dns_owner_name",
          "tag": "http-7"
        },
        {
          "scope": "nsx-op/dns_gateway_index_list",
          "tag": "test1/gateway"
        },
        {
          "scope": "nsx-op/dns_contributing_owners",
          "tag": "httproute/test1/http-1,httproute/test1/http-10,httproute/test1/http-11,httproute/test1/http-12,httproute/test1/http-13,httproute/test1/http-14,httproute/test1/http-15,httproute/test1/http-16,httproute/test1/http-17,httproute/test1/http-18"
        },
        {
          "scope": "nsx-op/dns_contributing_owners_ext",
          "tag": "httproute/test1/http-19,httproute/test1/http-2,httproute/test1/http-20,httproute/test1/http-3,httproute/test1/http-4,httproute/test1/http-5,httproute/test1/http-6,httproute/test1/http-8,httproute/test1/http-9"
        }
      ]
    }
  ]
}
```
8. Delete 6 HTTPRoutes
```
root@420aec474057587e08ae81c7f6ce8984 [ ~/wenying ]# kubectl -n test1 delete httproute http-11 http-12 http-13 http-14 http-15 http-20
httproute.gateway.networking.k8s.io "http-11" deleted from test1 namespace
httproute.gateway.networking.k8s.io "http-12" deleted from test1 namespace
httproute.gateway.networking.k8s.io "http-13" deleted from test1 namespace
httproute.gateway.networking.k8s.io "http-14" deleted from test1 namespace
httproute.gateway.networking.k8s.io "http-15" deleted from test1 namespace
httproute.gateway.networking.k8s.io "http-20" deleted from test1 namespace

root@420aec474057587e08ae81c7f6ce8984 [ ~/wenying ]# for i in {1..20}; do   status=$(kubectl get httproute -n test1 "http-$i" -o jsonpath='{.status.parents[*].conditions[?(@.type=="DNSRecordReady")].
status}' 2>/dev/null);   echo "http-$i: ${status:-Not Found / No Status}"; done
http-1: True
http-2: True
http-3: True
http-4: True
http-5: True
http-6: True
http-7: True
http-8: True
http-9: True
http-10: True
http-11: Not Found / No Status
http-12: Not Found / No Status
http-13: Not Found / No Status
http-14: Not Found / No Status
http-15: Not Found / No Status
http-16: True
http-17: True
http-18: True
http-19: True
http-20: Not Found / No Status
```
9. Check NSX DNSRecord status
```
root@420aec474057587e08ae81c7f6ce8984 [ ~/wenying ]#  curl -s -k -u ${cred} https://10.192.49.176/policy/api/v1/orgs/default/projects/project-quality/dns-records | jq '{
  result_count,
  results: [.results[] | {zone_path, record_name, record_type, record_values, tags, _revision}]
}'
{
  "result_count": 1,
  "results": [
    {
      "zone_path": "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
      "record_name": "httpbin",
      "record_type": "A",
      "record_values": [
        "192.168.0.7"
      ],
      "tags": [
        {
          "scope": "nsx-op/cluster",
          "tag": "6edf5c92-2967-41a3-9b7c-a3d50fca857b"
        },
        {
          "scope": "nsx-op/version",
          "tag": "1.0.0"
        },
        {
          "scope": "nsx-op/namespace_uid",
          "tag": "c54019ac-89cf-4877-a3df-feadbd4049bd"
        },
        {
          "scope": "nsx-op/dns_for",
          "tag": "httproute"
        },
        {
          "scope": "nsx-op/dns_owner_namespace",
          "tag": "test1"
        },
        {
          "scope": "nsx-op/dns_owner_name",
          "tag": "http-7"
        },
        {
          "scope": "nsx-op/dns_gateway_index_list",
          "tag": "test1/gateway"
        },
        {
          "scope": "nsx-op/dns_contributing_owners",
          "tag": "httproute/test1/http-1,httproute/test1/http-10,httproute/test1/http-16,httproute/test1/http-17,httproute/test1/http-18,httproute/test1/http-19,httproute/test1/http-2,httproute/test1/http-3,httproute/test1/http-4,httproute/test1/http-5"
        },
        {
          "scope": "nsx-op/dns_contributing_owners_ext",
          "tag": "httproute/test1/http-6,httproute/test1/http-8,httproute/test1/http-9"
        }
      ],
      "_revision": 91
    }
  ]
}
```
10. Add more HTTPRoute to 30 resources with the same hostname, checking the case about truncating the tag values
```
root@422a2cc5036c07e3ed894483ee25f2fb [ ~/wenying/dns_enhancements ]# for i in {1..30}; do   status=$(kubectl get httproute -n test1 "http-$i" -o jsonpath='{.status.parents[*].conditions[?(@.type=="DNSRecordReady")].status}' 2>/dev/null);   echo "http-$i: ${status:-Not Found / No Status}"; done
http-1: True
http-2: True
http-3: True
http-4: True
http-5: True
http-6: True
http-7: True
http-8: True
http-9: True
http-10: True
http-11: True
http-12: True
http-13: True
http-14: True
http-15: True
http-16: True
http-17: True
http-18: True
http-19: True
http-20: True
http-21: False
http-22: True
http-23: False
http-24: False
http-25: False
http-26: False
http-27: False
http-28: False
http-29: False
http-30: False

# kubectl -n test1 get httproute http-21 -ojsonpath='{.status.parents[*].conditions[?(@.type=="DNSRecordReady")]}'
{"lastTransitionTime":"2026-08-28T04:46:03Z","message":"DNS endpoint validation failed during record build: contributing owners count exceeds maximum tag capacity","observedGeneration":1,"reason":"DNSRecordFailed","status":"False","type":"DNSRecordReady"
```
Check NSX DNSRecord
```
root@422a2cc5036c07e3ed894483ee25f2fb [ ~/wenying/dns_enhancements ]#  curl -s -k -u ${cred} https://192.163.128.16/policy/api/v1/orgs/default/projects/project-quality/dns-records | jq '{
  result_count,
  results: [.results[] | {zone_path, record_name, record_type, record_values, tags}]
}'
{
  "result_count": 1,
  "results": [
    {
      "zone_path": "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
      "record_name": "httpbin",
      "record_type": "A",
      "record_values": [
        "192.168.0.10"
      ],
      "tags": [
        {
          "scope": "nsx-op/cluster",
          "tag": "454d4330-56fb-444f-b6df-7977d426689d"
        },
        {
          "scope": "nsx-op/version",
          "tag": "1.0.0"
        },
        {
          "scope": "nsx-op/namespace_uid",
          "tag": "7e8e3b23-59a3-4f03-b040-9effd03fa916"
        },
        {
          "scope": "nsx-op/dns_for",
          "tag": "httproute"
        },
        {
          "scope": "nsx-op/dns_owner_namespace",
          "tag": "test-1"
        },
        {
          "scope": "nsx-op/dns_owner_name",
          "tag": "http-5"
        },
        {
          "scope": "nsx-op/dns_gateway_index_list",
          "tag": "test-1/gateway"
        },
        {
          "scope": "nsx-op/dns_contributing_owners",
          "tag": "httproute/test-1/http-1,httproute/test-1/http-10,httproute/test-1/http-11,httproute/test-1/http-12,httproute/test-1/http-13,httproute/test-1/http-14,httproute/test-1/http-15,httproute/test-1/http-16,httproute/test-1/http-17,httproute/test-1/http-18"
        },
        {
          "scope": "nsx-op/dns_contributing_owners_ext",
          "tag": "httproute/test-1/http-19,httproute/test-1/http-2,httproute/test-1/http-20,httproute/test-1/http-22,httproute/test-1/http-3,httproute/test-1/http-4,httproute/test-1/http-6,httproute/test-1/http-7,httproute/test-1/http-8,httproute/test-1/http-9"
        }
      ]
    }
  ]
}
```
11. Reduce the number of HTTPRoute resources to 5, checking a single tag is sufficient for all HTTPRoutes per FQDN
```
# for i in {6..30}; do
  kubectl -n test1 delete httproute "http-$i"
done
httproute.gateway.networking.k8s.io "http-6" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-7" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-8" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-9" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-10" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-11" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-12" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-13" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-14" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-15" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-16" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-17" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-18" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-19" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-20" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-21" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-22" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-23" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-24" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-25" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-26" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-27" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-28" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-29" deleted from test-1 namespace
httproute.gateway.networking.k8s.io "http-30" deleted from test-1 namespace

# for i in {1..5}; do   status=$(kubectl get httproute -n test1 "http-$i" -o jsonpath='{.status.parents[*].conditions[?(@.type=="DNSRecordReady")].status}' 2>/dev/null);
   echo "http-$i: ${status:-Not Found / No Status}"; done
http-1: True
http-2: True
http-3: True
http-4: True
http-5: True
```
Check NSX DNSRecord status,
```
#  curl -s -k -u ${cred} https://192.163.128.16/policy/api/v1/orgs/default/projects/project-quality/dns-records | jq '{
  result_count,
  results: [.results[] | {zone_path, record_name, record_type, record_values, tags}]
}'
{
  "result_count": 1,
  "results": [
    {
      "zone_path": "/orgs/default/projects/project-quality/dns-services/default-dns-service/zones/zone1",
      "record_name": "httpbin",
      "record_type": "A",
      "record_values": [
        "192.168.0.10"
      ],
      "tags": [
        {
          "scope": "nsx-op/cluster",
          "tag": "454d4330-56fb-444f-b6df-7977d426689d"
        },
        {
          "scope": "nsx-op/version",
          "tag": "1.0.0"
        },
        {
          "scope": "nsx-op/namespace_uid",
          "tag": "7e8e3b23-59a3-4f03-b040-9effd03fa916"
        },
        {
          "scope": "nsx-op/dns_for",
          "tag": "httproute"
        },
        {
          "scope": "nsx-op/dns_owner_namespace",
          "tag": "test-1"
        },
        {
          "scope": "nsx-op/dns_owner_name",
          "tag": "http-5"
        },
        {
          "scope": "nsx-op/dns_gateway_index_list",
          "tag": "test-1/gateway"
        },
        {
          "scope": "nsx-op/dns_contributing_owners",
          "tag": "httproute/test-1/http-1,httproute/test-1/http-2,httproute/test-1/http-3,httproute/test-1/http-4"
        }
      ]
    }
  ]
}
```