### PR TITLE
Avoid infinite retry in nsx operator cleanup

### DIFF
--- a/pkg/clean/clean.go
+++ b/pkg/clean/clean.go
@@ -59,9 +59,19 @@ func Clean(ctx context.Context, cf *config.NSXOperatorConfig, log *logr.Logger, 
 		return errors.Join(nsxutil.ValidationFailed, err)
 	}
 	cf.LibMode = true
-	nsxClient := nsx.GetClient(cf)
-	if nsxClient == nil {
-		return nsxutil.GetNSXClientFailed
+	clientChan := make(chan *nsx.Client, 1)
+	go func() {
+		clientChan <- nsx.GetClient(cf)
+	}()
+
+	var nsxClient *nsx.Client
+	select {
+	case nsxClient = <-clientChan:
+		if nsxClient == nil {
+			return nsxutil.GetNSXClientFailed
+		}
+	case <-ctx.Done():
+		return errors.Join(nsxutil.TimeoutFailed, ctx.Err())
 	}
 	// add timeout for initialization
 	errChan := make(chan error)

--- a/pkg/clean/clean_service.go
+++ b/pkg/clean/clean_service.go
@@ -59,11 +59,11 @@ func (c *CleanupService) AddCleanupService(f cleanupFunc) *CleanupService {
 }
 
 func (c *CleanupService) retriable(err error) bool {
-	if err != nil && !errors.As(err, &nsxutil.TimeoutFailed) {
-		c.log.Info("Retrying to clean up NSX resources", "error", err)
-		return true
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errors.As(err, &nsxutil.TimeoutFailed) {
+		return false
 	}
-	return false
+	c.log.Info("Retrying to clean up NSX resources", "error", err)
+	return true
 }
 
 func (c *CleanupService) cleanupBeforeVPCDeletion(ctx context.Context) error {
@@ -130,6 +130,12 @@ func (c *CleanupService) cleanupVPCResourcesByVPCPath(ctx context.Context, vpcPa
 }
 
 func (c *CleanupService) vpcWorker(ctx context.Context, queue workqueue.TypedRateLimitingInterface[string], potentialVPCs sets.Set[string], completedVPCs sets.Set[string], mu *sync.Mutex, finalErrors chan error) bool {
+	if ctx.Err() != nil {
+		c.log.Info("VPC worker stopping because context is done", "error", ctx.Err())
+		queue.ShutDown()
+		return false
+	}
+
 	vpcPath, shutdown := queue.Get()
 	if shutdown {
 		return false
@@ -142,9 +148,11 @@ func (c *CleanupService) vpcWorker(ctx context.Context, queue workqueue.TypedRat
 	c.log.Info("VPC worker processing", "vpcPath", vpcPath, "vpcID", vpcID, "requeues", queue.NumRequeues(vpcPath))
 
 	err := c.cleanupVPCResourcesByVPCPath(ctx, vpcPath)
-	if err != nil && queue.NumRequeues(vpcPath) < maxRetries {
+	if err != nil && c.retriable(err) && queue.NumRequeues(vpcPath) < maxRetries {
 		c.log.Info("VPC cleanup failed, requeuing", "vpcPath", vpcPath, "vpcID", vpcID, "requeues", queue.NumRequeues(vpcPath)+1, "maxRetries", maxRetries)
-		queue.AddAfter(vpcPath, 10*time.Second)
+		// AddAfter will bypass the rate limiter and result NumRequeues always return 0
+		// Use AddRateLimited to ensure the NumRequeues check works correctly
+		queue.AddRateLimited(vpcPath)
 		return true
 	}
 
@@ -177,7 +185,8 @@ func (c *CleanupService) cleanPreCreatedVPCs(ctx context.Context) error {
 }
 
 func (c *CleanupService) cleanupAutoCreatedVPCs(ctx context.Context) error {
-	queue := workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]())
+	limiter := workqueue.NewTypedItemExponentialFailureRateLimiter[string](10*time.Second, 10*time.Second)
+	queue := workqueue.NewTypedRateLimitingQueue[string](limiter)
 	defer queue.ShutDown()
 
 	autoCreatedVPCs := c.vpcService.ListAutoCreatedVPCPaths()
@@ -204,6 +213,10 @@ func (c *CleanupService) cleanupAutoCreatedVPCs(ctx context.Context) error {
 	}
 
 	wg.Wait()
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 
 	if len(vpcFinalErrors) > 0 {
 		return <-vpcFinalErrors

--- a/pkg/clean/clean_service_test.go
+++ b/pkg/clean/clean_service_test.go
@@ -1,10 +1,14 @@
 package clean
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 func mockCleanupFunc() (interface{}, error) {
@@ -39,4 +43,24 @@ func TestAddCleanupService_Error(t *testing.T) {
 	assert.Len(t, service.vpcPreCleaners, 0)
 	assert.Len(t, service.vpcChildrenCleaners, 0)
 	assert.Len(t, service.infraCleaners, 0)
+}
+
+func TestCleanupService_Retriable(t *testing.T) {
+	log := logr.Discard()
+	service := &CleanupService{log: &log}
+
+	// nil error should return false
+	assert.False(t, service.retriable(nil))
+
+	// standard error should return true
+	assert.True(t, service.retriable(errors.New("some error")))
+
+	// context.Canceled should return false
+	assert.False(t, service.retriable(context.Canceled))
+
+	// context.DeadlineExceeded should return false
+	assert.False(t, service.retriable(context.DeadlineExceeded))
+
+	// TimeoutFailed should return false
+	assert.False(t, service.retriable(nsxutil.TimeoutFailed))
 }


### PR DESCRIPTION
This PR addresses that the cleanup service could enter an infinite retry loop
when encountering context timeouts or deadline exceeded errors.

It includes the following changes
- Refactored retriable to identify context errors as non-retriable
- Updated vpcWorker to check ctx.Err() and avoid requeuing on context cancellation, also fixed NumRequeues not effected issue
- Enforced the context timeout on nsx.GetClient

Testing done:

- Run command with another PI, obserse the cleanup interrupted by context
```
./test_timeout  -cluster=6f0a3a07-de27-4ffd-ad42-076d7d751770 -nsx-user=admin -nsx-passwd='W4*Iiwe9QJYIH2eo' -mgr-ip=10.192.81.187 -log-level=1  -timeout 1m
...
2026-08-10 17:04:57.000 INFO policy_tree.go:674 Batch deletion interrupted by context failedCount=0 processedBatches=0 resourceType=VpcSubnetPort successCount=0 totalBatches=1
2026-08-10 17:04:57.000 ERROR cleanup.go:31 Failed to clean up VpcSubnetPorts error="failed because of timeout\ncontext deadline exceeded" count=1 status=failed
2026-08-10 17:04:57.000 ERROR clean.go:100 Failed to delete the resources before deleting VPCs error="nsx error code: 289, message: Principal 'admin' with role '[enterprise_admin]' attempts to delete or modify an object of type nsx$SegmentPort it doesn't own. (createUser=wcp-cluster-user-6f0a3a07-de27-4ffd-ad42-076d7d751770-8e5b47eb-b9aa-4d7a-9c47-18548dd5d769, allowOverwrite=null)" resourceCount=7
```

- Run command without credential, observed the clean script stop with context deadline exceeded

```
./test_timeout \                                 
  -cluster 6f0a3a07-de27-4ffd-ad42-076d7d751770 \
  -mgr-ip 10.192.81.187 \
  -vc-sso-domain vsphere.local \
  -vc-endpoint lvn-dvm-10-192-81-75.dvm.lvn.broadcom.net \
  -log-level=2 \
  -timeout 5s
...
2026-08-10 16:45:20.000 ERROR vcclient.go:181 Failed to get token from cert,key pair error="ns0:FailedAuthentication: Invalid credentials"
2026-08-10 16:45:20.000 ERROR jwtcache.go:73 JWT cache failed to refresh JWT  error="ns0:FailedAuthentication: Invalid credentials"
2026-08-10 16:45:20.000 DEBUG jwtcache.go:49 Get JWT Refresh JWT error="ns0:FailedAuthentication: Invalid credentials"
```

- Run the cleanup script when VPC cannot be deleted, observed the requeues number is calculated correctly and VPC cleanup can stop

```
2026-08-10 03:19:46.000 INFO clean_service.go:205 VPC cleanup failed, requeuing maxRetries=12 requeues=12 vpcID=kube-system_9qdt9 vpcPath=/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9
2026-08-10 03:19:56.000 INFO clean_service.go:205 VPC worker processing requeues=12 vpcID=kube-system_9qdt9 vpcPath=/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9
2026-08-10 03:19:56.000 INFO clean_service.go:150 Cleaning VPC resources path=/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9
2026-08-10 03:19:56.000 INFO clean_service.go:150 Attempting to delete VPC vpcID=kube-system_9qdt9 vpcPath=/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9
2026-08-10 03:19:56.000 TRACE utils.go:361 HTTP req body={} head={"Accept":["application/json"],"Authorization":["--- CENSORED ---"],"Content-Type":["application/json"],"User-Agent":["vAPI/0.8.0 Go/go1.25.9 (linux; amd64)"],"Vapi-Ctx-Opid":["3b6cf34c-0d41-4916-a9d8-872e6941cb34"]} method=DELETE url=https://10.162.195.150/policy/api/v1/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9?is_recursive=true
2026-08-10 03:19:56.000 DEBUG utils.go:151 HTTP resp body={"error_code":610791,"error_message":"VPC subnet path=[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9] has existing subnet ports path=[[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9/ports/test]]","httpStatus":"BAD_REQUEST","module_name":"policy"} status code=400
2026-08-10 03:19:56.000 DEBUG transport.go:88 Error is configured as not retriable error="Unexpected error from backend manager () for StatusCode is 400,ErrorCode is 610791,Detail is VPC subnet path=[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9] has existing subnet ports path=[[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9/ports/test]]VPC subnet path=[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9] has existing subnet ports path=[[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9/ports/test]]"
2026-08-10 03:19:56.000 ERROR clean_service.go:150 Failed to delete VPC on NSX error="nsx error code: 610791, message: VPC subnet path=[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9] has existing subnet ports path=[[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9/ports/test]]" vpcID=kube-system_9qdt9 vpcPath=/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9
2026-08-10 03:19:56.000 ERROR clean_service.go:205 VPC cleanup permanently failed error="nsx error code: 610791, message: VPC subnet path=[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9] has existing subnet ports path=[[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9/ports/test]]" vpcID=kube-system_9qdt9 vpcPath=/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9
2026-08-10 03:19:56.000 ERROR clean.go:90 Failed to delete the auto created VPCs and their child resources error="nsx error code: 610791, message: VPC subnet path=[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9] has existing subnet ports path=[[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9/ports/test]]" vpcCount=3
2026-08-10 03:19:56.000 ERROR main.go:88 Failed to clean nsx resources error="failed to clean up\nnsx error code: 610791, message: VPC subnet path=[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9] has existing subnet ports path=[[/orgs/default/projects/project-quality/vpcs/kube-system_9qdt9/subnets/vm-default-3db825c6_9qdt9/ports/test]]"
```