### PR TITLE
[Cherry-pick] Update CA in nsx-cert secret only when new CA is non-empty (#1502)

### DIFF
--- a/pkg/nsx/services/nsxserviceaccount/cluster.go
+++ b/pkg/nsx/services/nsxserviceaccount/cluster.go
@@ -407,14 +407,14 @@ func (s *NSXServiceAccountService) ValidateAndUpdateRealizedNSXServiceAccount(ct
 	isUpdated := false
 	secret := &v1.Secret{}
 	isCheckCert := s.NSXClient.NSXCheckVersion(nsx.ServiceAccountCertRotation) && obj.Spec.EnableCertRotation
-	if ca != nil || isCheckCert {
+	if len(ca) > 0 || isCheckCert {
 		if err := s.Client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, secret); err != nil {
 			return err
 		}
 	}
 
 	// check CA is up-to-date
-	if ca != nil {
+	if len(ca) > 0 {
 		oldCA := secret.Data[CAName]
 		oldCAPool := x509.NewCertPool()
 		oldCAPool.AppendCertsFromPEM(oldCA)


### PR DESCRIPTION
ca is a []byte, so nil checks miss empty-but-non-nil slices; use len(ca) > 0 to correctly skip CA update in nsx-cert secret when no new CA is provided.

Cherry-pick https://github.com/vmware-tanzu/nsx-operator/commit/300cd34f0e31387e87045938ce1036addc59521c from `main` to `v9.1.1`