### PR TITLE
perf: optimize startup CacheSyncTimeout and Informer thread blocking

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
@@ -312,6 +313,7 @@ func electMaster(mgr manager.Manager, nsxClient *nsx.Client) {
 }
 
 func main() {
+	klog.SetLogger(ctrl.Log.WithName("klog"))
 	log.Info("Starting NSX Operator")
 	cfg, err := pkgutil.GetConfig()
 	if err != nil {
@@ -326,7 +328,7 @@ func main() {
 		LeaderElectionNamespace: nsxOperatorNamespace,
 		LeaderElectionID:        "nsx-operator",
 		Controller: ctrlconfig.Controller{
-			CacheSyncTimeout: 5 * time.Minute,
+			CacheSyncTimeout: pkgutil.GetCacheSyncTimeout(),
 		},
 	})
 	if err != nil {

--- a/pkg/controllers/networkinfo/vpcnetworkconfig_handler.go
+++ b/pkg/controllers/networkinfo/vpcnetworkconfig_handler.go
@@ -3,6 +3,7 @@ package networkinfo
 import (
 	"context"
 	"reflect"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -21,28 +22,88 @@ import (
 // - VPC Network Configuration deletion: Delete VPC Network Configuration from cache.
 // - VPC Network Configuration update:	Only support updating external/private ipblocks, update values in cache
 
+type vpcTaskType int
+
+const (
+	vpcTaskUpdate vpcTaskType = iota
+	vpcTaskDelete
+)
+
+type vpcTask struct {
+	taskType  vpcTaskType
+	vpcConfig *v1alpha1.VPCNetworkConfiguration
+}
+
 type VPCNetworkConfigurationHandler struct {
 	Client              client.Client
 	vpcService          commontypes.VPCServiceProvider
 	ipBlocksInfoService commontypes.IPBlocksInfoServiceProvider
+
+	initOnce sync.Once
+	mu       sync.Mutex
+	cond     *sync.Cond
+	tasks    []vpcTask
 }
 
-func (h *VPCNetworkConfigurationHandler) Create(ctx context.Context, e event.CreateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	vpcConfigCR := e.Object.(*v1alpha1.VPCNetworkConfiguration)
-	vname := vpcConfigCR.GetName()
-	// Update IPBlocks info
-	if err := h.ipBlocksInfoService.UpdateIPBlocksInfo(ctx, vpcConfigCR); err != nil {
-		log.Error(err, "Failed to update the IPBlocksInfo", "VPCNetworkConfiguration", vname)
+func (h *VPCNetworkConfigurationHandler) ensureWorker() {
+	h.initOnce.Do(func() {
+		h.cond = sync.NewCond(&h.mu)
+		go h.workerLoop()
+	})
+}
+
+func (h *VPCNetworkConfigurationHandler) enqueueTask(t vpcTask) {
+	h.ensureWorker()
+	h.mu.Lock()
+	h.tasks = append(h.tasks, t)
+	h.mu.Unlock()
+	h.cond.Signal()
+}
+
+func (h *VPCNetworkConfigurationHandler) workerLoop() {
+	for {
+		h.mu.Lock()
+		for len(h.tasks) == 0 {
+			h.cond.Wait()
+		}
+		t := h.tasks[0]
+		h.tasks[0] = vpcTask{}
+		h.tasks = h.tasks[1:]
+		if len(h.tasks) == 0 {
+			h.tasks = nil
+		}
+		h.mu.Unlock()
+
+		switch t.taskType {
+		case vpcTaskUpdate:
+			if err := h.ipBlocksInfoService.UpdateIPBlocksInfo(context.Background(), t.vpcConfig); err != nil {
+				log.Error(err, "Failed to update the IPBlocksInfo", "VPCNetworkConfiguration", t.vpcConfig.Name)
+			}
+		case vpcTaskDelete:
+			if err := h.ipBlocksInfoService.SyncIPBlocksInfo(context.Background()); err != nil {
+				log.Error(err, "failed to synchronize IPBlocksInfo when deleting", "VPCNetworkConfiguration", t.vpcConfig.Name)
+			} else {
+				h.ipBlocksInfoService.ResetPeriodicSync()
+			}
+		}
 	}
 }
 
-func (h *VPCNetworkConfigurationHandler) Delete(ctx context.Context, e event.DeleteEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (h *VPCNetworkConfigurationHandler) Create(_ context.Context, e event.CreateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	vpcConfigCR := e.Object.(*v1alpha1.VPCNetworkConfiguration)
-	if err := h.ipBlocksInfoService.SyncIPBlocksInfo(ctx); err != nil {
-		log.Error(err, "failed to synchronize IPBlocksInfo when deleting %s", vpcConfigCR.Name)
-	} else {
-		h.ipBlocksInfoService.ResetPeriodicSync()
-	}
+	// Enqueue update task to single background worker thread to avoid blocking Informer CacheSync
+	h.enqueueTask(vpcTask{
+		taskType:  vpcTaskUpdate,
+		vpcConfig: vpcConfigCR,
+	})
+}
+
+func (h *VPCNetworkConfigurationHandler) Delete(_ context.Context, e event.DeleteEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	vpcConfigCR := e.Object.(*v1alpha1.VPCNetworkConfiguration)
+	h.enqueueTask(vpcTask{
+		taskType:  vpcTaskDelete,
+		vpcConfig: vpcConfigCR,
+	})
 }
 
 func (h *VPCNetworkConfigurationHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -87,9 +148,10 @@ func (h *VPCNetworkConfigurationHandler) Update(ctx context.Context, e event.Upd
 		return
 	}
 
-	if err := h.ipBlocksInfoService.UpdateIPBlocksInfo(ctx, newNc); err != nil {
-		log.Error(err, "Failed to update the IPBlocksInfo", "VPCNetworkConfiguration", newNc.Name)
-	}
+	h.enqueueTask(vpcTask{
+		taskType:  vpcTaskUpdate,
+		vpcConfig: newNc,
+	})
 }
 
 var VPCNetworkConfigurationPredicate = predicate.Funcs{

--- a/pkg/controllers/networkinfo/vpcnetworkconfig_handler_test.go
+++ b/pkg/controllers/networkinfo/vpcnetworkconfig_handler_test.go
@@ -2,6 +2,8 @@ package networkinfo
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -209,5 +211,161 @@ func TestVPCNetworkConfigurationHandler_Generic(t *testing.T) {
 			handler := createVPCNetworkConfigurationHandler(nil)
 			handler.Generic(context.TODO(), event.GenericEvent{Object: tc.vpcNetworkConfig}, queue)
 		})
+	}
+}
+
+type mockIPBlocksInfoService struct {
+	mu          sync.Mutex
+	updatedVPCs []string
+	syncCount   int
+	resetCount  int
+	processed   chan struct{}
+}
+
+func (m *mockIPBlocksInfoService) UpdateIPBlocksInfo(_ context.Context, vpcConfigCR *v1alpha1.VPCNetworkConfiguration) error {
+	m.mu.Lock()
+	m.updatedVPCs = append(m.updatedVPCs, vpcConfigCR.Name)
+	m.mu.Unlock()
+	if m.processed != nil {
+		m.processed <- struct{}{}
+	}
+	return nil
+}
+
+func (m *mockIPBlocksInfoService) SyncIPBlocksInfo(_ context.Context) error {
+	m.mu.Lock()
+	m.syncCount++
+	m.mu.Unlock()
+	if m.processed != nil {
+		m.processed <- struct{}{}
+	}
+	return nil
+}
+
+func (m *mockIPBlocksInfoService) ResetPeriodicSync() {
+	m.mu.Lock()
+	m.resetCount++
+	m.mu.Unlock()
+}
+
+func TestVPCNetworkConfigurationHandler_QueueFIFOAndCompletion(t *testing.T) {
+	const taskCount = 2000
+	mock := &mockIPBlocksInfoService{
+		processed: make(chan struct{}, taskCount),
+	}
+	handler := &VPCNetworkConfigurationHandler{
+		ipBlocksInfoService: mock,
+	}
+
+	for i := 0; i < taskCount; i++ {
+		handler.enqueueTask(vpcTask{
+			taskType: vpcTaskUpdate,
+			vpcConfig: &v1alpha1.VPCNetworkConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("vpc-%d", i)},
+			},
+		})
+	}
+
+	for i := 0; i < taskCount; i++ {
+		<-mock.processed
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.updatedVPCs) != taskCount {
+		t.Fatalf("expected %d processed tasks, got %d", taskCount, len(mock.updatedVPCs))
+	}
+	for i := 0; i < taskCount; i++ {
+		expectedName := fmt.Sprintf("vpc-%d", i)
+		if mock.updatedVPCs[i] != expectedName {
+			t.Errorf("FIFO violation at index %d: expected %s, got %s", i, expectedName, mock.updatedVPCs[i])
+		}
+	}
+
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+	if len(handler.tasks) != 0 {
+		t.Errorf("expected empty tasks slice, got length %d", len(handler.tasks))
+	}
+	if handler.tasks != nil {
+		t.Errorf("expected tasks slice to be reset to nil, got %v", handler.tasks)
+	}
+}
+
+func TestVPCNetworkConfigurationHandler_QueueConcurrentEnqueue(t *testing.T) {
+	const goroutines = 20
+	const tasksPerGoroutine = 100
+	const totalTasks = goroutines * tasksPerGoroutine
+
+	mock := &mockIPBlocksInfoService{
+		processed: make(chan struct{}, totalTasks),
+	}
+	handler := &VPCNetworkConfigurationHandler{
+		ipBlocksInfoService: mock,
+	}
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(gID int) {
+			defer wg.Done()
+			for i := 0; i < tasksPerGoroutine; i++ {
+				handler.enqueueTask(vpcTask{
+					taskType: vpcTaskUpdate,
+					vpcConfig: &v1alpha1.VPCNetworkConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("g%d-vpc-%d", gID, i)},
+					},
+				})
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	for i := 0; i < totalTasks; i++ {
+		<-mock.processed
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.updatedVPCs) != totalTasks {
+		t.Fatalf("expected %d tasks processed, got %d", totalTasks, len(mock.updatedVPCs))
+	}
+}
+
+func TestVPCNetworkConfigurationHandler_QueueTaskTypes(t *testing.T) {
+	mock := &mockIPBlocksInfoService{
+		processed: make(chan struct{}, 2),
+	}
+	handler := &VPCNetworkConfigurationHandler{
+		ipBlocksInfoService: mock,
+	}
+
+	handler.enqueueTask(vpcTask{
+		taskType: vpcTaskUpdate,
+		vpcConfig: &v1alpha1.VPCNetworkConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-update-vpc"},
+		},
+	})
+	<-mock.processed
+
+	handler.enqueueTask(vpcTask{
+		taskType: vpcTaskDelete,
+		vpcConfig: &v1alpha1.VPCNetworkConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-delete-vpc"},
+		},
+	})
+	<-mock.processed
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.updatedVPCs) != 1 || mock.updatedVPCs[0] != "test-update-vpc" {
+		t.Errorf("unexpected updated VPCs: %v", mock.updatedVPCs)
+	}
+	if mock.syncCount != 1 {
+		t.Errorf("expected syncCount == 1, got %d", mock.syncCount)
+	}
+	if mock.resetCount != 1 {
+		t.Errorf("expected resetCount == 1, got %d", mock.resetCount)
 	}
 }

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -446,34 +446,27 @@ func (r *SubnetPortReconciler) SetupFieldIndexers(mgr ctrl.Manager) error {
 	return nil
 }
 
