### PR TITLE
Validate IPAddressType compatibility in SubnetConnectionBindingMap

### DIFF
--- a/pkg/controllers/subnetbinding/subnetbinding_controller.go
+++ b/pkg/controllers/subnetbinding/subnetbinding_controller.go
@@ -279,23 +279,33 @@ func (r *Reconciler) validateDependency(ctx context.Context, bindingMap *v1alpha
 	targetIsParent := !isBranch
 
 	// subnetName is trunk Subnet: it can have multiple branch Subnets, but CANNOT be a branch Subnet in any binding.
-	subnetPaths, err := r.validateVpcSubnetsBySubnetCR(ctx, bindingMap.Namespace, bindingMap.Spec.SubnetName, subnetIsParent)
+	subnetPaths, subnetIPType, err := r.validateVpcSubnetsBySubnetCR(ctx, bindingMap.Namespace, bindingMap.Spec.SubnetName, subnetIsParent)
 	if err != nil {
 		return "", nil, err
 	}
 	subnetPath := subnetPaths[0]
 
 	var targetSubnetPaths []string
+	var targetIPType v1alpha1.IPAddressType
 	if bindingMap.Spec.TargetSubnetName != "" {
 		// targetSubnetName is trunk Subnet: it can have multiple branch Subnets, but CANNOT be a branch Subnet in any binding.
-		targetSubnetPaths, err = r.validateVpcSubnetsBySubnetCR(ctx, targetNamespace, bindingMap.Spec.TargetSubnetName, targetIsParent)
+		targetSubnetPaths, targetIPType, err = r.validateVpcSubnetsBySubnetCR(ctx, targetNamespace, bindingMap.Spec.TargetSubnetName, targetIsParent)
 		if err != nil {
 			return "", nil, err
 		}
 	} else {
-		targetSubnetPaths, err = r.validateVpcSubnetsBySubnetSetCR(ctx, bindingMap.Namespace, bindingMap.Spec.TargetSubnetSetName)
+		targetSubnetPaths, targetIPType, err = r.validateVpcSubnetsBySubnetSetCR(ctx, bindingMap.Namespace, bindingMap.Spec.TargetSubnetSetName)
 		if err != nil {
 			return "", nil, err
+		}
+	}
+
+	if (isBranch && !common.IsSupersetIPAddressTypes(subnetIPType, targetIPType)) ||
+		(!isBranch && !common.IsSupersetIPAddressTypes(targetIPType, subnetIPType)) {
+		return "", nil, &errorWithRetry{
+			message: fmt.Sprintf("Incompatible IPAddressType: Subnet IPAddressType %s targetSubnet IPAddressType %s, isBranch mode:%t", subnetIPType, targetIPType, isBranch),
+			error:   fmt.Errorf("incompatible IPAddressType: Subnet IPAddressType %s targetSubnet IPAddressType %s, isBranch mode:%t", subnetIPType, targetIPType, isBranch),
+			retry:   false,
 		}
 	}
 
@@ -321,14 +331,21 @@ func (r *Reconciler) getPreferredVlan(ctx context.Context, bindingMap *v1alpha1.
 	return preferred
 }
 
-func (r *Reconciler) validateVpcSubnetsBySubnetCR(ctx context.Context, namespace, name string, isParent bool) ([]string, *errorWithRetry) {
+func normalizeIPAddressType(ipType v1alpha1.IPAddressType) v1alpha1.IPAddressType {
+	if ipType == "" {
+		return v1alpha1.IPAddressTypeIPv4
+	}
+	return ipType
+}
+
+func (r *Reconciler) validateVpcSubnetsBySubnetCR(ctx context.Context, namespace, name string, isParent bool) ([]string, v1alpha1.IPAddressType, *errorWithRetry) {
 	subnetCR := &v1alpha1.Subnet{}
 	subnetKey := types.NamespacedName{Namespace: namespace, Name: name}
 	// Check the Subnet CR existence.
 	err := r.Client.Get(ctx, subnetKey, subnetCR)
 	if err != nil {
 		log.Error(err, "Failed to get Subnet CR", "Subnet", subnetKey.String())
-		return nil, &errorWithRetry{
+		return nil, "", &errorWithRetry{
 			message: fmt.Sprintf("Unable to get Subnet CR %s", name),
 			retry:   false,
 			error:   fmt.Errorf("failed to get Subnet %s in Namespace %s with error: %v", name, namespace, err),
@@ -340,7 +357,7 @@ func (r *Reconciler) validateVpcSubnetsBySubnetCR(ctx context.Context, namespace
 	if anno, ok := subnetCR.GetAnnotations()[servicecommon.AnnotationAssociatedResource]; ok {
 		// Shared / Pre-created subnets cannot act as a trunk subnet in connection bindings.
 		if isParent {
-			return nil, &errorWithRetry{
+			return nil, "", &errorWithRetry{
 				message: fmt.Sprintf("Subnet %s/%s is a pre-created Subnet", namespace, name),
 				error:   fmt.Errorf("pre-created Subnet %s/%s cannot be a trunk Subnet", namespace, name),
 				retry:   false,
@@ -354,7 +371,7 @@ func (r *Reconciler) validateVpcSubnetsBySubnetCR(ctx context.Context, namespace
 			}
 		}
 		if !realized {
-			return nil, &errorWithRetry{
+			return nil, "", &errorWithRetry{
 				message: fmt.Sprintf("Subnet CR %s is not realized on NSX", name),
 				retry:   false,
 				error:   err,
@@ -365,7 +382,7 @@ func (r *Reconciler) validateVpcSubnetsBySubnetCR(ctx context.Context, namespace
 			// No need to retry as not support associated resource annotation
 			// changing after Subnet creation.
 			log.Error(err, "Failed to get NSX Subnet path for shared Subnet", "Subnet", subnetKey.String())
-			return nil, &errorWithRetry{
+			return nil, "", &errorWithRetry{
 				message: fmt.Sprintf("Failed to get NSX Subnet path for shared Subnet %s", name),
 				retry:   false,
 				error:   err,
@@ -381,7 +398,7 @@ func (r *Reconciler) validateVpcSubnetsBySubnetCR(ctx context.Context, namespace
 
 	if len(subnetPaths) == 0 {
 		log.Info("NSX VpcSubnets by Subnet CR do not exist", "Subnet", subnetKey.String())
-		return nil, &errorWithRetry{
+		return nil, "", &errorWithRetry{
 			message: fmt.Sprintf("Subnet CR %s is not realized on NSX", name),
 			retry:   false,
 			error:   fmt.Errorf("not found NSX VpcSubnets created by Subnet CR '%s/%s'", namespace, name),
@@ -394,7 +411,7 @@ func (r *Reconciler) validateVpcSubnetsBySubnetCR(ctx context.Context, namespace
 			bindings := r.SubnetBindingService.GetSubnetConnectionBindingMapsByChildSubnet(subnetPath)
 			if len(bindings) > 0 {
 				bmName := getBindingMapName(bindings[0])
-				return nil, &errorWithRetry{
+				return nil, "", &errorWithRetry{
 					message: fmt.Sprintf("Subnet CR %s is already used as a branch by %s", name, bmName),
 					error:   fmt.Errorf("the Subnet %s already works as a branch in SubnetConnectionBindingMap %s", name, bmName),
 					retry:   true,
@@ -406,7 +423,7 @@ func (r *Reconciler) validateVpcSubnetsBySubnetCR(ctx context.Context, namespace
 			bindings := r.SubnetBindingService.GetSubnetConnectionBindingMapsByParentSubnet(subnetPath)
 			if len(bindings) > 0 {
 				bmName := getBindingMapName(bindings[0])
-				return nil, &errorWithRetry{
+				return nil, "", &errorWithRetry{
 					message: fmt.Sprintf("Subnet CR %s is already used as a trunk by %s", name, bmName),
 					error:   fmt.Errorf("the Subnet %s already works as a trunk in SubnetConnectionBindingMap %s", name, bmName),
 					retry:   true,
@@ -415,16 +432,16 @@ func (r *Reconciler) validateVpcSubnetsBySubnetCR(ctx context.Context, namespace
 		}
 	}
 
-	return subnetPaths, nil
+	return subnetPaths, normalizeIPAddressType(subnetCR.Spec.IPAddressType), nil
 }
 
-func (r *Reconciler) validateVpcSubnetsBySubnetSetCR(ctx context.Context, namespace, name string) ([]string, *errorWithRetry) {
+func (r *Reconciler) validateVpcSubnetsBySubnetSetCR(ctx context.Context, namespace, name string) ([]string, v1alpha1.IPAddressType, *errorWithRetry) {
 	subnetSetCR := &v1alpha1.SubnetSet{}
 	subnetSetKey := types.NamespacedName{Namespace: namespace, Name: name}
 	err := r.Client.Get(ctx, subnetSetKey, subnetSetCR)
 	if err != nil {
 		log.Error(err, "Failed to get SubnetSet CR", "SubnetSet", subnetSetKey.String())
-		return nil, &errorWithRetry{
+		return nil, "", &errorWithRetry{
 			message: fmt.Sprintf("Unable to get SubnetSet CR %s", name),
 			error:   fmt.Errorf("failed to get SubnetSet %s in Namespace %s with error: %v", name, namespace, err),
 			retry:   false,
@@ -434,7 +451,7 @@ func (r *Reconciler) validateVpcSubnetsBySubnetSetCR(ctx context.Context, namesp
 	subnets := r.SubnetService.ListSubnetCreatedBySubnetSet(string(subnetSetCR.UID))
 	if len(subnets) == 0 {
 		log.Info("NSX VpcSubnets by SubnetSet CR do not exist", "SubnetSet", subnetSetKey.String())
-		return nil, &errorWithRetry{
+		return nil, "", &errorWithRetry{
 			message: fmt.Sprintf("SubnetSet CR %s is not realized on NSX", name),
 			error:   fmt.Errorf("no existing NSX VpcSubnet created by SubnetSet CR '%s/%s'", namespace, name),
 			retry:   false,
@@ -444,7 +461,7 @@ func (r *Reconciler) validateVpcSubnetsBySubnetSetCR(ctx context.Context, namesp
 	for i := range subnets {
 		subnetPaths[i] = *subnets[i].Path
 	}
-	return subnetPaths, nil
+	return subnetPaths, normalizeIPAddressType(subnetSetCR.Spec.IPAddressType), nil
 }
 
 func updateBindingMapStatusWithUnreadyCondition(c client.Client, ctx context.Context, obj client.Object, _ metav1.Time, _ error, args ...interface{}) {

--- a/pkg/controllers/subnetbinding/subnetbinding_controller_test.go
+++ b/pkg/controllers/subnetbinding/subnetbinding_controller_test.go
@@ -575,6 +575,161 @@ func TestValidateDependency(t *testing.T) {
 			},
 			expSubnet:        "/orgs/default/projects/default/vpcs/vpc-a/subnets/parent-subnet",
 			expTargetSubnets: []string{"/orgs/default/projects/default/vpcs/vpc-b/subnets/child-subnet"},
+		}, {
+			name: "incompatible IPAddressType: Parent IPv4 and Child IPv6 (Trunk mode)",
+			bindingMap: &v1alpha1.SubnetConnectionBindingMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+					SubnetName:        "v6-subnet",
+					TargetSubnetName:  "v4-subnet",
+					SubnetAssociation: v1alpha1.SubnetAssociationTrunk,
+				},
+			},
+			objects: []client.Object{
+				&v1alpha1.Subnet{
+					ObjectMeta: metav1.ObjectMeta{Name: "v4-subnet", Namespace: namespace, UID: "v4-uuid"},
+					Spec:       v1alpha1.SubnetSpec{IPAddressType: v1alpha1.IPAddressTypeIPv4},
+				},
+				&v1alpha1.Subnet{
+					ObjectMeta: metav1.ObjectMeta{Name: "v6-subnet", Namespace: namespace, UID: "v6-uuid"},
+					Spec:       v1alpha1.SubnetSpec{IPAddressType: v1alpha1.IPAddressTypeIPv6},
+				},
+			},
+			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService.SubnetStore), "GetByIndex", func(_ *subnet.SubnetStore, key, value string) []*model.VpcSubnet {
+					if value == "v4-uuid" {
+						return []*model.VpcSubnet{{Id: common.String("s1"), Path: common.String("/orgs/default/projects/default/vpcs/ns-1/subnets/v4-subnet")}}
+					}
+					return []*model.VpcSubnet{{Id: common.String("s2"), Path: common.String("/orgs/default/projects/default/vpcs/ns-1/subnets/v6-subnet")}}
+				})
+				return patches
+			},
+			expErr: "incompatible IPAddressType: Subnet IPAddressType IPv6 targetSubnet IPAddressType IPv4, isBranch mode:false",
+			expMsg: "Incompatible IPAddressType: Subnet IPAddressType IPv6 targetSubnet IPAddressType IPv4, isBranch mode:false",
+		}, {
+			name: "incompatible IPAddressType: Parent IPv4 and Child Dual-Stack (Trunk mode)",
+			bindingMap: &v1alpha1.SubnetConnectionBindingMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+					SubnetName:        "dualstack-subnet",
+					TargetSubnetName:  "v4-subnet",
+					SubnetAssociation: v1alpha1.SubnetAssociationTrunk,
+				},
+			},
+			objects: []client.Object{
+				&v1alpha1.Subnet{
+					ObjectMeta: metav1.ObjectMeta{Name: "v4-subnet", Namespace: namespace, UID: "v4-uuid"},
+					Spec:       v1alpha1.SubnetSpec{IPAddressType: v1alpha1.IPAddressTypeIPv4},
+				},
+				&v1alpha1.Subnet{
+					ObjectMeta: metav1.ObjectMeta{Name: "dualstack-subnet", Namespace: namespace, UID: "dual-uuid"},
+					Spec:       v1alpha1.SubnetSpec{IPAddressType: v1alpha1.IPAddressTypeIPv4IPv6},
+				},
+			},
+			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService.SubnetStore), "GetByIndex", func(_ *subnet.SubnetStore, key, value string) []*model.VpcSubnet {
+					if value == "v4-uuid" {
+						return []*model.VpcSubnet{{Id: common.String("s1"), Path: common.String("/orgs/default/projects/default/vpcs/ns-1/subnets/v4-subnet")}}
+					}
+					return []*model.VpcSubnet{{Id: common.String("s2"), Path: common.String("/orgs/default/projects/default/vpcs/ns-1/subnets/dualstack-subnet")}}
+				})
+				return patches
+			},
+			expErr: "incompatible IPAddressType: Subnet IPAddressType IPv4IPv6 targetSubnet IPAddressType IPv4, isBranch mode:false",
+			expMsg: "Incompatible IPAddressType: Subnet IPAddressType IPv4IPv6 targetSubnet IPAddressType IPv4, isBranch mode:false",
+		}, {
+			name: "incompatible IPAddressType: Parent IPv6 and Child Dual-Stack (Branch mode)",
+			bindingMap: &v1alpha1.SubnetConnectionBindingMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+					SubnetName:        "v6-subnet",
+					TargetSubnetName:  "dualstack-subnet",
+					SubnetAssociation: v1alpha1.SubnetAssociationBranch,
+				},
+			},
+			objects: []client.Object{
+				&v1alpha1.Subnet{
+					ObjectMeta: metav1.ObjectMeta{Name: "v6-subnet", Namespace: namespace, UID: "v6-uuid"},
+					Spec:       v1alpha1.SubnetSpec{IPAddressType: v1alpha1.IPAddressTypeIPv6},
+				},
+				&v1alpha1.Subnet{
+					ObjectMeta: metav1.ObjectMeta{Name: "dualstack-subnet", Namespace: namespace, UID: "dual-uuid"},
+					Spec:       v1alpha1.SubnetSpec{IPAddressType: v1alpha1.IPAddressTypeIPv4IPv6},
+				},
+			},
+			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService.SubnetStore), "GetByIndex", func(_ *subnet.SubnetStore, key, value string) []*model.VpcSubnet {
+					if value == "v6-uuid" {
+						return []*model.VpcSubnet{{Id: common.String("s1"), Path: common.String("/orgs/default/projects/default/vpcs/ns-1/subnets/v6-subnet")}}
+					}
+					return []*model.VpcSubnet{{Id: common.String("s2"), Path: common.String("/orgs/default/projects/default/vpcs/ns-1/subnets/dualstack-subnet")}}
+				})
+				return patches
+			},
+			expErr: "incompatible IPAddressType: Subnet IPAddressType IPv6 targetSubnet IPAddressType IPv4IPv6, isBranch mode:true",
+			expMsg: "Incompatible IPAddressType: Subnet IPAddressType IPv6 targetSubnet IPAddressType IPv4IPv6, isBranch mode:true",
+		}, {
+			name: "compatible IPAddressType: Parent Dual-Stack and Child IPv6 (Trunk mode)",
+			bindingMap: &v1alpha1.SubnetConnectionBindingMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+					SubnetName:        "v6-subnet",
+					TargetSubnetName:  "dualstack-subnet",
+					SubnetAssociation: v1alpha1.SubnetAssociationTrunk,
+				},
+			},
+			objects: []client.Object{
+				&v1alpha1.Subnet{
+					ObjectMeta: metav1.ObjectMeta{Name: "dualstack-subnet", Namespace: namespace, UID: "dual-uuid"},
+					Spec:       v1alpha1.SubnetSpec{IPAddressType: v1alpha1.IPAddressTypeIPv4IPv6},
+				},
+				&v1alpha1.Subnet{
+					ObjectMeta: metav1.ObjectMeta{Name: "v6-subnet", Namespace: namespace, UID: "v6-uuid"},
+					Spec:       v1alpha1.SubnetSpec{IPAddressType: v1alpha1.IPAddressTypeIPv6},
+				},
+			},
+			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService.SubnetStore), "GetByIndex", func(_ *subnet.SubnetStore, key, value string) []*model.VpcSubnet {
+					if value == "v6-uuid" {
+						return []*model.VpcSubnet{{Id: common.String("s1"), Path: common.String("/orgs/default/projects/default/vpcs/ns-1/subnets/v6-subnet")}}
+					}
+					return []*model.VpcSubnet{{Id: common.String("s2"), Path: common.String("/orgs/default/projects/default/vpcs/ns-1/subnets/dualstack-subnet")}}
+				})
+				return patches
+			},
+			expSubnet:        "/orgs/default/projects/default/vpcs/ns-1/subnets/v6-subnet",
+			expTargetSubnets: []string{"/orgs/default/projects/default/vpcs/ns-1/subnets/dualstack-subnet"},
+		}, {
+			name: "compatible IPAddressType: Unset IPAddressType defaults to IPv4 for both Parent and Child",
+			bindingMap: &v1alpha1.SubnetConnectionBindingMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+					SubnetName:        "unset-child",
+					TargetSubnetName:  "unset-parent",
+					SubnetAssociation: v1alpha1.SubnetAssociationTrunk,
+				},
+			},
+			objects: []client.Object{
+				&v1alpha1.Subnet{
+					ObjectMeta: metav1.ObjectMeta{Name: "unset-parent", Namespace: namespace, UID: "parent-uuid"},
+					Spec:       v1alpha1.SubnetSpec{},
+				},
+				&v1alpha1.Subnet{
+					ObjectMeta: metav1.ObjectMeta{Name: "unset-child", Namespace: namespace, UID: "child-uuid"},
+					Spec:       v1alpha1.SubnetSpec{},
+				},
+			},
+			patches: func(t *testing.T, r *Reconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyMethod(reflect.TypeOf(r.SubnetService.SubnetStore), "GetByIndex", func(_ *subnet.SubnetStore, key, value string) []*model.VpcSubnet {
+					if value == "child-uuid" {
+						return []*model.VpcSubnet{{Id: common.String("s1"), Path: common.String("/orgs/default/projects/default/vpcs/ns-1/subnets/unset-child")}}
+					}
+					return []*model.VpcSubnet{{Id: common.String("s2"), Path: common.String("/orgs/default/projects/default/vpcs/ns-1/subnets/unset-parent")}}
+				})
+				return patches
+			},
+			expSubnet:        "/orgs/default/projects/default/vpcs/ns-1/subnets/unset-child",
+			expTargetSubnets: []string{"/orgs/default/projects/default/vpcs/ns-1/subnets/unset-parent"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -789,7 +944,7 @@ func TestValidateVpcSubnetsBySubnetCR(t *testing.T) {
 			patches := tc.patches(t, r)
 			defer patches.Reset()
 
-			paths, err := r.validateVpcSubnetsBySubnetCR(ctx, subnetNamespace, subnetName, tc.isParent)
+			paths, _, err := r.validateVpcSubnetsBySubnetCR(ctx, subnetNamespace, subnetName, tc.isParent)
 			if tc.expErr != "" {
 				require.NotNil(t, err)
 				require.EqualError(t, err.error, tc.expErr)
@@ -893,7 +1048,7 @@ func TestValidateVpcSubnetsBySubnetSetCR(t *testing.T) {
 				defer patches.Reset()
 			}
 
-			paths, err := r.validateVpcSubnetsBySubnetSetCR(ctx, namespace, name)
+			paths, _, err := r.validateVpcSubnetsBySubnetSetCR(ctx, namespace, name)
 			if tc.expErr != "" {
 				require.NotNil(t, err)
 				require.EqualError(t, err.error, tc.expErr)

--- a/test/e2e/nsx_subnet_test.go
+++ b/test/e2e/nsx_subnet_test.go
@@ -122,6 +122,7 @@ func TestSubnetSet(t *testing.T) {
 		RunSubtest(t, "case=SubnetBindingAutoVLANAllocation", SubnetBindingAutoVLANAllocation)
 		RunSubtest(t, "case=SubnetBindingManualVLANAllocation", SubnetBindingManualVLANAllocation)
 		RunSubtest(t, "case=SubnetBindingBranchAssociation", SubnetBindingBranchAssociation)
+		RunSubtest(t, "case=SubnetBindingIPFamilyCompatibility", SubnetBindingIPFamilyCompatibility)
 	})
 }
 
@@ -1972,6 +1973,71 @@ func SubnetBindingBranchAssociation(t *testing.T) {
 	vlan, err := waitForBindingMapVlan(subnetTestNamespace, bindingName1)
 	require.NoError(t, err, "BindingMap %s should be ready and have an auto-allocated status.vlanTrafficTag with branch association", bindingName1)
 	assert.True(t, vlan >= 1 && vlan <= 4094, "Allocated VLAN should be between 1 and 4094")
+}
+
+// SubnetBindingIPFamilyCompatibility tests that IP family compatibility validation rejects binding an IPv6 child to an IPv4 parent.
+func SubnetBindingIPFamilyCompatibility(t *testing.T) {
+	if clusterInfo.podV6NetworkCIDR == "" {
+		t.Skip("cluster does not support IPv6; skipping SubnetBindingIPFamilyCompatibility test")
+	}
+
+	v4ParentName := "v4-parent-subnet-" + getRandomString()
+	v4ParentSubnet := &v1alpha1.Subnet{
+		ObjectMeta: v1.ObjectMeta{Name: v4ParentName, Namespace: subnetTestNamespace},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType:  v1alpha1.IPAddressTypeIPv4,
+			IPv4SubnetSize: 16,
+		},
+	}
+	_, err := testData.crdClientset.CrdV1alpha1().Subnets(subnetTestNamespace).Create(context.TODO(), v4ParentSubnet, v1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = testData.crdClientset.CrdV1alpha1().Subnets(subnetTestNamespace).Delete(context.TODO(), v4ParentName, v1.DeleteOptions{})
+	})
+	require.NoError(t, waitForSubnetReady(subnetTestNamespace, v4ParentName))
+
+	v6ChildName := "v6-child-subnet-" + getRandomString()
+	v6ChildSubnet := &v1alpha1.Subnet{
+		ObjectMeta: v1.ObjectMeta{Name: v6ChildName, Namespace: subnetTestNamespace},
+		Spec: v1alpha1.SubnetSpec{
+			IPAddressType:    v1alpha1.IPAddressTypeIPv6,
+			IPv6PrefixLength: 64,
+		},
+	}
+	_, err = testData.crdClientset.CrdV1alpha1().Subnets(subnetTestNamespace).Create(context.TODO(), v6ChildSubnet, v1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = testData.crdClientset.CrdV1alpha1().Subnets(subnetTestNamespace).Delete(context.TODO(), v6ChildName, v1.DeleteOptions{})
+	})
+
+	incompatibleBindingName := "binding-incompatible-" + getRandomString()
+	incompatibleBinding := &v1alpha1.SubnetConnectionBindingMap{
+		ObjectMeta: v1.ObjectMeta{Name: incompatibleBindingName, Namespace: subnetTestNamespace},
+		Spec: v1alpha1.SubnetConnectionBindingMapSpec{
+			SubnetName:        v6ChildName,
+			TargetSubnetName:  v4ParentName,
+			SubnetAssociation: v1alpha1.SubnetAssociationTrunk,
+		},
+	}
+	_, err = testData.crdClientset.CrdV1alpha1().SubnetConnectionBindingMaps(subnetTestNamespace).Create(context.TODO(), incompatibleBinding, v1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = testData.crdClientset.CrdV1alpha1().SubnetConnectionBindingMaps(subnetTestNamespace).Delete(context.TODO(), incompatibleBindingName, v1.DeleteOptions{})
+	})
+
+	err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+		b, err := testData.crdClientset.CrdV1alpha1().SubnetConnectionBindingMaps(subnetTestNamespace).Get(context.TODO(), incompatibleBindingName, v1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		for _, cond := range b.Status.Conditions {
+			if cond.Type == v1alpha1.Ready && cond.Status == corev1.ConditionFalse && strings.Contains(cond.Message, "Incompatible IPAddressType") {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	require.NoError(t, err, "BindingMap with incompatible IPAddressType should report ConditionFalse with 'Incompatible IPAddressType' message")
 }
 
 func createBindingTestSubnets(t *testing.T, numChildren int) (parentSubnetName string, childSubnetNames []string) {


### PR DESCRIPTION
Validate IPAddressType compatibility in SubnetConnectionBindingMap controller

Validate that SubnetConnectionBindingMap only allows binding between subnets with compatible IP address types (e.g. IPv4-IPv4, IPv6-IPv6, or DualStack with SingleStack).

TestDone:

## Testing Done

### Unit Tests (`pkg/controllers/subnetbinding`)
Added unit test cases in `TestValidateDependency` for IP family compatibility validation:
1. **Incompatible - Parent IPv4 & Child IPv6 (Trunk Mode)**: Expect validation failure with `Incompatible IPAddressType` error message.
2. **Incompatible - Parent IPv4 & Child Dual-Stack (Trunk Mode)**: Expect validation failure when Parent IPv4 cannot encompass Child Dual-Stack (`IPv4IPv6`).
3. **Incompatible - Parent IPv6 & Child Dual-Stack (Branch Mode)**: Expect validation failure when Parent IPv6 cannot encompass Child Dual-Stack (`IPv4IPv6`).
4. **Compatible - Parent Dual-Stack & Child IPv6 (Trunk Mode)**: Expect validation to pass as `IPv4IPv6` encompasses `IPv6`.
5. **Compatible - Unset `IPAddressType`**: Expect validation to pass by defaulting unset `IPAddressType` to `IPv4`.

### local test
Added `SubnetBindingIPFamilyCompatibility` subtest:
1. **IPv6 Child with IPv4 Parent**: Creates an IPv4 Parent Subnet and an IPv6 Child Subnet, then creates a `SubnetConnectionBindingMap` targeting the IPv4 Subnet.
2. **Verification**: Verifies that SCBM status condition is marked as `Ready: False` with `Incompatible IPAddressType` error message. Automatically skips if the cluster does not support IPv6.


```
k get SubnetConnectionBindingMap -A -oyaml
apiVersion: v1
items:
- apiVersion: crd.nsx.vmware.com/v1alpha1
  kind: SubnetConnectionBindingMap
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"crd.nsx.vmware.com/v1alpha1","kind":"SubnetConnectionBindingMap","metadata":{"annotations":{},"name":"scbm-neg-v6-to-v4","namespace":"default"},"spec":{"subnetAssociation":"Trunk","subnetName":"child-v6","targetSubnetName":"parent-v4"}}
    creationTimestamp: "2026-09-03T12:56:24Z"
    generation: 1
    name: scbm-neg-v6-to-v4
    namespace: default
    resourceVersion: "534745"
    uid: 9dc75823-d638-4aad-8420-820e748ad783
  spec:
    subnetAssociation: Trunk
    subnetName: child-v6
    targetSubnetName: parent-v4
  status:
    conditions:
    - lastTransitionTime: "2026-09-03T12:56:24Z"
      message: 'Incompatible IPAddressType: Subnet IPAddressType IPv6 targetSubnet
        IPAddressType IPv4, isBranch mode:false'
      reason: DependencyNotReady
      status: "False"
      type: Ready
kind: List
metadata:
  resourceVersion: ""
```