### PR TITLE
fix(pod): force reuse existing SubnetPort for StatefulSet pods

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -265,7 +265,7 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 		if lbReconciler := service.NewServiceLbReconciler(mgr, commonService, dnsRecordService); lbReconciler != nil {
 			reconcilerList = append(reconcilerList, lbReconciler)
 		}
-		// StatefulSet controller is always registered so that after NSX upgrades (e.g. to 9.2.0+)
+		// StatefulSet controller is always registered so that after NSX upgrades
 		// replica/GC logic can run without restarting the operator. Reconcile and CollectGarbage
 		// no-op until NSX version supports STS pods and vpc_wcp_enhance=true in config; delete cleanup still runs.
 		reconcilerList = append(reconcilerList, statefulsetcontroller.NewStatefulSetReconciler(mgr, subnetPortService))

--- a/pkg/controllers/networkinfo/vpcnetworkconfig_handler_test.go
+++ b/pkg/controllers/networkinfo/vpcnetworkconfig_handler_test.go
@@ -233,9 +233,6 @@ func (m *mockIPBlocksInfoService) SyncIPBlocksInfo(_ context.Context) error {
 	m.mu.Lock()
 	m.syncCount++
 	m.mu.Unlock()
-	if m.processed != nil {
-		m.processed <- struct{}{}
-	}
 	return nil
 }
 