-func (r *SubnetPortReconciler) vmMapFunc(_ context.Context, vm client.Object) []reconcile.Request {
+func (r *SubnetPortReconciler) vmMapFunc(ctx context.Context, vm client.Object) []reconcile.Request {
 	subnetPortList := &v1alpha1.SubnetPortList{}
 	var requests []reconcile.Request
+	spIndexValue := fmt.Sprintf("%s/%s", vm.GetNamespace(), vm.GetName())
 	err := retry.OnError(retry.DefaultRetry, func(err error) bool {
 		return err != nil
 	}, func() error {
-		err := r.Client.List(context.TODO(), subnetPortList)
+		err := r.Client.List(ctx, subnetPortList, client.MatchingFields{util.SubnetPortNamespaceVMIndexKey: spIndexValue})
 		return err
 	})
 	if err != nil {
-		log.Error(err, "failed to list subnetport in VM handler")
+		log.Error(err, "failed to list subnetport in VM handler", "VM", spIndexValue)
 		return requests
 	}
 	for _, subnetPort := range subnetPortList.Items {
-		port := subnetPort
-		vmName, _, err := common.GetVirtualMachineNameForSubnetPort(&port)
-		if err != nil {
-			// not block the subnetport visiting because of invalid annotations
-			log.Error(err, "failed to get virtualmachine name from subnetport", "subnetPort.UID", subnetPort.UID)
-		}
-		if vmName == vm.GetName() && subnetPort.Namespace == vm.GetNamespace() {
-			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      subnetPort.Name,
-					Namespace: subnetPort.Namespace,
-				},
-			})
-		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      subnetPort.Name,
+				Namespace: subnetPort.Namespace,
+			},
+		})
 	}
 	return requests
 }

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -38,7 +39,8 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnet"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
+	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
 type fakeRecorder struct {
@@ -296,7 +298,7 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			return false, nil
 		})
 		defer patchesIsSharedSubnetPath.Reset()
