### PR TITLE
perf: optimize startup CacheSyncTimeout, QPS, and Informer thread blocking

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
@@ -349,6 +350,7 @@ func electMaster(mgr manager.Manager, nsxClient *nsx.Client) {
 }
 
 func main() {
+	klog.SetLogger(ctrl.Log.WithName("klog"))
 	log.Info("Starting NSX Operator")
 	cfg, err := pkgutil.GetConfig()
 	if err != nil {
@@ -363,7 +365,7 @@ func main() {
 		LeaderElectionNamespace: nsxOperatorNamespace,
 		LeaderElectionID:        "nsx-operator",
 		Controller: ctrlconfig.Controller{
-			CacheSyncTimeout: 5 * time.Minute,
+			CacheSyncTimeout: pkgutil.GetCacheSyncTimeout(),
 		},
 	})
 	if err != nil {

--- a/pkg/controllers/networkinfo/vpcnetworkconfig_handler.go
+++ b/pkg/controllers/networkinfo/vpcnetworkconfig_handler.go
@@ -3,6 +3,7 @@ package networkinfo
 import (
 	"context"
 	"reflect"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -21,28 +22,79 @@ import (
 // - VPC Network Configuration deletion: Delete VPC Network Configuration from cache.
 // - VPC Network Configuration update:	Only support updating external/private ipblocks, update values in cache
 
+type vpcTaskType int
+
+const (
+	vpcTaskUpdate vpcTaskType = iota
+	vpcTaskDelete
+)
+
+const (
+	vpcTaskQueueCapacity = 1000
+)
+
+type vpcTask struct {
+	taskType  vpcTaskType
+	vpcConfig *v1alpha1.VPCNetworkConfiguration
+}
+
 type VPCNetworkConfigurationHandler struct {
 	Client              client.Client
 	vpcService          commontypes.VPCServiceProvider
 	ipBlocksInfoService commontypes.IPBlocksInfoServiceProvider
+
+	initOnce sync.Once
+	taskChan chan vpcTask
 }
 
-func (h *VPCNetworkConfigurationHandler) Create(ctx context.Context, e event.CreateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	vpcConfigCR := e.Object.(*v1alpha1.VPCNetworkConfiguration)
-	vname := vpcConfigCR.GetName()
-	// Update IPBlocks info
-	if err := h.ipBlocksInfoService.UpdateIPBlocksInfo(ctx, vpcConfigCR); err != nil {
-		log.Error(err, "Failed to update the IPBlocksInfo", "VPCNetworkConfiguration", vname)
+func (h *VPCNetworkConfigurationHandler) ensureWorker() {
+	h.initOnce.Do(func() {
+		h.taskChan = make(chan vpcTask, vpcTaskQueueCapacity)
+		go h.workerLoop()
+	})
+}
+
+func (h *VPCNetworkConfigurationHandler) enqueueTask(t vpcTask) {
+	h.ensureWorker()
+	select {
+	case h.taskChan <- t:
+	default:
+		log.Error(nil, "VPCNetworkConfiguration task channel full, dropping task", "taskType", t.taskType, "VPCNetworkConfiguration", t.vpcConfig.Name)
 	}
 }
 
-func (h *VPCNetworkConfigurationHandler) Delete(ctx context.Context, e event.DeleteEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	vpcConfigCR := e.Object.(*v1alpha1.VPCNetworkConfiguration)
-	if err := h.ipBlocksInfoService.SyncIPBlocksInfo(ctx); err != nil {
-		log.Error(err, "failed to synchronize IPBlocksInfo when deleting %s", vpcConfigCR.Name)
-	} else {
-		h.ipBlocksInfoService.ResetPeriodicSync()
+func (h *VPCNetworkConfigurationHandler) workerLoop() {
+	for t := range h.taskChan {
+		switch t.taskType {
+		case vpcTaskUpdate:
+			if err := h.ipBlocksInfoService.UpdateIPBlocksInfo(context.Background(), t.vpcConfig); err != nil {
+				log.Error(err, "Failed to update the IPBlocksInfo", "VPCNetworkConfiguration", t.vpcConfig.Name)
+			}
+		case vpcTaskDelete:
+			if err := h.ipBlocksInfoService.SyncIPBlocksInfo(context.Background()); err != nil {
+				log.Error(err, "failed to synchronize IPBlocksInfo when deleting", "VPCNetworkConfiguration", t.vpcConfig.Name)
+			} else {
+				h.ipBlocksInfoService.ResetPeriodicSync()
+			}
+		}
 	}
+}
+
+func (h *VPCNetworkConfigurationHandler) Create(_ context.Context, e event.CreateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	vpcConfigCR := e.Object.(*v1alpha1.VPCNetworkConfiguration)
+	// Enqueue update task to single background worker thread to avoid blocking Informer CacheSync
+	h.enqueueTask(vpcTask{
+		taskType:  vpcTaskUpdate,
+		vpcConfig: vpcConfigCR,
+	})
+}
+
+func (h *VPCNetworkConfigurationHandler) Delete(_ context.Context, e event.DeleteEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	vpcConfigCR := e.Object.(*v1alpha1.VPCNetworkConfiguration)
+	h.enqueueTask(vpcTask{
+		taskType:  vpcTaskDelete,
+		vpcConfig: vpcConfigCR,
+	})
 }
 
 func (h *VPCNetworkConfigurationHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -87,9 +139,10 @@ func (h *VPCNetworkConfigurationHandler) Update(ctx context.Context, e event.Upd
 		return
 	}
 
-	if err := h.ipBlocksInfoService.UpdateIPBlocksInfo(ctx, newNc); err != nil {
-		log.Error(err, "Failed to update the IPBlocksInfo", "VPCNetworkConfiguration", newNc.Name)
-	}
+	h.enqueueTask(vpcTask{
+		taskType:  vpcTaskUpdate,
+		vpcConfig: newNc,
+	})
 }
 
 var VPCNetworkConfigurationPredicate = predicate.Funcs{

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -547,34 +547,27 @@ func (r *SubnetPortReconciler) SetupFieldIndexers(mgr ctrl.Manager) error {
 	return nil
 }
 
-func (r *SubnetPortReconciler) vmMapFunc(_ context.Context, vm client.Object) []reconcile.Request {
+func (r *SubnetPortReconciler) vmMapFunc(ctx context.Context, vm client.Object) []reconcile.Request {
 	subnetPortList := &v1alpha1.SubnetPortList{}
 	var requests []reconcile.Request
+	spIndexValue := fmt.Sprintf("%s/%s", vm.GetNamespace(), vm.GetName())
 	err := retry.OnError(retry.DefaultRetry, func(err error) bool {
 		return err != nil
 	}, func() error {
-		err := r.Client.List(context.TODO(), subnetPortList)
+		err := r.Client.List(ctx, subnetPortList, client.MatchingFields{util.SubnetPortNamespaceVMIndexKey: spIndexValue})
 		return err
 	})
 	if err != nil {
-		log.Error(err, "failed to list subnetport in VM handler")
+		log.Error(err, "failed to list subnetport in VM handler", "VM", spIndexValue)
 		return requests
 	}
 	for _, subnetPort := range subnetPortList.Items {
-		port := subnetPort
-		vmName, _, err := common.GetVirtualMachineNameForSubnetPort(&port)
-		if err != nil {
-			// not block the subnetport visiting because of invalid annotations
-			log.Error(err, "failed to get virtualmachine name from subnetport", "subnetPort.UID", subnetPort.UID)
-		}
-		if vmName == vm.GetName() && subnetPort.Namespace == vm.GetNamespace() {
-			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      subnetPort.Name,
-					Namespace: subnetPort.Namespace,
-				},
-			})
-		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      subnetPort.Name,
+				Namespace: subnetPort.Namespace,
+			},
+		})
 	}
 	return requests
 }

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -1302,7 +1303,7 @@ func TestSubnetPortReconciler_vmMapFunc(t *testing.T) {
 		SubnetPortService: service,
 	}
 	subnetPortList := &v1alpha1.SubnetPortList{}
-	k8sClient.EXPECT().List(gomock.Any(), subnetPortList).Return(nil).Do(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	k8sClient.EXPECT().List(gomock.Any(), subnetPortList, client.MatchingFields{pkgutil.SubnetPortNamespaceVMIndexKey: "ns/vm1"}).Return(nil).Do(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 		a := list.(*v1alpha1.SubnetPortList)
 		a.Items = append(a.Items, v1alpha1.SubnetPort{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1326,6 +1327,72 @@ func TestSubnetPortReconciler_vmMapFunc(t *testing.T) {
 		NamespacedName: types.NamespacedName{
 			Name:      "subentport-1",
 			Namespace: "ns",
+		},
+	}, requests[0])
+}
+
+func TestSubnetPortReconciler_vmMapFunc_WithIndexer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	sp1 := &v1alpha1.SubnetPort{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sp-vm1-ns1",
+			Namespace: "ns1",
+			Annotations: map[string]string{
+				servicecommon.AnnotationAttachmentRef: "virtualmachine/vm1/port1",
+			},
+		},
+	}
+	sp2 := &v1alpha1.SubnetPort{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sp-vm2-ns1",
+			Namespace: "ns1",
+			Annotations: map[string]string{
+				servicecommon.AnnotationAttachmentRef: "virtualmachine/vm2/port1",
+			},
+		},
+	}
+	sp3 := &v1alpha1.SubnetPort{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sp-vm1-ns2",
+			Namespace: "ns2",
+			Annotations: map[string]string{
+				servicecommon.AnnotationAttachmentRef: "virtualmachine/vm1/port1",
+			},
+		},
+	}
+	sp4 := &v1alpha1.SubnetPort{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sp-no-vm",
+			Namespace: "ns1",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&v1alpha1.SubnetPort{}, pkgutil.SubnetPortNamespaceVMIndexKey, subnetPortNamespaceVMIndexFunc).
+		WithObjects(sp1, sp2, sp3, sp4).
+		Build()
+
+	r := &SubnetPortReconciler{
+		Client: fakeClient,
+	}
+
+	vm := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vm1",
+			Namespace: "ns1",
+		},
+	}
+
+	requests := r.vmMapFunc(context.TODO(), vm)
+	assert.Equal(t, 1, len(requests))
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "sp-vm1-ns1",
+			Namespace: "ns1",
 		},
 	}, requests[0])
 }

