### PR TITLE
Refactor SubnetConnectionBindingMap VLAN auto-allocation logic to services layer

### DIFF
--- a/pkg/controllers/subnetbinding/subnetbinding_controller.go
+++ b/pkg/controllers/subnetbinding/subnetbinding_controller.go
@@ -30,7 +30,6 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnet"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetbinding"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vlanpool"
-	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 var (
@@ -49,7 +48,6 @@ type Reconciler struct {
 	Scheme               *runtime.Scheme
 	SubnetService        *subnet.SubnetService
 	SubnetBindingService *subnetbinding.BindingService
-	VlanPoolService      *vlanpool.Service
 	StatusUpdater        common.StatusUpdater
 }
 
@@ -81,7 +79,6 @@ func NewReconciler(mgr ctrl.Manager, subnetService *subnet.SubnetService, subnet
 		Scheme:               mgr.GetScheme(),
 		SubnetService:        subnetService,
 		SubnetBindingService: subnetBindingService,
-		VlanPoolService:      vlanpool.NewService(subnetBindingService),
 		StatusUpdater:        common.NewStatusUpdater(mgr.GetClient(), subnetBindingService.NSXConfig, recorder, common.MetricResTypeSubnetConnectionBindingMap, "SubnetConnectionBindingMap", "SubnetConnectionBindingMap"),
 	}
 }
@@ -131,32 +128,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return common.ResultRequeueAfter60sec, nil
 	}
 
