### PR TITLE
Fix the vpc attachment deletion issue in e2e test

### DIFF
--- a/test/e2e/nsx_ipblocksinfo_test.go
+++ b/test/e2e/nsx_ipblocksinfo_test.go
@@ -142,8 +142,6 @@ func CustomIPBlocksInfo(t *testing.T) {
 		deleteChild := true
 		err := testData.nsxClient.VPCClient.Delete(defaultOrg, defaultProject, vpcId, &deleteChild)
 		require.NoError(t, err)
-		err = testData.nsxClient.VpcAttachmentClient.Delete(defaultOrg, defaultProject, vpcId, vpcAttachmentId)
-		require.NoError(t, err)
 	}()
 
 	// Create VPCNetworkConfigurations


### PR DESCRIPTION
Observed vpc attachment deletion is called after recursive vpc delete API, which
may result the following error in e2e test and fail the CustomIPBlocksInfo test

```
2026-08-11 06:24:01.000 DEBUG transport.go:88 Error is configured as not retriable error="StatusCode is 400,ErrorCode is 500045,Detail is An object with the same path=[/orgs/default/projects/project-quality/infra/shares/_project-quality--ipblocks-info-test] is marked for deletion. Either use another path or wait for the purge cycle (which runs every 5 minutes) for permanent removal of the object.An object with the same path=[/orgs/default/projects/project-quality/infra/shares/_project-quality--ipblocks-info-test] is marked for deletion. Either use another path or wait for the purge cycle (which runs every 5 minutes) for permanent removal of the object."
```