@@ -243,6 +240,9 @@ func (m *mockIPBlocksInfoService) ResetPeriodicSync() {
 	m.mu.Lock()
 	m.resetCount++
 	m.mu.Unlock()
+	if m.processed != nil {
+		m.processed <- struct{}{}
+	}
 }
 
 func TestVPCNetworkConfigurationHandler_QueueFIFOAndCompletion(t *testing.T) {

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -434,6 +434,19 @@ func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (b
 		log.Debug("NSX SubnetPort had been created, returning the existing NSX Subnet path", "pod.UID", pod.UID, "subnetPath", subnetPath)
 		return true, subnetPath, subnetSetUID, subnetSetLock, interfacetype, "", nil
 	}
+
+	// Check if this is a StatefulSet pod and we can reuse an existing SubnetPort
+	if nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig) {
+		stsUID := subnetport.GetStatefulSetUID(pod)
+		if port := r.SubnetPortService.GetExistingSubnetPortForStatefulSetPod(pod.Name, stsUID); port != nil {
+			if port.ParentPath != nil {
+				subnetPath = *port.ParentPath
+			}
+			log.Info("Found existing SubnetPort for StatefulSet pod, forcing old subnet", "podName", pod.Name, "stsUID", stsUID, "subnetPath", subnetPath)
+			return true, subnetPath, subnetSetUID, subnetSetLock, interfacetype, "", nil
+		}
+	}
+
 	log.Info("Got default SubnetSet for Pod, allocating the NSX Subnet", "subnetSet.Name", subnetSet.Name, "subnetSet.UID", subnetSet.UID, "pod.Name", pod.Name, "pod.UID", pod.UID)
 	if r.restoreMode {
 		// For restore case, Pod will be created on the Subnet with matching CIDR
@@ -465,7 +478,7 @@ func (r *PodReconciler) deleteSubnetPortByPodName(ctx context.Context, ns string
 
 	for _, nsxSubnetPort := range nsxSubnetPorts {
 		// Check if this subnet port was created for StatefulSet
-		// Only skip if STS feature is enabled (NSX 9.2.0+)
+		// Only skip if StatefulSet pod SubnetPort feature is enabled
 		if nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig) && r.isStatefulSetSubnetPort(nsxSubnetPort) {
 			log.Info("Ignoring subnet port deletion for StatefulSet pod",
 				"pod", name, "statefulset-uid", r.getStsUID(nsxSubnetPort))

--- a/pkg/controllers/pod/pod_controller_test.go
+++ b/pkg/controllers/pod/pod_controller_test.go
@@ -583,6 +583,46 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 			expectedInterfaceIPType: v1alpha1.IPAddressTypeIPv4,
 		},
 		{
+			name: "StatefulSetPodSubnetPortReuse",
+			prepareFunc: func(t *testing.T, pr *PodReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc((*subnetport.SubnetPortService).GetSubnetPathForSubnetPortFromStore,
+					func(s *subnetport.SubnetPortService, uid types.UID) string {
+						return ""
+					})
+				patches.ApplyFunc(nsx.StatefulSetPodSubnetPortFeatureEnabled,
+					func(client *nsx.Client, config *config.NSXOperatorConfig) bool {
+						return true
+					})
+				patches.ApplyFunc(subnetport.GetStatefulSetUID,
+					func(obj interface{}) string {
+						return "sts-uid"
+					})
+				patches.ApplyFunc((*subnetport.SubnetPortService).GetExistingSubnetPortForStatefulSetPod,
+					func(s *subnetport.SubnetPortService, podName string, stsUID string) *model.VpcSubnetPort {
+						path := "existing-sts-subnet-path"
+						return &model.VpcSubnetPort{
+							ParentPath: &path,
+						}
+					})
+				patches.ApplyFunc(common.GetDefaultSubnetSetByNamespace,
+					func(client client.Client, namespace string, resourceType string) (*v1alpha1.SubnetSet, error) {
+						return &v1alpha1.SubnetSet{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "subnetset-1",
+								UID:  "uid-1",
+							},
+							Spec: v1alpha1.SubnetSetSpec{
+								IPAddressType: v1alpha1.IPAddressTypeIPv4,
+							},
+						}, nil
+					})
+				return patches
+			},
+			expectedSubnetPath:      "existing-sts-subnet-path",
+			expectedIsExisting:      true,
+			expectedInterfaceIPType: v1alpha1.IPAddressTypeIPv4,
+		},
+		{
 			name: "NoGetDefaultSubnetSet",
 			prepareFunc: func(t *testing.T, pr *PodReconciler) *gomonkey.Patches {
 				patches := gomonkey.ApplyFunc((*subnetport.SubnetPortService).GetSubnetPathForSubnetPortFromStore,

--- a/pkg/controllers/statefulset/statefulset_controller.go
+++ b/pkg/controllers/statefulset/statefulset_controller.go
@@ -60,7 +60,7 @@ type StatefulSetReconciler struct {
 	StatusUpdater     common.StatusUpdater
 }
 
-// StatefulSetPodFeatureEnabled reports whether the StatefulSet pod SubnetPort feature is active (NSX 9.2.0+ and vpc_wcp_enhance=true in config).
+// StatefulSetPodFeatureEnabled reports whether the StatefulSet pod SubnetPort feature is active.
 func (r *StatefulSetReconciler) StatefulSetPodFeatureEnabled() bool {
 	return nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig)
 }

--- a/pkg/nsx/feature.go
+++ b/pkg/nsx/feature.go
@@ -5,7 +5,7 @@ package nsx
 
 import "github.com/vmware-tanzu/nsx-operator/pkg/config"
 
-// StatefulSetPodSubnetPortFeatureEnabled is true when NSX supports StatefulSet pod SubnetPorts
+// StatefulSetPodSubnetPortFeatureEnabled is true when NSX version is 9.1.2+ and vpc_wcp_enhance=true
 // and operator nsx_v3 sets vpc_wcp_enhance to true (omitted or false keeps the feature off).
 //
 //go:noinline

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -40,7 +40,7 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 	if _, ok := obj.(*corev1.Pod); ok {
 		appId = string(objMeta.UID)
 	}
-	_, stsUID := getStatefulSetInfo(obj)
+	stsUID := GetStatefulSetUID(obj)
 	var externalAddressBinding *model.ExternalAddressBinding
 	var err error
 	var addressBindings []model.PortAddressBindingEntry
@@ -242,18 +242,32 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 	return nsxSubnetPort, nil
 }
 
-// getStatefulSetInfo returns the StatefulSet name and UID if the pod's controller
+// GetStatefulSetUID returns the StatefulSet UID if the pod's controller
 // is a StatefulSet (matches real API server behavior: the STS sets controller=true).
-func getStatefulSetInfo(obj interface{}) (string, string) {
+func GetStatefulSetUID(obj interface{}) string {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
-		return "", ""
+		return ""
 	}
 	stsKind := appsv1.SchemeGroupVersion.WithKind("StatefulSet").Kind
 	if ref := metav1.GetControllerOf(pod); ref != nil && ref.Kind == stsKind {
-		return ref.Name, string(ref.UID)
+		return string(ref.UID)
 	}
-	return "", ""
+	return ""
+}
+
+// GetExistingSubnetPortForStatefulSetPod finds an existing SubnetPort for a StatefulSet pod
+func (service *SubnetPortService) GetExistingSubnetPortForStatefulSetPod(podName, stsUID string) *model.VpcSubnetPort {
+	if stsUID == "" {
+		return nil
+	}
+	existingPorts := service.SubnetPortStore.GetByIndex(common.TagScopeStatefulSetUID, stsUID)
+	for _, port := range existingPorts {
+		if nsxutil.FindTag(port.Tags, common.TagScopePodName) == podName {
+			return port
+		}
+	}
+	return nil
 }
 
 func (service *SubnetPortService) BuildSubnetPortIdAndName(obj *metav1.ObjectMeta, namespaceUID types.UID, stsUID string) (string, string) {
@@ -264,18 +278,13 @@ func (service *SubnetPortService) BuildSubnetPortIdAndName(obj *metav1.ObjectMet
 
 	// For StatefulSet pods: check if a SubnetPort with the same StatefulSet UID and pod name exists
 	// Note: STS UID is globally unique, so we only need to check pod name
-	// Only reuse if STS feature is enabled (NSX 9.2.0+ and vpc_wcp_enhance=true)
+	// Only reuse if StatefulSet pod SubnetPort feature is enabled
 	enableStsFeature := nsx.StatefulSetPodSubnetPortFeatureEnabled(service.NSXClient, service.NSXConfig)
-	if enableStsFeature && stsUID != "" {
-		existingPorts := service.SubnetPortStore.GetByIndex(common.TagScopeStatefulSetUID, stsUID)
-		for _, port := range existingPorts {
-			log.Debug("BuildSubnetPortIdAndName", "port", port.Id, "path", port.Path)
-			portName := nsxutil.FindTag(port.Tags, common.TagScopePodName)
-			if portName == obj.Name {
-				log.Info("Reusing existing SubnetPort for StatefulSet pod",
-					"podName", obj.Name, "stsUID", stsUID)
-				return *port.Id, *port.DisplayName
-			}
+	if enableStsFeature {
+		if port := service.GetExistingSubnetPortForStatefulSetPod(obj.Name, stsUID); port != nil {
+			log.Info("Reusing existing SubnetPort for StatefulSet pod",
+				"podName", obj.Name, "stsUID", stsUID, "portID", *port.Id)
+			return *port.Id, *port.DisplayName
 		}
 	}
 

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -1270,12 +1271,11 @@ func TestBuildExternalAddressBinding(t *testing.T) {
 	}
 }
 
-func TestGetStatefulSetInfo(t *testing.T) {
+func TestGetStatefulSetUID(t *testing.T) {
 	tests := []struct {
-		name         string
-		obj          interface{}
-		expectedName string
-		expectedUID  string
+		name        string
+		obj         interface{}
+		expectedUID string
 	}{
 		{
 			name: "StatefulSet pod with controller reference",
@@ -1292,8 +1292,7 @@ func TestGetStatefulSetInfo(t *testing.T) {
 					},
 				},
 			},
-			expectedName: "web",
-			expectedUID:  "sts-uid-123",
+			expectedUID: "sts-uid-123",
 		},
 		{
 			name: "StatefulSet owner but not controller (should ignore)",
@@ -1310,8 +1309,7 @@ func TestGetStatefulSetInfo(t *testing.T) {
 					},
 				},
 			},
-			expectedName: "",
-			expectedUID:  "",
+			expectedUID: "",
 		},
 		{
 			name: "Deployment pod with owner reference",
@@ -1326,8 +1324,7 @@ func TestGetStatefulSetInfo(t *testing.T) {
 					},
 				},
 			},
-			expectedName: "",
-			expectedUID:  "",
+			expectedUID: "",
 		},
 		{
 			name: "Standalone pod without owner",
@@ -1336,27 +1333,23 @@ func TestGetStatefulSetInfo(t *testing.T) {
 					OwnerReferences: []metav1.OwnerReference{},
 				},
 			},
-			expectedName: "",
-			expectedUID:  "",
+			expectedUID: "",
 		},
 		{
-			name:         "SubnetPort CR (not a pod)",
-			obj:          &v1alpha1.SubnetPort{},
-			expectedName: "",
-			expectedUID:  "",
+			name:        "SubnetPort CR (not a pod)",
+			obj:         &v1alpha1.SubnetPort{},
+			expectedUID: "",
 		},
 		{
-			name:         "Nil object",
-			obj:          nil,
-			expectedName: "",
-			expectedUID:  "",
+			name:        "Nil object",
+			obj:         nil,
+			expectedUID: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stsName, stsUID := getStatefulSetInfo(tt.obj)
-			assert.Equal(t, tt.expectedName, stsName)
+			stsUID := GetStatefulSetUID(tt.obj)
 			assert.Equal(t, tt.expectedUID, stsUID)
 		})
 	}
