### PR TITLE
Optimize startup cache sync timeout and delay initial GC (#1505)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -324,6 +325,9 @@ func main() {
 		LeaderElection:          cf.HAEnabled(),
 		LeaderElectionNamespace: nsxOperatorNamespace,
 		LeaderElectionID:        "nsx-operator",
+		Controller: ctrlconfig.Controller{
+			CacheSyncTimeout: 5 * time.Minute,
+		},
 	})
 	if err != nil {
 		log.Error(err, "Failed to init manager")

--- a/pkg/controllers/common/gc_test.go
+++ b/pkg/controllers/common/gc_test.go
@@ -1,0 +1,89 @@
+package common
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenericGarbageCollector(t *testing.T) {
+	// Save original startup delay and restore it afterwards
+	origDelay := GCStartupDelay
+	defer func() {
+		GCStartupDelay = origDelay
+	}()
+
+	// Set startup delay to 0 for testing immediate execution
+	GCStartupDelay = 0
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	var calledCount int32
+	f := func(ctx context.Context) error {
+		val := atomic.AddInt32(&calledCount, 1)
+		if val == 1 {
+			wg.Done()
+		}
+		return nil
+	}
+
+	cancel := make(chan bool)
+	done := make(chan struct{})
+
+	// Run GenericGarbageCollector with a short interval
+	go func() {
+		GenericGarbageCollector(cancel, 10*time.Millisecond, f)
+		close(done)
+	}()
+
+	// Wait for the first immediate call to complete
+	wg.Wait()
+
+	// Wait a bit more to see if it ticks again
+	time.Sleep(25 * time.Millisecond)
+
+	assert.GreaterOrEqual(t, int(atomic.LoadInt32(&calledCount)), 2, "GC should have run at least twice (initial + ticks)")
+
+	close(cancel)
+	<-done
+}
+
+func TestGenericGarbageCollector_WithDelay(t *testing.T) {
+	origDelay := GCStartupDelay
+	defer func() {
+		GCStartupDelay = origDelay
+	}()
+
+	// Set a short startup delay of 50ms for testing
+	GCStartupDelay = 50 * time.Millisecond
+
+	var calledCount int32
+	f := func(ctx context.Context) error {
+		atomic.AddInt32(&calledCount, 1)
+		return nil
+	}
+
+	cancel := make(chan bool)
+	done := make(chan struct{})
+
+	go func() {
+		GenericGarbageCollector(cancel, 10*time.Millisecond, f)
+		close(done)
+	}()
+
+	// Immediately after starting, it should not have run yet due to the startup delay
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&calledCount), "GC should not have run during the startup delay")
+
+	// Wait for the startup delay (50ms) to pass
+	time.Sleep(60 * time.Millisecond)
+	assert.GreaterOrEqual(t, int(atomic.LoadInt32(&calledCount)), 1, "GC should have run at least once after the startup delay")
+
+	close(cancel)
+	<-done
+}

--- a/pkg/controllers/common/utils.go
+++ b/pkg/controllers/common/utils.go
@@ -32,6 +32,7 @@ var (
 		servicecommon.DefaultPodNetwork: servicecommon.LabelDefaultPodSubnetSet,
 		servicecommon.DefaultVMNetwork:  servicecommon.LabelDefaultVMSubnetSet,
 	}
+	GCStartupDelay = 10 * time.Minute
 )
 
 func IsSharedSubnetPath(ctx context.Context, client k8sclient.Client, path string, ns string) (bool, error) {
@@ -291,6 +292,20 @@ func NumReconcile() int {
 
 func GenericGarbageCollector(cancel chan bool, timeout time.Duration, f func(ctx context.Context) error) {
 	ctx := context.Background()
+
+	if GCStartupDelay > 0 {
+		select {
+		case <-cancel:
+			return
+		case <-time.After(GCStartupDelay):
+		}
+	}
+
+	// Run the first garbage collection immediately after the startup delay
+	if err := f(ctx); err != nil {
+		log.Error(err, "failed to run initial garbage collection")
+	}
+
 	ticker := time.NewTicker(timeout)
 	defer ticker.Stop()
 


### PR DESCRIPTION
To prevent NSX Operator from failing to start in large-scale clusters (e.g., 500+ VPCs, 3300+ SubnetPorts) due to API Server congestion, this patch:

1. Increases the controller manager's CacheSyncTimeout from the default 2 minutes to 5 minutes. This provides a safer margin for initial Informer cache synchronization when dealing with a high volume of resources.
2. Introduces a global GCStartupDelay (defaulting to 10 minutes) for all controllers using GenericGarbageCollector. This delays the first run of garbage collection, effectively avoiding the "startup GC storm" where heavy concurrent List/Delete API requests collide with the initial cache sync.
3. Ensures the first garbage collection is triggered immediately after the startup delay expires, followed by periodic execution as configured.

Test Done:
on the live env , the nsx-operator could bootup