### PR TITLE
refactor(nsx): remove ConfigMap vpc_wcp_enhance check for StatefulSet…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -267,12 +267,12 @@ func startServiceController(mgr manager.Manager, nsxClient *nsx.Client) {
 		}
 		// StatefulSet controller is always registered so that after NSX upgrades
 		// replica/GC logic can run without restarting the operator. Reconcile and CollectGarbage
-		// no-op until NSX version supports STS pods and vpc_wcp_enhance=true in config; delete cleanup still runs.
+		// no-op until NSX version supports STS pods; delete cleanup still runs.
 		reconcilerList = append(reconcilerList, statefulsetcontroller.NewStatefulSetReconciler(mgr, subnetPortService))
-		if nsx.StatefulSetPodSubnetPortFeatureEnabled(commonService.NSXClient, commonService.NSXConfig) {
-			log.Info("NSX version and config allow StatefulSet Pod feature; StatefulSet controller will run replica/GC work")
+		if nsx.StatefulSetPodSubnetPortFeatureEnabled(commonService.NSXClient) {
+			log.Info("NSX version allows StatefulSet Pod feature; StatefulSet controller will run replica/GC work")
 		} else {
-			log.Info("StatefulSet Pod feature gated (NSX version and/or vpc_wcp_enhance!=true); StatefulSet controller registered but replica/GC no-op until enabled")
+			log.Info("StatefulSet Pod feature gated (NSX version does not support StatefulSetPod); StatefulSet controller registered but replica/GC no-op until enabled")
 		}
 		if cf.EnableInventory {
 			reconcilerList = append(reconcilerList, inventory.NewInventoryController(mgr.GetClient(), inventoryService, cf))

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -147,7 +147,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return common.ResultRequeue, err
 		}
 		if subnetPort != nil {
-			if nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig) && r.isStatefulSetSubnetPort(subnetPort) {
+			if nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient) && r.isStatefulSetSubnetPort(subnetPort) {
 				log.Info("Ignoring subnet port deletion for StatefulSet pod",
 					"pod", subnetPort.DisplayName, "statefulset-uid", r.getStsUID(subnetPort))
 				return common.ResultNormal, nil
@@ -382,7 +382,7 @@ func (r *PodReconciler) CollectGarbage(ctx context.Context) error {
 		if store != nil && store.Indexer != nil {
 			if nsxSubnetPort := store.GetByKey(elem); nsxSubnetPort != nil &&
 				r.SubnetPortService.NSXClient != nil &&
-				nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig) && r.isStatefulSetSubnetPort(nsxSubnetPort) {
+				nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient) && r.isStatefulSetSubnetPort(nsxSubnetPort) {
 				log.Info("Skipping pod GC for StatefulSet pod subnet port", "NSXSubnetPortID", elem, "statefulset-uid", r.getStsUID(nsxSubnetPort))
 				continue
 			}
@@ -436,7 +436,7 @@ func (r *PodReconciler) GetSubnetPathForPod(ctx context.Context, pod *v1.Pod) (b
 	}
 
 	// Check if this is a StatefulSet pod and we can reuse an existing SubnetPort
-	if nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig) {
+	if nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient) {
 		stsUID := subnetport.GetStatefulSetUID(pod)
 		if port := r.SubnetPortService.GetExistingSubnetPortForStatefulSetPod(pod.Name, stsUID); port != nil {
 			if port.ParentPath != nil {
@@ -479,7 +479,7 @@ func (r *PodReconciler) deleteSubnetPortByPodName(ctx context.Context, ns string
 	for _, nsxSubnetPort := range nsxSubnetPorts {
 		// Check if this subnet port was created for StatefulSet
 		// Only skip if StatefulSet pod SubnetPort feature is enabled
-		if nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig) && r.isStatefulSetSubnetPort(nsxSubnetPort) {
+		if nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient) && r.isStatefulSetSubnetPort(nsxSubnetPort) {
 			log.Info("Ignoring subnet port deletion for StatefulSet pod",
 				"pod", name, "statefulset-uid", r.getStsUID(nsxSubnetPort))
 			continue // Skip deletion

--- a/pkg/controllers/pod/pod_controller_test.go
+++ b/pkg/controllers/pod/pod_controller_test.go
@@ -590,7 +590,7 @@ func TestPodReconciler_GetSubnetPathForPod(t *testing.T) {
 						return ""
 					})
 				patches.ApplyFunc(nsx.StatefulSetPodSubnetPortFeatureEnabled,
-					func(client *nsx.Client, config *config.NSXOperatorConfig) bool {
+					func(client *nsx.Client) bool {
 						return true
 					})
 				patches.ApplyFunc(subnetport.GetStatefulSetUID,

--- a/pkg/controllers/statefulset/statefulset_controller.go
+++ b/pkg/controllers/statefulset/statefulset_controller.go
@@ -62,7 +62,7 @@ type StatefulSetReconciler struct {
 
 // StatefulSetPodFeatureEnabled reports whether the StatefulSet pod SubnetPort feature is active.
 func (r *StatefulSetReconciler) StatefulSetPodFeatureEnabled() bool {
-	return nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient, r.SubnetPortService.NSXConfig)
+	return nsx.StatefulSetPodSubnetPortFeatureEnabled(r.SubnetPortService.NSXClient)
 }
 
 func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/pkg/controllers/statefulset/statefulset_controller_test.go
+++ b/pkg/controllers/statefulset/statefulset_controller_test.go
@@ -2069,40 +2069,27 @@ func TestReconcile_NoOpWhenFeatureDisabled(t *testing.T) {
 }
 
 func TestStatefulSetPodFeatureEnabled_NSXCheckVersion(t *testing.T) {
-	defer patchNSXClientStatefulSetPodVersion(t, true)()
-	s := &subnetportservice.SubnetPortService{
-		Service: servicecommon.Service{
-			NSXClient: &nsx.Client{},
-			NSXConfig: testNSXConfigWithStatefulSetPodEnhance(),
-		},
-	}
-	r := &StatefulSetReconciler{SubnetPortService: s}
-	assert.True(t, r.StatefulSetPodFeatureEnabled())
-}
+	t.Run("enabled when NSX check version returns true", func(t *testing.T) {
+		defer patchNSXClientStatefulSetPodVersion(t, true)()
+		s := &subnetportservice.SubnetPortService{
+			Service: servicecommon.Service{
+				NSXClient: &nsx.Client{},
+			},
+		}
+		r := &StatefulSetReconciler{SubnetPortService: s}
+		assert.True(t, r.StatefulSetPodFeatureEnabled())
+	})
 
-func TestStatefulSetPodFeatureEnabled_DisabledWhenVpcWcpEnhanceUnset(t *testing.T) {
-	defer patchNSXClientStatefulSetPodVersion(t, true)()
-	s := &subnetportservice.SubnetPortService{
-		Service: servicecommon.Service{
-			NSXClient: &nsx.Client{},
-			NSXConfig: &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{EnforcementPoint: "vmc-enforcementpoint"}},
-		},
-	}
-	r := &StatefulSetReconciler{SubnetPortService: s}
-	assert.False(t, r.StatefulSetPodFeatureEnabled())
-}
-
-func TestStatefulSetPodFeatureEnabled_DisabledWhenVpcWcpEnhanceFalse(t *testing.T) {
-	defer patchNSXClientStatefulSetPodVersion(t, true)()
-	off := false
-	s := &subnetportservice.SubnetPortService{
-		Service: servicecommon.Service{
-			NSXClient: &nsx.Client{},
-			NSXConfig: &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{VpcWcpEnhance: &off}},
-		},
-	}
-	r := &StatefulSetReconciler{SubnetPortService: s}
-	assert.False(t, r.StatefulSetPodFeatureEnabled())
+	t.Run("disabled when NSX check version returns false", func(t *testing.T) {
+		defer patchNSXClientStatefulSetPodVersion(t, false)()
+		s := &subnetportservice.SubnetPortService{
+			Service: servicecommon.Service{
+				NSXClient: &nsx.Client{},
+			},
+		}
+		r := &StatefulSetReconciler{SubnetPortService: s}
+		assert.False(t, r.StatefulSetPodFeatureEnabled())
+	})
 }
 
 func TestCollectGarbage_GetPodErrorDoesNotSkipDelete(t *testing.T) {

--- a/pkg/nsx/feature.go
+++ b/pkg/nsx/feature.go
@@ -5,18 +5,14 @@ package nsx
 
 import "github.com/vmware-tanzu/nsx-operator/pkg/config"
 
-// StatefulSetPodSubnetPortFeatureEnabled is true when NSX version is 9.1.2+ and vpc_wcp_enhance=true
-// and operator nsx_v3 sets vpc_wcp_enhance to true (omitted or false keeps the feature off).
+// StatefulSetPodSubnetPortFeatureEnabled is true when NSX supports reusing subnet ports for statefulset pod.
 //
 //go:noinline
-func StatefulSetPodSubnetPortFeatureEnabled(client *Client, operatorConfig *config.NSXOperatorConfig) bool {
-	if client == nil || !client.NSXCheckVersion(StatefulSetPod) {
+func StatefulSetPodSubnetPortFeatureEnabled(client *Client) bool {
+	if client == nil {
 		return false
 	}
-	if operatorConfig == nil || operatorConfig.NsxConfig == nil {
-		return false
-	}
-	return operatorConfig.NsxConfig.VpcWcpEnhanceEnabled()
+	return client.NSXCheckVersion(StatefulSetPod)
 }
 
 // MacPoolDHCPFeatureEnabled is true when NSX supports MAC_POOL allocateAddresses for DHCP

--- a/pkg/nsx/feature_test.go
+++ b/pkg/nsx/feature_test.go
@@ -14,32 +14,26 @@ import (
 )
 
 func TestStatefulSetPodSubnetPortFeatureEnabled(t *testing.T) {
-	f := false
-	tr := true
 	nsxClient := &Client{}
 
 	t.Run("nil client", func(t *testing.T) {
-		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nil, &config.NSXOperatorConfig{}))
+		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nil))
 	})
 
-	t.Run("version supports and vpc_wcp_enhance opt-in", func(t *testing.T) {
-		p := gomonkey.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *Client, feature int) bool {
+	t.Run("version supports", func(t *testing.T) {
+		p := gomonkey.ApplyMethodFunc(&Client{}, "NSXCheckVersion", func(feature int) bool {
 			return feature == StatefulSetPod
 		})
 		defer p.Reset()
-		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, nil))
-		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: nil}))
-		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}))
-		assert.True(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{VpcWcpEnhance: &tr}}))
-		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{VpcWcpEnhance: &f}}))
+		assert.True(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient))
 	})
 
 	t.Run("version does not support", func(t *testing.T) {
-		p := gomonkey.ApplyMethod(reflect.TypeOf(nsxClient), "NSXCheckVersion", func(_ *Client, feature int) bool {
+		p := gomonkey.ApplyMethodFunc(&Client{}, "NSXCheckVersion", func(feature int) bool {
 			return false
 		})
 		defer p.Reset()
-		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient, &config.NSXOperatorConfig{NsxConfig: &config.NsxConfig{}}))
+		assert.False(t, StatefulSetPodSubnetPortFeatureEnabled(nsxClient))
 	})
 }
 

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -279,7 +279,7 @@ func (service *SubnetPortService) BuildSubnetPortIdAndName(obj *metav1.ObjectMet
 	// For StatefulSet pods: check if a SubnetPort with the same StatefulSet UID and pod name exists
 	// Note: STS UID is globally unique, so we only need to check pod name
 	// Only reuse if StatefulSet pod SubnetPort feature is enabled
-	enableStsFeature := nsx.StatefulSetPodSubnetPortFeatureEnabled(service.NSXClient, service.NSXConfig)
+	enableStsFeature := nsx.StatefulSetPodSubnetPortFeatureEnabled(service.NSXClient)
 	if enableStsFeature {
 		if port := service.GetExistingSubnetPortForStatefulSetPod(obj.Name, stsUID); port != nil {
 			log.Info("Reusing existing SubnetPort for StatefulSet pod",

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -1379,7 +1379,7 @@ func TestBuildSubnetPortIdAndName_existingPortByUID(t *testing.T) {
 		})
 	defer patches.Reset()
 	patchesStsFeat := gomonkey.ApplyFunc(nsx.StatefulSetPodSubnetPortFeatureEnabled,
-		func(_ *nsx.Client, _ *config.NSXOperatorConfig) bool {
+		func(_ *nsx.Client) bool {
 			return false
 		})
 	defer patchesStsFeat.Reset()
@@ -1427,7 +1427,7 @@ func TestBuildSubnetPortIdAndName_reuseSTSPortByUIDAndPodName(t *testing.T) {
 			return nil
 		})
 	patchesStsFeat := gomonkey.ApplyFunc(nsx.StatefulSetPodSubnetPortFeatureEnabled,
-		func(_ *nsx.Client, _ *config.NSXOperatorConfig) bool {
+		func(_ *nsx.Client) bool {
 			return true
 		})
 	defer patchesStsFeat.Reset()


### PR DESCRIPTION
… feature

The StatefulSet Pod SubnetPort feature is enabled by default on supported NSX versions. Checking the ConfigMap setting vpc_wcp_enhance is no longer necessary.

This change:
1. Simplifies StatefulSetPodSubnetPortFeatureEnabled signature to only accept the NSX Client and check client.NSXCheckVersion(StatefulSetPod).
2. Updates all callers in controllers, main, and builder to drop the NSXConfig parameter.
3. Updates unit tests accordingly.

Test Done
1. remove  the vpc_wcp_enhance from the configmap
2. the nsx version is 9.2.0.0
3. create the sts pod
4. check the log if the feature work