@@ -1731,5 +1724,86 @@ func TestBuildSubnetPortMultipleSameMACBindings(t *testing.T) {
 		assert.Equal(t, "00:11:22:33:44:55", *port.AddressBindings[1].MacAddress)
 		assert.Nil(t, port.AddressBindings[2].IpAddress)
 		assert.Equal(t, "00:11:22:33:44:55", *port.AddressBindings[2].MacAddress)
+	}
+}
+
+func TestGetExistingSubnetPortForStatefulSetPod(t *testing.T) {
+	service := &SubnetPortService{
+		SubnetPortStore: &SubnetPortStore{
+			ResourceStore: common.ResourceStore{
+				Indexer: cache.NewIndexer(keyFunc, cache.Indexers{
+					common.TagScopeStatefulSetUID: subnetPortIndexByStatefulSetUID,
+				}),
+			},
+		},
+	}
+
+	stsUID := "sts-uid-123"
+	podName := "test-pod-0"
+
+	// Add a matching port
+	matchingPort := &model.VpcSubnetPort{
+		Id: ptr.To("matching-port-id"),
+		Tags: []model.Tag{
+			{Scope: ptr.To(common.TagScopeStatefulSetUID), Tag: ptr.To(stsUID)},
+			{Scope: ptr.To(common.TagScopePodName), Tag: ptr.To(podName)},
+		},
+	}
+	service.SubnetPortStore.Add(matchingPort)
+
+	// Add a non-matching port (different pod name)
+	nonMatchingPort := &model.VpcSubnetPort{
+		Id: ptr.To("non-matching-port-id"),
+		Tags: []model.Tag{
+			{Scope: ptr.To(common.TagScopeStatefulSetUID), Tag: ptr.To(stsUID)},
+			{Scope: ptr.To(common.TagScopePodName), Tag: ptr.To("test-pod-1")},
+		},
+	}
+	service.SubnetPortStore.Add(nonMatchingPort)
+
+	tests := []struct {
+		name        string
+		podName     string
+		stsUID      string
+		expectedId  string
+		expectFound bool
+	}{
+		{
+			name:        "matching port found",
+			podName:     podName,
+			stsUID:      stsUID,
+			expectedId:  "matching-port-id",
+			expectFound: true,
+		},
+		{
+			name:        "no matching port for pod name",
+			podName:     "test-pod-2",
+			stsUID:      stsUID,
+			expectFound: false,
+		},
+		{
+			name:        "empty stsUID",
+			podName:     podName,
+			stsUID:      "",
+			expectFound: false,
+		},
+		{
+			name:        "no matching port for stsUID",
+			podName:     podName,
+			stsUID:      "other-sts-uid",
+			expectFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port := service.GetExistingSubnetPortForStatefulSetPod(tt.podName, tt.stsUID)
+			if tt.expectFound {
+				assert.NotNil(t, port)
+				assert.Equal(t, tt.expectedId, *port.Id)
+			} else {
+				assert.Nil(t, port)
+			}
+		})
 	}
 }

