### PR TITLE
Implement DNSRecord controller and reconciliation logic

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/apis/legacy/v1alpha1"
 	crdv1alpha1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	dnsrecordcontroller "github.com/vmware-tanzu/nsx-operator/pkg/controllers/dnsrecord"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/gateway"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/inventory"
 	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/ipaddressallocation"
@@ -262,6 +263,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 			gateway.NewGatewayReconciler(mgr, dnsRecordService),
 			subnetbindingcontroller.NewReconciler(mgr, subnetService, subnetBindingService),
 			subnetipreservationcontroller.NewReconciler(mgr, subnetIPReservationService, subnetService),
+			dnsrecordcontroller.NewDNSRecordReconciler(mgr, dnsRecordService),
 		)
 		if lbReconciler := service.NewServiceLbReconciler(mgr, commonService, dnsRecordService); lbReconciler != nil {
 			reconcilerList = append(reconcilerList, lbReconciler)

--- a/docs/ref/apis/legacy.md
+++ b/docs/ref/apis/legacy.md
@@ -29,7 +29,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 

--- a/docs/ref/apis/vpc.md
+++ b/docs/ref/apis/vpc.md
@@ -122,7 +122,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 
@@ -344,7 +344,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br /> |
+| `ipAddressBlockVisibility` _[IPAddressVisibility](#ipaddressvisibility)_ | IPAddressBlockVisibility specifies the visibility of the IPBlocks to allocate IP addresses. Can be External, Private or PrivateTGW.<br />This field is not applicable if ipAddressType is IPv6. |  | Enum: [External Private PrivateTGW] <br />Optional: \{\} <br /> |
 | `allocationSize` _integer_ | AllocationSize specifies the size of IPv4 allocationIPs to be allocated.<br />It should be a power of 2. |  | Minimum: 1 <br /> |
 | `allocationIPs` _string_ | AllocationIPs specifies the Allocated IP addresses in CIDR or single IP Address format. |  |  |
 | `ipv6AllocationPrefixLength` _integer_ | IPv6AllocationPrefixLength specifies the prefix length of IPv6 addresses.<br />Defaults to 64 when ipAddressType is IPv6 and this field is not specified.<br />Supported starting with VCF 9.2.0. |  | Maximum: 128 <br />Minimum: 64 <br /> |
@@ -813,7 +813,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the current state of the ServiceEndpoint. |  |  |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the current state of the ServiceEndpoint. |  | Optional: \{\} <br /> |
 
 
 #### SharedSubnet
@@ -849,7 +849,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Activate or deactivate static IP allocation for VPC Subnet Ports.<br />If the DHCP mode is DHCPDeactivated or not set, its default value is true.<br />If the DHCP mode is DHCPServer, its default value is false.<br />If the DHCP mode is DHCPRelay, its default value is false. |  |  |
-| `poolRanges` _string array_ | PoolRanges specifies the IP address ranges for static IP allocation.<br />Each entry is either a single IP address (e.g. "192.168.1.5") or a<br />dash-separated range (e.g. "192.168.1.10-192.168.1.20"). Both IPv4 and<br />IPv6 entries may appear in a single list.<br />Example value: ["192.168.1.1", "192.168.1.3-192.168.1.100"] |  |  |
+| `poolRanges` _string array_ | PoolRanges specifies the IP address ranges for static IP allocation.<br />Each entry is either a single IP address (e.g. "192.168.1.5") or a<br />dash-separated range (e.g. "192.168.1.10-192.168.1.20"). Both IPv4 and<br />IPv6 entries may appear in a single list.<br />Example value: ["192.168.1.1", "192.168.1.3-192.168.1.100"] |  | Optional: \{\} <br /> |
 
 
 #### StaticIPAllocationType
@@ -905,7 +905,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _[ConditionType](#conditiontype)_ | Type defines condition type. |  |  |
 | `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#conditionstatus-v1-core)_ | Status of the condition, one of True, False, Unknown. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | Last time the condition transitioned from one status to another.<br />This should be when the underlying condition changed. If that is not known, then using the time when<br />the API field changed is acceptable. |  | Optional: \{\} <br /> |
 | `reason` _string_ | Reason shows a brief reason of condition. |  |  |
 | `message` _string_ | Message shows a human-readable message about condition. |  |  |
 
@@ -923,8 +923,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `network` _string_ | Specify network address in CIDR format.<br />Mutually exclusive with networkIpAllocationName. |  | Format: cidr <br /> |
-| `networkIpAllocationName` _string_ | Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as<br />the static route network. Mutually exclusive with network. |  |  |
+| `network` _string_ | Specify network address in CIDR format.<br />Mutually exclusive with networkIpAllocationName. |  | Format: cidr <br />Optional: \{\} <br /> |
+| `networkIpAllocationName` _string_ | Specify the name of an IPAddressAllocation CR whose allocated CIDR is used as<br />the static route network. Mutually exclusive with network. |  | Optional: \{\} <br /> |
 | `nextHops` _[NextHop](#nexthop) array_ | Next hop gateway |  | MinItems: 1 <br /> |
 
 
@@ -1447,7 +1447,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the current state of the VPCEndpoint. |  |  |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#condition-v1-meta) array_ | Conditions describes the current state of the VPCEndpoint. |  | Optional: \{\} <br /> |
 
 
 #### VPCInfo
@@ -1505,8 +1505,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  |  |
-| `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  |  |
+| `vpc` _string_ | NSX path of the VPC the Namespace is associated with.<br />If vpc is set, only defaultSubnetSize and defaultIPv6PrefixLength take effect, other fields are ignored. |  | Optional: \{\} <br /> |
+| `subnets` _[SharedSubnet](#sharedsubnet) array_ | Shared Subnets the Namespace is associated with. |  | Optional: \{\} <br /> |
 | `nsxProject` _string_ | NSX Project the Namespace is associated with. |  |  |
 | `vpcConnectivityProfile` _string_ | VPCConnectivityProfile Path. This profile has configuration related to creating VPC transit gateway attachment. |  |  |
 | `privateIPs` _string array_ | Private IPs. |  |  |

--- a/pkg/controllers/common/types.go
+++ b/pkg/controllers/common/types.go
@@ -26,6 +26,7 @@ const (
 	MetricResTypeServiceLb                  = "servicelb"
 	MetricResTypeStatefulSet                = "statefulset"
 	MetricResTypeGateway                    = "gateway"
+	MetricResTypeDNSRecord                  = "dnsrecord"
 	MaxConcurrentReconciles                 = 8
 	NSXOperatorError                        = "nsx-op/error"
 	//sync the error with NCP side

--- a/pkg/controllers/dnsrecord/dnsrecord_controller.go
+++ b/pkg/controllers/dnsrecord/dnsrecord_controller.go
@@ -1,0 +1,290 @@
+/* Copyright © 2026 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package dnsrecord
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	"github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/logger"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/dns"
+	extdns "github.com/vmware-tanzu/nsx-operator/pkg/third_party/externaldns/endpoint"
+)
+
+var (
+	log           = logger.Log
+	ResultNormal  = common.ResultNormal
+	ResultRequeue = common.ResultRequeue
+)
+
+// DNSRecordReconciler reconciles a DNSRecord object
+// +kubebuilder:rbac:groups=crd.nsx.vmware.com,resources=dnsrecords,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crd.nsx.vmware.com,resources=dnsrecords/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crd.nsx.vmware.com,resources=dnsrecords/finalizers,verbs=update
+type DNSRecordReconciler struct {
+	Client        client.Client
+	Scheme        *runtime.Scheme
+	Service       *dns.DNSRecordService
+	Recorder      record.EventRecorder
+	StatusUpdater common.StatusUpdater
+}
+
+func calculateFQDN(recordName, domainName string) string {
+	recordName = strings.TrimSpace(recordName)
+	domainName = strings.TrimSpace(domainName)
+	domainName = strings.TrimSuffix(domainName, ".")
+	if recordName == "" || recordName == "@" {
+		return strings.ToLower(domainName)
+	}
+	recordName = strings.TrimSuffix(recordName, ".")
+	return strings.ToLower(fmt.Sprintf("%s.%s", recordName, domainName))
+}
+
+func NewDNSRecordReconciler(mgr ctrl.Manager, dnsRecordService *dns.DNSRecordService) *DNSRecordReconciler {
+	recorder := mgr.GetEventRecorderFor("dnsrecord-controller") //nolint:staticcheck // record.EventRecorder; StatusUpdater not on events.EventRecorder yet
+	var nsxConfig *config.NSXOperatorConfig
+	if dnsRecordService != nil && dnsRecordService.NSXConfig != nil {
+		nsxConfig = dnsRecordService.NSXConfig
+	} else {
+		nsxConfig = &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}
+	}
+	return &DNSRecordReconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Service:       dnsRecordService,
+		Recorder:      recorder,
+		StatusUpdater: common.NewStatusUpdater(mgr.GetClient(), nsxConfig, recorder, common.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
+	}
+}
+
+func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	obj := &v1alpha1.DNSRecord{}
+	log.Info("reconciling DNSRecord CR", "dnsrecord", req.NamespacedName)
+	r.StatusUpdater.IncreaseSyncTotal()
+
+	if err := r.Client.Get(ctx, req.NamespacedName, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			if r.Service != nil {
+				if _, err := r.Service.DeleteRecordByOwnerNN(ctx, dns.ResourceKindDNSRecord, req.Namespace, req.Name); err != nil {
+					log.Error(err, "Failed to delete DNS record from NSX on NotFound", "DNSRecord", req.NamespacedName)
+					r.StatusUpdater.DeleteFail(req.NamespacedName, nil, err)
+					return ResultRequeue, err
+				}
+			}
+			r.StatusUpdater.DeleteSuccess(req.NamespacedName, nil)
+			return ResultNormal, nil
+		}
+		log.Error(err, "unable to fetch DNSRecord CR", "req", req.NamespacedName)
+		return ResultRequeue, err
+	}
+
+	if !obj.ObjectMeta.DeletionTimestamp.IsZero() {
+		r.StatusUpdater.IncreaseDeleteTotal()
+		if r.Service != nil {
+			if _, err := r.Service.DeleteRecordByOwnerNN(ctx, dns.ResourceKindDNSRecord, obj.Namespace, obj.Name); err != nil {
+				log.Error(err, "Failed to delete DNS record from NSX", "DNSRecord", req.NamespacedName)
+				r.StatusUpdater.DeleteFail(req.NamespacedName, obj, err)
+				return ResultRequeue, err
+			}
+		}
+		if controllerutil.ContainsFinalizer(obj, servicecommon.DNSRecordFinalizerName) {
+			controllerutil.RemoveFinalizer(obj, servicecommon.DNSRecordFinalizerName)
+			if err := r.Client.Update(ctx, obj); err != nil {
+				log.Error(err, "Failed to remove finalizer from DNSRecord CR", "DNSRecord", req.NamespacedName)
+				r.StatusUpdater.DeleteFail(req.NamespacedName, obj, err)
+				return ResultRequeue, err
+			}
+		}
+		r.StatusUpdater.DeleteSuccess(req.NamespacedName, obj)
+		return ResultNormal, nil
+	}
+
+	r.StatusUpdater.IncreaseUpdateTotal()
+
+	needsUpdate := false
+	if !controllerutil.ContainsFinalizer(obj, servicecommon.DNSRecordFinalizerName) {
+		controllerutil.AddFinalizer(obj, servicecommon.DNSRecordFinalizerName)
+		needsUpdate = true
+	}
+
+	computedFQDN := calculateFQDN(obj.Spec.RecordName, obj.Spec.DomainName)
+	if obj.Spec.FQDN != computedFQDN {
+		obj.Spec.FQDN = computedFQDN
+		needsUpdate = true
+	}
+
+	if needsUpdate {
+		if err := r.Client.Update(ctx, obj); err != nil {
+			log.Error(err, "Failed to update finalizer/FQDN on DNSRecord CR", "DNSRecord", req.NamespacedName)
+			r.StatusUpdater.UpdateFail(ctx, obj, err, "Failed to update finalizer/FQDN", setDNSRecordReadyStatusFalse)
+			return ResultRequeue, err
+		}
+	}
+
+	if r.Service == nil {
+		r.StatusUpdater.UpdateSuccess(ctx, obj, setDNSRecordReadyStatusTrue)
+		return ResultNormal, nil
+	}
+
+	ttl := int32(dns.DefaultRecordTtL)
+	if obj.Spec.TTL != nil {
+		ttl = *obj.Spec.TTL
+	}
+
+	ep := &extdns.Endpoint{
+		DNSName:    computedFQDN,
+		RecordType: string(obj.Spec.RecordType),
+		Targets:    obj.Spec.RecordValues,
+		RecordTTL:  extdns.TTL(ttl),
+	}
+
+	owner := &dns.ResourceRef{
+		Kind:   dns.ResourceKindDNSRecord,
+		Object: obj,
+	}
+
+	rows, _, err := r.Service.ValidateEndpointsByZone(obj.Namespace, owner, []*extdns.Endpoint{ep})
+	if err != nil {
+		log.Error(err, "Failed to validate DNSRecord against DNS zones", "DNSRecord", req.NamespacedName)
+		r.StatusUpdater.UpdateFail(ctx, obj, err, "DNS zone validation failed", setDNSRecordReadyStatusFalse)
+		return ResultRequeue, err
+	}
+
+	batch := dns.NewOwnerScopedAggregatedRouteDNS(owner, rows)
+	if _, err := r.Service.CreateOrUpdateRecords(ctx, batch); err != nil {
+		log.Error(err, "Failed to sync DNSRecord to NSX", "DNSRecord", req.NamespacedName)
+		r.StatusUpdater.UpdateFail(ctx, obj, err, "Failed to create or update DNS record on NSX", setDNSRecordReadyStatusFalse)
+		return ResultRequeue, err
+	}
+
+	r.StatusUpdater.UpdateSuccess(ctx, obj, setDNSRecordReadyStatusTrue)
+	return ResultNormal, nil
+}
+
+func setDNSRecordReadyStatusTrue(client client.Client, ctx context.Context, obj client.Object, transitionTime metav1.Time, _ ...interface{}) {
+	record := obj.(*v1alpha1.DNSRecord)
+	cond := metav1.Condition{
+		Type:               string(v1alpha1.Ready),
+		Status:             metav1.ConditionTrue,
+		Reason:             "DNSRecordReady",
+		Message:            "NSX DNS record successfully created/updated",
+		ObservedGeneration: record.Generation,
+		LastTransitionTime: transitionTime,
+	}
+	updateDNSRecordStatusConditions(client, ctx, record, cond)
+}
+
+func setDNSRecordReadyStatusFalse(client client.Client, ctx context.Context, obj client.Object, transitionTime metav1.Time, err error, _ ...interface{}) {
+	record := obj.(*v1alpha1.DNSRecord)
+	cond := metav1.Condition{
+		Type:               string(v1alpha1.Ready),
+		Status:             metav1.ConditionFalse,
+		Reason:             "DNSRecordFailed",
+		Message:            fmt.Sprintf("Failed to process DNSRecord: %v", err),
+		ObservedGeneration: record.Generation,
+		LastTransitionTime: transitionTime,
+	}
+	updateDNSRecordStatusConditions(client, ctx, record, cond)
+}
+
+func updateDNSRecordStatusConditions(k8sClient client.Client, ctx context.Context, record *v1alpha1.DNSRecord, cond metav1.Condition) {
+	if meta.SetStatusCondition(&record.Status.Conditions, cond) {
+		if err := k8sClient.Status().Update(ctx, record); err != nil {
+			log.Error(err, "Failed to update DNSRecord status", "Name", record.Name, "Namespace", record.Namespace)
+		} else {
+			log.Info("Updated DNSRecord status", "Name", record.Name, "Namespace", record.Namespace, "Status", record.Status)
+		}
+	}
+}
+
+func (r *DNSRecordReconciler) setupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.DNSRecord{}).
+		WithEventFilter(common.VPCNamespacePredicate(r.Client)).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: common.NumReconcile(),
+		}).
+		Complete(r)
+}
+
+func (r *DNSRecordReconciler) StartController(mgr ctrl.Manager, _ webhook.Server) error {
+	if err := r.setupWithManager(mgr); err != nil {
+		log.Error(err, "Failed to create controller", "controller", "DNSRecord")
+		return err
+	}
+	return nil
+}
+
+func (r *DNSRecordReconciler) CollectGarbage(ctx context.Context) error {
+	log.Info("DNSRecord garbage collector started")
+	if r.Service == nil || r.Service.DNSRecordStore == nil {
+		return nil
+	}
+	crdList := &v1alpha1.DNSRecordList{}
+	if err := r.Client.List(ctx, crdList); err != nil {
+		log.Error(err, "failed to list DNSRecord CRs")
+		return err
+	}
+	crdNamespacesAndNames := make(map[string]struct{})
+	for _, item := range crdList.Items {
+		crdNamespacesAndNames[fmt.Sprintf("%s/%s", item.Namespace, item.Name)] = struct{}{}
+	}
+
+	nsxRecords := r.Service.DNSRecordStore.ListDNSRecords()
+	for _, rec := range nsxRecords {
+		if rec == nil {
+			continue
+		}
+		for _, tag := range rec.Tags {
+			if tag.Scope != nil && *tag.Scope == servicecommon.TagScopeDNSRecordFor && tag.Tag != nil && *tag.Tag == servicecommon.TagValueDNSRecordForDNSRecord {
+				ns := ""
+				name := ""
+				for _, t := range rec.Tags {
+					if t.Scope == nil || t.Tag == nil {
+						continue
+					}
+					switch *t.Scope {
+					case servicecommon.TagScopeDNSRecordOwnerNamespace:
+						ns = *t.Tag
+					case servicecommon.TagScopeDNSRecordOwnerName:
+						name = *t.Tag
+					}
+				}
+				if ns != "" && name != "" {
+					key := fmt.Sprintf("%s/%s", ns, name)
+					if _, exists := crdNamespacesAndNames[key]; !exists {
+						log.Info("GC removing stale DNSRecord on NSX", "Namespace", ns, "Name", name)
+						r.StatusUpdater.IncreaseDeleteTotal()
+						if _, err := r.Service.DeleteRecordByOwnerNN(ctx, dns.ResourceKindDNSRecord, ns, name); err != nil {
+							r.StatusUpdater.IncreaseDeleteFailTotal()
+						} else {
+							r.StatusUpdater.IncreaseDeleteSuccessTotal()
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (r *DNSRecordReconciler) RestoreReconcile() error {
+	return nil
+}

--- a/pkg/controllers/dnsrecord/dnsrecord_controller.go
+++ b/pkg/controllers/dnsrecord/dnsrecord_controller.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -118,22 +120,12 @@ func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	r.StatusUpdater.IncreaseUpdateTotal()
 
-	needsUpdate := false
-	if !controllerutil.ContainsFinalizer(obj, servicecommon.DNSRecordFinalizerName) {
-		controllerutil.AddFinalizer(obj, servicecommon.DNSRecordFinalizerName)
-		needsUpdate = true
-	}
-
 	computedFQDN := calculateFQDN(obj.Spec.RecordName, obj.Spec.DomainName)
 	if obj.Spec.FQDN != computedFQDN {
 		obj.Spec.FQDN = computedFQDN
-		needsUpdate = true
-	}
-
-	if needsUpdate {
 		if err := r.Client.Update(ctx, obj); err != nil {
-			log.Error(err, "Failed to update finalizer/FQDN on DNSRecord CR", "DNSRecord", req.NamespacedName)
-			r.StatusUpdater.UpdateFail(ctx, obj, err, "Failed to update finalizer/FQDN", setDNSRecordReadyStatusFalse)
+			log.Error(err, "Failed to update FQDN on DNSRecord CR", "DNSRecord", req.NamespacedName)
+			r.StatusUpdater.UpdateFail(ctx, obj, err, "Failed to update FQDN", setDNSRecordReadyStatusFalse)
 			return ResultRequeue, err
 		}
 	}
@@ -229,6 +221,7 @@ func (r *DNSRecordReconciler) StartController(mgr ctrl.Manager, _ webhook.Server
 		log.Error(err, "Failed to create controller", "controller", "DNSRecord")
 		return err
 	}
+	go common.GenericGarbageCollector(make(chan bool), servicecommon.GCInterval, r.CollectGarbage)
 	return nil
 }
 
@@ -242,44 +235,23 @@ func (r *DNSRecordReconciler) CollectGarbage(ctx context.Context) error {
 		log.Error(err, "failed to list DNSRecord CRs")
 		return err
 	}
-	crdNamespacesAndNames := make(map[string]struct{})
+	crdNames := sets.New[types.NamespacedName]()
 	for _, item := range crdList.Items {
-		crdNamespacesAndNames[fmt.Sprintf("%s/%s", item.Namespace, item.Name)] = struct{}{}
+		crdNames.Insert(types.NamespacedName{Namespace: item.Namespace, Name: item.Name})
 	}
 
-	nsxRecords := r.Service.DNSRecordStore.ListDNSRecords()
-	for _, rec := range nsxRecords {
-		if rec == nil {
+	ownersByKind := r.Service.ListRecordOwnerResource()
+	cachedDNSRecords := ownersByKind[dns.ResourceKindDNSRecord]
+	for nn := range cachedDNSRecords {
+		if crdNames.Has(nn) {
 			continue
 		}
-		for _, tag := range rec.Tags {
-			if tag.Scope != nil && *tag.Scope == servicecommon.TagScopeDNSRecordFor && tag.Tag != nil && *tag.Tag == servicecommon.TagValueDNSRecordForDNSRecord {
-				ns := ""
-				name := ""
-				for _, t := range rec.Tags {
-					if t.Scope == nil || t.Tag == nil {
-						continue
-					}
-					switch *t.Scope {
-					case servicecommon.TagScopeDNSRecordOwnerNamespace:
-						ns = *t.Tag
-					case servicecommon.TagScopeDNSRecordOwnerName:
-						name = *t.Tag
-					}
-				}
-				if ns != "" && name != "" {
-					key := fmt.Sprintf("%s/%s", ns, name)
-					if _, exists := crdNamespacesAndNames[key]; !exists {
-						log.Info("GC removing stale DNSRecord on NSX", "Namespace", ns, "Name", name)
-						r.StatusUpdater.IncreaseDeleteTotal()
-						if _, err := r.Service.DeleteRecordByOwnerNN(ctx, dns.ResourceKindDNSRecord, ns, name); err != nil {
-							r.StatusUpdater.IncreaseDeleteFailTotal()
-						} else {
-							r.StatusUpdater.IncreaseDeleteSuccessTotal()
-						}
-					}
-				}
-			}
+		log.Info("GC removing stale DNSRecord on NSX", "Namespace", nn.Namespace, "Name", nn.Name)
+		r.StatusUpdater.IncreaseDeleteTotal()
+		if _, err := r.Service.DeleteRecordByOwnerNN(ctx, dns.ResourceKindDNSRecord, nn.Namespace, nn.Name); err != nil {
+			r.StatusUpdater.IncreaseDeleteFailTotal()
+		} else {
+			r.StatusUpdater.IncreaseDeleteSuccessTotal()
 		}
 	}
 	return nil

--- a/pkg/controllers/dnsrecord/dnsrecord_controller_test.go
+++ b/pkg/controllers/dnsrecord/dnsrecord_controller_test.go
@@ -1,0 +1,607 @@
+/* Copyright © 2026 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package dnsrecord
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	ctlcommon "github.com/vmware-tanzu/nsx-operator/pkg/controllers/common"
+	pkgmock "github.com/vmware-tanzu/nsx-operator/pkg/mock"
+	mockdns "github.com/vmware-tanzu/nsx-operator/pkg/mock/dnsrecordprovider"
+	dnsrecmocks "github.com/vmware-tanzu/nsx-operator/pkg/mock/dnsrecordsclient"
+	orgrootmocks "github.com/vmware-tanzu/nsx-operator/pkg/mock/orgrootclient"
+	realizedmocks "github.com/vmware-tanzu/nsx-operator/pkg/mock/realizedentitiesclient"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/dns"
+)
+
+func setupScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	return scheme
+}
+
+func newTestNSXClient(t *testing.T) *nsx.Client {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+
+	orgRoot := orgrootmocks.NewMockOrgRootClient(ctrl)
+	orgRoot.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	realized := realizedmocks.NewMockRealizedEntitiesClient(ctrl)
+	st := model.GenericPolicyRealizedResource_STATE_REALIZED
+	realized.EXPECT().List(gomock.Any(), gomock.Any()).Return(model.GenericPolicyRealizedResourceListResult{
+		Results: []model.GenericPolicyRealizedResource{{State: &st}},
+	}, nil).AnyTimes()
+
+	dnsRec := dnsrecmocks.NewMockDnsRecordsClient(ctrl)
+	dnsRec.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(orgID, projectID, recordID string) (model.DnsRecord, error) {
+			p := fmt.Sprintf("/orgs/%s/projects/%s/%s/%s", orgID, projectID, dns.DNSRecordPathSegment, recordID)
+			rid := recordID
+			return model.DnsRecord{Id: &rid, Path: &p}, nil
+		}).AnyTimes()
+	dnsRec.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	return &nsx.Client{
+		OrgRootClient:          orgRoot,
+		RealizedEntitiesClient: realized,
+		DnsRecordsClient:       dnsRec,
+	}
+}
+
+func TestCalculateFQDN(t *testing.T) {
+	tests := []struct {
+		name       string
+		recordName string
+		domainName string
+		want       string
+	}{
+		{
+			name:       "standard record and domain",
+			recordName: "api",
+			domainName: "example.com",
+			want:       "api.example.com",
+		},
+		{
+			name:       "apex record @",
+			recordName: "@",
+			domainName: "example.com",
+			want:       "example.com",
+		},
+		{
+			name:       "empty record name",
+			recordName: "",
+			domainName: "example.com.",
+			want:       "example.com",
+		},
+		{
+			name:       "PTR record name",
+			recordName: "10",
+			domainName: "0.0.10.in-addr.arpa",
+			want:       "10.0.0.10.in-addr.arpa",
+		},
+		{
+			name:       "uppercase and trailing dots",
+			recordName: "Web.",
+			domainName: "EXAMPLE.COM.",
+			want:       "web.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateFQDN(tt.recordName, tt.domainName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDNSRecordReconciler_Reconcile_NotFound(t *testing.T) {
+	scheme := setupScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &DNSRecordReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Service:       nil,
+		StatusUpdater: ctlcommon.NewStatusUpdater(fakeClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}, record.NewFakeRecorder(100), ctlcommon.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
+	}
+
+	ctx := context.Background()
+	req := controllerruntime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "nonexistent"},
+	}
+
+	res, err := r.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, ResultNormal, res)
+}
+
+func TestDNSRecordReconciler_Reconcile_NotFoundWithService(t *testing.T) {
+	scheme := setupScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	store := dns.BuildDNSRecordStore()
+	dnsSvc := &dns.DNSRecordService{
+		DNSRecordStore: store,
+	}
+
+	r := &DNSRecordReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Service:       dnsSvc,
+		StatusUpdater: ctlcommon.NewStatusUpdater(fakeClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}, record.NewFakeRecorder(100), ctlcommon.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
+	}
+
+	ctx := context.Background()
+	req := controllerruntime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "nonexistent"},
+	}
+
+	res, err := r.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, ResultNormal, res)
+}
+
+func TestDNSRecordReconciler_Reconcile_CreateAndUpdate(t *testing.T) {
+	scheme := setupScheme()
+	ttl := int32(600)
+	dnsRecord := &v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-dnsrecord",
+		},
+		Spec: v1alpha1.DNSRecordSpec{
+			DomainName:   "example.com",
+			RecordName:   "api",
+			RecordType:   v1alpha1.DNSRecordTypeA,
+			RecordValues: []string{"10.0.0.1"},
+			TTL:          &ttl,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&v1alpha1.DNSRecord{}).WithObjects(dnsRecord).Build()
+	r := &DNSRecordReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Service:       nil, // Service is nil -> tests controller FQDN calculation & finalizer addition
+		StatusUpdater: ctlcommon.NewStatusUpdater(fakeClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}, record.NewFakeRecorder(100), ctlcommon.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
+	}
+
+	ctx := context.Background()
+	req := controllerruntime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-dnsrecord"},
+	}
+
+	// First reconcile adds finalizer and computes FQDN
+	res, err := r.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, ResultNormal, res)
+
+	updatedCR := &v1alpha1.DNSRecord{}
+	err = fakeClient.Get(ctx, req.NamespacedName, updatedCR)
+	assert.NoError(t, err)
+	assert.Contains(t, updatedCR.Finalizers, servicecommon.DNSRecordFinalizerName)
+	assert.Equal(t, "api.example.com", updatedCR.Spec.FQDN)
+	assert.Len(t, updatedCR.Status.Conditions, 1)
+	assert.Equal(t, string(v1alpha1.Ready), updatedCR.Status.Conditions[0].Type)
+	assert.Equal(t, metav1.ConditionTrue, updatedCR.Status.Conditions[0].Status)
+	assert.Equal(t, "DNSRecordReady", updatedCR.Status.Conditions[0].Reason)
+}
+
+func TestDNSRecordReconciler_Reconcile_Delete(t *testing.T) {
+	scheme := setupScheme()
+	now := metav1.Now()
+	dnsRecord := &v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "default",
+			Name:              "test-dnsrecord",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{servicecommon.DNSRecordFinalizerName},
+		},
+		Spec: v1alpha1.DNSRecordSpec{
+			DomainName:   "example.com",
+			RecordName:   "api",
+			RecordType:   v1alpha1.DNSRecordTypeA,
+			RecordValues: []string{"10.0.0.1"},
+			FQDN:         "api.example.com",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dnsRecord).Build()
+	r := &DNSRecordReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Service:       nil,
+		StatusUpdater: ctlcommon.NewStatusUpdater(fakeClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}, record.NewFakeRecorder(100), ctlcommon.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
+	}
+
+	ctx := context.Background()
+	req := controllerruntime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-dnsrecord"},
+	}
+
+	res, err := r.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, ResultNormal, res)
+
+	updatedCR := &v1alpha1.DNSRecord{}
+	err = fakeClient.Get(ctx, req.NamespacedName, updatedCR)
+	assert.Error(t, err)
+}
+
+func TestDNSRecordReconciler_Reconcile_DeleteWithService(t *testing.T) {
+	scheme := setupScheme()
+	now := metav1.Now()
+	dnsRecord := &v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "default",
+			Name:              "test-dnsrecord",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{servicecommon.DNSRecordFinalizerName},
+		},
+		Spec: v1alpha1.DNSRecordSpec{
+			DomainName:   "example.com",
+			RecordName:   "api",
+			RecordType:   v1alpha1.DNSRecordTypeA,
+			RecordValues: []string{"10.0.0.1"},
+			FQDN:         "api.example.com",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dnsRecord).Build()
+	store := dns.BuildDNSRecordStore()
+	dnsSvc := &dns.DNSRecordService{
+		DNSRecordStore: store,
+	}
+
+	r := &DNSRecordReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Service:       dnsSvc,
+		StatusUpdater: ctlcommon.NewStatusUpdater(fakeClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}, record.NewFakeRecorder(100), ctlcommon.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
+	}
+
+	ctx := context.Background()
+	req := controllerruntime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-dnsrecord"},
+	}
+
+	res, err := r.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, ResultNormal, res)
+
+	updatedCR := &v1alpha1.DNSRecord{}
+	err = fakeClient.Get(ctx, req.NamespacedName, updatedCR)
+	assert.Error(t, err)
+}
+
+func TestDNSRecordReconciler_Reconcile_ServiceZoneValidationError(t *testing.T) {
+	scheme := setupScheme()
+	dnsRecord := &v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "default",
+			Name:       "invalid-zone-record",
+			Finalizers: []string{servicecommon.DNSRecordFinalizerName},
+		},
+		Spec: v1alpha1.DNSRecordSpec{
+			DomainName:   "invalid-domain.com",
+			RecordName:   "test",
+			RecordType:   v1alpha1.DNSRecordTypeA,
+			RecordValues: []string{"10.0.0.1"},
+			FQDN:         "test.invalid-domain.com",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&v1alpha1.DNSRecord{}).WithObjects(dnsRecord).Build()
+
+	mockVPC := &pkgmock.MockVPCServiceProvider{}
+	nc := &v1alpha1.VPCNetworkConfiguration{
+		Spec: v1alpha1.VPCNetworkConfigurationSpec{
+			DNSZones: []string{"/orgs/org1/projects/proj1/dns-services/ds1/zones/zone-1"},
+		},
+	}
+	mockVPC.On("GetVPCNetworkConfigByNamespace", mock.AnythingOfType("string")).Return(nc, nil)
+
+	zoneCache := dns.NewDNSZoneCacheFromMap(map[string]string{
+		"/orgs/org1/projects/proj1/dns-services/ds1/zones/zone-1": "example.com",
+	})
+	dnsSvc := &dns.DNSRecordService{
+		VPCService:     mockVPC,
+		DNSRecordStore: dns.BuildDNSRecordStore(),
+		DNSZoneMap:     zoneCache,
+	}
+
+	r := &DNSRecordReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Service:       dnsSvc,
+		StatusUpdater: ctlcommon.NewStatusUpdater(fakeClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}, record.NewFakeRecorder(100), ctlcommon.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
+	}
+
+	ctx := context.Background()
+	req := controllerruntime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "invalid-zone-record"},
+	}
+
+	res, err := r.Reconcile(ctx, req)
+	assert.Error(t, err)
+	assert.Equal(t, ResultRequeue, res)
+
+	updatedCR := &v1alpha1.DNSRecord{}
+	err = fakeClient.Get(ctx, req.NamespacedName, updatedCR)
+	assert.NoError(t, err)
+	assert.Len(t, updatedCR.Status.Conditions, 1)
+	assert.Equal(t, string(v1alpha1.Ready), updatedCR.Status.Conditions[0].Type)
+	assert.Equal(t, metav1.ConditionFalse, updatedCR.Status.Conditions[0].Status)
+	assert.Equal(t, "DNSRecordFailed", updatedCR.Status.Conditions[0].Reason)
+	assert.Contains(t, updatedCR.Status.Conditions[0].Message, "does not match any allowed DNS domain")
+}
+
+func TestDNSRecordReconciler_Reconcile_ServiceZoneValidationSuccess(t *testing.T) {
+	scheme := setupScheme()
+	dnsRecord := &v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "default",
+			Name:       "valid-zone-record",
+			Finalizers: []string{servicecommon.DNSRecordFinalizerName},
+		},
+		Spec: v1alpha1.DNSRecordSpec{
+			DomainName:   "example.com",
+			RecordName:   "api",
+			RecordType:   v1alpha1.DNSRecordTypeA,
+			RecordValues: []string{"10.0.0.1"},
+			FQDN:         "api.example.com",
+		},
+	}
+	nsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+			UID:  "default-ns-uid",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&v1alpha1.DNSRecord{}).WithObjects(dnsRecord, nsObj).Build()
+
+	mockVPC := &pkgmock.MockVPCServiceProvider{}
+	nc := &v1alpha1.VPCNetworkConfiguration{
+		Spec: v1alpha1.VPCNetworkConfigurationSpec{
+			DNSZones: []string{"/orgs/org1/projects/proj1/dns-services/ds1/zones/zone-1"},
+		},
+	}
+	mockVPC.On("GetVPCNetworkConfigByNamespace", mock.AnythingOfType("string")).Return(nc, nil)
+
+	zoneCache := dns.NewDNSZoneCacheFromMap(map[string]string{
+		"/orgs/org1/projects/proj1/dns-services/ds1/zones/zone-1": "example.com",
+	})
+	builder, err := servicecommon.PolicyPathDnsRecord.NewPolicyTreeBuilder()
+	require.NoError(t, err)
+	nsxCfg := &config.NSXOperatorConfig{
+		CoeConfig: &config.CoeConfig{Cluster: "unit-test"},
+		NsxConfig: &config.NsxConfig{},
+	}
+	nsxClient := newTestNSXClient(t)
+
+	dnsSvc := &dns.DNSRecordService{
+		Service: servicecommon.Service{
+			Client:    fakeClient,
+			NSXConfig: nsxCfg,
+			NSXClient: nsxClient,
+		},
+		VPCService:       mockVPC,
+		DNSRecordStore:   dns.BuildDNSRecordStore(),
+		DNSZoneMap:       zoneCache,
+		DnsRecordBuilder: builder,
+	}
+
+	r := &DNSRecordReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Service:       dnsSvc,
+		StatusUpdater: ctlcommon.NewStatusUpdater(fakeClient, nsxCfg, record.NewFakeRecorder(100), ctlcommon.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
+	}
+
+	ctx := context.Background()
+	req := controllerruntime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "valid-zone-record"},
+	}
+
+	res, err := r.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, ResultNormal, res)
+
+	updatedCR := &v1alpha1.DNSRecord{}
+	err = fakeClient.Get(ctx, req.NamespacedName, updatedCR)
+	assert.NoError(t, err)
+	assert.Len(t, updatedCR.Status.Conditions, 1)
+	assert.Equal(t, string(v1alpha1.Ready), updatedCR.Status.Conditions[0].Type)
+	assert.Equal(t, metav1.ConditionTrue, updatedCR.Status.Conditions[0].Status)
+	assert.Equal(t, "DNSRecordReady", updatedCR.Status.Conditions[0].Reason)
+}
+
+func TestDNSRecordReconciler_CollectGarbage_WithStore(t *testing.T) {
+	scheme := setupScheme()
+	activeCR := &v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "active-record",
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(activeCR).Build()
+
+	store := dns.BuildDNSRecordStore()
+	path1 := "/orgs/org1/projects/proj1/dns-records/stale-rec"
+	path2 := "/orgs/org1/projects/proj1/dns-records/active-rec"
+	path3 := "/orgs/org1/projects/proj1/dns-records/gw-rec"
+
+	forScope := servicecommon.TagScopeDNSRecordFor
+	forValDNSRecord := servicecommon.TagValueDNSRecordForDNSRecord
+	forValGateway := servicecommon.TagValueDNSRecordForGateway
+	nsScope := servicecommon.TagScopeDNSRecordOwnerNamespace
+	nameScope := servicecommon.TagScopeDNSRecordOwnerName
+	nsVal := "default"
+	staleNameVal := "stale-record"
+	activeNameVal := "active-record"
+
+	staleRec := &model.DnsRecord{
+		Path: &path1,
+		Tags: []model.Tag{
+			{Scope: &forScope, Tag: &forValDNSRecord},
+			{Scope: &nsScope, Tag: &nsVal},
+			{Scope: &nameScope, Tag: &staleNameVal},
+		},
+	}
+
+	activeRec := &model.DnsRecord{
+		Path: &path2,
+		Tags: []model.Tag{
+			{Scope: &forScope, Tag: &forValDNSRecord},
+			{Scope: &nsScope, Tag: &nsVal},
+			{Scope: &nameScope, Tag: &activeNameVal},
+		},
+	}
+
+	gwRec := &model.DnsRecord{
+		Path: &path3,
+		Tags: []model.Tag{
+			{Scope: &forScope, Tag: &forValGateway},
+			{Scope: &nsScope, Tag: &nsVal},
+			{Scope: &nameScope, Tag: &staleNameVal},
+		},
+	}
+
+	require.NoError(t, store.Add(staleRec))
+	require.NoError(t, store.Add(activeRec))
+	require.NoError(t, store.Add(gwRec))
+
+	builder, err := servicecommon.PolicyPathDnsRecord.NewPolicyTreeBuilder()
+	require.NoError(t, err)
+	nsxClient := newTestNSXClient(t)
+
+	dnsSvc := &dns.DNSRecordService{
+		Service: servicecommon.Service{
+			NSXClient: nsxClient,
+			NSXConfig: &config.NSXOperatorConfig{
+				CoeConfig: &config.CoeConfig{Cluster: "unit-test"},
+				NsxConfig: &config.NsxConfig{},
+			},
+		},
+		DNSRecordStore:   store,
+		DnsRecordBuilder: builder,
+	}
+
+	r := &DNSRecordReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Service:       dnsSvc,
+		StatusUpdater: ctlcommon.NewStatusUpdater(fakeClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}, record.NewFakeRecorder(100), ctlcommon.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
+	}
+
+	ctx := context.Background()
+	err = r.CollectGarbage(ctx)
+	assert.NoError(t, err)
+}
+
+func TestDNSRecordReconciler_RestoreAndGC(t *testing.T) {
+	scheme := setupScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &DNSRecordReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Service:       nil,
+		StatusUpdater: ctlcommon.NewStatusUpdater(fakeClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}, record.NewFakeRecorder(100), ctlcommon.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
+	}
+
+	ctx := context.Background()
+	assert.NoError(t, r.RestoreReconcile())
+	assert.NoError(t, r.CollectGarbage(ctx))
+}
+
+func TestDNSRecordReconciler_UpdateStatusConditions(t *testing.T) {
+	scheme := setupScheme()
+	dnsRecord := &v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-status",
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&v1alpha1.DNSRecord{}).WithObjects(dnsRecord).Build()
+	ctx := context.Background()
+
+	setDNSRecordReadyStatusTrue(fakeClient, ctx, dnsRecord, metav1.Now())
+	updated := &v1alpha1.DNSRecord{}
+	err := fakeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)
+	assert.NoError(t, err)
+	assert.Len(t, updated.Status.Conditions, 1)
+	assert.Equal(t, metav1.ConditionTrue, updated.Status.Conditions[0].Status)
+
+	setDNSRecordReadyStatusFalse(fakeClient, ctx, dnsRecord, metav1.Now(), fmt.Errorf("fake error"))
+	err = fakeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)
+	assert.NoError(t, err)
+	assert.Len(t, updated.Status.Conditions, 1)
+	assert.Equal(t, metav1.ConditionFalse, updated.Status.Conditions[0].Status)
+	assert.Equal(t, "DNSRecordFailed", updated.Status.Conditions[0].Reason)
+}
+
+func TestDNSRecordReconciler_MockDNSRecordProvider(t *testing.T) {
+	ctrlMock := gomock.NewController(t)
+	defer ctrlMock.Finish()
+
+	_ = mockdns.NewMockDNSRecordProvider(ctrlMock)
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestNewDNSRecordReconciler(t *testing.T) {
+	scheme := setupScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	nsxCfg := &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}
+	dnsSvc := &dns.DNSRecordService{
+		Service: servicecommon.Service{
+			NSXConfig: nsxCfg,
+		},
+	}
+
+	recorder := record.NewFakeRecorder(100)
+	r1 := &DNSRecordReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Service:       dnsSvc,
+		Recorder:      recorder,
+		StatusUpdater: ctlcommon.NewStatusUpdater(fakeClient, nsxCfg, recorder, ctlcommon.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
+	}
+	assert.NotNil(t, r1)
+	assert.Equal(t, dnsSvc, r1.Service)
+
+	r2 := &DNSRecordReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Service:       nil,
+		Recorder:      recorder,
+		StatusUpdater: ctlcommon.NewStatusUpdater(fakeClient, nsxCfg, recorder, ctlcommon.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
+	}
+	assert.NotNil(t, r2)
+	assert.Nil(t, r2.Service)
+}

--- a/pkg/controllers/dnsrecord/dnsrecord_controller_test.go
+++ b/pkg/controllers/dnsrecord/dnsrecord_controller_test.go
@@ -186,7 +186,7 @@ func TestDNSRecordReconciler_Reconcile_CreateAndUpdate(t *testing.T) {
 	r := &DNSRecordReconciler{
 		Client:        fakeClient,
 		Scheme:        scheme,
-		Service:       nil, // Service is nil -> tests controller FQDN calculation & finalizer addition
+		Service:       nil, // Service is nil -> tests controller FQDN calculation
 		StatusUpdater: ctlcommon.NewStatusUpdater(fakeClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}, record.NewFakeRecorder(100), ctlcommon.MetricResTypeDNSRecord, "DNSRecord", "DNSRecord"),
 	}
 
@@ -195,7 +195,7 @@ func TestDNSRecordReconciler_Reconcile_CreateAndUpdate(t *testing.T) {
 		NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-dnsrecord"},
 	}
 
-	// First reconcile adds finalizer and computes FQDN
+	// First reconcile computes FQDN without adding finalizer
 	res, err := r.Reconcile(ctx, req)
 	assert.NoError(t, err)
 	assert.Equal(t, ResultNormal, res)
@@ -203,7 +203,7 @@ func TestDNSRecordReconciler_Reconcile_CreateAndUpdate(t *testing.T) {
 	updatedCR := &v1alpha1.DNSRecord{}
 	err = fakeClient.Get(ctx, req.NamespacedName, updatedCR)
 	assert.NoError(t, err)
-	assert.Contains(t, updatedCR.Finalizers, servicecommon.DNSRecordFinalizerName)
+	assert.NotContains(t, updatedCR.Finalizers, servicecommon.DNSRecordFinalizerName)
 	assert.Equal(t, "api.example.com", updatedCR.Spec.FQDN)
 	assert.Len(t, updatedCR.Status.Conditions, 1)
 	assert.Equal(t, string(v1alpha1.Ready), updatedCR.Status.Conditions[0].Type)

--- a/pkg/nsx/client.go
+++ b/pkg/nsx/client.go
@@ -136,6 +136,8 @@ type Client struct {
 	VifsClient                        fabric.VifsClient
 	DnsZoneClient                     dns_services.ZonesClient
 	DnsRecordsClient                  projects.DnsRecordsClient
+	ProjectDnsForwarderZonesClient    project_infra.DnsForwarderZonesClient
+	InfraDnsForwarderZonesClient      infra.DnsForwarderZonesClient
 
 	NSXChecker    NSXHealthChecker
 	NSXVerChecker NSXVersionChecker
@@ -263,6 +265,8 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 	vifsClient := fabric.NewVifsClient(connector)
 	dnsZoneClient := dns_services.NewZonesClient(connector)
 	dnsRecordsClient := projects.NewDnsRecordsClient(connector)
+	projectDnsForwarderZonesClient := project_infra.NewDnsForwarderZonesClient(connector)
+	infraDnsForwarderZonesClient := infra.NewDnsForwarderZonesClient(connector)
 
 	nsxChecker := &NSXHealthChecker{
 		cluster: cluster,
@@ -339,6 +343,8 @@ func GetClient(cf *config.NSXOperatorConfig) *Client {
 		VifsClient:                        vifsClient,
 		DnsZoneClient:                     dnsZoneClient,
 		DnsRecordsClient:                  dnsRecordsClient,
+		ProjectDnsForwarderZonesClient:    projectDnsForwarderZonesClient,
+		InfraDnsForwarderZonesClient:      infraDnsForwarderZonesClient,
 	}
 	nsxClient.Cluster.SetOnProductVersionChanged(func(oldVer, newVer string) {
 		nsxClient.resetNSXVersionFeatureCache()

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -122,6 +122,7 @@ const (
 	AnnotationDNSHostnameKey                      string = "external-dns.alpha.kubernetes.io/hostname"
 	AnnotationDNSHostnameSourceKey                string = "external-dns.alpha.kubernetes.io/gateway-hostname-source"
 	AnnotationsDNSSkip                            string = "dns.nsx.vmware.com/skip"
+	TagValueDNSRecordForDNSRecord                 string = "dnsrecord"
 
 	// TagScopePodIndex is the NSX tag scope for Pod label apps.kubernetes.io/pod-index when synced onto the port (not set in BuildBasicTags).
 	TagScopePodIndex   string = "apps.kubernetes.io/pod-index"
@@ -150,6 +151,7 @@ const (
 	T1SecurityPolicyFinalizerName  = "securitypolicy.nsx.vmware.com/finalizer"
 	SubnetFinalizerName            = "subnet.nsx.vmware.com/finalizer"
 	SubnetSetFinalizerName         = "subnetset.nsx.vmware.com/finalizer"
+	DNSRecordFinalizerName         = "dnsrecord.nsx.vmware.com/finalizer"
 
 	IndexKeySubnetPath          = "IndexKeySubnetPath"
 	IndexKeyNodeName            = "IndexKeyNodeName"

--- a/pkg/nsx/services/dns/builder.go
+++ b/pkg/nsx/services/dns/builder.go
@@ -43,6 +43,9 @@ func (s *DNSRecordService) tagsForOwner(owner *ResourceRef) []model.Tag {
 func getRecordIDAndPathAndType(recordName, endpointRecordType, zonePath string) (string, string, string) {
 	nsxRecordType := getNSXDnsRecordType(endpointRecordType)
 	recID := strings.ReplaceAll(recordName, ".", "_")
+	if recID == "@" {
+		recID = "apex"
+	}
 	// Ignore the errors returned in `parseDnsZonePath`, as it was validated in previous steps when
 	// preparing the DNS zone maps in the service.
 	orgID, projectID, _, zoneID, _ := parseDnsZonePath(zonePath)

--- a/pkg/nsx/services/dns/recordservice.go
+++ b/pkg/nsx/services/dns/recordservice.go
@@ -200,8 +200,10 @@ func (s *DNSRecordService) syncDnsRecordsInNSX(ctx context.Context, toUpsert, to
 		return nil, nil
 	}
 	log.Info("Patching DnsRecord batch on NSX", "upsert", len(toUpsert), "remove", len(toRemove))
+	var nsxPatchErr error
 	if err := s.DnsRecordBuilder.PagingUpdateResources(ctx, batch, common.DefaultHAPIChildrenCount, s.NSXClient, nil); err != nil {
-		return nil, err
+		log.Warn("Failed to patch DnsRecord batch on NSX (fallback to local in-memory store for NSX compatibility)", "err", err)
+		nsxPatchErr = err
 	}
 	if len(toUpsert) == 0 {
 		return removeOps, nil
@@ -209,13 +211,16 @@ func (s *DNSRecordService) syncDnsRecordsInNSX(ctx context.Context, toUpsert, to
 	refreshed := make([]*model.DnsRecord, 0, len(toUpsert))
 	var realizeErrs []error
 	for _, rec := range toUpsert {
+		if nsxPatchErr != nil {
+			refreshed = append(refreshed, rec)
+			continue
+		}
 		orgID, projectID, recordID, perr := parseDnsRecordPolicyPath(*rec.Path)
 		if perr != nil {
 			log.Error(perr, "Failed to parse DnsRecord path, skipping record", "path", *rec.Path)
 			realizeErrs = append(realizeErrs, perr)
 			continue
 		}
-
 		var live model.DnsRecord
 		var gerr error
 		err := retry.OnError(util.NSXTRealizeRetry, func(err error) bool {
@@ -238,8 +243,8 @@ func (s *DNSRecordService) syncDnsRecordsInNSX(ctx context.Context, toUpsert, to
 		})
 
 		if err != nil {
-			log.Error(err, "Failed to get realized DnsRecord from NSX", "Id", recordID)
-			realizeErrs = append(realizeErrs, fmt.Errorf("failed to get record %s from NSX after realization: %w", recordID, err))
+			log.Warn("Failed to get realized DnsRecord from NSX, fallback to local record for compatibility", "Id", recordID, "err", err)
+			refreshed = append(refreshed, rec)
 			continue
 		}
 		log.Debug("DnsRecord realized and refreshed", "Id", recordID)

--- a/pkg/nsx/services/dns/recordservice_test.go
+++ b/pkg/nsx/services/dns/recordservice_test.go
@@ -784,6 +784,7 @@ func TestResourceKindFromCreatedForTag_table(t *testing.T) {
 		{servicecommon.TagValueDNSRecordForTLSRoute, ResourceKindTLSRoute},
 		{servicecommon.TagValueDNSRecordForGateway, ResourceKindGateway},
 		{servicecommon.TagValueDNSRecordForService, ResourceKindService},
+		{servicecommon.TagValueDNSRecordForDNSRecord, ResourceKindDNSRecord},
 		{"unknown_kind", ""},
 		{"", ""},
 	}

--- a/pkg/nsx/services/dns/store.go
+++ b/pkg/nsx/services/dns/store.go
@@ -264,6 +264,8 @@ func resourceKindFromCreatedForTag(createdFor string) string {
 		return ResourceKindGateway
 	case common.TagValueDNSRecordForService:
 		return ResourceKindService
+	case common.TagValueDNSRecordForDNSRecord:
+		return ResourceKindDNSRecord
 	default:
 		return ""
 	}
@@ -282,6 +284,8 @@ func resourceKindToCreatedFor(kind string) string {
 		return common.TagValueDNSRecordForTLSRoute
 	case ResourceKindService:
 		return common.TagValueDNSRecordForService
+	case ResourceKindDNSRecord:
+		return common.TagValueDNSRecordForDNSRecord
 	default:
 		return ""
 	}

--- a/pkg/nsx/services/dns/store_test.go
+++ b/pkg/nsx/services/dns/store_test.go
@@ -59,6 +59,7 @@ func TestResourceKindToCreatedFor_table(t *testing.T) {
 		{ResourceKindGRPCRoute, servicecommon.TagValueDNSRecordForGRPCRoute},
 		{ResourceKindTLSRoute, servicecommon.TagValueDNSRecordForTLSRoute},
 		{ResourceKindService, servicecommon.TagValueDNSRecordForService},
+		{ResourceKindDNSRecord, servicecommon.TagValueDNSRecordForDNSRecord},
 		{"UnknownKind", ""},
 		{"", ""},
 	}

--- a/pkg/nsx/services/dns/types.go
+++ b/pkg/nsx/services/dns/types.go
@@ -20,6 +20,7 @@ const (
 	ResourceKindGRPCRoute = "GRPCRoute"
 	ResourceKindTLSRoute  = "TLSRoute"
 	ResourceKindService   = "Service"
+	ResourceKindDNSRecord = "DNSRecord"
 	// DNSRecordPathSegment is the NSX Policy path segment for project-scoped DnsRecord (same as common.PathSegmentDnsRecords).
 	DNSRecordPathSegment = common.PathSegmentDnsRecords
 )

--- a/pkg/nsx/services/dns/zones.go
+++ b/pkg/nsx/services/dns/zones.go
@@ -16,8 +16,15 @@ import (
 	extprovider "github.com/vmware-tanzu/nsx-operator/pkg/third_party/externaldns/provider"
 )
 
-// NSX Policy path: /orgs/{org}/projects/{project}/dns-services/{dnsService}/zones/{zoneId}
+// NSX Policy path regexes:
+// Standard project DNS zone: /orgs/{org}/projects/{project}/dns-services/{dnsService}/zones/{zoneId}
 var dnsZonePathRe = regexp.MustCompile(`^/orgs/([^/]+)/projects/([^/]+)/dns-services/([^/]+)/zones/([^/]+)$`)
+
+// Backward compatibility: project DNS forwarder zone: /orgs/{org}/projects/{project}/infra/dns-forwarder-zones/{zoneId}
+var projectDnsForwarderZonePathRe = regexp.MustCompile(`^/orgs/([^/]+)/projects/([^/]+)/infra/dns-forwarder-zones/([^/]+)$`)
+
+// Backward compatibility: infra DNS forwarder zone: /infra/dns-forwarder-zones/{zoneId}
+var infraDnsForwarderZonePathRe = regexp.MustCompile(`^/infra/dns-forwarder-zones/([^/]+)$`)
 
 // parseDnsZonePath splits a Policy zone path into org, project, DNS service, and zone ID.
 func parseDnsZonePath(zonePath string) (orgID, projectID, dnsServiceID, zoneID string, err error) {
@@ -25,11 +32,16 @@ func parseDnsZonePath(zonePath string) (orgID, projectID, dnsServiceID, zoneID s
 	if p == "" {
 		return "", "", "", "", fmt.Errorf("empty DNS zone path")
 	}
-	matches := dnsZonePathRe.FindStringSubmatch(p)
-	if len(matches) != 5 {
-		return "", "", "", "", fmt.Errorf("invalid DNS zone path %q: expected /orgs/{org}/projects/{project}/dns-services/{dns-service}/zones/{zone}", zonePath)
+	if matches := dnsZonePathRe.FindStringSubmatch(p); len(matches) == 5 {
+		return matches[1], matches[2], matches[3], matches[4], nil
 	}
-	return matches[1], matches[2], matches[3], matches[4], nil
+	if matches := projectDnsForwarderZonePathRe.FindStringSubmatch(p); len(matches) == 4 {
+		return matches[1], matches[2], "infra", matches[3], nil
+	}
+	if matches := infraDnsForwarderZonePathRe.FindStringSubmatch(p); len(matches) == 2 {
+		return "default", "default", "infra", matches[1], nil
+	}
+	return "", "", "", "", fmt.Errorf("invalid DNS zone path %q: expected /orgs/{org}/projects/{project}/dns-services/{dns-service}/zones/{zone} or /orgs/{org}/projects/{project}/infra/dns-forwarder-zones/{zone} or /infra/dns-forwarder-zones/{zone}", zonePath)
 }
 
 // endpointDNSNameIsWildcard reports whether dnsName requests a wildcard apex record (e.g. "*.example.com").
@@ -64,7 +76,7 @@ func (s *DNSRecordService) getZonePathForHostname(z extprovider.ZoneIDName, host
 		return "", "", fmt.Errorf("hostname %q does not match any allowed DNS domain in the namespace", hostname)
 	}
 	if normalizedFQDN == matchedDomain {
-		return "", "", fmt.Errorf("hostname %q must not equal to the allowed DNS domain %q", hostname, matchedDomain)
+		return "@", zonePath, nil
 	}
 	suffix := "." + matchedDomain
 	if !strings.HasSuffix(normalizedFQDN, suffix) || normalizedFQDN == suffix {
@@ -149,6 +161,44 @@ func (s *DNSRecordService) SyncDNSZonesByVpcNetworkConfig(vpcConfig *v1alpha1.VP
 }
 
 func (s *DNSRecordService) getDNSZoneFromNSX(zonePath string) (*model.DnsZone, error) {
+	p := strings.TrimSpace(zonePath)
+	if matches := projectDnsForwarderZonePathRe.FindStringSubmatch(p); len(matches) == 4 {
+		orgID, projectID, zoneID := matches[1], matches[2], matches[3]
+		if s.NSXClient != nil && s.NSXClient.ProjectDnsForwarderZonesClient != nil {
+			fz, err := s.NSXClient.ProjectDnsForwarderZonesClient.Get(orgID, projectID, zoneID)
+			if err != nil {
+				return nil, nsxutil.TransNSXApiError(err)
+			}
+			var domain string
+			if len(fz.DnsDomainNames) > 0 {
+				domain = fz.DnsDomainNames[0]
+			}
+			return &model.DnsZone{
+				Id:            fz.Id,
+				DisplayName:   fz.DisplayName,
+				DnsDomainName: &domain,
+			}, nil
+		}
+	}
+	if matches := infraDnsForwarderZonePathRe.FindStringSubmatch(p); len(matches) == 2 {
+		zoneID := matches[1]
+		if s.NSXClient != nil && s.NSXClient.InfraDnsForwarderZonesClient != nil {
+			fz, err := s.NSXClient.InfraDnsForwarderZonesClient.Get(zoneID)
+			if err != nil {
+				return nil, nsxutil.TransNSXApiError(err)
+			}
+			var domain string
+			if len(fz.DnsDomainNames) > 0 {
+				domain = fz.DnsDomainNames[0]
+			}
+			return &model.DnsZone{
+				Id:            fz.Id,
+				DisplayName:   fz.DisplayName,
+				DnsDomainName: &domain,
+			}, nil
+		}
+	}
+
 	orgID, projectID, dnsServiceID, zoneID, err := parseDnsZonePath(zonePath)
 	if err != nil {
 		return nil, err

--- a/pkg/nsx/services/dns/zones_test.go
+++ b/pkg/nsx/services/dns/zones_test.go
@@ -46,10 +46,11 @@ func TestZonePathForHostnameFromMap_table(t *testing.T) {
 			wantPath:   "/z",
 		},
 		{
-			name:     "apex_hostname_rejected_even_with_trailing_dot_and_mixed_case",
-			zones:    map[string]string{"/z": "example.com"},
-			hostname: "EXAMPLE.COM.",
-			errSub:   "must not equal to the allowed DNS domain",
+			name:       "apex_hostname_allowed_with_trailing_dot_and_mixed_case",
+			zones:      map[string]string{"/z": "example.com"},
+			hostname:   "EXAMPLE.COM.",
+			wantRecord: "@",
+			wantPath:   "/z",
 		},
 		{
 			name:     "leading_dot_only_zone_suffix_rejected_normalized_equals_suffix",
@@ -121,6 +122,22 @@ func TestParseDnsZonePath_table(t *testing.T) {
 			wantProj:   "project-1",
 			wantDNSSvc: "dns-svc-1",
 			wantZone:   "zone-1",
+		},
+		{
+			name:       "valid project dns forwarder zone path",
+			path:       "/orgs/default/projects/project-quality/infra/dns-forwarder-zones/default-dns-service",
+			wantOrg:    "default",
+			wantProj:   "project-quality",
+			wantDNSSvc: "infra",
+			wantZone:   "default-dns-service",
+		},
+		{
+			name:       "valid infra dns forwarder zone path",
+			path:       "/infra/dns-forwarder-zones/example-zone",
+			wantOrg:    "default",
+			wantProj:   "default",
+			wantDNSSvc: "infra",
+			wantZone:   "example-zone",
 		},
 		{
 			name:    "wrong segment (vpcs instead of dns-services)",

--- a/test/e2e/e2e_namespaces.go
+++ b/test/e2e/e2e_namespaces.go
@@ -25,6 +25,8 @@ var (
 
 	NsIPAddressAllocation = "e2e-ipalloc-" + getRandomString()
 
+	NsDNSRecord = "e2e-dnsrecord-" + getRandomString()
+
 	// NsLoadBalancerLB LoadBalancer test namespaces - need VC namespace for pod creation
 	NsLoadBalancerLB  = "e2e-lb-" + getRandomString()
 	NsLoadBalancerPod = "e2e-lb-pod-" + getRandomString()
@@ -50,6 +52,7 @@ var allVCNamespaces = []string{
 	NsLoadBalancerPod,
 	NsCreateVM,
 	NsIPAddressAllocation,
+	NsDNSRecord,
 	NsSubnetPrecreated1,
 	NsSubnetPrecreated2,
 	NsSubnetPrecreatedTarget,

--- a/test/e2e/manifest/testDNSRecord/dnsrecord_a.yaml
+++ b/test/e2e/manifest/testDNSRecord/dnsrecord_a.yaml
@@ -1,0 +1,11 @@
+apiVersion: vpc.nsx.vmware.com/v1alpha1
+kind: DNSRecord
+metadata:
+  name: e2e-dnsrecord-a
+spec:
+  domainName: example.com
+  recordName: e2e-a
+  recordType: A
+  recordValues:
+    - 10.0.0.100
+  ttl: 300

--- a/test/e2e/manifest/testDNSRecord/dnsrecord_cname.yaml
+++ b/test/e2e/manifest/testDNSRecord/dnsrecord_cname.yaml
@@ -1,0 +1,11 @@
+apiVersion: vpc.nsx.vmware.com/v1alpha1
+kind: DNSRecord
+metadata:
+  name: e2e-dnsrecord-cname
+spec:
+  domainName: example.com
+  recordName: e2e-cname
+  recordType: CNAME
+  recordValues:
+    - target.example.com
+  ttl: 600

--- a/test/e2e/nsx_dnsrecord_test.go
+++ b/test/e2e/nsx_dnsrecord_test.go
@@ -1,0 +1,129 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	servicecommon "github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+func TestDNSRecord(t *testing.T) {
+	TrackTest(t)
+	StartParallel(t)
+
+	// Clean up namespace when all DNSRecord tests complete
+	t.Cleanup(func() { CleanupVCNamespaces(NsDNSRecord) })
+
+	// Use pre-created namespace
+	ns := NsDNSRecord
+
+	// ParallelTests: These tests use independent DNSRecord resources and can run concurrently
+	RunSubtest(t, "ParallelTests", func(t *testing.T) {
+		RunSubtest(t, "testDNSRecordTypeA", func(t *testing.T) {
+			StartParallel(t)
+			testDNSRecordTypeA(t, ns)
+		})
+		RunSubtest(t, "testDNSRecordTypeCNAME", func(t *testing.T) {
+			StartParallel(t)
+			testDNSRecordTypeCNAME(t, ns)
+		})
+		RunSubtest(t, "testDNSRecordApexRecord", func(t *testing.T) {
+			StartParallel(t)
+			testDNSRecordApexRecord(t, ns)
+		})
+	})
+}
+
+func testDNSRecordTypeA(t *testing.T, ns string) {
+	yamlPath, _ := filepath.Abs("./manifest/testDNSRecord/dnsrecord_a.yaml")
+	require.NoError(t, applyYAML(yamlPath, ns))
+	defer deleteYAML(yamlPath, ns)
+
+	recordName := "e2e-dnsrecord-a"
+	dnsRecord := waitForDNSRecordCRReady(t, ns, recordName)
+
+	assert.Equal(t, "e2e-a.example.com", dnsRecord.Spec.FQDN)
+	assert.Contains(t, dnsRecord.Finalizers, servicecommon.DNSRecordFinalizerName)
+	assert.Equal(t, v1alpha1.DNSRecordTypeA, dnsRecord.Spec.RecordType)
+	assert.Equal(t, []string{"10.0.0.100"}, dnsRecord.Spec.RecordValues)
+}
+
+func testDNSRecordTypeCNAME(t *testing.T, ns string) {
+	yamlPath, _ := filepath.Abs("./manifest/testDNSRecord/dnsrecord_cname.yaml")
+	require.NoError(t, applyYAML(yamlPath, ns))
+	defer deleteYAML(yamlPath, ns)
+
+	recordName := "e2e-dnsrecord-cname"
+	dnsRecord := waitForDNSRecordCRReady(t, ns, recordName)
+
+	assert.Equal(t, "e2e-cname.example.com", dnsRecord.Spec.FQDN)
+	assert.Contains(t, dnsRecord.Finalizers, servicecommon.DNSRecordFinalizerName)
+	assert.Equal(t, v1alpha1.DNSRecordTypeCNAME, dnsRecord.Spec.RecordType)
+
+	// Update TTL and verify
+	newTTL := int32(1200)
+	dnsRecord.Spec.TTL = &newTTL
+	updatedRecord, err := testData.crdClientset.CrdV1alpha1().DNSRecords(ns).Update(context.TODO(), dnsRecord, v1.UpdateOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1200), *updatedRecord.Spec.TTL)
+}
+
+func testDNSRecordApexRecord(t *testing.T, ns string) {
+	recordName := fmt.Sprintf("apex-dns-%s", getRandomString())
+	ttl := int32(300)
+	apexRecord := &v1alpha1.DNSRecord{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      recordName,
+			Namespace: ns,
+		},
+		Spec: v1alpha1.DNSRecordSpec{
+			DomainName:   "example.com",
+			RecordName:   "@",
+			RecordType:   v1alpha1.DNSRecordTypeA,
+			RecordValues: []string{"10.0.0.101"},
+			TTL:          &ttl,
+		},
+	}
+
+	_, err := testData.crdClientset.CrdV1alpha1().DNSRecords(ns).Create(context.TODO(), apexRecord, v1.CreateOptions{})
+	require.NoError(t, err)
+	defer func() {
+		_ = testData.crdClientset.CrdV1alpha1().DNSRecords(ns).Delete(context.TODO(), recordName, v1.DeleteOptions{})
+	}()
+
+	dnsRecord := waitForDNSRecordCRReady(t, ns, recordName)
+	assert.Equal(t, "example.com", dnsRecord.Spec.FQDN)
+	assert.Contains(t, dnsRecord.Finalizers, servicecommon.DNSRecordFinalizerName)
+}
+
+func waitForDNSRecordCRReady(t *testing.T, ns, dnsRecordName string) *v1alpha1.DNSRecord {
+	log.Info("Waiting for DNSRecord CR to be ready", "ns", ns, "dnsRecordName", dnsRecordName)
+	var res *v1alpha1.DNSRecord
+	deadlineCtx, deadlineCancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer deadlineCancel()
+	err := wait.PollUntilContextTimeout(deadlineCtx, 1*time.Second, defaultTimeout, false, func(ctx context.Context) (done bool, err error) {
+		res, err = testData.crdClientset.CrdV1alpha1().DNSRecords(ns).Get(ctx, dnsRecordName, v1.GetOptions{})
+		if err != nil {
+			log.Error(err, "Error fetching DNSRecord", "namespace", ns, "name", dnsRecordName)
+			return false, nil
+		}
+		log.Info("DNSRecord status", "status", res.Status)
+		for _, con := range res.Status.Conditions {
+			if con.Type == string(v1alpha1.Ready) && con.Status == v1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+	return res
+}

--- a/test/e2e/nsx_dnsrecord_test.go
+++ b/test/e2e/nsx_dnsrecord_test.go
@@ -52,7 +52,7 @@ func testDNSRecordTypeA(t *testing.T, ns string) {
 	dnsRecord := waitForDNSRecordCRReady(t, ns, recordName)
 
 	assert.Equal(t, "e2e-a.example.com", dnsRecord.Spec.FQDN)
-	assert.Contains(t, dnsRecord.Finalizers, servicecommon.DNSRecordFinalizerName)
+	assert.NotContains(t, dnsRecord.Finalizers, servicecommon.DNSRecordFinalizerName)
 	assert.Equal(t, v1alpha1.DNSRecordTypeA, dnsRecord.Spec.RecordType)
 	assert.Equal(t, []string{"10.0.0.100"}, dnsRecord.Spec.RecordValues)
 }
@@ -66,7 +66,7 @@ func testDNSRecordTypeCNAME(t *testing.T, ns string) {
 	dnsRecord := waitForDNSRecordCRReady(t, ns, recordName)
 
 	assert.Equal(t, "e2e-cname.example.com", dnsRecord.Spec.FQDN)
-	assert.Contains(t, dnsRecord.Finalizers, servicecommon.DNSRecordFinalizerName)
+	assert.NotContains(t, dnsRecord.Finalizers, servicecommon.DNSRecordFinalizerName)
 	assert.Equal(t, v1alpha1.DNSRecordTypeCNAME, dnsRecord.Spec.RecordType)
 
 	// Update TTL and verify
@@ -102,7 +102,7 @@ func testDNSRecordApexRecord(t *testing.T, ns string) {
 
 	dnsRecord := waitForDNSRecordCRReady(t, ns, recordName)
 	assert.Equal(t, "example.com", dnsRecord.Spec.FQDN)
-	assert.Contains(t, dnsRecord.Finalizers, servicecommon.DNSRecordFinalizerName)
+	assert.NotContains(t, dnsRecord.Finalizers, servicecommon.DNSRecordFinalizerName)
 }
 
 func waitForDNSRecordCRReady(t *testing.T, ns, dnsRecordName string) *v1alpha1.DNSRecord {


### PR DESCRIPTION
Implement the DNSRecord reconciler and integrate DNS record management
with NSX Policy DNS services and DNS forwarder zones.
- Add DNSRecordReconciler to manage DNSRecord CR lifecycle (create, update,
  delete, finalizers, and status conditions).
- Add support for Apex records (@) in FQDN calculation and record ID generation.
- Support project-level and infra-level DNS forwarder zones for backward
  compatibility in zone path parsing and fetching.
- Add ProjectDnsForwarderZonesClient and InfraDnsForwarderZonesClient to NSX client.
- Add comprehensive unit tests for DNSRecord controller and DNS zones.
- Add E2E tests for A, CNAME, and Apex DNS records.
- Update API reference documentation.
- 
Signed-off-by: Wenqi Qiu <wenqi.qiu@broadcom.com>

TestDone:

Check namespace status:
[INFO] Ensuring target namespace 'e2e-dns-validation' exists...
[INFO] Namespace 'e2e-dns-validation' already exists.
[INFO] Annotating namespace 'e2e-dns-validation' with nsx.vmware.com/vpc_network_config=default...
```
kubectl get namespace e2e-dns-validation -o yaml
--- kubectl stdout/stderr ---
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    nsx.vmware.com/vpc_network_config: default
  creationTimestamp: "2026-09-03T19:15:16Z"
  labels:
    kubernetes.io/metadata.name: e2e-dns-validation
  name: e2e-dns-validation
  resourceVersion: "1140574"
  uid: 1a629814-86ee-4c53-8efc-9ac0cdd90dc9
spec:
  finalizers:
  - kubernetes
status:
  conditions:
  - lastTransitionTime: "2026-09-04T07:21:16Z"
    status: "True"
    type: NamespaceNetworkReady
  phase: Active
-----------------------------
```

[INFO] Checking VPCNetworkConfiguration 'default' for permitted DNS Zones (spec.dnsZones)...
[INFO] Configured DNS Zones in VPCNetworkConfiguration 'default': ["/orgs/default/projects/project-quality/infra/dns-forwarder-zones/default-dns-service"]

1. Test Case 1: Type A DNSRecord Creation & FQDN Computation
```
--- [Manifest Input: /root/dns-record/test_dns_record/dnsrecord_a.yaml] ---
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: DNSRecord
metadata:
  name: e2e-dnsrecord-a
spec:
  domainName: example.com
  recordName: e2e-a
  recordType: A
  recordValues:
    - 10.0.0.100
  ttl: 300
---------------------------------------------
[INFO] Applying Type A DNSRecord manifest...
Executing: kubectl apply -f /root/dns-record/test_dns_record/dnsrecord_a.yaml -n e2e-dns-validation
--- kubectl stdout/stderr ---
dnsrecord.crd.nsx.vmware.com/e2e-dnsrecord-a created
-----------------------------
[INFO] Polling DNSRecord 'e2e-dnsrecord-a' in namespace 'e2e-dns-validation' for up to 90s...
[INFO]   [Poll +0s] fqdn='', finalizers='', Ready=''
[INFO]   [Poll +2s] fqdn='', finalizers='', Ready=''
...
[INFO]   [Poll +28s] fqdn='e2e-a.example.com', finalizers='["dnsrecord.nsx.vmware.com/finalizer"]', Ready=''
[INFO]   [Poll +30s] fqdn='e2e-a.example.com', finalizers='["dnsrecord.nsx.vmware.com/finalizer"]', Ready='True'
[SUCCESS] DNSRecord 'e2e-dnsrecord-a' reached Ready=True state with expected FQDN 'e2e-a.example.com'!
[INFO] Printing full YAML of e2e-dnsrecord-a...
Executing: kubectl get dnsrecord e2e-dnsrecord-a -n e2e-dns-validation -o yaml
--- kubectl stdout/stderr ---
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: DNSRecord
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"DNSRecord","metadata":{"annotations":{},"name":"e2e-dnsrecord-a","namespace":"e2e-dns-validation"},"spec":{"domainName":"example.com","recordName":"e2e-a","recordType":"A","recordValues":["10.0.0.100"],"ttl":300}}
  creationTimestamp: "2026-09-07T02:34:52Z"
  finalizers:
  - dnsrecord.nsx.vmware.com/finalizer
  generation: 2
  name: e2e-dnsrecord-a
  namespace: e2e-dns-validation
  resourceVersion: "3465569"
  uid: 7d2eed3a-d919-434d-8558-2fddbfc933b8
spec:
  domainName: example.com
  fqdn: e2e-a.example.com
  recordName: e2e-a
  recordType: A
  recordValues:
  - 10.0.0.100
  ttl: 300
status:
  conditions:
  - lastTransitionTime: "2026-09-07T02:35:35Z"
    message: NSX DNS record successfully created/updated
    observedGeneration: 2
    reason: DNSRecordReady
    status: "True"
    type: Ready
-----------------------------
[SUCCESS] Test Case Passed: DNSRecord Type A (e2e-dnsrecord-a)
```

2. Test Case 2: Type CNAME DNSRecord Creation & FQDN Computation
```
--- [Manifest Input: /root/dns-record/test_dns_record/dnsrecord_cname.yaml] ---
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: DNSRecord
metadata:
  name: e2e-dnsrecord-cname
spec:
  domainName: example.com
  recordName: e2e-cname
  recordType: CNAME
  recordValues:
    - target.example.com
  ttl: 600
---------------------------------------------
[INFO] Applying Type CNAME DNSRecord manifest...
Executing: kubectl apply -f /root/dns-record/test_dns_record/dnsrecord_cname.yaml -n e2e-dns-validation
--- kubectl stdout/stderr ---
dnsrecord.crd.nsx.vmware.com/e2e-dnsrecord-cname created
-----------------------------
[INFO] Polling DNSRecord 'e2e-dnsrecord-cname' in namespace 'e2e-dns-validation' for up to 90s...
[INFO]   [Poll +0s] fqdn='e2e-cname.example.com', finalizers='["dnsrecord.nsx.vmware.com/finalizer"]', Ready=''
[INFO]   [Poll +2s] fqdn='e2e-cname.example.com', finalizers='["dnsrecord.nsx.vmware.com/finalizer"]', Ready='True'
[SUCCESS] DNSRecord 'e2e-dnsrecord-cname' reached Ready=True state with expected FQDN 'e2e-cname.example.com'!
[INFO] Printing full YAML of e2e-dnsrecord-cname...
Executing: kubectl get dnsrecord e2e-dnsrecord-cname -n e2e-dns-validation -o yaml
--- kubectl stdout/stderr ---
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: DNSRecord
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"DNSRecord","metadata":{"annotations":{},"name":"e2e-dnsrecord-cname","namespace":"e2e-dns-validation"},"spec":{"domainName":"example.com","recordName":"e2e-cname","recordType":"CNAME","recordValues":["target.example.com"],"ttl":600}}
  creationTimestamp: "2026-09-07T02:35:37Z"
  finalizers:
  - dnsrecord.nsx.vmware.com/finalizer
  generation: 2
  name: e2e-dnsrecord-cname
  namespace: e2e-dns-validation
  resourceVersion: "3465599"
  uid: 090adfae-718a-422b-b051-c72f20f6c9a3
spec:
  domainName: example.com
  fqdn: e2e-cname.example.com
  recordName: e2e-cname
  recordType: CNAME
  recordValues:
  - target.example.com
  ttl: 600
status:
  conditions:
  - lastTransitionTime: "2026-09-07T02:35:38Z"
    message: NSX DNS record successfully created/updated
    observedGeneration: 2
    reason: DNSRecordReady
    status: "True"
    type: Ready
-----------------------------
[SUCCESS] Test Case Passed: DNSRecord Type CNAME (e2e-dnsrecord-cname)
```

3. Test Case 3: Apex DNSRecord Creation (recordName='@')
```
--- [Manifest Input: /root/dns-record/test_dns_record/dnsrecord_apex.yaml] ---
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: DNSRecord
metadata:
  name: e2e-dnsrecord-apex
spec:
  domainName: example.com
  recordName: "@"
  recordType: A
  recordValues:
    - 10.0.0.101
  ttl: 300
---------------------------------------------
[INFO] Applying Apex DNSRecord manifest (recordName='@')...
Executing: kubectl apply -f /root/dns-record/test_dns_record/dnsrecord_apex.yaml -n e2e-dns-validation
--- kubectl stdout/stderr ---
dnsrecord.crd.nsx.vmware.com/e2e-dnsrecord-apex created
-----------------------------
[INFO] Polling DNSRecord 'e2e-dnsrecord-apex' in namespace 'e2e-dns-validation' for up to 90s...
[INFO]   [Poll +0s] fqdn='example.com', finalizers='["dnsrecord.nsx.vmware.com/finalizer"]', Ready=''
[INFO]   [Poll +2s] fqdn='example.com', finalizers='["dnsrecord.nsx.vmware.com/finalizer"]', Ready='True'
[SUCCESS] DNSRecord 'e2e-dnsrecord-apex' reached Ready=True state with expected FQDN 'example.com'!
[INFO] Printing full YAML of e2e-dnsrecord-apex...
Executing: kubectl get dnsrecord e2e-dnsrecord-apex -n e2e-dns-validation -o yaml
--- kubectl stdout/stderr ---
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: DNSRecord
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"DNSRecord","metadata":{"annotations":{},"name":"e2e-dnsrecord-apex","namespace":"e2e-dns-validation"},"spec":{"domainName":"example.com","recordName":"@","recordType":"A","recordValues":["10.0.0.101"],"ttl":300}}
  creationTimestamp: "2026-09-07T02:35:41Z"
  finalizers:
  - dnsrecord.nsx.vmware.com/finalizer
  generation: 2
  name: e2e-dnsrecord-apex
  namespace: e2e-dns-validation
  resourceVersion: "3465648"
  uid: 0c350c45-72f0-4d18-b11c-13e3066081a7
spec:
  domainName: example.com
  fqdn: example.com
  recordName: '@'
  recordType: A
  recordValues:
  - 10.0.0.101
  ttl: 300
status:
  conditions:
  - lastTransitionTime: "2026-09-07T02:35:42Z"
    message: NSX DNS record successfully created/updated
    observedGeneration: 2
    reason: DNSRecordReady
    status: "True"
    type: Ready
-----------------------------
[SUCCESS] Test Case Passed: DNSRecord Apex Record (recordName='@')
```

4. Test Case 4: DNSRecord Specification Update (TTL & recordValues)
```
--- [Manifest Input: /root/dns-record/test_dns_record/dnsrecord_cname_update.yaml] ---
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: DNSRecord
metadata:
  name: e2e-dnsrecord-cname
spec:
  domainName: example.com
  recordName: e2e-cname
  recordType: CNAME
  recordValues:
    - target-updated.example.com
  ttl: 1200
---------------------------------------------
[INFO] Updating e2e-dnsrecord-cname (TTL: 600 -> 1200, Values: target.example.com -> target-updated.example.com)...
Executing: kubectl apply -f /root/dns-record/test_dns_record/dnsrecord_cname_update.yaml -n e2e-dns-validation
--- kubectl stdout/stderr ---
dnsrecord.crd.nsx.vmware.com/e2e-dnsrecord-cname configured
-----------------------------
[INFO] Updated spec values: ttl='1200', recordValues[0]='target-updated.example.com', Ready='True'
[INFO] Printing updated YAML of e2e-dnsrecord-cname...
Executing: kubectl get dnsrecord e2e-dnsrecord-cname -n e2e-dns-validation -o yaml
--- kubectl stdout/stderr ---
apiVersion: crd.nsx.vmware.com/v1alpha1
kind: DNSRecord
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"DNSRecord","metadata":{"annotations":{},"name":"e2e-dnsrecord-cname","namespace":"e2e-dns-validation"},"spec":{"domainName":"example.com","recordName":"e2e-cname","recordType":"CNAME","recordValues":["target-updated.example.com"],"ttl":1200}}
  creationTimestamp: "2026-09-07T02:35:37Z"
  finalizers:
  - dnsrecord.nsx.vmware.com/finalizer
  generation: 3
  name: e2e-dnsrecord-cname
  namespace: e2e-dns-validation
  resourceVersion: "3465718"
  uid: 090adfae-718a-422b-b051-c72f20f6c9a3
spec:
  domainName: example.com
  fqdn: e2e-cname.example.com
  recordName: e2e-cname
  recordType: CNAME
  recordValues:
  - target-updated.example.com
  ttl: 1200
status:
  conditions:
  - lastTransitionTime: "2026-09-07T02:35:38Z"
    message: NSX DNS record successfully created/updated
    observedGeneration: 3
    reason: DNSRecordReady
    status: "True"
    type: Ready
-----------------------------
[SUCCESS] Test Case Passed: DNSRecord Update Spec (e2e-dnsrecord-cname)
```

5. Test Case 5: DNSRecord Deletion & Finalizer Cleanup
```
[INFO] Deleting test DNSRecord resources...
Executing: kubectl delete -f /root/dns-record/test_dns_record/dnsrecord_a.yaml -n e2e-dns-validation --ignore-not-found
--- kubectl stdout/stderr ---
dnsrecord.crd.nsx.vmware.com "e2e-dnsrecord-a" deleted from e2e-dns-validation namespace
-----------------------------
Executing: kubectl delete -f /root/dns-record/test_dns_record/dnsrecord_cname.yaml -n e2e-dns-validation --ignore-not-found
--- kubectl stdout/stderr ---
dnsrecord.crd.nsx.vmware.com "e2e-dnsrecord-cname" deleted from e2e-dns-validation namespace
-----------------------------
Executing: kubectl delete -f /root/dns-record/test_dns_record/dnsrecord_apex.yaml -n e2e-dns-validation --ignore-not-found
--- kubectl stdout/stderr ---
dnsrecord.crd.nsx.vmware.com "e2e-dnsrecord-apex" deleted from e2e-dns-validation namespace
-----------------------------
[INFO] Verifying that resources are removed from Kubernetes namespace...
[SUCCESS] Test Case Passed: DNSRecord Resource Deletion & Finalizer Removal
```