### PR TITLE
refactor: use standard workqueue and default rate limiting

### DIFF
--- a/pkg/controllers/networkinfo/networkinfo_controller.go
+++ b/pkg/controllers/networkinfo/networkinfo_controller.go
@@ -640,11 +640,11 @@ func (r *NetworkInfoReconciler) setupWithManager(mgr ctrl.Manager) error {
 			// For modified network config, currently only support appending ips to private ip blocks,
 			// and modifying the pre-created subnets.
 			&v1alpha1.VPCNetworkConfiguration{},
-			&VPCNetworkConfigurationHandler{
-				Client:              mgr.GetClient(),
-				vpcService:          r.Service,
-				ipBlocksInfoService: r.IPBlocksInfoService,
-			},
+			NewVPCNetworkConfigurationHandler(
+				mgr.GetClient(),
+				r.Service,
+				r.IPBlocksInfoService,
+			),
 			builder.WithPredicates(VPCNetworkConfigurationPredicate)).
 		Watches(
 			&v1alpha1.SubnetSet{},

--- a/pkg/controllers/networkinfo/vpcnetworkconfig_handler.go
+++ b/pkg/controllers/networkinfo/vpcnetworkconfig_handler.go
@@ -3,8 +3,9 @@ package networkinfo
 import (
 	"context"
 	"reflect"
-	"sync"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,79 +23,74 @@ import (
 // - VPC Network Configuration deletion: Delete VPC Network Configuration from cache.
 // - VPC Network Configuration update:	Only support updating external/private ipblocks, update values in cache
 
-type vpcTaskType int
-
-const (
-	vpcTaskUpdate vpcTaskType = iota
-	vpcTaskDelete
-)
-
-const (
-	vpcTaskQueueCapacity = 1000
-)
-
-type vpcTask struct {
-	taskType  vpcTaskType
-	vpcConfig *v1alpha1.VPCNetworkConfiguration
-}
-
 type VPCNetworkConfigurationHandler struct {
 	Client              client.Client
 	vpcService          commontypes.VPCServiceProvider
 	ipBlocksInfoService commontypes.IPBlocksInfoServiceProvider
 
-	initOnce sync.Once
-	taskChan chan vpcTask
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
 }
 
-func (h *VPCNetworkConfigurationHandler) ensureWorker() {
-	h.initOnce.Do(func() {
-		h.taskChan = make(chan vpcTask, vpcTaskQueueCapacity)
-		go h.workerLoop()
-	})
-}
-
-func (h *VPCNetworkConfigurationHandler) enqueueTask(t vpcTask) {
-	h.ensureWorker()
-	select {
-	case h.taskChan <- t:
-	default:
-		log.Error(nil, "VPCNetworkConfiguration task channel full, dropping task", "taskType", t.taskType, "VPCNetworkConfiguration", t.vpcConfig.Name)
+// NewVPCNetworkConfigurationHandler creates a new VPCNetworkConfigurationHandler and starts its worker.
+func NewVPCNetworkConfigurationHandler(client client.Client, vpcService commontypes.VPCServiceProvider, ipBlocksInfoService commontypes.IPBlocksInfoServiceProvider) *VPCNetworkConfigurationHandler {
+	limiter := workqueue.NewTypedItemExponentialFailureRateLimiter[types.NamespacedName](1*time.Second, 30*time.Second)
+	h := &VPCNetworkConfigurationHandler{
+		Client:              client,
+		vpcService:          vpcService,
+		ipBlocksInfoService: ipBlocksInfoService,
+		queue:               workqueue.NewTypedRateLimitingQueue[types.NamespacedName](limiter),
 	}
+	go h.workerLoop()
+	return h
+}
+
+func (h *VPCNetworkConfigurationHandler) enqueueTask(req types.NamespacedName) {
+	h.queue.Add(req)
 }
 
 func (h *VPCNetworkConfigurationHandler) workerLoop() {
-	for t := range h.taskChan {
-		switch t.taskType {
-		case vpcTaskUpdate:
-			if err := h.ipBlocksInfoService.UpdateIPBlocksInfo(context.Background(), t.vpcConfig); err != nil {
-				log.Error(err, "Failed to update the IPBlocksInfo", "VPCNetworkConfiguration", t.vpcConfig.Name)
-			}
-		case vpcTaskDelete:
-			if err := h.ipBlocksInfoService.SyncIPBlocksInfo(context.Background()); err != nil {
-				log.Error(err, "failed to synchronize IPBlocksInfo when deleting", "VPCNetworkConfiguration", t.vpcConfig.Name)
-			} else {
-				h.ipBlocksInfoService.ResetPeriodicSync()
-			}
+	for {
+		req, shutdown := h.queue.Get()
+		if shutdown {
+			return
 		}
+
+		err := h.processTask(req)
+		if err != nil {
+			log.Error(err, "Failed to process VPCNetworkConfiguration task, requeuing", "VPCNetworkConfiguration", req.Name)
+			h.queue.AddRateLimited(req)
+		} else {
+			h.queue.Forget(req)
+		}
+		h.queue.Done(req)
 	}
 }
 
+func (h *VPCNetworkConfigurationHandler) processTask(req types.NamespacedName) error {
+	vpcConfig := &v1alpha1.VPCNetworkConfiguration{}
+	err := h.Client.Get(context.Background(), req, vpcConfig)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// VPCNetworkConfiguration has been deleted
+			if syncErr := h.ipBlocksInfoService.SyncIPBlocksInfo(context.Background()); syncErr != nil {
+				return syncErr
+			}
+			h.ipBlocksInfoService.ResetPeriodicSync()
+			return nil
+		}
+		return err
+	}
+
+	// VPCNetworkConfiguration exists (Create/Update)
+	return h.ipBlocksInfoService.UpdateIPBlocksInfo(context.Background(), vpcConfig)
+}
+
 func (h *VPCNetworkConfigurationHandler) Create(_ context.Context, e event.CreateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	vpcConfigCR := e.Object.(*v1alpha1.VPCNetworkConfiguration)
-	// Enqueue update task to single background worker thread to avoid blocking Informer CacheSync
-	h.enqueueTask(vpcTask{
-		taskType:  vpcTaskUpdate,
-		vpcConfig: vpcConfigCR,
-	})
+	h.enqueueTask(types.NamespacedName{Name: e.Object.GetName(), Namespace: e.Object.GetNamespace()})
 }
 
 func (h *VPCNetworkConfigurationHandler) Delete(_ context.Context, e event.DeleteEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	vpcConfigCR := e.Object.(*v1alpha1.VPCNetworkConfiguration)
-	h.enqueueTask(vpcTask{
-		taskType:  vpcTaskDelete,
-		vpcConfig: vpcConfigCR,
-	})
+	h.enqueueTask(types.NamespacedName{Name: e.Object.GetName(), Namespace: e.Object.GetNamespace()})
 }
 
 func (h *VPCNetworkConfigurationHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -139,10 +135,7 @@ func (h *VPCNetworkConfigurationHandler) Update(ctx context.Context, e event.Upd
 		return
 	}
 
-	h.enqueueTask(vpcTask{
-		taskType:  vpcTaskUpdate,
-		vpcConfig: newNc,
-	})
+	h.enqueueTask(types.NamespacedName{Name: newNc.GetName(), Namespace: newNc.GetNamespace()})
 }
 
 var VPCNetworkConfigurationPredicate = predicate.Funcs{

--- a/pkg/controllers/networkinfo/vpcnetworkconfig_handler_test.go
+++ b/pkg/controllers/networkinfo/vpcnetworkconfig_handler_test.go
@@ -2,11 +2,14 @@ package networkinfo
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/workqueue"
@@ -64,11 +67,7 @@ func createVPCNetworkConfigurationHandler(objs []client.Object) *VPCNetworkConfi
 		SyncTask: nil,
 	}
 
-	return &VPCNetworkConfigurationHandler{
-		Client:              fakeClient,
-		vpcService:          vpcService,
-		ipBlocksInfoService: ipBlocksInfoService,
-	}
+	return NewVPCNetworkConfigurationHandler(fakeClient, vpcService, ipBlocksInfoService)
 }
 
 func TestVPCNetworkConfigurationHandler_Create(t *testing.T) {
@@ -209,5 +208,162 @@ func TestVPCNetworkConfigurationHandler_Generic(t *testing.T) {
 			handler := createVPCNetworkConfigurationHandler(nil)
 			handler.Generic(context.TODO(), event.GenericEvent{Object: tc.vpcNetworkConfig}, queue)
 		})
+	}
+}
+
+type mockIPBlocksInfoService struct {
+	mu          sync.Mutex
+	updatedVPCs []string
+	syncCount   int
+	resetCount  int
+	processed   chan struct{}
+}
+
+func (m *mockIPBlocksInfoService) UpdateIPBlocksInfo(_ context.Context, vpcConfigCR *v1alpha1.VPCNetworkConfiguration) error {
+	m.mu.Lock()
+	m.updatedVPCs = append(m.updatedVPCs, vpcConfigCR.Name)
+	m.mu.Unlock()
+	if m.processed != nil {
+		m.processed <- struct{}{}
+	}
+	return nil
+}
+
+func (m *mockIPBlocksInfoService) SyncIPBlocksInfo(_ context.Context) error {
+	m.mu.Lock()
+	m.syncCount++
+	m.mu.Unlock()
+	if m.processed != nil {
+		m.processed <- struct{}{}
+	}
+	return nil
+}
+
+func (m *mockIPBlocksInfoService) ResetPeriodicSync() {
+	m.mu.Lock()
+	m.resetCount++
+	m.mu.Unlock()
+}
+
+func TestVPCNetworkConfigurationHandler_QueueFIFOAndCompletion(t *testing.T) {
+	const taskCount = 2000
+	mock := &mockIPBlocksInfoService{
+		processed: make(chan struct{}, taskCount),
+	}
+
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+	objs := []client.Object{}
+	for i := 0; i < taskCount; i++ {
+		objs = append(objs, &v1alpha1.VPCNetworkConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("vpc-%d", i)},
+		})
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	handler := NewVPCNetworkConfigurationHandler(fakeClient, nil, mock)
+
+	for i := 0; i < taskCount; i++ {
+		handler.enqueueTask(k8stypes.NamespacedName{Name: fmt.Sprintf("vpc-%d", i)})
+	}
+
+	for i := 0; i < taskCount; i++ {
+		<-mock.processed
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.updatedVPCs) != taskCount {
+		t.Fatalf("expected %d processed tasks, got %d", taskCount, len(mock.updatedVPCs))
+	}
+	for i := 0; i < taskCount; i++ {
+		expectedName := fmt.Sprintf("vpc-%d", i)
+		if mock.updatedVPCs[i] != expectedName {
+			t.Errorf("FIFO violation at index %d: expected %s, got %s", i, expectedName, mock.updatedVPCs[i])
+		}
+	}
+
+	if handler.queue.Len() != 0 {
+		t.Errorf("expected empty tasks slice, got length %d", handler.queue.Len())
+	}
+}
+
+func TestVPCNetworkConfigurationHandler_QueueConcurrentEnqueue(t *testing.T) {
+	const goroutines = 20
+	const tasksPerGoroutine = 100
+	const totalTasks = goroutines * tasksPerGoroutine
+
+	mock := &mockIPBlocksInfoService{
+		processed: make(chan struct{}, totalTasks),
+	}
+
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+	objs := []client.Object{}
+	for g := 0; g < goroutines; g++ {
+		for i := 0; i < tasksPerGoroutine; i++ {
+			objs = append(objs, &v1alpha1.VPCNetworkConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("g%d-vpc-%d", g, i)},
+			})
+		}
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	handler := NewVPCNetworkConfigurationHandler(fakeClient, nil, mock)
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(gID int) {
+			defer wg.Done()
+			for i := 0; i < tasksPerGoroutine; i++ {
+				handler.enqueueTask(k8stypes.NamespacedName{Name: fmt.Sprintf("g%d-vpc-%d", gID, i)})
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	for i := 0; i < totalTasks; i++ {
+		<-mock.processed
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.updatedVPCs) != totalTasks {
+		t.Fatalf("expected %d tasks processed, got %d", totalTasks, len(mock.updatedVPCs))
+	}
+}
+
+func TestVPCNetworkConfigurationHandler_QueueTaskTypes(t *testing.T) {
+	mock := &mockIPBlocksInfoService{
+		processed: make(chan struct{}, 2),
+	}
+
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+	objs := []client.Object{
+		&v1alpha1.VPCNetworkConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-update-vpc"},
+		},
+		// "test-delete-vpc" is NOT added to fakeClient, so Get() will return NotFound
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	handler := NewVPCNetworkConfigurationHandler(fakeClient, nil, mock)
+
+	handler.enqueueTask(k8stypes.NamespacedName{Name: "test-update-vpc"})
+	<-mock.processed
+
+	handler.enqueueTask(k8stypes.NamespacedName{Name: "test-delete-vpc"})
+	<-mock.processed
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.updatedVPCs) != 1 || mock.updatedVPCs[0] != "test-update-vpc" {
+		t.Errorf("unexpected updated VPCs: %v", mock.updatedVPCs)
+	}
+	if mock.syncCount != 1 {
+		t.Errorf("expected syncCount == 1, got %d", mock.syncCount)
+	}
+	if mock.resetCount != 1 {
+		t.Errorf("expected resetCount == 1, got %d", mock.resetCount)
 	}
 }

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnet"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/subnetport"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/vpc"
-	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 	pkgutil "github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
@@ -337,7 +337,7 @@ func TestSubnetPortReconciler_Reconcile(t *testing.T) {
 			return false, nil
 		})
 		defer patchesIsSharedSubnetPath.Reset()