--- a/pkg/nsx/services/subnetport/subnetport_test.go
+++ b/pkg/nsx/services/subnetport/subnetport_test.go
@@ -105,6 +105,27 @@ func (c *fakeIPPoolClient) List(orgIdParam string, projectIdParam string, vpcIdP
 	return model.IpAddressPoolListResult{}, nil
 }
 
+type mockErrorIPPoolClient struct {
+	fakeIPPoolClient
+	err error
+}
+
+func (c *mockErrorIPPoolClient) Get(orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error) {
+	return model.IpAddressPool{}, c.err
+}
+
+type mockFuncIPPoolClient struct {
+	fakeIPPoolClient
+	getFunc func(orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error)
+}
+
+func (c *mockFuncIPPoolClient) Get(orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error) {
+	if c.getFunc != nil {
+		return c.getFunc(orgIdParam, projectIdParam, vpcIdParam, subnetIdParam, poolIdParam)
+	}
+	return c.fakeIPPoolClient.Get(orgIdParam, projectIdParam, vpcIdParam, subnetIdParam, poolIdParam)
+}
+
 type fakeStatsClient struct{}
 
 func (c *fakeStatsClient) Get(orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, cursorParam *string, enforcementPointPathParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.DhcpServerStatistics, error) {
@@ -1401,9 +1422,8 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
 			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
-					return model.IpAddressPool{}, fmt.Errorf("mock static error")
-				})
+				service.NSXClient.IPPoolClient = &mockErrorIPPoolClient{err: fmt.Errorf("mock static error")}
+				return nil
 			},
 			expectedValue: false,
 			expectedErr:   "mock static error",