-	vlanID, autoAllocatedVlan, vlanErr := r.reconcileVlanTrafficTag(ctx, bindingMapCR, targetSubnetPaths, false)
-	if vlanErr != nil {
-		r.releaseAutoAllocatedVlan(targetSubnetPaths, bindingMapCR, vlanID)
-		r.StatusUpdater.UpdateFail(ctx, bindingMapCR, vlanErr, "failed to reconcile VLAN traffic tag", updateBindingMapStatusWithUnreadyCondition, "VlanAllocationFailed", vlanErr.message)
-		if !vlanErr.retry {
-			return common.ResultNormal, nil
+	preferredVlan := r.getPreferredVlan(ctx, bindingMapCR)
+
+	if vlanID, err := r.SubnetBindingService.CreateOrUpdateSubnetConnectionBindingMap(bindingMapCR, preferredVlan, subnetPath, targetSubnetPaths); err != nil {
+		if vlanpool.IsVlanAllocationError(err) {
+			r.StatusUpdater.UpdateFail(ctx, bindingMapCR, err, "failed to reconcile VLAN traffic tag", updateBindingMapStatusWithUnreadyCondition, "VlanAllocationFailed", err.Error())
+		} else {
+			r.StatusUpdater.UpdateFail(ctx, bindingMapCR, err, "failure to configure SubnetConnectionBindingMaps on NSX", updateBindingMapStatusWithUnreadyCondition, "ConfigureFailed", fmt.Sprintf("Failed to realize SubnetConnectionBindingMap %s on NSX", req.Name))
 		}
 		return common.ResultRequeue, nil
+	} else {
+		// Update SubnetConnectionBindingMap with ready condition
+		r.StatusUpdater.UpdateSuccess(ctx, bindingMapCR, updateBindingMapStatusWithReadyCondition, vlanID)
 	}
 
-	if err := r.SubnetBindingService.CreateOrUpdateSubnetConnectionBindingMap(bindingMapCR, vlanID, subnetPath, targetSubnetPaths); err != nil {
-		if autoAllocatedVlan && nsxutil.IsVpcOverlapVlanError(err) {
-			vlanID = r.handleVlanAllocationFallback(ctx, bindingMapCR, targetSubnetPaths, subnetPath, req, vlanID)
-			if vlanID == 0 {
-				return common.ResultRequeue, nil
-			}
-		} else {
-			r.releaseAutoAllocatedVlan(targetSubnetPaths, bindingMapCR, vlanID)
-			// Update SubnetConnectionBindingMap with not-ready condition
-			r.StatusUpdater.UpdateFail(ctx, bindingMapCR, err, "failure to configure SubnetConnectionBindingMaps on NSX", updateBindingMapStatusWithUnreadyCondition, "ConfigureFailed", fmt.Sprintf("Failed to realize SubnetConnectionBindingMap %s on NSX", req.Name))
-			return common.ResultRequeue, nil
-		}
-	}
-	r.commitAutoAllocatedVlan(targetSubnetPaths, bindingMapCR, vlanID)
-	// Update SubnetConnectionBindingMap with ready condition
-	r.StatusUpdater.UpdateSuccess(ctx, bindingMapCR, updateBindingMapStatusWithReadyCondition, vlanID)
 	return common.ResultNormal, nil
 }
 
@@ -317,92 +302,23 @@ func (r *Reconciler) validateDependency(ctx context.Context, bindingMap *v1alpha
 	return subnetPath, targetSubnetPaths, nil
 }
 
-// handleVlanAllocationFallback performs a second try for VLAN allocation when the initial auto-allocation
-// conflicts with existing configurations on NSX. The initial allocation relies on a local cache which
-// might be out of sync due to race conditions or external changes. By setting fromNSX=true, this function
-// bypasses the local cache and queries the real-time available VLAN directly from the NSX API.
-func (r *Reconciler) handleVlanAllocationFallback(ctx context.Context, bindingMapCR *v1alpha1.SubnetConnectionBindingMap, targetSubnetPaths []string, subnetPath string, req ctrl.Request, initialVlanID int64) int64 {
-	log.Info("VLAN allocation conflict with NSX cache, fallback to query NSX", "SubnetConnectionBindingMap", req.NamespacedName)
-	r.releaseAutoAllocatedVlan(targetSubnetPaths, bindingMapCR, initialVlanID)
-
-	vlanID, _, vlanErr := r.reconcileVlanTrafficTag(ctx, bindingMapCR, targetSubnetPaths, true)
-	if vlanErr != nil {
-		r.releaseAutoAllocatedVlan(targetSubnetPaths, bindingMapCR, vlanID)
-		r.StatusUpdater.UpdateFail(ctx, bindingMapCR, vlanErr, "failed to reconcile VLAN traffic tag from NSX", updateBindingMapStatusWithUnreadyCondition, "VlanAllocationFailed", vlanErr.message)
-		return 0
-	}
-	if err := r.SubnetBindingService.CreateOrUpdateSubnetConnectionBindingMap(bindingMapCR, vlanID, subnetPath, targetSubnetPaths); err != nil {
-		r.releaseAutoAllocatedVlan(targetSubnetPaths, bindingMapCR, vlanID)
-		r.StatusUpdater.UpdateFail(ctx, bindingMapCR, err, "failure to configure SubnetConnectionBindingMaps on NSX after fallback", updateBindingMapStatusWithUnreadyCondition, "ConfigureFailed", fmt.Sprintf("Failed to realize SubnetConnectionBindingMap %s on NSX", req.Name))
-		return 0
-	}
-	return vlanID
-}
-
-func (r *Reconciler) releaseAutoAllocatedVlan(targetSubnetPaths []string, bindingMap *v1alpha1.SubnetConnectionBindingMap, vlanID int64) {
-	// vlanID == 0 means the VLAN auto-allocation failed or hasn't occurred, so there is nothing to release.
-	// When reconcileVlanTrafficTag() fails (e.g., VLAN pool is exhausted), it returns the default Go zero
-	// value 0 for vlanID alongside the error. Since the caller still triggers the release function in the
-	// error branch to ensure rollback, the vlanID == 0 check acts as an internal safety guard to prevent
-	// the underlying VlanPoolService from attempting to release an unallocated/invalid VLAN 0.
-	if vlanID == 0 {
-		return
-	}
-	r.VlanPoolService.ReleasePending(targetSubnetPaths, vlanID)
-}
-
-func (r *Reconciler) commitAutoAllocatedVlan(targetSubnetPaths []string, bindingMap *v1alpha1.SubnetConnectionBindingMap, vlanID int64) {
-	// vlanID == 0 means the VLAN auto-allocation failed or hasn't occurred, so there is nothing to commit.
-	if vlanID == 0 {
-		return
-	}
-	r.VlanPoolService.CommitPending(targetSubnetPaths, vlanID)
-}
-
-func (r *Reconciler) reconcileVlanTrafficTag(ctx context.Context, bindingMap *v1alpha1.SubnetConnectionBindingMap, targetSubnetPaths []string, fromNSX bool) (int64, bool, *errorWithRetry) {
-	if bindingMap.Spec.HasVlanTrafficTag() {
-		vlan := *bindingMap.Spec.VLANTrafficTag
-		if err := r.VlanPoolService.ValidateManualVlan(targetSubnetPaths, vlan, string(bindingMap.UID), fromNSX); err != nil {
-			return 0, false, &errorWithRetry{
-				message: err.Error(),
-				error:   err,
-				retry:   true,
-			}
-		}
-		return vlan, false, nil
-	}
-
-	// Try to reuse already allocated VLAN from cache
-	if !fromNSX {
-		existingBMs := r.SubnetBindingService.BindingStore.GetByIndex("bindingMapCRUID", string(bindingMap.UID))
-		if len(existingBMs) > 0 && existingBMs[0].VlanTrafficTag != nil {
-			vlan := *existingBMs[0].VlanTrafficTag
-			return vlan, true, nil
-		}
-	}
-
+func (r *Reconciler) getPreferredVlan(ctx context.Context, bindingMap *v1alpha1.SubnetConnectionBindingMap) int64 {
 	preferred := int64(-1)
-	if bindingMap.Spec.SubnetName != "" {
+	childSubnetName := bindingMap.Spec.SubnetName
+	if bindingMap.Spec.IsBranchAssociation() {
+		childSubnetName = bindingMap.Spec.TargetSubnetName
+	}
+	if childSubnetName != "" {
 		childSubnet := &v1alpha1.Subnet{}
-		if err := r.Client.Get(ctx, types.NamespacedName{Namespace: bindingMap.Namespace, Name: bindingMap.Spec.SubnetName}, childSubnet); err == nil {
+		if err := r.Client.Get(ctx, types.NamespacedName{Namespace: bindingMap.Namespace, Name: childSubnetName}, childSubnet); err == nil {
 			if childSubnet.Status.VLANExtension.VLANID != 0 {
 				preferred = int64(childSubnet.Status.VLANExtension.VLANID)
 			}
 		} else {
-			log.Error(err, "Failed to get child Subnet for VLAN allocation", "Subnet", bindingMap.Spec.SubnetName)
+			log.Error(err, "Failed to get child Subnet for VLAN allocation", "Subnet", childSubnetName)
 		}
 	}
-
-	vlan, err := r.VlanPoolService.Allocate(targetSubnetPaths, string(bindingMap.UID), preferred, fromNSX)
-	if err != nil {
-		return 0, true, &errorWithRetry{
-			message: err.Error(),
-			error:   err,
-			retry:   true,
-		}
-	}
-
-	return vlan, true, nil
+	return preferred
 }
 
 func (r *Reconciler) validateVpcSubnetsBySubnetCR(ctx context.Context, namespace, name string, isParent bool) ([]string, *errorWithRetry) {

--- a/pkg/controllers/subnetbinding/subnetbinding_controller_test.go
+++ b/pkg/controllers/subnetbinding/subnetbinding_controller_test.go
@@ -200,16 +200,44 @@ func TestReconcile(t *testing.T) {
 				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "validateDependency", func(_ *Reconciler, ctx context.Context, bindingMap *v1alpha1.SubnetConnectionBindingMap) (string, []string, *errorWithRetry) {
 					return "/subnet-child", []string{"/subnet-parent"}, nil
 				})
-				patches.ApplyPrivateMethod(reflect.TypeOf(r), "reconcileVlanTrafficTag", func(_ *Reconciler, ctx context.Context, bindingMap *v1alpha1.SubnetConnectionBindingMap, parentSubnetPaths []string, fromNSX bool) (int64, bool, *errorWithRetry) {
-					return 0, true, nil
-				})
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetBindingService), "CreateOrUpdateSubnetConnectionBindingMap",
-					func(_ *subnetbinding.BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, vlanID int64, childSubnetPath string, parentSubnetPaths []string) error {
-						return fmt.Errorf("failed to configure NSX")
+					func(_ *subnetbinding.BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, preferredVlan int64, childSubnetPath string, parentSubnetPaths []string) (int64, error) {
+						return 0, fmt.Errorf("failed to configure NSX")
 					})
 				return patches
 			},
 			expectRes: controllerscommon.ResultRequeue,
+			verify: func(t *testing.T, r *Reconciler) {
+				got := &v1alpha1.SubnetConnectionBindingMap{}
+				require.NoError(t, r.Client.Get(context.Background(), request.NamespacedName, got))
+				require.Len(t, got.Status.Conditions, 1)
+				assert.Equal(t, string(v1alpha1.Ready), string(got.Status.Conditions[0].Type))
+				assert.Equal(t, string(corev1.ConditionFalse), string(got.Status.Conditions[0].Status))
+				assert.Equal(t, "ConfigureFailed", got.Status.Conditions[0].Reason)
+			},
+		}, {
+			name:    "Failed to create/update SubnetConnectionBindingMap due to VLAN allocation error",
+			objects: []client.Object{validBM1},
+			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "validateDependency", func(_ *Reconciler, ctx context.Context, bindingMap *v1alpha1.SubnetConnectionBindingMap) (string, []string, *errorWithRetry) {
+					return "/subnet-child", []string{"/subnet-parent"}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(r.SubnetBindingService), "CreateOrUpdateSubnetConnectionBindingMap",
+					func(_ *subnetbinding.BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, preferredVlan int64, childSubnetPath string, parentSubnetPaths []string) (int64, error) {
+						return 0, &vlanpool.VlanAllocationError{Err: fmt.Errorf("no available VLAN in pool")}
+					})
+				return patches
+			},
+			expectRes: controllerscommon.ResultRequeue,
+			verify: func(t *testing.T, r *Reconciler) {
+				got := &v1alpha1.SubnetConnectionBindingMap{}
+				require.NoError(t, r.Client.Get(context.Background(), request.NamespacedName, got))
+				require.Len(t, got.Status.Conditions, 1)
+				assert.Equal(t, string(v1alpha1.Ready), string(got.Status.Conditions[0].Type))
+				assert.Equal(t, string(corev1.ConditionFalse), string(got.Status.Conditions[0].Status))
+				assert.Equal(t, "VlanAllocationFailed", got.Status.Conditions[0].Reason)
+				assert.Contains(t, got.Status.Conditions[0].Message, "no available VLAN in pool")
+			},
 		}, {
 			name:    "Failed to reconcile when SubnetAssociation is specified on unsupported NSX version",
 			objects: []client.Object{bmWithSubnetAssociation},
@@ -228,12 +256,9 @@ func TestReconcile(t *testing.T) {
 				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "validateDependency", func(_ *Reconciler, ctx context.Context, bindingMap *v1alpha1.SubnetConnectionBindingMap) (string, []string, *errorWithRetry) {
 					return "/subnet-child", []string{"/subnet-parent"}, nil
 				})
-				patches.ApplyPrivateMethod(reflect.TypeOf(r), "reconcileVlanTrafficTag", func(_ *Reconciler, ctx context.Context, bindingMap *v1alpha1.SubnetConnectionBindingMap, parentSubnetPaths []string, fromNSX bool) (int64, bool, *errorWithRetry) {
-					return 0, true, nil
-				})
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetBindingService), "CreateOrUpdateSubnetConnectionBindingMap",
-					func(_ *subnetbinding.BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, vlanID int64, childSubnetPath string, parentSubnetPaths []string) error {
-						return nil
+					func(_ *subnetbinding.BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, preferredVlan int64, childSubnetPath string, parentSubnetPaths []string) (int64, error) {
+						return 201, nil
 					})
 				return patches
 			},
@@ -255,13 +280,9 @@ func TestReconcile(t *testing.T) {
 				patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(r), "validateDependency", func(_ *Reconciler, ctx context.Context, bindingMap *v1alpha1.SubnetConnectionBindingMap) (string, []string, *errorWithRetry) {
 					return "/subnet-child", []string{"/subnet-parent"}, nil
 				})