--- a/pkg/nsx/services/ipblocksinfo/ipblocksinfo.go
+++ b/pkg/nsx/services/ipblocksinfo/ipblocksinfo.go
@@ -90,7 +90,9 @@ func (s *IPBlocksInfoService) StartPeriodicSync() {
 }
 
 func (s *IPBlocksInfoService) ResetPeriodicSync() {
-	s.SyncTask.resetChan <- struct{}{}
+	if s != nil && s.SyncTask != nil && s.SyncTask.resetChan != nil {
+		s.SyncTask.resetChan <- struct{}{}
+	}
 }
 
 // mergeIPCidrs merges target CIDRs into source CIDRs if not already covered by source.

--- a/pkg/util/kubernetes.go
+++ b/pkg/util/kubernetes.go
@@ -4,23 +4,85 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 const (
-	localhostIP           = "127.0.0.1"
-	localhostIPv6         = "::1"
-	defaultK8sServicePort = "6443"
-	K8sServicePortEnv     = "KUBERNETES_SERVICE_PORT"
+	localhostIP             = "127.0.0.1"
+	localhostIPv6           = "::1"
+	defaultK8sServicePort   = "6443"
+	K8sServicePortEnv       = "KUBERNETES_SERVICE_PORT"
+	K8sClientQPSEnv         = "K8S_CLIENT_QPS"
+	K8sClientBurstEnv       = "K8S_CLIENT_BURST"
+	K8sClientTimeoutEnv     = "K8S_CLIENT_TIMEOUT"
+	CacheSyncTimeoutEnv     = "CACHE_SYNC_TIMEOUT"
+	DefaultK8sClientQPS     = float32(100)
+	DefaultK8sClientBurst   = 200
+	DefaultK8sClientTimeout = 2 * time.Minute
+	DefaultCacheSyncTimeout = 5 * time.Minute
 )