@@ -1426,11 +1446,14 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
 			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
-					return model.IpAddressPool{
-						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(0)},
-					}, nil
-				})
+				service.NSXClient.IPPoolClient = &mockFuncIPPoolClient{
+					getFunc: func(orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error) {
+						return model.IpAddressPool{
+							PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(0)},
+						}, nil
+					},
+				}
+				return nil
 			},
 			expectedValue: false,
 		},
@@ -1472,11 +1495,14 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
 			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
-					return model.IpAddressPool{
-						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(10)},
-					}, nil
-				})
+				service.NSXClient.IPPoolClient = &mockFuncIPPoolClient{
+					getFunc: func(orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error) {
+						return model.IpAddressPool{
+							PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(10)},
+						}, nil
+					},
+				}
+				return nil
 			},
 			expectedValue: true,
 		},
@@ -1486,11 +1512,14 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			interfaceIPType:        v1alpha1.IPAddressTypeIPv4,
 			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, _ string) (model.IpAddressPool, error) {
-					return model.IpAddressPool{
-						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(10), RequestedIpAllocations: common.Int64(10)},
-					}, nil
-				})
+				service.NSXClient.IPPoolClient = &mockFuncIPPoolClient{
+					getFunc: func(orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error) {
+						return model.IpAddressPool{
+							PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(10), RequestedIpAllocations: common.Int64(10)},
+						}, nil
+					},
+				}
+				return nil
 			},
 			expectedValue: false,
 			sharedSubnet:  true,
@@ -1523,12 +1552,8 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			interfaceIPType:        v1alpha1.IPAddressTypeIPv6,
 			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv6,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, poolId string) (model.IpAddressPool, error) {
-					if poolId == "static-ipv6-default" {
-						return model.IpAddressPool{}, fmt.Errorf("mock ipv6 static pool error")
-					}
-					return model.IpAddressPool{}, nil
-				})
+				service.NSXClient.IPPoolClient = &mockErrorIPPoolClient{err: fmt.Errorf("mock ipv6 static pool error")}
+				return nil
 			},
 			expectedValue: false,
 			expectedErr:   "mock ipv6 static pool error",