-				patches.ApplyPrivateMethod(reflect.TypeOf(r), "reconcileVlanTrafficTag", func(_ *Reconciler, ctx context.Context, bindingMap *v1alpha1.SubnetConnectionBindingMap, parentSubnetPaths []string, fromNSX bool) (int64, bool, *errorWithRetry) {
-					return 301, true, nil
-				})
 				patches.ApplyMethod(reflect.TypeOf(r.SubnetBindingService), "CreateOrUpdateSubnetConnectionBindingMap",
-					func(_ *subnetbinding.BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, vlanID int64, childSubnetPath string, parentSubnetPaths []string) error {
-						assert.Equal(t, int64(301), vlanID)
-						return nil
+					func(_ *subnetbinding.BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, preferredVlan int64, childSubnetPath string, parentSubnetPaths []string) (int64, error) {
+						return 301, nil
 					})
 				return patches
 			},
@@ -1439,196 +1460,4 @@ func createFakeReconciler(objs ...client.Object) *Reconciler {
 	}
 
 	return NewReconciler(mgr, subnetService, bindingService)
-}
-
-func TestReconcileVlanTrafficTag(t *testing.T) {
-	bm1 := &v1alpha1.SubnetConnectionBindingMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "bm-1",
-			UID:       "uuid-1",
-		},
-		Spec: v1alpha1.SubnetConnectionBindingMapSpec{
-			SubnetName:       "subnet-child-1",
-			TargetSubnetName: "subnet-parent-1",
-			VLANTrafficTag:   v1alpha1.VLANTrafficTagPtr(201),
-		},
-	}
-	bm2 := &v1alpha1.SubnetConnectionBindingMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "bm-2",
-			UID:       "uuid-2",
-		},
-		Spec: v1alpha1.SubnetConnectionBindingMapSpec{
-			SubnetName:       "subnet-child-2",
-			TargetSubnetName: "subnet-parent-2",
-		},
-	}
-	bm3 := &v1alpha1.SubnetConnectionBindingMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "bm-3",
-			UID:       "uuid-3",
-		},
-		Spec: v1alpha1.SubnetConnectionBindingMapSpec{
-			SubnetName:       "subnet-child-3",
-			TargetSubnetName: "subnet-parent-3",
-		},
-	}
-	childSubnet := &v1alpha1.Subnet{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "subnet-child-2",
-		},
-		Status: v1alpha1.SubnetStatus{
-			VLANExtension: v1alpha1.VLANExtension{
-				VLANID: 300,
-			},
-		},
-	}
-	childSubnetNoVlan := &v1alpha1.Subnet{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "subnet-child-3",
-		},
-		Status: v1alpha1.SubnetStatus{
-			VLANExtension: v1alpha1.VLANExtension{
-				VLANID: 0,
-			},
-		},
-	}
-
-	for _, tc := range []struct {
-		name       string
-		bindingMap *v1alpha1.SubnetConnectionBindingMap
-		objects    []client.Object
-		patches    func(t *testing.T, r *Reconciler) *gomonkey.Patches
-		expErr     bool
-		expVlan    *int64
-		fromNSX    bool
-	}{
-		{
-			name:       "Manual VLAN successfully validated",
-			bindingMap: bm1,
-			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(r.VlanPoolService), "ValidateManualVlan", func(_ *vlanpool.Service, parentSubnetPaths []string, vlan int64, excludeCRUID string, fromNSX bool) error {
-					return nil
-				})
-			},
-			expErr:  false,
-			expVlan: v1alpha1.VLANTrafficTagPtr(201),
-		},
-		{
-			name:       "Manual VLAN validation failed",
-			bindingMap: bm1,
-			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(r.VlanPoolService), "ValidateManualVlan", func(_ *vlanpool.Service, parentSubnetPaths []string, vlan int64, excludeCRUID string, fromNSX bool) error {
-					return fmt.Errorf("conflict")
-				})
-			},
-			expErr: true,
-		},
-		{
-			name:       "Auto allocate VLAN successfully with VLAN ext subnet (preferred VLAN ID is used)",
-			bindingMap: bm2,
-			objects:    []client.Object{childSubnet, bm2},
-			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VlanPoolService), "Allocate", func(_ *vlanpool.Service, parentSubnetPaths []string, excludeCRUID string, preferred int64, fromNSX bool) (int64, error) {
-					assert.Equal(t, int64(300), preferred)
-					return 300, nil
-				})
-				return patches
-			},
-			expErr:  false,
-			expVlan: v1alpha1.VLANTrafficTagPtr(300),
-		},
-		{
-			name:       "Auto allocate VLAN successfully when child Subnet is not a VLAN ext subnet",
-			bindingMap: bm3,
-			objects:    []client.Object{childSubnetNoVlan, bm3},
-			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VlanPoolService), "Allocate", func(_ *vlanpool.Service, parentSubnetPaths []string, excludeCRUID string, preferred int64, fromNSX bool) (int64, error) {
-					assert.Equal(t, int64(-1), preferred)
-					return 100, nil
-				})
-				return patches
-			},
-			expErr:  false,
-			expVlan: v1alpha1.VLANTrafficTagPtr(100),
-		},
-		{
-			name:       "Auto allocate VLAN successfully when child Subnet does not exist",
-			bindingMap: bm2,
-			objects:    []client.Object{bm2},
-			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.VlanPoolService), "Allocate", func(_ *vlanpool.Service, parentSubnetPaths []string, excludeCRUID string, preferred int64, fromNSX bool) (int64, error) {
-					assert.Equal(t, int64(-1), preferred)
-					return 100, nil
-				})
-				return patches
-			},
-			expErr:  false,
-			expVlan: v1alpha1.VLANTrafficTagPtr(100),
-		},
-		{
-			name:       "Auto allocate VLAN from cache when fromNSX is false",
-			bindingMap: bm2,
-			objects:    []client.Object{bm2},
-			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetBindingService.BindingStore), "GetByIndex", func(_ *subnetbinding.BindingStore, key string, value string) []*model.SubnetConnectionBindingMap {
-					return []*model.SubnetConnectionBindingMap{
-						{
-							VlanTrafficTag: v1alpha1.VLANTrafficTagPtr(100),
-						},
-					}
-				})
-				return patches
-			},
-			expErr:  false,
-			expVlan: v1alpha1.VLANTrafficTagPtr(100),
-			fromNSX: false,
-		},
-		{
-			name:       "Bypass cache and allocate VLAN when fromNSX is true",
-			bindingMap: bm2,
-			objects:    []client.Object{bm2},
-			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
-				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetBindingService.BindingStore), "GetByIndex", func(_ *subnetbinding.BindingStore, key string, value string) []*model.SubnetConnectionBindingMap {
-					return []*model.SubnetConnectionBindingMap{
-						{
-							VlanTrafficTag: v1alpha1.VLANTrafficTagPtr(100),
-						},
-					}
-				})
-				patches.ApplyMethod(reflect.TypeOf(r.VlanPoolService), "Allocate", func(_ *vlanpool.Service, parentSubnetPaths []string, excludeCRUID string, preferred int64, fromNSX bool) (int64, error) {
-					assert.True(t, fromNSX)
-					return 101, nil
-				})
-				return patches
-			},
-			expErr:  false,
-			expVlan: v1alpha1.VLANTrafficTagPtr(101),
-			fromNSX: true,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.TODO()
-			bm := tc.bindingMap.DeepCopy()
-			r := createFakeReconciler(tc.objects...)
-			if tc.patches != nil {
-				patches := tc.patches(t, r)
-				defer patches.Reset()
-			}
-			vlanID, _, err := r.reconcileVlanTrafficTag(ctx, bm, []string{"/parent"}, tc.fromNSX)
-			if tc.expErr {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				if tc.expVlan != nil {
-					assert.Equal(t, *tc.expVlan, vlanID)
-				}
-			}
-		})
-	}
 }