+
+func GetK8sClientQPS() float32 {
+	if val := os.Getenv(K8sClientQPSEnv); val != "" {
+		if qps, err := strconv.ParseFloat(val, 32); err == nil && qps > 0 {
+			return float32(qps)
+		}
+	}
+	return DefaultK8sClientQPS
+}
+
+func GetK8sClientBurst() int {
+	if val := os.Getenv(K8sClientBurstEnv); val != "" {
+		if burst, err := strconv.Atoi(val); err == nil && burst > 0 {
+			return burst
+		}
+	}
+	return DefaultK8sClientBurst
+}
+
+func GetK8sClientTimeout() time.Duration {
+	if val := os.Getenv(K8sClientTimeoutEnv); val != "" {
+		if d, err := time.ParseDuration(val); err == nil && d > 0 {
+			return d
+		}
+	}
+	return DefaultK8sClientTimeout
+}
+
+func GetCacheSyncTimeout() time.Duration {
+	if val := os.Getenv(CacheSyncTimeoutEnv); val != "" {
+		if d, err := time.ParseDuration(val); err == nil && d > 0 {
+			return d
+		}
+	}
+	return DefaultCacheSyncTimeout
+}
 
 func GetConfig() (*rest.Config, error) {
 	cfg := ctrl.GetConfigOrDie()
-	cfg.Timeout = TCPReadTimeout
+	if cfg.QPS <= 0 {
+		cfg.QPS = GetK8sClientQPS()
+	}
+	if cfg.Burst <= 0 {
+		cfg.Burst = GetK8sClientBurst()
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = GetK8sClientTimeout()
+	}
+
+	if cfg.RateLimiter == nil {
+		cfg.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(cfg.QPS, cfg.Burst)
+	}
+
+	log.Info("Loaded Kubernetes client configuration", "QPS", cfg.QPS, "Burst", cfg.Burst, "Timeout", cfg.Timeout, "CacheSyncTimeout", GetCacheSyncTimeout())
+
 	var healthy bool
 	var getHealthErr error
 

--- a/pkg/util/kubernetes_test.go
+++ b/pkg/util/kubernetes_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
@@ -94,7 +95,34 @@ func TestGetConfig(t *testing.T) {
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, tt.expectedHost, cfg.Host)
+				assert.Equal(t, DefaultK8sClientQPS, cfg.QPS)
+				assert.Equal(t, DefaultK8sClientBurst, cfg.Burst)
+				assert.Equal(t, DefaultK8sClientTimeout, cfg.Timeout)
+				assert.NotNil(t, cfg.RateLimiter)
 			}
 		})
 	}
