### PR TITLE
Support allowed_use_cases in vpcipaddressusage eas api

### DIFF
--- a/build/yaml/crd/eas/eas.nsx.vmware.com_vpcipaddressusages.yaml
+++ b/build/yaml/crd/eas/eas.nsx.vmware.com_vpcipaddressusages.yaml
@@ -76,6 +76,11 @@ spec:
                   required:
                   - count
                   type: object
+                allowedUseCases:
+                  description: The list of Allowed Use Cases.
+                  items:
+                    type: string
+                  type: array
                 available:
                   description: Available IP address space.
                   format: int64

--- a/go.mod
+++ b/go.mod
@@ -34,8 +34,8 @@ require (
 	github.com/vmware/govmomi v0.53.1
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.8.0
 	github.com/vmware/vsphere-automation-sdk-go/runtime v0.8.0
-	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.0.0-20260614145640-9b3a306dd40d
-	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20260614145640-9b3a306dd40d
+	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260731022611-0b74bd8dd86c
+	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.6.1-0.20260731022611-0b74bd8dd86c
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.53.0
@@ -56,6 +56,7 @@ require (
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	go.uber.org/mock v0.6.0
+	k8s.io/klog/v2 v2.140.0
 	sigs.k8s.io/gateway-api v1.5.1
 )
 
@@ -157,7 +158,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.35.0 // indirect
 	k8s.io/component-base v0.35.1 // indirect
 	k8s.io/gengo/v2 v2.0.0-20260408192533-25e2208e0dc3 // indirect
-	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kms v0.35.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -226,10 +226,10 @@ github.com/vmware/vsphere-automation-sdk-go/lib v0.8.0 h1:u1SXOTM6D4Ygb3jeidj2Rd
 github.com/vmware/vsphere-automation-sdk-go/lib v0.8.0/go.mod h1:8d5JTwjpM/Z03n/IZb0fwmXkJNWvWwuLXBqoakqYio4=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.8.0 h1:KnDIX9LY0nru7iMQTg0sy9vChhyorPo5OdASM2MaAcI=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.8.0/go.mod h1:DzLetYAmw1+vj7bqElRWEpuy40WYE/woL3alsymYa/c=
-github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.0.0-20260614145640-9b3a306dd40d h1:0e8+fVUGeGVw3bVZuF16zRfyI3jmS9PPEUaPPbuL0fs=
-github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.0.0-20260614145640-9b3a306dd40d/go.mod h1:C3JVOHRVLrGBQ8kTWAiGYlRz5UQC5qAcTdt3tvA+5P0=
-github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20260614145640-9b3a306dd40d h1:vuLe5Bqk7AucZdV6C1MgaZSPTt/4diiID56RkefLhrs=
-github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.0.0-20260614145640-9b3a306dd40d/go.mod h1:fDH7JI080OD5t6TGwjJx3mMX/g6W7t6Radlome6hze8=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260731022611-0b74bd8dd86c h1:+MwEfbdVsFBxIeT6AgP9o/7UjoY/5B2ZtavaIJQ2Vh0=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260731022611-0b74bd8dd86c/go.mod h1:C3JVOHRVLrGBQ8kTWAiGYlRz5UQC5qAcTdt3tvA+5P0=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.6.1-0.20260731022611-0b74bd8dd86c h1:X17pexQXN7j8lyEBdgdC/5nj4PtKHOteJKcOZ5SsGWM=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.6.1-0.20260731022611-0b74bd8dd86c/go.mod h1:fDH7JI080OD5t6TGwjJx3mMX/g6W7t6Radlome6hze8=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 h1:S2dVYn90KE98chqDkyE9Z4N61UnQd+KOfgp5Iu53llk=

--- a/pkg/apis/eas/v1alpha1/vpcipaddressusage_types.go
+++ b/pkg/apis/eas/v1alpha1/vpcipaddressusage_types.go
@@ -39,6 +39,8 @@ type VPCIPAddressBlock struct {
 	Visibility IPAddressVisibility `json:"visibility,omitempty"`
 	// AllocatedByVPC contains the CIDR, used IP range and subnet access mode etc.
 	AllocatedByVPC AllocatedByVPC `json:"allocatedByVPC,omitempty"`
+	// The list of Allowed Use Cases.
+	AllowedUseCases []string `json:"allowedUseCases,omitempty"`
 	// The list of CIDRs.
 	// +listType=atomic
 	CIDRs []string `json:"cidrs,omitempty"`

--- a/pkg/apis/eas/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/eas/v1alpha1/zz_generated.deepcopy.go
@@ -362,6 +362,11 @@ func (in *VPCIPAddress) DeepCopy() *VPCIPAddress {
 func (in *VPCIPAddressBlock) DeepCopyInto(out *VPCIPAddressBlock) {
 	*out = *in
 	in.AllocatedByVPC.DeepCopyInto(&out.AllocatedByVPC)
+	if in.AllowedUseCases != nil {
+		in, out := &in.AllowedUseCases, &out.AllowedUseCases
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.CIDRs != nil {
 		in, out := &in.CIDRs, &out.CIDRs
 		*out = make([]string, len(*in))

--- a/pkg/eas/storage/vpcipaddressusage.go
+++ b/pkg/eas/storage/vpcipaddressusage.go
@@ -120,12 +120,13 @@ func ConvertVpcIpAddressBlocks(nsxBlocks *model.VpcIpAddressBlocks, vpcName, nam
 			ipBlockName = ":" + ipBlockName
 		}
 		block := easv1alpha1.VPCIPAddressBlock{
-			IPBlockName:    ipBlockName,
-			CIDRs:          b.Cidrs,
-			Available:      DerefInt64(b.Available),
-			Total:          DerefInt64(b.Total),
-			PercentageUsed: DerefString(b.PercentageUsed),
-			Visibility:     visibility,
+			IPBlockName:     ipBlockName,
+			CIDRs:           b.Cidrs,
+			Available:       DerefInt64(b.Available),
+			Total:           DerefInt64(b.Total),
+			PercentageUsed:  DerefString(b.PercentageUsed),
+			Visibility:      visibility,
+			AllowedUseCases: b.AllowedUseCases,
 		}
 		block.ExcludedIPs = convertIPPoolRanges(b.ExcludedIps)
 		block.Ranges = convertIPPoolRanges(b.Ranges)

--- a/pkg/eas/storage/vpcipaddressusage_test.go
+++ b/pkg/eas/storage/vpcipaddressusage_test.go
@@ -94,14 +94,16 @@ func TestConvertVpcIpAddressBlocks_WithRangesAndAllocatedByVPC(t *testing.T) {
 	pathSubnet := "/orgs/o1/projects/p1/vpcs/v1/subnets/sub-1"
 	addrOther := "10.0.0.7"
 	pathOther := "/some/other/path/leaf"
+	allowedUseCases := []string{"LB_FRONTEND"}
 
 	nsx := &model.VpcIpAddressBlocks{
 		IpBlocks: []model.VpcIpAddressBlock{
 			{
-				Cidrs:          []string{"10.0.0.0/8"},
-				PercentageUsed: &pct,
-				ExcludedIps:    []model.IpPoolRange{{Start: &start, End: &end}},
-				Ranges:         []model.IpPoolRange{{Start: &start, End: &end}},
+				Cidrs:           []string{"10.0.0.0/8"},
+				PercentageUsed:  &pct,
+				ExcludedIps:     []model.IpPoolRange{{Start: &start, End: &end}},
+				Ranges:          []model.IpPoolRange{{Start: &start, End: &end}},
+				AllowedUseCases: allowedUseCases,
 				AllocatedByVpc: &model.AllocatedByVpc{
 					AccessMode: &am,
 					Count:      &count,
@@ -121,6 +123,7 @@ func TestConvertVpcIpAddressBlocks_WithRangesAndAllocatedByVPC(t *testing.T) {
 	assert.Equal(t, "10.0.0.1", b.ExcludedIPs[0].Start)
 	assert.Equal(t, "10.0.0.10", b.ExcludedIPs[0].End)
 	require.Len(t, b.Ranges, 1)
+	assert.Equal(t, allowedUseCases, b.AllowedUseCases)
 	assert.Equal(t, easv1alpha1.PublicSubnet, b.AllocatedByVPC.AccessMode)
 	assert.Equal(t, int64(3), b.AllocatedByVPC.Count)
 	require.Len(t, b.AllocatedByVPC.IPAddresses, 3)


### PR DESCRIPTION
Support allowed_use_cases in vpcipaddressusage eas api

Testing Done:
```
k get vpcipaddressusages -n small-ns -o yaml
apiVersion: v1
items:
- apiVersion: eas.nsx.vmware.com/v1alpha1
  ipBlocks:
...
  - allocatedByVPC:
      accessMode: Public
      count: 0
      percentageUsed: "0"
    allowedUseCases:
    - LB_FRONTEND
    available: 65536
    cidrs:
    - 16.16.0.0/16
    ipBlockName: :ipc-test
    percentageUsed: "0.0"
    total: 65536
    visibility: External
  kind: VPCIPAddressUsage
  metadata:
    name: small-vpc
    namespace: small-ns
kind: List
metadata:
  resourceVersion: ""
```