--- a/pkg/nsx/services/subnetbinding/subnetbinding.go
+++ b/pkg/nsx/services/subnetbinding/subnetbinding.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vlanpool"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
@@ -26,7 +27,8 @@ var (
 type BindingService struct {
 	builder *servicecommon.PolicyTreeBuilder[*model.SubnetConnectionBindingMap]
 	servicecommon.Service
-	BindingStore *BindingStore
+	BindingStore    *BindingStore
+	VlanPoolService *vlanpool.Service
 }
 
 // InitializeService initializes SubnetConnectionBindingMap service.
@@ -40,6 +42,7 @@ func InitializeService(service servicecommon.Service) (*BindingService, error) {
 		BindingStore: SetupStore(),
 		builder:      builder,
 	}
+	bindingService.VlanPoolService = vlanpool.NewService(bindingService)
 
 	wg.Add(1)
 	go service.InitializeResourceStore(&wg, fatalErrors, ResourceTypeSubnetConnectionBindingMap, nil, bindingService.BindingStore)
@@ -55,7 +58,49 @@ func InitializeService(service servicecommon.Service) (*BindingService, error) {
 
 // CreateOrUpdateSubnetConnectionBindingMap creates or updates the SubnetConnectionBindingMaps with the given
 // SubnetConnectionBindingMap CR under subnetPath (spec.subnetName) and targetSubnetPaths (target Subnet/SubnetSet).
+// It reconciles VLAN traffic tag allocation and handles fallback logic if NSX VLAN overlap occurs.
 func (s *BindingService) CreateOrUpdateSubnetConnectionBindingMap(
+	subnetBinding *v1alpha1.SubnetConnectionBindingMap,
+	preferredVlan int64,
+	subnetPath string,
+	targetSubnetPaths []string) (int64, error) {
+
+	parentSubnetPaths := targetSubnetPaths
+	if subnetBinding.Spec.IsBranchAssociation() {
+		parentSubnetPaths = []string{subnetPath}
+	}
+
+	vlanID, err := s.ReconcileVlanTrafficTag(subnetBinding, preferredVlan, parentSubnetPaths, false)
+	if err != nil {
+		return 0, err
+	}
+
+	err = s.createOrUpdateBindingMapInternal(subnetBinding, vlanID, subnetPath, targetSubnetPaths)
+	if err != nil {
+		if !subnetBinding.Spec.HasVlanTrafficTag() && nsxutil.IsVpcOverlapVlanError(err) {
+			log.Info("VLAN allocation conflict with NSX cache, fallback to query NSX", "SubnetConnectionBindingMap", subnetBinding.Name)
+			s.getVlanPoolService().ReleasePending(parentSubnetPaths, vlanID)
+
+			fallbackVlanID, fallbackErr := s.ReconcileVlanTrafficTag(subnetBinding, preferredVlan, parentSubnetPaths, true)
+			if fallbackErr != nil {
+				return 0, fallbackErr
+			}
+			if applyErr := s.createOrUpdateBindingMapInternal(subnetBinding, fallbackVlanID, subnetPath, targetSubnetPaths); applyErr != nil {
+				s.getVlanPoolService().ReleasePending(parentSubnetPaths, fallbackVlanID)
+				return 0, applyErr
+			}
+			vlanID = fallbackVlanID
+		} else {
+			s.getVlanPoolService().ReleasePending(parentSubnetPaths, vlanID)
+			return 0, err
+		}
+	}
+
+	s.getVlanPoolService().CommitPending(parentSubnetPaths, vlanID)
+	return vlanID, nil
+}
+
+func (s *BindingService) createOrUpdateBindingMapInternal(
 	subnetBinding *v1alpha1.SubnetConnectionBindingMap,
 	vlanID int64,
 	subnetPath string,

--- a/pkg/nsx/services/subnetbinding/subnetbinding.go
+++ b/pkg/nsx/services/subnetbinding/subnetbinding.go
@@ -70,34 +70,39 @@ func (s *BindingService) CreateOrUpdateSubnetConnectionBindingMap(
 		parentSubnetPaths = []string{subnetPath}
 	}
 
-	vlanID, err := s.ReconcileVlanTrafficTag(subnetBinding, preferredVlan, parentSubnetPaths, false)
-	if err != nil {
+	// reconcileVlanAndBindingMapFn encapsulates the logic of allocating a VLAN and applying the SubnetConnectionBindingMap.
+	// It ensures that the pending VLAN allocation is properly committed on success or released on failure.
+	reconcileVlanAndBindingMapFn := func(fromNSX bool) (int64, error) {
+		vlanID, err := s.ReconcileVlanTrafficTag(subnetBinding, preferredVlan, parentSubnetPaths, fromNSX)
+		if err != nil {
+			return 0, err
+		}
+		err = s.createOrUpdateBindingMapInternal(subnetBinding, vlanID, subnetPath, targetSubnetPaths)
+		if err == nil {
+			s.getVlanPoolService().CommitPending(parentSubnetPaths, vlanID)
+			return vlanID, nil
+		}
+		s.getVlanPoolService().ReleasePending(parentSubnetPaths, vlanID)
 		return 0, err
 	}
 
-	err = s.createOrUpdateBindingMapInternal(subnetBinding, vlanID, subnetPath, targetSubnetPaths)
-	if err != nil {
-		if !subnetBinding.Spec.HasVlanTrafficTag() && nsxutil.IsVpcOverlapVlanError(err) {
-			log.Info("VLAN allocation conflict with NSX cache, fallback to query NSX", "SubnetConnectionBindingMap", subnetBinding.Name)
-			s.getVlanPoolService().ReleasePending(parentSubnetPaths, vlanID)
-
-			fallbackVlanID, fallbackErr := s.ReconcileVlanTrafficTag(subnetBinding, preferredVlan, parentSubnetPaths, true)
-			if fallbackErr != nil {
-				return 0, fallbackErr
-			}
-			if applyErr := s.createOrUpdateBindingMapInternal(subnetBinding, fallbackVlanID, subnetPath, targetSubnetPaths); applyErr != nil {
-				s.getVlanPoolService().ReleasePending(parentSubnetPaths, fallbackVlanID)
-				return 0, applyErr
-			}
-			vlanID = fallbackVlanID
-		} else {
-			s.getVlanPoolService().ReleasePending(parentSubnetPaths, vlanID)
-			return 0, err
-		}
+	// First attempt: try to allocate a VLAN using the local cache to avoid expensive NSX API calls.
+	vlanID, err := reconcileVlanAndBindingMapFn(false)
+	if err == nil {
+		return vlanID, nil
 	}
 
-	s.getVlanPoolService().CommitPending(parentSubnetPaths, vlanID)
-	return vlanID, nil
+	// Fallback attempt: if the VLAN allocation conflicts with NSX (e.g., due to out-of-sync local cache)
+	// and the user hasn't explicitly specified a VLAN, query NSX directly for the latest used VLANs and retry.
+	if !subnetBinding.Spec.HasVlanTrafficTag() && nsxutil.IsVpcOverlapVlanError(err) {
+		log.Info("VLAN allocation conflict with NSX cache, fallback to query NSX", "SubnetConnectionBindingMap", subnetBinding.Name)
+		newVlanID, applyErr := reconcileVlanAndBindingMapFn(true)
+		if applyErr != nil {
+			return 0, applyErr
+		}
+		return newVlanID, nil
+	}
+	return 0, err
 }
 
 func (s *BindingService) createOrUpdateBindingMapInternal(

--- a/pkg/nsx/services/subnetbinding/subnetbinding_test.go
+++ b/pkg/nsx/services/subnetbinding/subnetbinding_test.go
@@ -3,22 +3,27 @@ package subnetbinding
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	stderrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
 	orgroot_mocks "github.com/vmware-tanzu/nsx-operator/pkg/mock/orgrootclient"
 	search_mocks "github.com/vmware-tanzu/nsx-operator/pkg/mock/searchclient"
 	bindingmap_mocks "github.com/vmware-tanzu/nsx-operator/pkg/mock/subnetconnectionbindingmapclient"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vlanpool"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
@@ -370,11 +375,12 @@ func TestCreateOrUpdateSubnetConnectionBindingMap(t *testing.T) {
 			}
 			tc.prepareFunc()
 
-			err := svc.CreateOrUpdateSubnetConnectionBindingMap(binding1, 201, *childSubnet.Path, []string{*parentSubnet2.Path})
+			vlanID, err := svc.CreateOrUpdateSubnetConnectionBindingMap(binding1, 201, *childSubnet.Path, []string{*parentSubnet2.Path})
 			if tc.expErr != "" {
 				require.EqualError(t, err, tc.expErr)
 			} else {
 				require.Nil(t, err)
+				assert.Equal(t, int64(201), vlanID)
 			}
 
 			bms := svc.BindingStore.List()
@@ -531,6 +537,228 @@ func TestDeleteSubnetConnectionBindingMaps(t *testing.T) {
 			}
 			bms := svc.BindingStore.List()
 			assert.ElementsMatch(t, tc.expBindingMapsInStore, bms)
+		})
+	}
+}
+
+func TestCreateOrUpdateSubnetConnectionBindingMap_FallbackAndErrors(t *testing.T) {
+	vlanOverlapError := nsxutil.NewNSXApiError(&model.ApiError{
+		ErrorCode:    Int64(int64(nsxutil.VpcOverlapVlanErrorCode)),
+		ErrorMessage: String("VLAN overlapped"),
+	}, stderrors.ErrorType_ERROR)
+	genericError := fmt.Errorf("generic internal error")
+
+	bmAuto := &v1alpha1.SubnetConnectionBindingMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "bm-auto",
+			UID:       "uuid-auto",
+		},
+		Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+			SubnetName:       "subnet-child",
+			TargetSubnetName: "subnet-parent",
+		},
+	}
+
+	bmManual := &v1alpha1.SubnetConnectionBindingMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "bm-manual",
+			UID:       "uuid-manual",
+		},
+		Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+			SubnetName:       "subnet-child",
+			TargetSubnetName: "subnet-parent",
+			VLANTrafficTag:   v1alpha1.VLANTrafficTagPtr(201),
+		},
+	}
+
+	bmBranch := &v1alpha1.SubnetConnectionBindingMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "bm-branch",
+			UID:       "uuid-branch",
+		},
+		Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+			SubnetName:        "trunk-subnet",
+			TargetSubnetName:  "branch-subnet",
+			SubnetAssociation: v1alpha1.SubnetAssociationBranch,
+		},
+	}
+
+	for _, tc := range []struct {
+		name       string
+		bindingMap *v1alpha1.SubnetConnectionBindingMap
+		patches    func(svc *BindingService) *gomonkey.Patches
+		expVlan    int64
+		expErr     error
+	}{
+		{
+			name:       "ReconcileVlanTrafficTag initial error",
+			bindingMap: bmAuto,
+			patches: func(svc *BindingService) *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(svc), "ReconcileVlanTrafficTag",
+					func(_ *BindingService, bindingMap *v1alpha1.SubnetConnectionBindingMap, preferred int64, targetSubnetPaths []string, fromNSX bool) (int64, error) {
+						return 0, &vlanpool.VlanAllocationError{Err: fmt.Errorf("pool exhausted")}
+					})
+			},
+			expVlan: 0,
+			expErr:  &vlanpool.VlanAllocationError{Err: fmt.Errorf("pool exhausted")},
+		},
+		{
+			name:       "VPC overlap error triggers fallback success",
+			bindingMap: bmAuto,
+			patches: func(svc *BindingService) *gomonkey.Patches {
+				reconcileCalls := 0
+				internalCalls := 0
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(svc), "ReconcileVlanTrafficTag",
+					func(_ *BindingService, bindingMap *v1alpha1.SubnetConnectionBindingMap, preferred int64, targetSubnetPaths []string, fromNSX bool) (int64, error) {
+						reconcileCalls++
+						if reconcileCalls == 1 {
+							assert.False(t, fromNSX)
+							return 101, nil
+						}
+						assert.True(t, fromNSX)
+						return 102, nil
+					})
+				patches.ApplyPrivateMethod(reflect.TypeOf(svc), "createOrUpdateBindingMapInternal",
+					func(_ *BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, vlanID int64, subnetPath string, targetSubnetPaths []string) error {
+						internalCalls++
+						if internalCalls == 1 {
+							assert.Equal(t, int64(101), vlanID)
+							return vlanOverlapError
+						}
+						assert.Equal(t, int64(102), vlanID)
+						return nil
+					})
+				return patches
+			},
+			expVlan: 102,
+			expErr:  nil,
+		},
+		{
+			name:       "VPC overlap error fallback ReconcileVlanTrafficTag fails",
+			bindingMap: bmAuto,
+			patches: func(svc *BindingService) *gomonkey.Patches {
+				reconcileCalls := 0
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(svc), "ReconcileVlanTrafficTag",
+					func(_ *BindingService, bindingMap *v1alpha1.SubnetConnectionBindingMap, preferred int64, targetSubnetPaths []string, fromNSX bool) (int64, error) {
+						reconcileCalls++
+						if reconcileCalls == 1 {
+							return 101, nil
+						}
+						return 0, fmt.Errorf("fallback reconcile failed")
+					})
+				patches.ApplyPrivateMethod(reflect.TypeOf(svc), "createOrUpdateBindingMapInternal",
+					func(_ *BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, vlanID int64, subnetPath string, targetSubnetPaths []string) error {
+						return vlanOverlapError
+					})
+				return patches
+			},
+			expVlan: 0,
+			expErr:  fmt.Errorf("fallback reconcile failed"),
+		},
+		{
+			name:       "VPC overlap error fallback createOrUpdateBindingMapInternal fails",
+			bindingMap: bmAuto,
+			patches: func(svc *BindingService) *gomonkey.Patches {
+				reconcileCalls := 0
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(svc), "ReconcileVlanTrafficTag",
+					func(_ *BindingService, bindingMap *v1alpha1.SubnetConnectionBindingMap, preferred int64, targetSubnetPaths []string, fromNSX bool) (int64, error) {
+						reconcileCalls++
+						if reconcileCalls == 1 {
+							return 101, nil
+						}
+						return 102, nil
+					})
+				patches.ApplyPrivateMethod(reflect.TypeOf(svc), "createOrUpdateBindingMapInternal",
+					func(_ *BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, vlanID int64, subnetPath string, targetSubnetPaths []string) error {
+						if vlanID == 101 {
+							return vlanOverlapError
+						}
+						return fmt.Errorf("secondary apply failed")
+					})
+				return patches
+			},
+			expVlan: 0,
+			expErr:  fmt.Errorf("secondary apply failed"),
+		},
+		{
+			name:       "Manual VLAN VPC overlap error does not trigger fallback",
+			bindingMap: bmManual,
+			patches: func(svc *BindingService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(svc), "ReconcileVlanTrafficTag",
+					func(_ *BindingService, bindingMap *v1alpha1.SubnetConnectionBindingMap, preferred int64, targetSubnetPaths []string, fromNSX bool) (int64, error) {
+						return 201, nil
+					})
+				patches.ApplyPrivateMethod(reflect.TypeOf(svc), "createOrUpdateBindingMapInternal",
+					func(_ *BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, vlanID int64, subnetPath string, targetSubnetPaths []string) error {
+						return vlanOverlapError
+					})
+				return patches
+			},
+			expVlan: 0,
+			expErr:  vlanOverlapError,
+		},
+		{
+			name:       "Non-overlap internal error returns directly",
+			bindingMap: bmAuto,
+			patches: func(svc *BindingService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(svc), "ReconcileVlanTrafficTag",
+					func(_ *BindingService, bindingMap *v1alpha1.SubnetConnectionBindingMap, preferred int64, targetSubnetPaths []string, fromNSX bool) (int64, error) {
+						return 101, nil
+					})
+				patches.ApplyPrivateMethod(reflect.TypeOf(svc), "createOrUpdateBindingMapInternal",
+					func(_ *BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, vlanID int64, subnetPath string, targetSubnetPaths []string) error {
+						return genericError
+					})
+				return patches
+			},
+			expVlan: 0,
+			expErr:  genericError,
+		},
+		{
+			name:       "Branch mode passes trunk subnet path for VLAN allocation",
+			bindingMap: bmBranch,
+			patches: func(svc *BindingService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(svc), "ReconcileVlanTrafficTag",
+					func(_ *BindingService, bindingMap *v1alpha1.SubnetConnectionBindingMap, preferred int64, parentSubnetPaths []string, fromNSX bool) (int64, error) {
+						assert.Equal(t, []string{"/trunk-subnet"}, parentSubnetPaths)
+						return 105, nil
+					})
+				patches.ApplyPrivateMethod(reflect.TypeOf(svc), "createOrUpdateBindingMapInternal",
+					func(_ *BindingService, subnetBinding *v1alpha1.SubnetConnectionBindingMap, vlanID int64, subnetPath string, targetSubnetPaths []string) error {
+						assert.Equal(t, int64(105), vlanID)
+						return nil
+					})
+				return patches
+			},
+			expVlan: 105,
+			expErr:  nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &BindingService{
+				BindingStore: SetupStore(),
+			}
+			svc.VlanPoolService = vlanpool.NewService(svc)
+			if tc.patches != nil {
+				patches := tc.patches(svc)
+				defer patches.Reset()
+			}
+
+			subnetPath := "/child"
+			if tc.bindingMap.Spec.IsBranchAssociation() {
+				subnetPath = "/trunk-subnet"
+			}
+			vlanID, err := svc.CreateOrUpdateSubnetConnectionBindingMap(tc.bindingMap, -1, subnetPath, []string{"/parent"})
+			if tc.expErr != nil {
+				require.Error(t, err)
+				assert.Equal(t, tc.expErr.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expVlan, vlanID)
+			}
 		})
 	}
 }