+}
+
+func TestGetConfigEnvVars(t *testing.T) {
+	t.Setenv(K8sClientQPSEnv, "250.5")
+	t.Setenv(K8sClientBurstEnv, "500")
+	t.Setenv(K8sClientTimeoutEnv, "3m")
+	t.Setenv(CacheSyncTimeoutEnv, "10m")
+
+	assert.Equal(t, float32(250.5), GetK8sClientQPS())
+	assert.Equal(t, 500, GetK8sClientBurst())
+	assert.Equal(t, 3*time.Minute, GetK8sClientTimeout())
+	assert.Equal(t, 10*time.Minute, GetCacheSyncTimeout())
+
+	// Test invalid env vars fallback to defaults
+	t.Setenv(K8sClientQPSEnv, "invalid")
+	t.Setenv(K8sClientBurstEnv, "-1")
+	t.Setenv(K8sClientTimeoutEnv, "invalid")
+	t.Setenv(CacheSyncTimeoutEnv, "invalid")
+
+	assert.Equal(t, DefaultK8sClientQPS, GetK8sClientQPS())
+	assert.Equal(t, DefaultK8sClientBurst, GetK8sClientBurst())
+	assert.Equal(t, DefaultK8sClientTimeout, GetK8sClientTimeout())
+	assert.Equal(t, DefaultCacheSyncTimeout, GetCacheSyncTimeout())
 }


### PR DESCRIPTION

During nsx-operator startup, CacheSyncTimeout errors occurred for VPCNetworkConfiguration and VirtualMachine informers. Investigation revealed three contributing factors:

1. Informer Thread Blocking via Synchronous NSX-T REST Calls:
   - VPCNetworkConfigurationHandler.Create() executed synchronous UpdateIPBlocksInfo() calls (calling NSX-T REST APIs) directly within client-go's single-threaded Informer event dispatch thread during initial cache sync.
   - Fixed by decoupling UpdateIPBlocksInfo() and SyncIPBlocksInfo() onto a single background worker thread with a task queue (enqueueTask). This preserves single-threaded serial execution order and prevents goroutine explosion without blocking Informer.HasSynced().

2. O(N*M) Unindexed List Operations in Event Handlers:
   - vmMapFunc in SubnetPortReconciler performed an unindexed full r.Client.List() of all SubnetPort objects in the cluster for every VirtualMachine event during Informer sync.
   - Fixed by utilizing the pre-registered field indexer (MatchingFields{util.SubnetPortNamespaceVMIndexKey: spIndexValue}), reducing list lookups from O(N*M) cluster-wide scans to O(1) in-memory index fetches.

3. Client-Go Rate Limiting and Config Visibility:
   - Added environment variable support for tuning client-go and controller settings without recompilation: - K8S_CLIENT_QPS (default: 100) - K8S_CLIENT_BURST (default: 200) - K8S_CLIENT_TIMEOUT (default: 2m) - CACHE_SYNC_TIMEOUT (default: 5m)
   - Connected klog to ctrl.Log in cmd/main.go to surface native client-go throttling warnings.
   - Added logging of active client configurations on startup.
   
   
  Test Done:
  1. test in the scale env, nsx-operator could bootup without crash