### PR TITLE
Add VCF version requirement descriptions for IPv6 API fields

### DIFF
--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_ipaddressallocations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_ipaddressallocations.yaml
@@ -84,7 +84,7 @@ spec:
                 default: IPv4
                 description: |-
                   IPAddressType specifies the IP address type of the IPAddressAllocation.
-                  IPv6 is supported starting with VCF 9.2.0.
+                  Supported starting with VCF 9.2.0.
                 enum:
                 - IPv4
                 - IPv6

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_ipaddressallocations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_ipaddressallocations.yaml
@@ -82,7 +82,9 @@ spec:
                   rule: self == oldSelf
               ipAddressType:
                 default: IPv4
-                description: IPAddressType specifies the IP address type of the IPAddressAllocation.
+                description: |-
+                  IPAddressType specifies the IP address type of the IPAddressAllocation.
+                  IPv6 is supported starting with VCF 9.2.0.
                 enum:
                 - IPv4
                 - IPv6
@@ -101,6 +103,7 @@ spec:
                 description: |-
                   IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses.
                   Defaults to 64 when ipAddressType is IPv6 and this field is not specified.
+                  Supported starting with VCF 9.2.0.
                 maximum: 128
                 minimum: 64
                 type: integer

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetconnectionbindingmaps.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetconnectionbindingmaps.yaml
@@ -130,7 +130,8 @@ spec:
                   type: object
                 type: array
               vlanTrafficTag:
-                description: VLANTrafficTag is the realized VLAN traffic tag for this binding.
+                description: VLANTrafficTag is the realized VLAN traffic tag for this
+                  binding.
                 format: int64
                 type: integer
             type: object

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetipreservations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetipreservations.yaml
@@ -60,7 +60,7 @@ spec:
               ipAddressType:
                 description: |-
                   IPAddressType defines the IP address type of the SubnetIPReservation.
-                  IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
+                  Supported starting with VCF 9.2.0.
                 enum:
                 - IPv4
                 - IPv6

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetipreservations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetipreservations.yaml
@@ -58,7 +58,9 @@ spec:
             description: SubnetIPReservationSpec defines the desired state of SubnetIPReservation
             properties:
               ipAddressType:
-                description: IPAddressType defines the IP address type of the SubnetIPReservation.
+                description: |-
+                  IPAddressType defines the IP address type of the SubnetIPReservation.
+                  IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
                 enum:
                 - IPv4
                 - IPv6

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
@@ -77,6 +77,7 @@ spec:
                   DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType
                   is set, IP families of InterfaceIPType should be a superset of
                   StaticIPAllocationType.
+                  IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
                 enum:
                 - IPv4
                 - IPv6
@@ -92,6 +93,7 @@ spec:
                   and static allocation are enabled), use this to define which families
                   should be allocated from the static IP pools. If not specified, this field
                   will be back-filled based on InterfaceIPType and Subnet configuration.
+                  IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
                 enum:
                 - IPv4
                 - IPv6

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetports.yaml
@@ -77,7 +77,7 @@ spec:
                   DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType
                   is set, IP families of InterfaceIPType should be a superset of
                   StaticIPAllocationType.
-                  IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
+                  Supported starting with VCF 9.2.0.
                 enum:
                 - IPv4
                 - IPv6
@@ -93,7 +93,7 @@ spec:
                   and static allocation are enabled), use this to define which families
                   should be allocated from the static IP pools. If not specified, this field
                   will be back-filled based on InterfaceIPType and Subnet configuration.
-                  IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
+                  Supported starting with VCF 9.2.0.
                 enum:
                 - IPv4
                 - IPv6

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
@@ -121,8 +121,9 @@ spec:
                 type: object
               ipAddressType:
                 default: IPv4
-                description: IPAddressType defines the IP address type that will be
-                  allocated for the Subnet.
+                description: |-
+                  IPAddressType defines the IP address type that will be allocated for the Subnet.
+                  IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
                 enum:
                 - IPv4
                 - IPv6
@@ -146,7 +147,9 @@ spec:
                 - message: Value is immutable
                   rule: self == oldSelf
               ipv6PrefixLength:
-                description: IPv6 prefix length for the Subnet (e.g. 64 means /64).
+                description: |-
+                  IPv6 prefix length for the Subnet (e.g. 64 means /64).
+                  Supported starting with VCF 9.2.0.
                 maximum: 127
                 minimum: 2
                 type: integer
@@ -184,7 +187,9 @@ spec:
                     || size(self.dhcpServerAdditionalConfig.reservedIPRanges)==0)
                     || has(self.mode) && self.mode=='DHCPServer'
               subnetDHCPv6Config:
-                description: DHCPv6 configuration for Subnet.
+                description: |-
+                  DHCPv6 configuration for Subnet.
+                  Supported starting with VCF 9.2.0.
                 properties:
                   dhcpv6ServerAdditionalConfig:
                     description: Additional DHCPv6 server config for a VPC Subnet.

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnets.yaml
@@ -123,7 +123,7 @@ spec:
                 default: IPv4
                 description: |-
                   IPAddressType defines the IP address type that will be allocated for the Subnet.
-                  IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
+                  Supported starting with VCF 9.2.0.
                 enum:
                 - IPv4
                 - IPv6

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
@@ -69,8 +69,9 @@ spec:
                 - PrivateTGW
                 type: string
               ipAddressType:
-                description: IPAddressType defines the IP address type that will be
-                  allocated for subnets in the SubnetSet.
+                description: |-
+                  IPAddressType defines the IP address type that will be allocated for subnets in the SubnetSet.
+                  IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
                 enum:
                 - IPv4
                 - IPv6
@@ -84,8 +85,9 @@ spec:
                 - message: Value is immutable
                   rule: self == oldSelf
               ipv6PrefixLength:
-                description: IPv6 prefix length for subnets in the SubnetSet (e.g.
-                  64 means /64).
+                description: |-
+                  IPv6 prefix length for subnets in the SubnetSet (e.g. 64 means /64).
+                  Supported starting with VCF 9.2.0.
                 maximum: 127
                 minimum: 2
                 type: integer
@@ -123,7 +125,9 @@ spec:
                     || size(self.dhcpServerAdditionalConfig.reservedIPRanges)==0)
                     || has(self.mode) && self.mode=='DHCPServer'
               subnetDHCPv6Config:
-                description: DHCPv6 configuration for subnets in the SubnetSet.
+                description: |-
+                  DHCPv6 configuration for subnets in the SubnetSet.
+                  Supported starting with VCF 9.2.0.
                 properties:
                   dhcpv6ServerAdditionalConfig:
                     description: Additional DHCPv6 server config for a VPC Subnet.

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_subnetsets.yaml
@@ -71,7 +71,7 @@ spec:
               ipAddressType:
                 description: |-
                   IPAddressType defines the IP address type that will be allocated for subnets in the SubnetSet.
-                  IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
+                  Supported starting with VCF 9.2.0.
                 enum:
                 - IPv4
                 - IPv6

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
@@ -53,7 +53,6 @@ spec:
               defaultIPv6PrefixLength:
                 description: |-
                   Default prefix length of IPv6 Subnets.
-                  Defaults to 64.
                   Supported starting with VCF 9.2.0.
                 maximum: 127
                 minimum: 2

--- a/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
+++ b/build/yaml/crd/vpc/crd.nsx.vmware.com_vpcnetworkconfigurations.yaml
@@ -51,7 +51,10 @@ spec:
               in the default VPCNetworkConfiguration.
             properties:
               defaultIPv6PrefixLength:
-                description: Default prefix length of IPv6 Subnets.
+                description: |-
+                  Default prefix length of IPv6 Subnets.
+                  Defaults to 64.
+                  Supported starting with VCF 9.2.0.
                 maximum: 127
                 minimum: 2
                 type: integer

--- a/docs/ref/apis/legacy.md
+++ b/docs/ref/apis/legacy.md
@@ -29,7 +29,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -121,7 +121,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 
@@ -265,12 +265,12 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br /> |
+| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br />Optional: \{\} <br /> |
 | `allocationSize` _integer_ | AllocationSize specifies the size of IPv4 allocationIPs to be allocated.<br />It should be a power of 2. |  | Minimum: 1 <br /> |
 | `allocationIPs` _string_ | AllocationIPs specifies the Allocated IP addresses in CIDR or single IP Address format. |  |  |
