### PR TITLE
fix(mixed-mode): ignore namespace on conflicting T1 and VPC annotations

### DIFF
--- a/pkg/config/mixed_mode.go
+++ b/pkg/config/mixed_mode.go
@@ -50,6 +50,19 @@ func hasT1ActivationAnnotation(annotations map[string]string) bool {
 	return false
 }
 
+// resolveNamespaceProvider determines whether a namespace belongs to T1 and/or VPC
+// provider based on its annotations. If both VPC and T1 annotations are present on
+// the same namespace, this is an illegal state; it logs an error and returns (false, false).
+func resolveNamespaceProvider(annotations map[string]string) (isT1 bool, isVPC bool) {
+	hasVPC := strings.TrimSpace(annotations[VPCNetworkConfigAnnotation]) != ""
+	hasT1 := hasT1ActivationAnnotation(annotations)
+	if hasVPC && hasT1 {
+		log.Error(nil, "Conflicting network provider annotations (both T1 and VPC are present); namespace will be ignored")
+		return false, false
+	}
+	return hasT1, hasVPC
+}
+
 var (
 	capabilitiesGVR = schema.GroupVersionResource{
 		Group:    "iaas.vmware.com",
@@ -149,11 +162,12 @@ func scanNamespaceProvidersFromAPI(ctx context.Context, clientset kubernetes.Int
 		list, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 		if err == nil {
 			for _, item := range list.Items {
-				annotations := item.GetAnnotations()
-				if _, ok := annotations[VPCNetworkConfigAnnotation]; ok {
-					hasVPC = true
-				} else if hasT1ActivationAnnotation(annotations) {
+				isT1, isVPC := resolveNamespaceProvider(item.GetAnnotations())
+				if isT1 {
 					hasT1 = true
+				}
+				if isVPC {
+					hasVPC = true
 				}
 				if hasT1 && hasVPC {
 					break
@@ -190,11 +204,12 @@ func scanNamespaceProvidersFromCache(ctx context.Context, reader client.Reader) 
 		return false, false, err
 	}
 	for _, item := range nsList.Items {
-		annotations := item.GetAnnotations()
-		if _, ok := annotations[VPCNetworkConfigAnnotation]; ok {
-			hasVPC = true
-		} else if hasT1ActivationAnnotation(annotations) {
+		isT1, isVPC := resolveNamespaceProvider(item.GetAnnotations())
+		if isT1 {
 			hasT1 = true
+		}
+		if isVPC {
+			hasVPC = true
 		}
 		if hasT1 && hasVPC {
 			break
@@ -299,6 +314,10 @@ func InitMixedMode(ctx context.Context, cfg *rest.Config, enableVPCNetwork bool)
 }
 
 func initMixedModeWithClients(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface, enableVPCNetwork bool) {
+	stateMu.Lock()
+	storedEnableVPCNetwork = enableVPCNetwork
+	stateMu.Unlock()
+
 	// checkPerNamespaceProvidersSupported retries on transient errors; runs outside
 	// the mutex to avoid holding the lock during potentially many retries.
 	supported, _ := checkPerNamespaceProvidersSupported(ctx, dynClient)
@@ -321,7 +340,6 @@ func initMixedModeWithClients(ctx context.Context, clientset kubernetes.Interfac
 	stateMu.Lock()
 	defer stateMu.Unlock()
 	storedClientset = clientset
-	storedEnableVPCNetwork = enableVPCNetwork
 	// The capability can be changed in day2. However, we intentionally do NOT poll or watch this capability during runtime to save API Server overhead.
 	// By design, if it changes from deactivated to activated, an external component will restart the nsx-operator pod; changing from activated to deactivated is not a valid scenario.
 	perNamespaceProvidersSupported = &supported
@@ -425,7 +443,8 @@ func IsPerNamespaceProvidersSupported() bool {
 
 // IsVPCNamespace reports whether ns should be treated as a VPC namespace.
 // In mixed mode (when per-namespace providers are supported), a non-empty
-// VPCNetworkConfigAnnotation marks a VPC namespace.
+// VPCNetworkConfigAnnotation marks a VPC namespace. When both VPC and T1 annotations
+// are present on the namespace, it returns false (illegal conflicting state).
 // In legacy mode (pre-9.2), the whole cluster runs a single provider, so the
 // cluster-level HasVPCNamespaces flag (derived from EnableVPCNetwork) is
 // returned regardless of the namespace.
@@ -436,21 +455,24 @@ func IsVPCNamespace(ns *v1.Namespace) bool {
 		return false
 	}
 	if IsPerNamespaceProvidersSupported() {
-		return strings.TrimSpace(ns.Annotations[VPCNetworkConfigAnnotation]) != ""
+		_, isVPC := resolveNamespaceProvider(ns.Annotations)
+		return isVPC
 	}
 	return HasVPCNamespaces()
 }
 
 // IsT1Namespace reports whether ns should be treated as a T1 namespace.
 // In mixed mode (when per-namespace providers are supported), an explicit T1 activation
-// annotation (nsx.vmware.com/t1_default_config, etc.) marks a T1 namespace.
+// annotation (nsx.vmware.com/t1_default_config, etc.) marks a T1 namespace. When both
+// VPC and T1 annotations are present on the namespace, it returns false (illegal conflicting state).
 // In legacy mode (pre-9.2), the cluster-level HasT1Namespaces flag is returned.
 func IsT1Namespace(ns *v1.Namespace) bool {
 	if ns == nil {
 		return false
 	}
 	if IsPerNamespaceProvidersSupported() {
-		return hasT1ActivationAnnotation(ns.Annotations)
+		isT1, _ := resolveNamespaceProvider(ns.Annotations)
+		return isT1
 	}
 	return HasT1Namespaces()
 }

--- a/pkg/config/mixed_mode.go
+++ b/pkg/config/mixed_mode.go
@@ -53,11 +53,15 @@ func hasT1ActivationAnnotation(annotations map[string]string) bool {
 // resolveNamespaceProvider determines whether a namespace belongs to T1 and/or VPC
 // provider based on its annotations. If both VPC and T1 annotations are present on
 // the same namespace, this is an illegal state; it logs an error and returns (false, false).
-func resolveNamespaceProvider(annotations map[string]string) (isT1 bool, isVPC bool) {
+func resolveNamespaceProvider(nsName string, annotations map[string]string) (isT1 bool, isVPC bool) {
 	hasVPC := strings.TrimSpace(annotations[VPCNetworkConfigAnnotation]) != ""
 	hasT1 := hasT1ActivationAnnotation(annotations)
 	if hasVPC && hasT1 {
-		log.Error(nil, "Conflicting network provider annotations (both T1 and VPC are present); namespace will be ignored")
+		if nsName != "" {
+			log.Error(nil, "Conflicting network provider annotations (both T1 and VPC are present); namespace will be ignored", "namespace", nsName)
+		} else {
+			log.Error(nil, "Conflicting network provider annotations (both T1 and VPC are present); namespace will be ignored")
+		}
 		return false, false
 	}
 	return hasT1, hasVPC
@@ -162,7 +166,7 @@ func scanNamespaceProvidersFromAPI(ctx context.Context, clientset kubernetes.Int
 		list, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 		if err == nil {
 			for _, item := range list.Items {
-				isT1, isVPC := resolveNamespaceProvider(item.GetAnnotations())
+				isT1, isVPC := resolveNamespaceProvider(item.Name, item.GetAnnotations())
 				if isT1 {
 					hasT1 = true
 				}
@@ -204,7 +208,7 @@ func scanNamespaceProvidersFromCache(ctx context.Context, reader client.Reader) 
 		return false, false, err
 	}
 	for _, item := range nsList.Items {
-		isT1, isVPC := resolveNamespaceProvider(item.GetAnnotations())
+		isT1, isVPC := resolveNamespaceProvider(item.Name, item.GetAnnotations())
 		if isT1 {
 			hasT1 = true
 		}
@@ -455,7 +459,7 @@ func IsVPCNamespace(ns *v1.Namespace) bool {
 		return false
 	}
 	if IsPerNamespaceProvidersSupported() {
-		_, isVPC := resolveNamespaceProvider(ns.Annotations)
+		_, isVPC := resolveNamespaceProvider(ns.Name, ns.Annotations)
 		return isVPC
 	}
 	return HasVPCNamespaces()
@@ -471,7 +475,7 @@ func IsT1Namespace(ns *v1.Namespace) bool {
 		return false
 	}
 	if IsPerNamespaceProvidersSupported() {
-		isT1, _ := resolveNamespaceProvider(ns.Annotations)
+		isT1, _ := resolveNamespaceProvider(ns.Name, ns.Annotations)
 		return isT1
 	}
 	return HasT1Namespaces()

--- a/pkg/config/mixed_mode.go
+++ b/pkg/config/mixed_mode.go
@@ -50,6 +50,11 @@ func hasT1ActivationAnnotation(annotations map[string]string) bool {
 	return false
 }
 
+var (
+	conflictLogMu            sync.Mutex
+	loggedConflictNamespaces = make(map[string]struct{})
+)
+
 // resolveNamespaceProvider determines whether a namespace belongs to T1 and/or VPC
 // provider based on its annotations. If both VPC and T1 annotations are present on
 // the same namespace, this is an illegal state; it logs an error and returns (false, false).
@@ -58,11 +63,26 @@ func resolveNamespaceProvider(nsName string, annotations map[string]string) (isT
 	hasT1 := hasT1ActivationAnnotation(annotations)
 	if hasVPC && hasT1 {
 		if nsName != "" {
-			log.Error(nil, "Conflicting network provider annotations (both T1 and VPC are present); namespace will be ignored", "namespace", nsName)
+			var shouldLog bool
+			conflictLogMu.Lock()
+			if _, alreadyLogged := loggedConflictNamespaces[nsName]; !alreadyLogged {
+				loggedConflictNamespaces[nsName] = struct{}{}
+				shouldLog = true
+			}
+			conflictLogMu.Unlock()
+
+			if shouldLog {
+				log.Error(nil, "Conflicting network provider annotations (both T1 and VPC are present); namespace will be ignored", "namespace", nsName)
+			}
 		} else {
 			log.Error(nil, "Conflicting network provider annotations (both T1 and VPC are present); namespace will be ignored")
 		}
 		return false, false
+	}
+	if nsName != "" {
+		conflictLogMu.Lock()
+		delete(loggedConflictNamespaces, nsName)
+		conflictLogMu.Unlock()
 	}
 	return hasT1, hasVPC
 }

--- a/pkg/config/mixed_mode_test.go
+++ b/pkg/config/mixed_mode_test.go
@@ -336,6 +336,30 @@ func TestScanNamespaceProvidersFromAPI(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, t1)
 	assert.True(t, vpc)
+
+	// dual annotated namespace is ignored and does not set T1 or VPC
+	nsDual := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kube-state-metrics",
+			Annotations: map[string]string{
+				"nsx.vmware.com/vpc_network_config": "system",
+				"vmware-system-shared-t1":           "true",
+			},
+		},
+	}
+	nsT1Only := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns-t1-only",
+			Annotations: map[string]string{
+				"nsx.vmware.com/t1_default_config": "true",
+			},
+		},
+	}
+	clientsetDual := kubernetesfake.NewClientset(nsDual, nsT1Only)
+	t1, vpc, err = scanNamespaceProvidersFromAPI(ctx, clientsetDual)
+	assert.NoError(t, err)
+	assert.True(t, t1)
+	assert.False(t, vpc)
 }
 
 func TestScanNamespaceProvidersFromCache(t *testing.T) {
@@ -373,6 +397,31 @@ func TestScanNamespaceProvidersFromCache(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, t1)
 	assert.True(t, vpc)
+
+	// cache with dual annotated namespace is ignored and does not set T1 or VPC
+	readerDual := &stubReader{items: []v1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kube-state-metrics",
+				Annotations: map[string]string{
+					"nsx.vmware.com/vpc_network_config": "system",
+					"vmware-system-shared-t1":           "true",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns-t1-only",
+				Annotations: map[string]string{
+					"nsx.vmware.com/t1_default_config": "true",
+				},
+			},
+		},
+	}}
+	t1, vpc, err = scanNamespaceProvidersFromCache(ctx, readerDual)
+	assert.NoError(t, err)
+	assert.True(t, t1)
+	assert.False(t, vpc)
 
 	// list error is propagated
 	errReader := &stubReader{err: errors.New("list failed")}
@@ -504,6 +553,24 @@ func TestIsVPCNamespace(t *testing.T) {
 		assert.False(t, IsVPCNamespace(ns))
 	})
 
+	t.Run("per-namespace on dual vpc and t1 annotation returns false", func(t *testing.T) {
+		resetMixedModeState()
+		supported := true
+		stateMu.Lock()
+		perNamespaceProvidersSupported = &supported
+		stateMu.Unlock()
+		ns := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kube-state-metrics",
+				Annotations: map[string]string{
+					"nsx.vmware.com/vpc_network_config": "system",
+					"vmware-system-shared-t1":           "true",
+				},
+			},
+		}
+		assert.False(t, IsVPCNamespace(ns))
+	})
+
 	t.Run("per-namespace off IsVPCNamespace uses cluster flags", func(t *testing.T) {
 		resetMixedModeState()
 		supported := false
@@ -543,6 +610,24 @@ func TestIsT1Namespace(t *testing.T) {
 			},
 		}
 		assert.True(t, IsT1Namespace(ns))
+	})
+
+	t.Run("per-namespace on dual vpc and t1 annotation returns false", func(t *testing.T) {
+		resetMixedModeState()
+		supported := true
+		stateMu.Lock()
+		perNamespaceProvidersSupported = &supported
+		stateMu.Unlock()
+		ns := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kube-state-metrics",
+				Annotations: map[string]string{
+					"nsx.vmware.com/vpc_network_config": "system",
+					"vmware-system-shared-t1":           "true",
+				},
+			},
+		}
+		assert.False(t, IsT1Namespace(ns))
 	})
 
 	t.Run("per-namespace on bare namespace counts as false", func(t *testing.T) {

--- a/pkg/config/mixed_mode_test.go
+++ b/pkg/config/mixed_mode_test.go
@@ -704,6 +704,41 @@ func TestGettersAndSetMixedModeStateForTest(t *testing.T) {
 	})
 }
 
+func TestResolveNamespaceProvider_Dedup(t *testing.T) {
+	resetMixedModeState()
+	dualAnno := map[string]string{
+		VPCNetworkConfigAnnotation: "system",
+		T1DefaultConfigAnnotation:  "true",
+	}
+
+	isT1, isVPC := resolveNamespaceProvider("test-ns", dualAnno)
+	assert.False(t, isT1)
+	assert.False(t, isVPC)
+
+	conflictLogMu.Lock()
+	_, logged := loggedConflictNamespaces["test-ns"]
+	conflictLogMu.Unlock()
+	assert.True(t, logged)
+
+	// Second call with conflict should remain in logged set and return false, false
+	isT1, isVPC = resolveNamespaceProvider("test-ns", dualAnno)
+	assert.False(t, isT1)
+	assert.False(t, isVPC)
+
+	// Valid annotation should clear the namespace from logged set
+	validVpcAnno := map[string]string{
+		VPCNetworkConfigAnnotation: "system",
+	}
+	isT1, isVPC = resolveNamespaceProvider("test-ns", validVpcAnno)
+	assert.False(t, isT1)
+	assert.True(t, isVPC)
+
+	conflictLogMu.Lock()
+	_, loggedAfter := loggedConflictNamespaces["test-ns"]
+	conflictLogMu.Unlock()
+	assert.False(t, loggedAfter)
+}
+
 func resetMixedModeState() {
 	stateMu.Lock()
 	defer stateMu.Unlock()
@@ -711,6 +746,9 @@ func resetMixedModeState() {
 	hasVPCNamespaces = false
 	stateInitialized = false
 	perNamespaceProvidersSupported = nil
+	conflictLogMu.Lock()
+	loggedConflictNamespaces = make(map[string]struct{})
+	conflictLogMu.Unlock()
 }
 
 func makeNamespace(name, vpcAnnotation string) *v1.Namespace {


### PR DESCRIPTION
When a namespace has conflicting T1 and VPC annotations, treat it as
an illegal state, log an error, and ignore it (fail-close).

Testing Done:
1. Automation Tests:
   Pipelines for T1 and VPC passed, details refer to the NCP patch info.

2. Manual Test on Supervisor Testbed:
   Step 1. Enable mixed-mode capability on Supervisor testbed.
   Step 2. Verify startup scan logs with namespace context:
           Started nsx-operator on a testbed with conflicting namespace xxx.
           Verified the error log explicitly records the namespace name:
           > 2026-09-07T02:44:45.890442308Z stdout F 2026-09-07 02:44:45.000 ERROR mixed_mode.go:75 Conflicting network provider annotations (both T1 and VPC are present); namespace will be ignored namespace=xxx
   Step 3. Verify fail-close behavior:
           Created a SecurityPolicy in the conflict namespace and confirmed that the SecurityPolicy was not reconciled.