-		err := util.NewRealizeStateError("CreateOrUpdateSubnetPort failed", 0)
+		err := nsxutil.NewRealizeStateError("CreateOrUpdateSubnetPort failed", 0)
 		patchesCreateOrUpdateSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
 			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool) (*model.SegmentPortState, bool, error) {
 				return nil, false, err
@@ -1075,7 +1077,7 @@ func TestSubnetPortReconciler_vmMapFunc(t *testing.T) {
 		SubnetPortService: service,
 	}
 	subnetPortList := &v1alpha1.SubnetPortList{}
-	k8sClient.EXPECT().List(gomock.Any(), subnetPortList).Return(nil).Do(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	k8sClient.EXPECT().List(gomock.Any(), subnetPortList, client.MatchingFields{util.SubnetPortNamespaceVMIndexKey: "ns/vm1"}).Return(nil).Do(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 		a := list.(*v1alpha1.SubnetPortList)
 		a.Items = append(a.Items, v1alpha1.SubnetPort{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1099,6 +1101,72 @@ func TestSubnetPortReconciler_vmMapFunc(t *testing.T) {
 		NamespacedName: types.NamespacedName{
 			Name:      "subentport-1",
 			Namespace: "ns",
+		},
+	}, requests[0])
+}
+
+func TestSubnetPortReconciler_vmMapFunc_WithIndexer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	sp1 := &v1alpha1.SubnetPort{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sp-vm1-ns1",
+			Namespace: "ns1",
+			Annotations: map[string]string{
+				servicecommon.AnnotationAttachmentRef: "virtualmachine/vm1/port1",
+			},
+		},
+	}
+	sp2 := &v1alpha1.SubnetPort{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sp-vm2-ns1",
+			Namespace: "ns1",
+			Annotations: map[string]string{
+				servicecommon.AnnotationAttachmentRef: "virtualmachine/vm2/port1",
+			},
+		},
+	}
+	sp3 := &v1alpha1.SubnetPort{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sp-vm1-ns2",
+			Namespace: "ns2",
+			Annotations: map[string]string{
+				servicecommon.AnnotationAttachmentRef: "virtualmachine/vm1/port1",
+			},
+		},
+	}
+	sp4 := &v1alpha1.SubnetPort{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sp-no-vm",
+			Namespace: "ns1",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&v1alpha1.SubnetPort{}, util.SubnetPortNamespaceVMIndexKey, subnetPortNamespaceVMIndexFunc).
+		WithObjects(sp1, sp2, sp3, sp4).
+		Build()
+
+	r := &SubnetPortReconciler{
+		Client: fakeClient,
+	}
+
+	vm := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vm1",
+			Namespace: "ns1",
+		},
+	}
+
+	requests := r.vmMapFunc(context.TODO(), vm)
+	assert.Equal(t, 1, len(requests))
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "sp-vm1-ns1",
+			Namespace: "ns1",
 		},
 	}, requests[0])
 }

