### PR TITLE
Reject allow-all and IPBlock egress rules with named ports in SecurityPolicy

### DIFF
--- a/pkg/nsx/services/securitypolicy/expand.go
+++ b/pkg/nsx/services/securitypolicy/expand.go
@@ -51,6 +51,12 @@ func (service *SecurityPolicyService) expandRule(obj *v1alpha1.SecurityPolicy, r
 		return nil, []*model.Rule{nsxRule}, nil
 	}
 
+	// The rule contains at least one named port. Named ports can only be resolved when the
+	// target pods are determinable, so reject rule shapes that make resolution impossible.
+	if err := validateNamedPortRule(rule); err != nil {
+		return nil, nil, err
+	}
+
 	var nsxRules []*model.Rule
 	// nsxGroups is a slice for the IPSet groups referred by a security Rule if named port is configured.
 	var nsxGroups []*model.Group
@@ -154,6 +160,33 @@ func (service *SecurityPolicyService) expandRuleByService(obj *v1alpha1.Security
 	}
 	log.Debug("Built rule by service entry", "nsxRule", nsxRule)
 	return nsxGroups, nsxRule, nil
+}
+
+// validateNamedPortRule rejects rule shapes whose named ports cannot be resolved. A named port is
+// resolved by looking up the target pods, so for an egress (OUT) rule the destination must select
+// pods. An allow-all egress rule (no destination peers) or one whose destinations are ipBlocks
+// provides no pods to resolve against, which would otherwise result in no NSX rule being realized.
+// This aligns with NCP's validation behavior. The caller must only invoke this for rules that
+// contain a named port.
+func validateNamedPortRule(rule *v1alpha1.SecurityPolicyRule) error {
+	ruleDirection, err := getRuleDirection(rule)
+	if err != nil {
+		return err
+	}
+	if ruleDirection != "OUT" {
+		return nil
+	}
+
+	outPeers := rule.Destinations
+	if len(outPeers) == 0 {
+		return &nsxutil.ValidationError{Desc: "Allow-all egress rules are not supported with named port"}
+	}
+	for _, peer := range outPeers {
+		if len(peer.IPBlocks) > 0 {
+			return &nsxutil.ValidationError{Desc: "ipBlock selectors in egress rules are not supported with named port"}
+		}
+	}
+	return nil
 }
 
 // Resolve a named port to port number by rule and policy selector.

--- a/pkg/nsx/services/securitypolicy/expand_test.go
+++ b/pkg/nsx/services/securitypolicy/expand_test.go
@@ -5,6 +5,7 @@ package securitypolicy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -28,6 +29,7 @@ import (
 	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+	nsxutil "github.com/vmware-tanzu/nsx-operator/pkg/nsx/util"
 )
 
 func TestSecurityPolicyService_buildRuleIPGroup(t *testing.T) {
@@ -304,6 +306,37 @@ var secPolicy = &v1alpha1.SecurityPolicy{
 }
 
 func Test_ExpandRule(t *testing.T) {
+	testSecPolicy := secPolicy.DeepCopy()
+	testSecPolicy.Spec.Rules = append(testSecPolicy.Spec.Rules, v1alpha1.SecurityPolicyRule{
+		Name:      "rule4",
+		Action:    &allowAction,
+		Direction: &directionOut,
+		Ports: []v1alpha1.SecurityPolicyPort{
+			{
+				Protocol: "TCP",
+				Port:     intstr.IntOrString{Type: intstr.String, StrVal: "http"},
+			},
+		},
+		Destinations: []v1alpha1.SecurityPolicyPeer{},
+	})
+	testSecPolicy.Spec.Rules = append(testSecPolicy.Spec.Rules, v1alpha1.SecurityPolicyRule{
+		Name:      "rule5",
+		Action:    &allowAction,
+		Direction: &directionOut,
+		Ports: []v1alpha1.SecurityPolicyPort{
+			{
+				Protocol: "TCP",
+				Port:     intstr.IntOrString{Type: intstr.String, StrVal: "http"},
+			},
+		},
+		Destinations: []v1alpha1.SecurityPolicyPeer{
+			{
+				IPBlocks: []v1alpha1.IPBlock{
+					{CIDR: "192.168.1.0/24"},
+				},
+			},
+		},
+	})
 	ruleTagsFn := func(policyType string) []model.Tag {
 		return []model.Tag{
 			{Scope: common.String("nsx-op/cluster"), Tag: common.String("k8scl-one")},
@@ -537,6 +570,18 @@ func Test_ExpandRule(t *testing.T) {
 					Tags:           spT1RuleTags,
 				},
 			},
+		}, {
+			name:       "VPC: rule with named ports for SecurityPolicy but empty To (Egress)",
+			vpcEnabled: true,
+			ruleIdx:    3,
+			createdFor: common.ResourceTypeSecurityPolicy,
+			expErr:     "Allow-all egress rules are not supported with named port",
+		}, {
+			name:       "VPC: rule with named ports for SecurityPolicy but IPBlocks in To (Egress)",
+			vpcEnabled: true,
+			ruleIdx:    4,
+			createdFor: common.ResourceTypeSecurityPolicy,
+			expErr:     "ipBlock selectors in egress rules are not supported with named port",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -562,12 +607,16 @@ func Test_ExpandRule(t *testing.T) {
 				vpcService: &mockVPCService,
 			}
 			svc.setUpStore(common.TagValueScopeSecurityPolicyUID, false)
-			ruleBaseID := svc.buildRuleID(secPolicy, tc.ruleIdx, tc.createdFor)
+			ruleBaseID := svc.buildRuleID(testSecPolicy, tc.ruleIdx, tc.createdFor)
 
-			rule := secPolicy.Spec.Rules[tc.ruleIdx]
-			nsxGroups, nsxRules, err := svc.expandRule(secPolicy, &rule, tc.ruleIdx, ruleBaseID, tc.createdFor, &VPCInfo[0])
+			rule := testSecPolicy.Spec.Rules[tc.ruleIdx]
+			nsxGroups, nsxRules, err := svc.expandRule(testSecPolicy, &rule, tc.ruleIdx, ruleBaseID, tc.createdFor, &VPCInfo[0])
 			if tc.expErr != "" {
 				require.EqualError(t, err, tc.expErr)
+				// The error must be a *ValidationError so that controllers matching it via
+				// errors.As can surface a validation failure to the user.
+				var validationErr *nsxutil.ValidationError
+				assert.True(t, errors.As(err, &validationErr))
 			} else {
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
Allow-all egress rules and IPBlock egress rules with named ports are not supported because the target pods cannot be determined to resolve the named ports. This behavior is specifically aligned with NCP's validation behavior and avoids silent failure where no security policy rule is realized on NSX.

ValidationError is now raised to ensure the controller annotates the NetworkPolicy with "NETWORK_POLICY_VALIDATION_FAILED" properly.


(cherry picked from commit 503febbf8b5fe4e8eb64068e2d87087668b0a151)