### PR TITLE
Fix default subnetset with shared subnet deletion issue

### DIFF
--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -187,7 +187,7 @@ func (r *NetworkInfoReconciler) updateDefaultSubnetSet(ctx context.Context, subn
 		if subnetSetCR != nil {
 			// Delete the default SubnetSet if it is created with auto-created Subnets and the current supported IP address type is not a superset of the SubnetSet IP address type.
 			// e.g. if the current supported IP address type is IPv4 or IPv6, and the SubnetSet IP address type is IPv4IPv6, then the SubnetSet shall be deleted and recreated
-			if !common.IsSupersetIPAddressTypes(autoCreatedIPAddressType, subnetSetCR.Spec.IPAddressType) {
+			if !common.IsSupersetIPAddressTypes(autoCreatedIPAddressType, subnetSetCR.Spec.IPAddressType) && subnetSetCR.Spec.SubnetNames == nil {
 				log.Info("Delete default SubnetSet", commonservice.LabelDefaultNetwork, subnetSetType, "Namespace", ns, "existingIPAddressType", subnetSetCR.Spec.IPAddressType, "desiredIPAddressType", autoCreatedIPAddressType)
 				err = r.Client.Delete(ctx, subnetSetCR)
 				if err != nil {

--- a/pkg/controllers/networkinfo/networkinfo_controller_test.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller_test.go
@@ -2649,45 +2649,80 @@ func TestNetworkInfoReconciler_UpdateDefaultSubnetSet(t *testing.T) {
 		hasPrecreatedSubnet      bool
 		subnetSetList            []client.Object
 		expectErrStr             string
+		existingIPAddressType    v1alpha1.IPAddressType
+		subnetNames              []string
+		// Unified verification fields:
+		expectNotExists        bool
+		expectIPAddressType    v1alpha1.IPAddressType
+		expectSubnetNames      *[]string
+		expectIPv6PrefixLength int
 	}{
 		{
 			name:                     "Create default SubnetSet",
 			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv4,
 			hasPrecreatedSubnet:      false,
+			expectIPAddressType:      v1alpha1.IPAddressTypeIPv4,
 		},
 		{
 			name:                     "Delete default SubnetSet 1",
 			autoCreatedIPAddressType: "",
 			hasPrecreatedSubnet:      false,
 			subnetSetList:            []client.Object{subnetSet},
+			expectNotExists:          true,
 		},
 		{
 			name:                     "Delete default SubnetSet 2",
 			autoCreatedIPAddressType: "",
 			hasPrecreatedSubnet:      true,
 			subnetSetList:            []client.Object{subnetSet},
+			expectNotExists:          true,
 		},
 		{
 			name:                     "Existing default SubnetSet",
 			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv4,
 			hasPrecreatedSubnet:      false,
 			subnetSetList:            []client.Object{subnetSet},
+			expectIPAddressType:      v1alpha1.IPAddressTypeIPv4,
 		},
 		{
 			name:                     "Existing default SubnetSet with IPAddressType change",
 			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv6,
 			hasPrecreatedSubnet:      false,
 			subnetSetList:            []client.Object{subnetSet},
+			expectIPAddressType:      v1alpha1.IPAddressTypeIPv6,
+			expectIPv6PrefixLength:   80,
 		},
 		{
 			name:                     "Create default SubnetSet with IPv6",
 			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv6,
 			hasPrecreatedSubnet:      false,
+			expectIPAddressType:      v1alpha1.IPAddressTypeIPv6,
+			expectIPv6PrefixLength:   80,
 		},
 		{
 			name:                     "Create default SubnetSet with dual stack",
 			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv4IPv6,
 			hasPrecreatedSubnet:      false,
+			expectIPAddressType:      v1alpha1.IPAddressTypeIPv4IPv6,
+			expectIPv6PrefixLength:   80,
+		},
+		{
+			name:                     "Existing default SubnetSet with subnetNames and IPAddressType change (no delete)",
+			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv4,
+			existingIPAddressType:    v1alpha1.IPAddressTypeIPv4IPv6,
+			subnetNames:              []string{"subnet-1"},
+			hasPrecreatedSubnet:      false,
+			subnetSetList:            []client.Object{subnetSet},
+			expectIPAddressType:      v1alpha1.IPAddressTypeIPv4IPv6,
+			expectSubnetNames:        &[]string{"subnet-1"},
+		},
+		{
+			name:                     "Existing default SubnetSet without subnetNames and IPAddressType change (delete)",
+			autoCreatedIPAddressType: v1alpha1.IPAddressTypeIPv4,
+			existingIPAddressType:    v1alpha1.IPAddressTypeIPv4IPv6,
+			hasPrecreatedSubnet:      false,
+			subnetSetList:            []client.Object{subnetSet},
+			expectIPAddressType:      v1alpha1.IPAddressTypeIPv4,
 		},
 	}
 
@@ -2704,6 +2739,12 @@ func TestNetworkInfoReconciler_UpdateDefaultSubnetSet(t *testing.T) {
 					AccessMode:     "Public",
 					IPv4SubnetSize: 32,
 				},
+			}
+			if tc.existingIPAddressType != "" {
+				subnetSet.Spec.IPAddressType = tc.existingIPAddressType
+			}
+			if len(tc.subnetNames) > 0 {
+				subnetSet.Spec.SubnetNames = &tc.subnetNames
 			}
 
 			var objs []client.Object
@@ -2738,17 +2779,22 @@ func TestNetworkInfoReconciler_UpdateDefaultSubnetSet(t *testing.T) {
 					}
 				}
 			}
-			if tc.name == "Existing default SubnetSet" {
-				updated := &v1alpha1.SubnetSet{}
-				require.NoError(t, r.Client.Get(ctx, types.NamespacedName{Namespace: "ns-1", Name: "pod-default"}, updated))
-				// IPv6PrefixLength must not be propagated to an existing SubnetSet because
-				// NSX subnets have an immutable IPv6PrefixLength.
-				assert.Equal(t, subnetSet.Spec.IPv6PrefixLength, updated.Spec.IPv6PrefixLength)
-			}
-			if tc.name == "Existing default SubnetSet with IPAddressType change" {
-				updated := &v1alpha1.SubnetSet{}
-				require.NoError(t, r.Client.Get(ctx, types.NamespacedName{Namespace: "ns-1", Name: "pod-default"}, updated))
-				assert.Equal(t, v1alpha1.IPAddressTypeIPv6, updated.Spec.IPAddressType)
+
+			updated := &v1alpha1.SubnetSet{}
+			err := r.Client.Get(ctx, types.NamespacedName{Namespace: "ns-1", Name: "pod-default"}, updated)
+			if tc.expectNotExists {
+				assert.True(t, apierrors.IsNotFound(err))
+			} else {
+				require.NoError(t, err)
+				if tc.expectIPAddressType != "" {
+					assert.Equal(t, tc.expectIPAddressType, updated.Spec.IPAddressType)
+				}
+				if tc.expectSubnetNames != nil {
+					assert.Equal(t, tc.expectSubnetNames, updated.Spec.SubnetNames)
+				} else {
+					assert.Nil(t, updated.Spec.SubnetNames)
+				}
+				assert.Equal(t, tc.expectIPv6PrefixLength, updated.Spec.IPv6PrefixLength)
 			}
 		})
 	}


### PR DESCRIPTION
Default SubnetSet with shared subnets should not be deleted if the vpc cidr does not match the subnetset IPAddressType.

Testing done:

Create a vpc without private and privatetgw cidr. Create a namespace with the vpc and a shared subnet for vm/pod default subnetset.

Observe default subnetset will be created and wont be deleted.

```
kubectl get subnetset -n test   
NAME          ACCESSMODE   IPADDRESSTYPE   IPV4SUBNETSIZE   IPV6PREFIXLENGTH   NETWORKADDRESSES
pod-default                IPv4                                                192.168.0.32/27
vm-default                 IPv4                                                192.168.0.32/27
```