-		err := util.NewRealizeStateError("CreateOrUpdateSubnetPort failed", 0)
+		err := nsxutil.NewRealizeStateError("CreateOrUpdateSubnetPort failed", 0)
 		patchesCreateOrUpdateSubnetPort := gomonkey.ApplyFunc((*subnetport.SubnetPortService).CreateOrUpdateSubnetPort,
 			func(s *subnetport.SubnetPortService, obj interface{}, nsxSubnet *model.VpcSubnet, contextID string, tags *map[string]string, isVmSubnetPort bool, restoreMode bool, interfaceIPType v1alpha1.IPAddressType) (*model.SegmentPortState, error) {
 				return nil, err

--- a/pkg/util/kubernetes.go
+++ b/pkg/util/kubernetes.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -19,33 +17,11 @@ const (
 	localhostIPv6           = "::1"
 	defaultK8sServicePort   = "6443"
 	K8sServicePortEnv       = "KUBERNETES_SERVICE_PORT"
-	K8sClientQPSEnv         = "K8S_CLIENT_QPS"
-	K8sClientBurstEnv       = "K8S_CLIENT_BURST"
 	K8sClientTimeoutEnv     = "K8S_CLIENT_TIMEOUT"
 	CacheSyncTimeoutEnv     = "CACHE_SYNC_TIMEOUT"
-	DefaultK8sClientQPS     = float32(100)
-	DefaultK8sClientBurst   = 200
 	DefaultK8sClientTimeout = 2 * time.Minute
 	DefaultCacheSyncTimeout = 5 * time.Minute
 )
-
-func GetK8sClientQPS() float32 {
-	if val := os.Getenv(K8sClientQPSEnv); val != "" {
-		if qps, err := strconv.ParseFloat(val, 32); err == nil && qps > 0 {
-			return float32(qps)
-		}
-	}
-	return DefaultK8sClientQPS
-}
-
-func GetK8sClientBurst() int {
-	if val := os.Getenv(K8sClientBurstEnv); val != "" {
-		if burst, err := strconv.Atoi(val); err == nil && burst > 0 {
-			return burst
-		}
-	}
-	return DefaultK8sClientBurst
-}
 
 func GetK8sClientTimeout() time.Duration {
 	if val := os.Getenv(K8sClientTimeoutEnv); val != "" {
@@ -67,21 +43,11 @@ func GetCacheSyncTimeout() time.Duration {
 
 func GetConfig() (*rest.Config, error) {
 	cfg := ctrl.GetConfigOrDie()
-	if cfg.QPS <= 0 {
-		cfg.QPS = GetK8sClientQPS()
-	}
-	if cfg.Burst <= 0 {
-		cfg.Burst = GetK8sClientBurst()
-	}
 	if cfg.Timeout <= 0 {
 		cfg.Timeout = GetK8sClientTimeout()
 	}
-
-	if cfg.RateLimiter == nil {
-		cfg.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(cfg.QPS, cfg.Burst)
-	}
-
-	log.Info("Loaded Kubernetes client configuration", "QPS", cfg.QPS, "Burst", cfg.Burst, "Timeout", cfg.Timeout, "CacheSyncTimeout", GetCacheSyncTimeout())
+	cacheSyncTimeout := GetCacheSyncTimeout()
+	log.Info("Loaded Kubernetes client configuration", "QPS", cfg.QPS, "Burst", cfg.Burst, "Timeout", cfg.Timeout, "CacheSyncTimeout", cacheSyncTimeout)
 
 	var healthy bool
 	var getHealthErr error

--- a/pkg/util/kubernetes_test.go
+++ b/pkg/util/kubernetes_test.go
@@ -95,34 +95,23 @@ func TestGetConfig(t *testing.T) {
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, tt.expectedHost, cfg.Host)
-				assert.Equal(t, DefaultK8sClientQPS, cfg.QPS)
-				assert.Equal(t, DefaultK8sClientBurst, cfg.Burst)
 				assert.Equal(t, DefaultK8sClientTimeout, cfg.Timeout)
-				assert.NotNil(t, cfg.RateLimiter)
 			}
 		})
 	}
 }
 
 func TestGetConfigEnvVars(t *testing.T) {
-	t.Setenv(K8sClientQPSEnv, "250.5")
-	t.Setenv(K8sClientBurstEnv, "500")
 	t.Setenv(K8sClientTimeoutEnv, "3m")
 	t.Setenv(CacheSyncTimeoutEnv, "10m")
 
-	assert.Equal(t, float32(250.5), GetK8sClientQPS())
-	assert.Equal(t, 500, GetK8sClientBurst())
 	assert.Equal(t, 3*time.Minute, GetK8sClientTimeout())
 	assert.Equal(t, 10*time.Minute, GetCacheSyncTimeout())
 
 	// Test invalid env vars fallback to defaults
-	t.Setenv(K8sClientQPSEnv, "invalid")
-	t.Setenv(K8sClientBurstEnv, "-1")
 	t.Setenv(K8sClientTimeoutEnv, "invalid")
 	t.Setenv(CacheSyncTimeoutEnv, "invalid")
 
-	assert.Equal(t, DefaultK8sClientQPS, GetK8sClientQPS())
-	assert.Equal(t, DefaultK8sClientBurst, GetK8sClientBurst())
 	assert.Equal(t, DefaultK8sClientTimeout, GetK8sClientTimeout())
 	assert.Equal(t, DefaultCacheSyncTimeout, GetCacheSyncTimeout())
 }


### PR DESCRIPTION
refactor: use standard workqueue and default rate limiting

    This commit refactors the VPCNetworkConfigurationHandler and Kubernetes
    client configuration to use standard libraries and defaults:

    1. Replaced the custom slice-based task queue in VPCNetworkConfigurationHandler
       with client-go's standard workqueue (TypedRateLimitingQueue). This provides
       built-in deduplication and exponential backoff retry mechanisms for failed
       NSX-T API calls, preventing potential memory leaks and ensuring eventual
       consistency.

    2. Removed custom K8S_CLIENT_QPS and K8S_CLIENT_BURST environment variable
       overrides, reverting to client-go's default unlimited rate limiting
       behavior (QPS = -1) to prevent unintended client-side throttling.
       
       
Test done:
test case 1:
run the manager, check the timestamp:
2026-08-19 00:50:26.000 INFO main.go:317 I'm the master now
2026-08-19 00:50:52.000 INFO controller.go:320 Starting workers controller=subnet ...