--- a/pkg/nsx/services/subnetbinding/vlan_allocation.go
+++ b/pkg/nsx/services/subnetbinding/vlan_allocation.go
@@ -8,8 +8,44 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vlanpool"
 )
+
+func (s *BindingService) getVlanPoolService() *vlanpool.Service {
+	if s.VlanPoolService == nil {
+		s.VlanPoolService = vlanpool.NewService(s)
+	}
+	return s.VlanPoolService
+}
+
+func (s *BindingService) ReconcileVlanTrafficTag(bindingMap *v1alpha1.SubnetConnectionBindingMap, preferred int64, parentSubnetPaths []string, fromNSX bool) (int64, error) {
+	vlanPoolSvc := s.getVlanPoolService()
+	if bindingMap.Spec.HasVlanTrafficTag() {
+		vlan := *bindingMap.Spec.VLANTrafficTag
+		if err := vlanPoolSvc.ValidateManualVlan(parentSubnetPaths, vlan, string(bindingMap.UID), fromNSX); err != nil {
+			return 0, err
+		}
+		return vlan, nil
+	}
+
+	// Try to reuse already allocated VLAN from cache
+	if !fromNSX {
+		existingBMs := s.BindingStore.GetByIndex("bindingMapCRUID", string(bindingMap.UID))
+		if len(existingBMs) > 0 && existingBMs[0].VlanTrafficTag != nil {
+			vlan := *existingBMs[0].VlanTrafficTag
+			return vlan, nil
+		}
+	}
+
+	vlan, err := vlanPoolSvc.Allocate(parentSubnetPaths, string(bindingMap.UID), preferred, fromNSX)
+	if err != nil {
+		return 0, err
+	}
+
+	return vlan, nil
+}
 
 // CollectUsedVlansOnParentSubnetsFromCache returns VLAN tags already used on the given parent Subnet paths by
 // querying local cache.
