### PR TITLE
refactor(dns): update DNS annotations for external-dns compatibility

### DIFF
--- a/pkg/controllers/gateway/gateway_dns.go
+++ b/pkg/controllers/gateway/gateway_dns.go
@@ -17,7 +17,7 @@ import (
 	extdns "github.com/vmware-tanzu/nsx-operator/pkg/third_party/externaldns/endpoint"
 )
 
-// parseDNSHostnamesFromAnnotation returns trimmed unique FQDNs from nsx.vmware.com/hostname using the same
+// parseDNSHostnamesFromAnnotation returns trimmed unique FQDNs from external-dns.alpha.kubernetes.io/hostname using the same
 // gateway-hostname-source + hostname annotation path as Gateway direct DNS (comma-separated tokens are supported).
 func parseDNSHostnamesFromAnnotation(annotations map[string]string) []string {
 	if len(annotations) == 0 {

--- a/pkg/controllers/gateway/handlers.go
+++ b/pkg/controllers/gateway/handlers.go
@@ -356,7 +356,7 @@ func predicateNetworkInfoAllowedDNSDomainsChanged() predicate.Predicate {
 	}
 }
 
-// networkInfoToGatewayDNSRequests enqueues Gateways in the NetworkInfo namespace that are managed, have a usable LB IP, and set nsx.vmware.com/hostname.
+// networkInfoToGatewayDNSRequests enqueues Gateways in the NetworkInfo namespace that are managed, have a usable LB IP, and set external-dns.alpha.kubernetes.io/hostname.
 func (r *GatewayReconciler) networkInfoToGatewayDNSRequests(ctx context.Context, obj client.Object) []reconcile.Request {
 	ni, ok := obj.(*v1alpha1.NetworkInfo)
 	if !ok || ni == nil {

--- a/pkg/controllers/service/service_lb_dns.go
+++ b/pkg/controllers/service/service_lb_dns.go
@@ -35,7 +35,7 @@ const (
 	reasonServiceDNSRecordFailed     = "DNSRecordFailed"
 )
 
-// parseDNSHostnamesFromAnnotation returns trimmed unique FQDNs from nsx.vmware.com/hostname using the same
+// parseDNSHostnamesFromAnnotation returns trimmed unique FQDNs from external-dns.alpha.kubernetes.io/hostname using the same
 // gateway-hostname-source + hostname annotation path as Gateway direct DNS (comma-separated tokens are supported).
 func parseDNSHostnamesFromAnnotation(annotations map[string]string) []string {
 	if len(annotations) == 0 {

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -118,9 +118,9 @@ const (
 	TagValueDNSRecordForGRPCRoute       string = "grpcroute"
 	TagValueDNSRecordForTLSRoute        string = "tlsroute"
 	TagValueDNSRecordForService         string = "service"
-	AnnotationDNSHostnameKey            string = "nsx.vmware.com/hostname"
-	AnnotationDNSHostnameSourceKey      string = "nsx.vmware.com/gateway-hostname-source"
-	AnnotationsDNSSkip                  string = "nsx.vmware.com/skip"
+	AnnotationDNSHostnameKey            string = "external-dns.alpha.kubernetes.io/hostname"
+	AnnotationDNSHostnameSourceKey      string = "external-dns.alpha.kubernetes.io/gateway-hostname-source"
+	AnnotationsDNSSkip                  string = "dns.nsx.vmware.com/skip"
 
 	// TagScopePodIndex is the NSX tag scope for Pod label apps.kubernetes.io/pod-index when synced onto the port (not set in BuildBasicTags).
 	TagScopePodIndex   string = "apps.kubernetes.io/pod-index"

--- a/pkg/third_party/externaldns/annotations/hostnames.go
+++ b/pkg/third_party/externaldns/annotations/hostnames.go
@@ -18,7 +18,7 @@ func SplitHostnameAnnotation(input string) []string {
 }
 
 // HostnamesFromAnnotations extracts hostnames from the annotation identified by hostnameKey
-// (e.g. nsx.vmware.com/hostname or external-dns.alpha.kubernetes.io/hostname).
+// (e.g. external-dns.alpha.kubernetes.io/hostname).
 func HostnamesFromAnnotations(input map[string]string, hostnameKey string) []string {
 	if hostnameKey == "" {
 		return nil


### PR DESCRIPTION
To support the secure ingress use case on VDS and ensure a smooth migration path from VDS to NSX VPC in the future, the secure ingress on NSX VPC needs to be compatible with external-dns annotations.

This commit updates the following annotations:
- `nsx.vmware.com/hostname` -> `external-dns.alpha.kubernetes.io/hostname`
- `nsx.vmware.com/gateway-hostname-source` -> `external-dns.alpha.kubernetes.io/gateway-hostname-source`
- `nsx.vmware.com/skip` -> `dns.nsx.vmware.com/skip`