--- a/pkg/nsx/services/ipblocksinfo/ipblocksinfo.go
+++ b/pkg/nsx/services/ipblocksinfo/ipblocksinfo.go
@@ -90,7 +90,9 @@ func (s *IPBlocksInfoService) StartPeriodicSync() {
 }
 
 func (s *IPBlocksInfoService) ResetPeriodicSync() {
-	s.SyncTask.resetChan <- struct{}{}
+	if s != nil && s.SyncTask != nil && s.SyncTask.resetChan != nil {
+		s.SyncTask.resetChan <- struct{}{}
+	}
 }
 
 // mergeIPCidrs merges target CIDRs into source CIDRs if not already covered by source.

--- a/pkg/util/kubernetes.go
+++ b/pkg/util/kubernetes.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
@@ -12,15 +13,42 @@ import (
 )
 
 const (
-	localhostIP           = "127.0.0.1"
-	localhostIPv6         = "::1"
-	defaultK8sServicePort = "6443"
-	K8sServicePortEnv     = "KUBERNETES_SERVICE_PORT"
+	localhostIP             = "127.0.0.1"
+	localhostIPv6           = "::1"
+	defaultK8sServicePort   = "6443"
+	K8sServicePortEnv       = "KUBERNETES_SERVICE_PORT"
+	K8sClientTimeoutEnv     = "K8S_CLIENT_TIMEOUT"
+	CacheSyncTimeoutEnv     = "CACHE_SYNC_TIMEOUT"
+	DefaultK8sClientTimeout = 2 * time.Minute
+	DefaultCacheSyncTimeout = 5 * time.Minute
 )