@@ -1539,14 +1564,17 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			interfaceIPType:        v1alpha1.IPAddressTypeIPv6,
 			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv6,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, poolId string) (model.IpAddressPool, error) {
-					if poolId == "static-ipv6-default" {
-						return model.IpAddressPool{
-							PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(20)},
-						}, nil
-					}
-					return model.IpAddressPool{}, nil
-				})
+				service.NSXClient.IPPoolClient = &mockFuncIPPoolClient{
+					getFunc: func(orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error) {
+						if poolIdParam == "static-ipv6-default" {
+							return model.IpAddressPool{
+								PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(20)},
+							}, nil
+						}
+						return model.IpAddressPool{}, nil
+					},
+				}
+				return nil
 			},
 			expectedValue: true,
 		},
@@ -1556,16 +1584,19 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			interfaceIPType:        v1alpha1.IPAddressTypeIPv4IPv6,
 			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4IPv6,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, poolId string) (model.IpAddressPool, error) {
-					if poolId == "static-ipv4-default" {
+				service.NSXClient.IPPoolClient = &mockFuncIPPoolClient{
+					getFunc: func(orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error) {
+						if poolIdParam == "static-ipv4-default" {
+							return model.IpAddressPool{
+								PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(0)},
+							}, nil
+						}
 						return model.IpAddressPool{
-							PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(0)},
+							PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(100)},
 						}, nil
-					}
-					return model.IpAddressPool{
-						PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(100)},
-					}, nil
-				})
+					},
+				}
+				return nil
 			},
 			expectedValue: false,
 		},
@@ -1575,19 +1606,22 @@ func TestSubnetPortService_AllocatePortFromSubnet(t *testing.T) {
 			interfaceIPType:        v1alpha1.IPAddressTypeIPv4IPv6,
 			staticIPAllocationType: v1alpha1.StaticIPAllocationTypeIPv4IPv6,
 			prepareFunc: func(service *SubnetPortService) *gomonkey.Patches {
-				return gomonkey.ApplyMethod(reflect.TypeOf(service.NSXClient.IPPoolClient), "Get", func(_ *fakeIPPoolClient, _, _, _, _, poolId string) (model.IpAddressPool, error) {
-					if poolId == "static-ipv4-default" {
-						return model.IpAddressPool{
-							PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(10)},
-						}, nil
-					}
-					if poolId == "static-ipv6-default" {
-						return model.IpAddressPool{
-							PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(0)},
-						}, nil
-					}
-					return model.IpAddressPool{}, nil
-				})
+				service.NSXClient.IPPoolClient = &mockFuncIPPoolClient{
+					getFunc: func(orgIdParam string, projectIdParam string, vpcIdParam string, subnetIdParam string, poolIdParam string) (model.IpAddressPool, error) {
+						if poolIdParam == "static-ipv4-default" {
+							return model.IpAddressPool{
+								PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(10)},
+							}, nil
+						}
+						if poolIdParam == "static-ipv6-default" {
+							return model.IpAddressPool{
+								PoolUsage: &model.PolicyPoolUsage{TotalIps: common.Int64(0)},
+							}, nil
+						}
+						return model.IpAddressPool{}, nil
+					},
+				}
+				return nil
 			},
 			expectedValue: false,
 		},


### PR DESCRIPTION
When a StatefulSet pod is recreated, a new Pod UID is assigned. If the original Subnet reaches full capacity, GetSubnetPathForPod failed to recognize the existing SubnetPort because it only queried by Pod UID. This caused a new Subnet to be allocated while builder.go still attempted to reuse the existing SubnetPort ID by stsUID, leading to a Subnet/Port path mismatch and NSX attachment ID conflict error. Fix this issue by:
1. Exporting GetStatefulSetInfo and GetExistingSubnetPortForStatefulSetPod in the subnetport service.
2. Checking for existing StatefulSet SubnetPorts via stsUID + podName in GetSubnetPathForPod, forcing the original Subnet path when found.
3. Adding portID to the reuse log in builder.go for observability.


Test Done:
Cast 1:
1. create rc with instance = 10
2. create the sts pod with instance = 3
3. update the rc with instance = 30
4. delete one of the sts pod
5. check if the pod could be recreated and the subnetport is reused