@@ -73,9 +109,8 @@ func (s *BindingService) listBindingMapsByParentSubnetPath(parentSubnetPath stri
 	}
 
 	pathEscaped := strings.ReplaceAll(parentSubnetPath, "/", "\\/")
-	// TODO：update here to support bridge mode.
-	queryParam := fmt.Sprintf("%s:%s AND marked_for_delete:false AND subnet_path:%s",
-		servicecommon.ResourceType, ResourceTypeSubnetConnectionBindingMap, pathEscaped)
+	queryParam := fmt.Sprintf("%s:%s AND marked_for_delete:false AND ((subnet_path:%s AND subnet_association:TRUNK) OR (parent_path:%s AND subnet_association:BRANCH))",
+		servicecommon.ResourceType, ResourceTypeSubnetConnectionBindingMap, pathEscaped, pathEscaped)
 
 	store := &localStore{ResourceStore: servicecommon.ResourceStore{
 		Indexer:     cache.NewIndexer(keyFunc, cache.Indexers{}),

--- a/pkg/nsx/services/subnetbinding/vlan_allocation.go
+++ b/pkg/nsx/services/subnetbinding/vlan_allocation.go
@@ -109,7 +109,7 @@ func (s *BindingService) listBindingMapsByParentSubnetPath(parentSubnetPath stri
 	}
 
 	pathEscaped := strings.ReplaceAll(parentSubnetPath, "/", "\\/")
-	queryParam := fmt.Sprintf("%s:%s AND marked_for_delete:false AND ((subnet_path:%s AND subnet_association:TRUNK) OR (parent_path:%s AND subnet_association:BRANCH))",
+	queryParam := fmt.Sprintf("%s:%s AND marked_for_delete:false AND ((subnet_path:%s AND NOT subnet_association:BRANCH) OR (parent_path:%s AND subnet_association:BRANCH))",
 		servicecommon.ResourceType, ResourceTypeSubnetConnectionBindingMap, pathEscaped, pathEscaped)
 
 	store := &localStore{ResourceStore: servicecommon.ResourceStore{

--- a/pkg/nsx/services/subnetbinding/vlan_allocation_test.go
+++ b/pkg/nsx/services/subnetbinding/vlan_allocation_test.go
@@ -120,7 +120,7 @@ func TestListBindingMapsByParentSubnetPath(t *testing.T) {
 			ResourceType: String(ResourceTypeSubnetConnectionBindingMap),
 		}
 		dv, _ := common.NewConverter().ConvertToVapi(bm, model.SubnetConnectionBindingMapBindingType())
-		expectedQuery := fmt.Sprintf("%s:%s AND marked_for_delete:false AND ((subnet_path:\\/parent AND subnet_association:TRUNK) OR (parent_path:\\/parent AND subnet_association:BRANCH))",
+		expectedQuery := fmt.Sprintf("%s:%s AND marked_for_delete:false AND ((subnet_path:\\/parent AND NOT subnet_association:BRANCH) OR (parent_path:\\/parent AND subnet_association:BRANCH))",
 			common.ResourceType, ResourceTypeSubnetConnectionBindingMap)
 		fakeQueryClient.EXPECT().List(expectedQuery, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SearchResponse{
 			Results: []*data.StructValue{dv.(*data.StructValue)},

--- a/pkg/nsx/services/subnetbinding/vlan_allocation_test.go
+++ b/pkg/nsx/services/subnetbinding/vlan_allocation_test.go
@@ -2,17 +2,22 @@ package subnetbinding
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	search_mocks "github.com/vmware-tanzu/nsx-operator/pkg/mock/searchclient"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vlanpool"
 	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
@@ -115,7 +120,9 @@ func TestListBindingMapsByParentSubnetPath(t *testing.T) {
 			ResourceType: String(ResourceTypeSubnetConnectionBindingMap),
 		}
 		dv, _ := common.NewConverter().ConvertToVapi(bm, model.SubnetConnectionBindingMapBindingType())
-		fakeQueryClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SearchResponse{
+		expectedQuery := fmt.Sprintf("%s:%s AND marked_for_delete:false AND ((subnet_path:\\/parent AND subnet_association:TRUNK) OR (parent_path:\\/parent AND subnet_association:BRANCH))",
+			common.ResourceType, ResourceTypeSubnetConnectionBindingMap)
+		fakeQueryClient.EXPECT().List(expectedQuery, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SearchResponse{
 			Results: []*data.StructValue{dv.(*data.StructValue)},
 		}, nil).Times(1)
 
@@ -174,4 +181,139 @@ func TestBindingMapCRUID(t *testing.T) {
 	bm2 := &model.SubnetConnectionBindingMap{}
 	uid2 := bindingMapCRUID(bm2)
 	assert.Equal(t, "", uid2)
+}
+
+func TestReconcileVlanTrafficTag(t *testing.T) {
+	bm1 := &v1alpha1.SubnetConnectionBindingMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "bm-1",
+			UID:       "uuid-1",
+		},
+		Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+			SubnetName:       "subnet-child-1",
+			TargetSubnetName: "subnet-parent-1",
+			VLANTrafficTag:   v1alpha1.VLANTrafficTagPtr(201),
+		},
+	}
+	bm2 := &v1alpha1.SubnetConnectionBindingMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "bm-2",
+			UID:       "uuid-2",
+		},
+		Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+			SubnetName:       "subnet-child-2",
+			TargetSubnetName: "subnet-parent-2",
+		},
+	}
+
+	for _, tc := range []struct {
+		name       string
+		bindingMap *v1alpha1.SubnetConnectionBindingMap
+		preferred  int64
+		patches    func(t *testing.T, svc *BindingService) *gomonkey.Patches
+		expErr     bool
+		expVlan    *int64
+		fromNSX    bool
+	}{
+		{
+			name:       "Manual VLAN successfully validated",
+			bindingMap: bm1,
+			preferred:  -1,
+			patches: func(t *testing.T, svc *BindingService) *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(svc.VlanPoolService), "ValidateManualVlan", func(_ *vlanpool.Service, parentSubnetPaths []string, vlan int64, excludeCRUID string, fromNSX bool) error {
+					return nil
+				})
+			},
+			expErr:  false,
+			expVlan: v1alpha1.VLANTrafficTagPtr(201),
+		},
+		{
+			name:       "Manual VLAN validation failed",
+			bindingMap: bm1,
+			preferred:  -1,
+			patches: func(t *testing.T, svc *BindingService) *gomonkey.Patches {
+				return gomonkey.ApplyMethod(reflect.TypeOf(svc.VlanPoolService), "ValidateManualVlan", func(_ *vlanpool.Service, parentSubnetPaths []string, vlan int64, excludeCRUID string, fromNSX bool) error {
+					return fmt.Errorf("conflict")
+				})
+			},
+			expErr: true,
+		},
+		{
+			name:       "Auto allocate VLAN successfully with preferred VLAN ID",
+			bindingMap: bm2,
+			preferred:  300,
+			patches: func(t *testing.T, svc *BindingService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(svc.VlanPoolService), "Allocate", func(_ *vlanpool.Service, parentSubnetPaths []string, excludeCRUID string, preferred int64, fromNSX bool) (int64, error) {
+					assert.Equal(t, int64(300), preferred)
+					return 300, nil
+				})
+				return patches
+			},
+			expErr:  false,
+			expVlan: v1alpha1.VLANTrafficTagPtr(300),
+		},
+		{
+			name:       "Auto allocate VLAN from cache when fromNSX is false",
+			bindingMap: bm2,
+			preferred:  -1,
+			patches: func(t *testing.T, svc *BindingService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(svc.BindingStore), "GetByIndex", func(_ *BindingStore, key string, value string) []*model.SubnetConnectionBindingMap {
+					return []*model.SubnetConnectionBindingMap{
+						{
+							VlanTrafficTag: v1alpha1.VLANTrafficTagPtr(100),
+						},
+					}
+				})
+				return patches
+			},
+			expErr:  false,
+			expVlan: v1alpha1.VLANTrafficTagPtr(100),
+			fromNSX: false,
+		},
+		{
+			name:       "Bypass cache and allocate VLAN when fromNSX is true",
+			bindingMap: bm2,
+			preferred:  -1,
+			patches: func(t *testing.T, svc *BindingService) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(svc.BindingStore), "GetByIndex", func(_ *BindingStore, key string, value string) []*model.SubnetConnectionBindingMap {
+					return []*model.SubnetConnectionBindingMap{
+						{
+							VlanTrafficTag: v1alpha1.VLANTrafficTagPtr(100),
+						},
+					}
+				})
+				patches.ApplyMethod(reflect.TypeOf(svc.VlanPoolService), "Allocate", func(_ *vlanpool.Service, parentSubnetPaths []string, excludeCRUID string, preferred int64, fromNSX bool) (int64, error) {
+					assert.True(t, fromNSX)
+					return 101, nil
+				})
+				return patches
+			},
+			expErr:  false,
+			expVlan: v1alpha1.VLANTrafficTagPtr(101),
+			fromNSX: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bm := tc.bindingMap.DeepCopy()
+			svc := &BindingService{
+				BindingStore: SetupStore(),
+			}
+			svc.VlanPoolService = vlanpool.NewService(svc)
+			if tc.patches != nil {
+				patches := tc.patches(t, svc)
+				defer patches.Reset()
+			}
+			vlanID, err := svc.ReconcileVlanTrafficTag(bm, tc.preferred, []string{"/parent"}, tc.fromNSX)
+			if tc.expErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				if tc.expVlan != nil {
+					assert.Equal(t, *tc.expVlan, vlanID)
+				}
+			}
+		})
+	}
 }