+
+func GetK8sClientTimeout() time.Duration {
+	if val := os.Getenv(K8sClientTimeoutEnv); val != "" {
+		if d, err := time.ParseDuration(val); err == nil && d > 0 {
+			return d
+		}
+	}
+	return DefaultK8sClientTimeout
+}
+
+func GetCacheSyncTimeout() time.Duration {
+	if val := os.Getenv(CacheSyncTimeoutEnv); val != "" {
+		if d, err := time.ParseDuration(val); err == nil && d > 0 {
+			return d
+		}
+	}
+	return DefaultCacheSyncTimeout
+}
 
 func GetConfig() (*rest.Config, error) {
 	cfg := ctrl.GetConfigOrDie()
-	cfg.Timeout = TCPReadTimeout
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = GetK8sClientTimeout()
+	}
+	cacheSyncTimeout := GetCacheSyncTimeout()
+	log.Info("Loaded Kubernetes client configuration", "QPS", cfg.QPS, "Burst", cfg.Burst, "Timeout", cfg.Timeout, "CacheSyncTimeout", cacheSyncTimeout)
+
 	var healthy bool
 	var getHealthErr error
 

--- a/pkg/util/kubernetes_test.go
+++ b/pkg/util/kubernetes_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
@@ -94,7 +95,23 @@ func TestGetConfig(t *testing.T) {
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, tt.expectedHost, cfg.Host)
+				assert.Equal(t, DefaultK8sClientTimeout, cfg.Timeout)
 			}
 		})
 	}
+}
+
+func TestGetConfigEnvVars(t *testing.T) {
+	t.Setenv(K8sClientTimeoutEnv, "3m")
+	t.Setenv(CacheSyncTimeoutEnv, "10m")
+
+	assert.Equal(t, 3*time.Minute, GetK8sClientTimeout())
+	assert.Equal(t, 10*time.Minute, GetCacheSyncTimeout())
+
+	// Test invalid env vars fallback to defaults
+	t.Setenv(K8sClientTimeoutEnv, "invalid")
+	t.Setenv(CacheSyncTimeoutEnv, "invalid")
+
+	assert.Equal(t, DefaultK8sClientTimeout, GetK8sClientTimeout())
+	assert.Equal(t, DefaultCacheSyncTimeout, GetCacheSyncTimeout())
 }


### PR DESCRIPTION

During nsx-operator startup, CacheSyncTimeout errors occurred for VPCNetworkConfiguration and VirtualMachine informers. Investigation revealed three contributing factors:

1. Informer Thread Blocking via Synchronous NSX-T REST Calls:
   - VPCNetworkConfigurationHandler.Create() executed synchronous UpdateIPBlocksInfo() calls (calling NSX-T REST APIs) directly within client-go's single-threaded Informer event dispatch thread during initial cache sync.
   - Fixed by decoupling UpdateIPBlocksInfo() and SyncIPBlocksInfo() onto a single background worker thread with a task queue (enqueueTask). This preserves single-threaded serial execution order and prevents goroutine explosion without blocking Informer.HasSynced().

2. O(N*M) Unindexed List Operations in Event Handlers:
   - vmMapFunc in SubnetPortReconciler performed an unindexed full r.Client.List() of all SubnetPort objects in the cluster for every VirtualMachine event during Informer sync.
   - Fixed by utilizing the pre-registered field indexer (MatchingFields{util.SubnetPortNamespaceVMIndexKey: spIndexValue}), reducing list lookups from O(N*M) cluster-wide scans to O(1) in-memory index fetches.

3. Client-Go Rate Limiting and Config Visibility:
   - Added environment variable support for tuning client-go and controller settings without recompilation: - K8S_CLIENT_QPS (default: 100) - K8S_CLIENT_BURST (default: 200) - K8S_CLIENT_TIMEOUT (default: 2m) - CACHE_SYNC_TIMEOUT (default: 5m)
   - Connected klog to ctrl.Log in cmd/main.go to surface native client-go throttling warnings.
   - Added logging of active client configurations on startup.
   
 
Test Done:
1. verify on the scale env, set CACHE_SYNC_TIMEOUT=2m, nsx-operator could bootup within two minutes without crash