-| `ipv6AllocationPrefixLength` _integer_ | IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses.<br />Defaults to 64 when ipAddressType is IPv6 and this field is not specified. |  | Maximum: 128 <br />Minimum: 64 <br /> |
-| `ipAddressType` _[IPAllocationAddressType](#ipallocationaddresstype)_ | IPAddressType specifies the IP address type of the IPAddressAllocation. | IPv4 | Enum: [IPv4 IPv6] <br /> |
-| `ipBlockName` _string_ | IPBlockName specifies name of the IPBlock to allocate IP addresses. |  |  |
+| `ipv6AllocationPrefixLength` _integer_ | IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses.<br />Defaults to 64 when ipAddressType is IPv6 and this field is not specified.<br />Supported starting with VCF 9.2.0. |  | Maximum: 128 <br />Minimum: 64 <br /> |
+| `ipAddressType` _[IPAllocationAddressType](#ipallocationaddresstype)_ | IPAddressType specifies the IP address type of the IPAddressAllocation.<br />Supported starting with VCF 9.2.0. | IPv4 | Enum: [IPv4 IPv6] <br /> |
+| `ipBlockName` _string_ | IPBlockName specifies name of the IPBlock to allocate IP addresses. |  | Optional: \{\} <br /> |
 
 
 #### IPAddressAllocationStatus
@@ -734,7 +734,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the current state of the ServiceEndpoint. |  |  |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the current state of the ServiceEndpoint. |  | Optional: \{\} <br /> |
 
 
 #### SharedSubnet
@@ -770,7 +770,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Activate or deactivate static IP allocation for VPC Subnet Ports.<br />If the DHCP mode is DHCPDeactivated or not set, its default value is true.<br />If the DHCP mode is DHCPServer, its default value is false.<br />If the DHCP mode is DHCPRelay, its default value is false. |  |  |
-| `poolRanges` _string array_ | PoolRanges specifies the IP address ranges for static IP allocation.<br />Each entry is either a single IP address (e.g. "192.168.1.5") or a<br />dash-separated range (e.g. "192.168.1.10-192.168.1.20"). Both IPv4 and<br />IPv6 entries may appear in a single list.<br />Example value: ["192.168.1.1", "192.168.1.3-192.168.1.100"] |  |  |
+| `poolRanges` _string array_ | PoolRanges specifies the IP address ranges for static IP allocation.<br />Each entry is either a single IP address (e.g. "192.168.1.5") or a<br />dash-separated range (e.g. "192.168.1.10-192.168.1.20"). Both IPv4 and<br />IPv6 entries may appear in a single list.<br />Example value: ["192.168.1.1", "192.168.1.3-192.168.1.100"] |  | Optional: \{\} <br /> |
 
 
 #### StaticIPAllocationType
@@ -826,7 +826,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 
@@ -844,8 +844,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `network` _string_ | Specify network address in CIDR format.<br />Mutually exclusive with networkIpAllocationName. |  | Format: cidr <br /> |
-| `networkIpAllocationName` _string_ | Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as<br />the static route network. Mutually exclusive with network. |  |  |
+| `network` _string_ | Specify network address in CIDR format.<br />Mutually exclusive with networkIpAllocationName. |  | Format: cidr <br />Optional: \{\} <br /> |
+| `networkIpAllocationName` _string_ | Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as<br />the static route network. Mutually exclusive with network. |  | Optional: \{\} <br /> |
 | `nextHops` _[NextHop](#nexthop) array_ | Next hop gateway |  | MinItems: 1 <br /> |
 
 
@@ -940,7 +940,7 @@ _Appears in:_
 | `subnetName` _string_ | SubnetName is the Subnet name which this SubnetConnectionBindingMap is associated. |  |  |
 | `targetSubnetSetName` _string_ | TargetSubnetSetName specifies the target SubnetSet which a Subnet is connected to. |  | Optional: \{\} <br /> |
 | `targetSubnetName` _string_ | TargetSubnetName specifies the target Subnet which a Subnet is connected to. |  | Optional: \{\} <br /> |
-| `vlanTrafficTag` _integer_ | VLANTrafficTag is the VLAN tag configured in the binding. Note, the value of VLANTrafficTag should be<br />unique on the target Subnet or SubnetSet. |  | Maximum: 4094 <br />Minimum: 1 <br />Required: \{\} <br /> |
+| `vlanTrafficTag` _integer_ | VLANTrafficTag is the VLAN tag configured in the binding. Note, the value of VLANTrafficTag should be<br />unique on the target Subnet or SubnetSet. When omitted, the system automatically allocates a VLAN ID. |  | Maximum: 4094 <br />Minimum: 1 <br />Optional: \{\} <br /> |
 
 
 #### SubnetConnectionBindingMapStatus
@@ -957,6 +957,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `conditions` _[Condition](#condition) array_ | Conditions described if the SubnetConnectionBindingMaps is configured on NSX or not.<br />Condition type "" |  |  |
+| `vlanTrafficTag` _integer_ | VLANTrafficTag is the realized VLAN traffic tag for this binding. |  |  |
 
 
 #### SubnetDHCPConfig
@@ -1030,7 +1031,7 @@ _Appears in:_
 | `subnet` _string_ | Subnet specifies the Subnet to reserve IPs from.<br />The Subnet needs to have static IP allocation activated. |  | Required: \{\} <br /> |
 | `numberOfIPs` _integer_ | NumberOfIPs defines number of IPs requested to be reserved. |  | Maximum: 100 <br />Minimum: 1 <br /> |
 | `reservedIPs` _string array_ | ReservedIPs represents array of Reserved IPs. It can contain IP addresses,<br />IP Address range and CIDRs.<br />Supported formats include: ["192.168.1.1", "192.168.1.3-192.168.1.100", "192.168.2.0/28",<br />"2001:db8::1", "2001:db8::1-2001:db8::ff", "2001:db8::1/64"] |  | MinItems: 1 <br /> |
-| `ipAddressType` _[IPAddressType](#ipaddresstype)_ | IPAddressType defines the IP address type of the SubnetIPReservation. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
+| `ipAddressType` _[IPAddressType](#ipaddresstype)_ | IPAddressType defines the IP address type of the SubnetIPReservation.<br />Supported starting with VCF 9.2.0. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
 
 
 #### SubnetIPReservationStatus
@@ -1154,8 +1155,8 @@ _Appears in:_
 | `subnet` _string_ | Subnet defines the parent Subnet name of the SubnetPort. |  |  |
 | `subnetSet` _string_ | SubnetSet defines the parent SubnetSet name of the SubnetPort. |  |  |
 | `addressBindings` _[PortAddressBinding](#portaddressbinding) array_ | AddressBindings defines static address bindings used for the SubnetPort. |  |  |
-| `interfaceIPType` _[IPAddressType](#ipaddresstype)_ | InterfaceIPType decides the address families of static IP allocation, when<br />DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType<br />is set, IP families of InterfaceIPType should be a superset of<br />StaticIPAllocationType. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
-| `staticIPAllocationType` _[StaticIPAllocationType](#staticipallocationtype)_ | StaticIPAllocationType explicitly requests static IP allocation of the<br />specified the address families. In a mixed-mode Subnet (where both DHCP<br />and static allocation are enabled), use this to define which families<br />should be allocated from the static IP pools. If not specified, this field<br />will be back-filled based on InterfaceIPType and Subnet configuration. |  | Enum: [IPv4 IPv6 IPv4IPv6 None] <br /> |
+| `interfaceIPType` _[IPAddressType](#ipaddresstype)_ | InterfaceIPType decides the address families of static IP allocation, when<br />DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType<br />is set, IP families of InterfaceIPType should be a superset of<br />StaticIPAllocationType.<br />Supported starting with VCF 9.2.0. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
+| `staticIPAllocationType` _[StaticIPAllocationType](#staticipallocationtype)_ | StaticIPAllocationType explicitly requests static IP allocation of the<br />specified the address families. In a mixed-mode Subnet (where both DHCP<br />and static allocation are enabled), use this to define which families<br />should be allocated from the static IP pools. If not specified, this field<br />will be back-filled based on InterfaceIPType and Subnet configuration.<br />Supported starting with VCF 9.2.0. |  | Enum: [IPv4 IPv6 IPv4IPv6 None] <br /> |
 | `portSettingName` _string_ | Name of PortSetting associated with this SubnetPort. |  |  |
 
 
@@ -1209,12 +1210,12 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `ipAddressType` _[IPAddressType](#ipaddresstype)_ | IPAddressType defines the IP address type that will be allocated for subnets in the SubnetSet. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
+| `ipAddressType` _[IPAddressType](#ipaddresstype)_ | IPAddressType defines the IP address type that will be allocated for subnets in the SubnetSet.<br />Supported starting with VCF 9.2.0. |  | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
 | `ipv4SubnetSize` _integer_ | Size of IPv4 Subnet based upon estimated workload count. |  | Maximum: 65536 <br /> |
-| `ipv6PrefixLength` _integer_ | IPv6 prefix length for subnets in the SubnetSet (e.g. 64 means /64). |  | Maximum: 127 <br />Minimum: 2 <br /> |
+| `ipv6PrefixLength` _integer_ | IPv6 prefix length for subnets in the SubnetSet (e.g. 64 means /64).<br />Supported starting with VCF 9.2.0. |  | Maximum: 127 <br />Minimum: 2 <br /> |
 | `accessMode` _[AccessMode](#accessmode)_ | Access mode of IPv4 Subnet, accessible only from within VPC or from outside VPC. |  | Enum: [Private Public PrivateTGW] <br /> |
 | `subnetDHCPConfig` _[SubnetDHCPConfig](#subnetdhcpconfig)_ | Subnet DHCP configuration. |  |  |
-| `subnetDHCPv6Config` _[SubnetDHCPv6Config](#subnetdhcpv6config)_ | DHCPv6 configuration for subnets in the SubnetSet. |  |  |
+| `subnetDHCPv6Config` _[SubnetDHCPv6Config](#subnetdhcpv6config)_ | DHCPv6 configuration for subnets in the SubnetSet.<br />Supported starting with VCF 9.2.0. |  |  |
 | `subnetNames` _string_ | The names of the Subnets that have been created in advance.<br />It is mutually exclusive with the other fields like IPv4SubnetSize, AccessMode, and SubnetDHCPConfig.<br />Once this field is set, the other fields cannot be set. |  |  |
 
 
@@ -1249,13 +1250,13 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `vpcName` _string_ | VPC name of the Subnet. |  |  |
-| `ipAddressType` _[IPAddressType](#ipaddresstype)_ | IPAddressType defines the IP address type that will be allocated for the Subnet. | IPv4 | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
+| `ipAddressType` _[IPAddressType](#ipaddresstype)_ | IPAddressType defines the IP address type that will be allocated for the Subnet.<br />Supported starting with VCF 9.2.0. | IPv4 | Enum: [IPv4 IPv6 IPv4IPv6] <br /> |
 | `ipv4SubnetSize` _integer_ | Size of IPv4 Subnet based upon estimated workload count. |  | Maximum: 65536 <br /> |
-| `ipv6PrefixLength` _integer_ | IPv6 prefix length for the Subnet (e.g. 64 means /64). |  | Maximum: 127 <br />Minimum: 2 <br /> |
+| `ipv6PrefixLength` _integer_ | IPv6 prefix length for the Subnet (e.g. 64 means /64).<br />Supported starting with VCF 9.2.0. |  | Maximum: 127 <br />Minimum: 2 <br /> |
 | `accessMode` _[AccessMode](#accessmode)_ | Access mode of IPv4 Subnet, accessible only from within VPC or from outside VPC. |  | Enum: [Private Public PrivateTGW L2Only] <br /> |
 | `ipAddresses` _string array_ | Subnet CIDRS. |  | MaxItems: 2 <br />MinItems: 0 <br /> |
 | `subnetDHCPConfig` _[SubnetDHCPConfig](#subnetdhcpconfig)_ | DHCP configuration for Subnet. |  |  |
-| `subnetDHCPv6Config` _[SubnetDHCPv6Config](#subnetdhcpv6config)_ | DHCPv6 configuration for Subnet. |  |  |
+| `subnetDHCPv6Config` _[SubnetDHCPv6Config](#subnetdhcpv6config)_ | DHCPv6 configuration for Subnet.<br />Supported starting with VCF 9.2.0. |  |  |
 | `advancedConfig` _[SubnetAdvancedConfig](#subnetadvancedconfig)_ | VPC Subnet advanced configuration. |  |  |
 | `vlanConnectionName` _string_ | Distributed VLAN Connection name. |  |  |
 
@@ -1347,7 +1348,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the current state of the VPCEndpoint. |  |  |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the current state of the VPCEndpoint. |  | Optional: \{\} <br /> |
 
 
 #### VPCInfo
@@ -1405,15 +1406,15 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  |  |
-| `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  |  |
+| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  | Optional: \{\} <br /> |
+| `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  | Optional: \{\} <br /> |
 | `nsxProject` _string_ | NSX Project the Namespace is associated with. |  |  |
 | `vpcConnectivityProfile` _string_ | VPCConnectivityProfile Path. This profile has configuration related to creating VPC transit gateway attachment. |  |  |
 | `privateIPs` _string array_ | Private IPs. |  |  |
 | `defaultSubnetSize` _integer_ | Default size of IPv4 Subnets. |  | Maximum: 65536 <br /> |
 | `dnsZones` _string array_ | DNSZones specifies the list of permitted DNS zones, identified by their NSX paths. |  |  |
-| `defaultIPv6PrefixLength` _integer_ | Default prefix length of IPv6 Subnets. |  | Maximum: 127 <br />Minimum: 2 <br /> |
-| `loadBalancerVPC` _string_ | NSX Policy path of the Load Balancer VPC. If set, load balancer resources (such as virtual servers and LB pools) of the Namespace will be created on this VPC's load balancer, instead of the Namespace's primary VPC. |  |  |
+| `defaultIPv6PrefixLength` _integer_ | Default prefix length of IPv6 Subnets.<br />Supported starting with VCF 9.2.0. |  | Maximum: 127 <br />Minimum: 2 <br /> |
+| `loadBalancerVPC` _string_ | NSX Policy path of the Load Balancer VPC. If set, load balancer resources (such as virtual servers and LB pools) of the Namespace will be created on this VPC's load balancer, instead of the Namespace's primary VPC. |  | Optional: \{\} <br /> |
 
 
 #### VPCNetworkConfigurationStatus

--- a/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
+++ b/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
@@ -68,11 +68,13 @@ type IPAddressAllocationSpec struct {
 	AllocationIPs string `json:"allocationIPs,omitempty"`
 	// IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses.
 	// Defaults to 64 when ipAddressType is IPv6 and this field is not specified.
+	// Supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Minimum:=64
 	// +kubebuilder:validation:Maximum:=128
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	IPv6AllocationPrefixLength int `json:"ipv6AllocationPrefixLength,omitempty"`
 	// IPAddressType specifies the IP address type of the IPAddressAllocation.
+	// IPv6 is supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Enum=IPv4;IPv6
 	// +kubebuilder:default=IPv4
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"

--- a/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
+++ b/pkg/apis/vpc/v1alpha1/ipaddressallocation_types.go
@@ -74,7 +74,7 @@ type IPAddressAllocationSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	IPv6AllocationPrefixLength int `json:"ipv6AllocationPrefixLength,omitempty"`
 	// IPAddressType specifies the IP address type of the IPAddressAllocation.
-	// IPv6 is supported starting with VCF 9.2.0.
+	// Supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Enum=IPv4;IPv6
 	// +kubebuilder:default=IPv4
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"

--- a/pkg/apis/vpc/v1alpha1/subnet_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnet_types.go
@@ -53,7 +53,7 @@ type SubnetSpec struct {
 	// VPC name of the Subnet.
 	VPCName string `json:"vpcName,omitempty"`
 	// IPAddressType defines the IP address type that will be allocated for the Subnet.
-	// IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
+	// Supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
 	// +kubebuilder:default=IPv4
 	IPAddressType IPAddressType `json:"ipAddressType,omitempty"`

--- a/pkg/apis/vpc/v1alpha1/subnet_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnet_types.go
@@ -53,6 +53,7 @@ type SubnetSpec struct {
 	// VPC name of the Subnet.
 	VPCName string `json:"vpcName,omitempty"`
 	// IPAddressType defines the IP address type that will be allocated for the Subnet.
+	// IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
 	// +kubebuilder:default=IPv4
 	IPAddressType IPAddressType `json:"ipAddressType,omitempty"`
@@ -61,6 +62,7 @@ type SubnetSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// IPv6 prefix length for the Subnet (e.g. 64 means /64).
+	// Supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Minimum:=2
 	// +kubebuilder:validation:Maximum:=127
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
@@ -76,6 +78,7 @@ type SubnetSpec struct {
 	// DHCP configuration for Subnet.
 	SubnetDHCPConfig SubnetDHCPConfig `json:"subnetDHCPConfig,omitempty"`
 	// DHCPv6 configuration for Subnet.
+	// Supported starting with VCF 9.2.0.
 	SubnetDHCPv6Config SubnetDHCPv6Config `json:"subnetDHCPv6Config,omitempty"`
 	// VPC Subnet advanced configuration.
 	AdvancedConfig SubnetAdvancedConfig `json:"advancedConfig,omitempty"`

--- a/pkg/apis/vpc/v1alpha1/subnetipreservation_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetipreservation_types.go
@@ -35,7 +35,7 @@ type SubnetIPReservationSpec struct {
 	ReservedIPs []string `json:"reservedIPs,omitempty"`
 
 	// IPAddressType defines the IP address type of the SubnetIPReservation.
-	// IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
+	// Supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	IPAddressType IPAddressType `json:"ipAddressType,omitempty"`

--- a/pkg/apis/vpc/v1alpha1/subnetipreservation_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetipreservation_types.go
@@ -35,6 +35,7 @@ type SubnetIPReservationSpec struct {
 	ReservedIPs []string `json:"reservedIPs,omitempty"`
 
 	// IPAddressType defines the IP address type of the SubnetIPReservation.
+	// IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	IPAddressType IPAddressType `json:"ipAddressType,omitempty"`

--- a/pkg/apis/vpc/v1alpha1/subnetport_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetport_types.go
@@ -29,6 +29,7 @@ type SubnetPortSpec struct {
 	// DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType
 	// is set, IP families of InterfaceIPType should be a superset of
 	// StaticIPAllocationType.
+	// IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
 	InterfaceIPType IPAddressType `json:"interfaceIPType,omitempty"`
 	// StaticIPAllocationType explicitly requests static IP allocation of the
@@ -36,6 +37,7 @@ type SubnetPortSpec struct {
 	// and static allocation are enabled), use this to define which families
 	// should be allocated from the static IP pools. If not specified, this field
 	// will be back-filled based on InterfaceIPType and Subnet configuration.
+	// IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6;None
 	StaticIPAllocationType StaticIPAllocationType `json:"staticIPAllocationType,omitempty"`
 	// Name of PortSetting associated with this SubnetPort.

--- a/pkg/apis/vpc/v1alpha1/subnetport_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetport_types.go
@@ -29,7 +29,7 @@ type SubnetPortSpec struct {
 	// DHCP or SLAAC is not activated on the Subnet. When StaticIPAllocationType
 	// is set, IP families of InterfaceIPType should be a superset of
 	// StaticIPAllocationType.
-	// IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
+	// Supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
 	InterfaceIPType IPAddressType `json:"interfaceIPType,omitempty"`
 	// StaticIPAllocationType explicitly requests static IP allocation of the
@@ -37,7 +37,7 @@ type SubnetPortSpec struct {
 	// and static allocation are enabled), use this to define which families
 	// should be allocated from the static IP pools. If not specified, this field
 	// will be back-filled based on InterfaceIPType and Subnet configuration.
-	// IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
+	// Supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6;None
 	StaticIPAllocationType StaticIPAllocationType `json:"staticIPAllocationType,omitempty"`
 	// Name of PortSetting associated with this SubnetPort.

--- a/pkg/apis/vpc/v1alpha1/subnetset_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetset_types.go
@@ -17,6 +17,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(self.subnetDHCPv6Config) || !has(self.subnetDHCPv6Config.mode) || self.subnetDHCPv6Config.mode!='DHCPRelay' && self.subnetDHCPv6Config.mode!='DHCPServerStateless'", message="DHCPRelay or DHCPServerStateless is not supported in SubnetSet"
 type SubnetSetSpec struct {
 	// IPAddressType defines the IP address type that will be allocated for subnets in the SubnetSet.
+	// IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
 	IPAddressType IPAddressType `json:"ipAddressType,omitempty"`
 	// Size of IPv4 Subnet based upon estimated workload count.
@@ -24,6 +25,7 @@ type SubnetSetSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// IPv6 prefix length for subnets in the SubnetSet (e.g. 64 means /64).
+	// Supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Minimum:=2
 	// +kubebuilder:validation:Maximum:=127
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
@@ -34,6 +36,7 @@ type SubnetSetSpec struct {
 	// Subnet DHCP configuration.
 	SubnetDHCPConfig SubnetDHCPConfig `json:"subnetDHCPConfig,omitempty"`
 	// DHCPv6 configuration for subnets in the SubnetSet.
+	// Supported starting with VCF 9.2.0.
 	SubnetDHCPv6Config SubnetDHCPv6Config `json:"subnetDHCPv6Config,omitempty"`
 	// The names of the Subnets that have been created in advance.
 	// It is mutually exclusive with the other fields like IPv4SubnetSize, AccessMode, and SubnetDHCPConfig.

--- a/pkg/apis/vpc/v1alpha1/subnetset_types.go
+++ b/pkg/apis/vpc/v1alpha1/subnetset_types.go
@@ -17,7 +17,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(self.subnetDHCPv6Config) || !has(self.subnetDHCPv6Config.mode) || self.subnetDHCPv6Config.mode!='DHCPRelay' && self.subnetDHCPv6Config.mode!='DHCPServerStateless'", message="DHCPRelay or DHCPServerStateless is not supported in SubnetSet"
 type SubnetSetSpec struct {
 	// IPAddressType defines the IP address type that will be allocated for subnets in the SubnetSet.
-	// IPv6 and IPv4IPv6 are supported starting with VCF 9.2.0.
+	// Supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Enum=IPv4;IPv6;IPv4IPv6
 	IPAddressType IPAddressType `json:"ipAddressType,omitempty"`
 	// Size of IPv4 Subnet based upon estimated workload count.

--- a/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
@@ -40,6 +40,8 @@ type VPCNetworkConfigurationSpec struct {
 	DNSZones []string `json:"dnsZones,omitempty"`
 
 	// Default prefix length of IPv6 Subnets.
+	// Defaults to 64.
+	// Supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Minimum:=2
 	// +kubebuilder:validation:Maximum:=127
 	DefaultIPv6PrefixLength int `json:"defaultIPv6PrefixLength,omitempty"`

--- a/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/vpc/v1alpha1/vpcnetworkconfiguration_types.go
@@ -40,7 +40,6 @@ type VPCNetworkConfigurationSpec struct {
 	DNSZones []string `json:"dnsZones,omitempty"`
 
 	// Default prefix length of IPv6 Subnets.
-	// Defaults to 64.
 	// Supported starting with VCF 9.2.0.
 	// +kubebuilder:validation:Minimum:=2
 	// +kubebuilder:validation:Maximum:=127


### PR DESCRIPTION
Add VCF version requirement descriptions for IPv6 API fields

Update API Go struct comments and CRD manifests to explicitly document VCF
9.2.0 version requirements for IPv6 and dual-stack fields.