--- a/pkg/nsx/services/vlanpool/vlanpool.go
+++ b/pkg/nsx/services/vlanpool/vlanpool.go
@@ -1,14 +1,13 @@
 package vlanpool
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetbinding"
 )
 
 const (
@@ -33,8 +32,25 @@ type Service struct {
 	poolStates sync.Map // poolKey -> *poolState
 }
 
-func NewService(collector *subnetbinding.BindingService) *Service {
+func NewService(collector VlanCollector) *Service {
 	return &Service{collector: collector}
+}
+
+type VlanAllocationError struct {
+	Err error
+}
+
+func (e *VlanAllocationError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *VlanAllocationError) Unwrap() error {
+	return e.Err
+}
+
+func IsVlanAllocationError(err error) bool {
+	var allocErr *VlanAllocationError
+	return errors.As(err, &allocErr)
 }
 
 func poolKey(parentSubnetPaths []string) string {
@@ -80,7 +96,7 @@ func unavailableVlans(used, pending sets.Set[int]) sets.Set[int] {
 func (s *Service) Allocate(parentSubnetPaths []string, excludeCRUID string, preferred int64, fromNSX bool) (int64, error) {
 	used, err := s.collectUsed(parentSubnetPaths, excludeCRUID, fromNSX)
 	if err != nil {
-		return 0, err
+		return 0, &VlanAllocationError{Err: err}
 	}
 
 	state := s.getPoolState(parentSubnetPaths)
@@ -101,11 +117,14 @@ func (s *Service) Allocate(parentSubnetPaths []string, excludeCRUID string, pref
 			return id, nil
 		}
 	}
-	return 0, fmt.Errorf("no available VLAN in pool [%d, %d] for target Subnet or SubnetSet", poolStart, poolEnd)
+	return 0, &VlanAllocationError{Err: fmt.Errorf("no available VLAN in pool [%d, %d] for target Subnet or SubnetSet", poolStart, poolEnd)}
 }
 
 // CommitPending removes a VLAN from the in-flight allocation set after it is realized on NSX.
 func (s *Service) CommitPending(parentSubnetPaths []string, vlan int64) {
+	if vlan == 0 {
+		return
+	}
 	state := s.getPoolState(parentSubnetPaths)
 	state.mu.Lock()
 	defer state.mu.Unlock()
@@ -121,7 +140,7 @@ func (s *Service) ReleasePending(parentSubnetPaths []string, vlan int64) {
 func (s *Service) ValidateManualVlan(parentSubnetPaths []string, vlan int64, excludeCRUID string, fromNSX bool) error {
 	used, err := s.collectUsed(parentSubnetPaths, excludeCRUID, fromNSX)
 	if err != nil {
-		return err
+		return &VlanAllocationError{Err: err}
 	}
 
 	state := s.getPoolState(parentSubnetPaths)
@@ -130,7 +149,7 @@ func (s *Service) ValidateManualVlan(parentSubnetPaths []string, vlan int64, exc
 
 	cleanupCommittedPending(used, state.pending)
 	if unavailableVlans(used, state.pending).Has(int(vlan)) {
-		return fmt.Errorf("vlanTrafficTag %d is already used on target Subnet or SubnetSet", vlan)
+		return &VlanAllocationError{Err: fmt.Errorf("vlanTrafficTag %d is already used on target Subnet or SubnetSet", vlan)}
 	}
 	state.pending.Insert(int(vlan))
 	return nil

--- a/pkg/nsx/services/vlanpool/vlanpool_test.go
+++ b/pkg/nsx/services/vlanpool/vlanpool_test.go
@@ -50,12 +50,36 @@ func TestAllocate_PoolExhausted(t *testing.T) {
 	svc := &Service{collector: &fakeVlanCollector{used: used}}
 	_, err := svc.Allocate([]string{"/parent"}, "", -1, false)
 	require.Error(t, err)
+	assert.True(t, IsVlanAllocationError(err))
 }
 
 func TestValidateManualVlan_Conflict(t *testing.T) {
 	svc := &Service{collector: &fakeVlanCollector{used: sets.New(50)}}
 	err := svc.ValidateManualVlan([]string{"/parent"}, 50, "", false)
 	require.Error(t, err)
+	assert.True(t, IsVlanAllocationError(err))
+}
+
+func TestIsVlanAllocationError(t *testing.T) {
+	assert.False(t, IsVlanAllocationError(nil))
+	assert.False(t, IsVlanAllocationError(assert.AnError))
+
+	allocErr := &VlanAllocationError{Err: assert.AnError}
+	assert.True(t, IsVlanAllocationError(allocErr))
+	assert.Equal(t, assert.AnError.Error(), allocErr.Error())
+	assert.Equal(t, assert.AnError, allocErr.Unwrap())
+}
+
+func TestCommitPending_ZeroVlan(t *testing.T) {
+	svc := &Service{collector: &fakeVlanCollector{used: sets.New[int]()}}
+	parentPaths := []string{"/parent"}
+
+	// CommitPending with vlan 0 should be a no-op safety guard
+	svc.CommitPending(parentPaths, 0)
+
+	// Verify state is clean
+	state := svc.getPoolState(parentPaths)
+	assert.Equal(t, 0, state.pending.Len())
 }
 
 func TestAllocate_ParallelPreferredDoesNotDuplicate(t *testing.T) {

--- a/test/e2e/nsx_subnet_test.go
+++ b/test/e2e/nsx_subnet_test.go
@@ -121,6 +121,7 @@ func TestSubnetSet(t *testing.T) {
 		RunSubtest(t, "case=SubnetBindingAutoVLANWithExistingBinding", SubnetBindingAutoVLANWithExistingBinding)
 		RunSubtest(t, "case=SubnetBindingAutoVLANAllocation", SubnetBindingAutoVLANAllocation)
 		RunSubtest(t, "case=SubnetBindingManualVLANAllocation", SubnetBindingManualVLANAllocation)
+		RunSubtest(t, "case=SubnetBindingBranchAssociation", SubnetBindingBranchAssociation)
 	})
 }
 
@@ -1890,6 +1891,31 @@ func SubnetBindingManualVLANAllocation(t *testing.T) {
 	vlan, err := waitForBindingMapVlan(subnetTestNamespace, bindingName1)
 	require.NoError(t, err, "BindingMap %s should be ready and have the manual status.vlanTrafficTag", bindingName1)
 	assert.Equal(t, manualVlan, vlan, "status.vlanTrafficTag should match the user-specified VLANTrafficTag")
+}
+
+// SubnetBindingBranchAssociation tests that branch subnet association works and auto-allocates a VLAN.
+func SubnetBindingBranchAssociation(t *testing.T) {
+	parentSubnetName, childSubnetNames := createBindingTestSubnets(t, 1)
+	childSubnetName1 := childSubnetNames[0]
+	bindingName1 := "binding-branch-1-" + getRandomString()
+
+	binding := &v1alpha1.SubnetConnectionBindingMap{
+		ObjectMeta: v1.ObjectMeta{Name: bindingName1, Namespace: subnetTestNamespace},
+		Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+			SubnetName:        childSubnetName1,
+			TargetSubnetName:  parentSubnetName,
+			SubnetAssociation: v1alpha1.SubnetAssociationBranch,
+		},
+	}
+	_, err := testData.crdClientset.CrdV1alpha1().SubnetConnectionBindingMaps(subnetTestNamespace).Create(context.TODO(), binding, v1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = testData.crdClientset.CrdV1alpha1().SubnetConnectionBindingMaps(subnetTestNamespace).Delete(context.TODO(), bindingName1, v1.DeleteOptions{})
+	})
+
+	vlan, err := waitForBindingMapVlan(subnetTestNamespace, bindingName1)
+	require.NoError(t, err, "BindingMap %s should be ready and have an auto-allocated status.vlanTrafficTag with branch association", bindingName1)
+	assert.True(t, vlan >= 1 && vlan <= 4094, "Allocated VLAN should be between 1 and 4094")
 }
 
 func createBindingTestSubnets(t *testing.T, numChildren int) (parentSubnetName string, childSubnetNames []string) {


### PR DESCRIPTION
Refactor SubnetConnectionBindingMap VLAN allocation to NSX service layer

Encapsulate the VLAN traffic tag allocation, validation, and fallback 
logic into `BindingService` within the `subnetbinding` service package, 
reducing complexity in `subnetbinding_controller`.

Update NSX search query in `listBindingMapsByParentSubnetPath` to support 
  both Trunk and Branch (`subnet_association`) association modes when collecting 
  used VLANs.


Signed-off-by: Wenqi Qiu <wenqi.qiu@broadcom.com>


TestDone:

1. test auto-allocate VLAN ID, create subnetconnectionbindingmap without `VLANTRAFFICTAG`, 
```
kubectl get subnetconnectionbindingmap binding-trunk-auto-1 -n default -w
NAME                   SUBNET           TARGETSUBNET    TARGETSUBNETSET   VLANTRAFFICTAG   SUBNETASSOCIATION
binding-trunk-auto-1   child-subnet-1   parent-subnet                     1                Trunk

kubectl get subnetconnectionbindingmap binding-trunk-auto-1 -n default -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetConnectionBindingMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetConnectionBindingMap","metadata":{"annotations":{},"name":"binding-trunk-auto-1","namespace":"default"},"spec":{"subnetAssociation":"Trunk","subnetName":"child-subnet-1","targetSubnetName":"parent-subnet"}}
  creationTimestamp: "2026-08-11T17:42:05Z"
  generation: 1
  name: binding-trunk-auto-1
  namespace: default
  resourceVersion: "1282372"
  uid: 4b8f01c7-faf4-4da3-86c3-78b936011d88
spec:
  subnetAssociation: Trunk
  subnetName: child-subnet-1
  targetSubnetName: parent-subnet
status:
  conditions:
  - lastTransitionTime: "2026-08-11T17:47:11Z"
    status: "True"
    type: Ready
  vlanTrafficTag: 1
```

create two subnetbindingmap:

```
kubectl get subnetconnectionbindingmap -n default
NAME                   SUBNET           TARGETSUBNET    TARGETSUBNETSET   VLANTRAFFICTAG   SUBNETASSOCIATION
binding-trunk-auto-1   child-subnet-1   parent-subnet                     1                Trunk
binding-trunk-auto-2   child-subnet-2   parent-subnet                     2                Trunk
```

2. test `SUBNETASSOCIATION`

```
kubectl get subnetconnectionbindingmap -n default -w
NAME                   SUBNET           TARGETSUBNET     TARGETSUBNETSET   VLANTRAFFICTAG   SUBNETASSOCIATION
binding-branch-auto    parent-subnet    child-subnet-3                     3                Branch
binding-trunk-auto-1   child-subnet-1   parent-subnet                      1                Trunk
binding-trunk-auto-2   child-subnet-2   parent-subnet                      2                Trunk

kubectl get subnetconnectionbindingmap binding-branch-auto -n default -oyaml
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: SubnetConnectionBindingMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetConnectionBindingMap","metadata":{"annotations":{},"name":"binding-branch-auto","namespace":"default"},"spec":{"subnetAssociation":"Branch","subnetName":"parent-subnet","targetSubnetName":"child-subnet-3"}}
  creationTimestamp: "2026-08-12T02:38:06Z"
  generation: 1
  name: binding-branch-auto
  namespace: default
  resourceVersion: "1586649"
  uid: 7a06a8ce-6fb1-45f3-9f19-8ee087cb52e7
spec:
  subnetAssociation: Branch
  subnetName: parent-subnet
  targetSubnetName: child-subnet-3
status:
  conditions:
  - lastTransitionTime: "2026-08-12T02:38:37Z"
    status: "True"
    type: Ready
  vlanTrafficTag: 3
```