### PR TITLE
Support reuse-port annotation for cpVM migration and skip vm-default …

### DIFF
--- a/pkg/controllers/namespace/namespace_controller.go
+++ b/pkg/controllers/namespace/namespace_controller.go
@@ -154,6 +154,10 @@ func (r *NamespaceReconciler) createDefaultSubnetSet(ctx context.Context, ns str
 	defaultSubnetSets := getDefaultSubnetsets(namespaceType)
 	ipFamily := r.NSXConfig.K8sConfig.GetIPAddressType()
 	for name, subnetSetType := range defaultSubnetSets {
+		if ns == "kube-system" && name == types.DefaultVMSubnetSet && r.NSXConfig.NsxConfig.VpcWcpEnhanceEnabled() {
+			log.Info("Skipping default SubnetSet creation for kube-system in Supervisor 2.0")
+			continue
+		}
 		if err := retry.OnError(retry.DefaultRetry, func(err error) bool {
 			return err != nil
 		}, func() error {

--- a/pkg/controllers/namespace/namespace_controller_test.go
+++ b/pkg/controllers/namespace/namespace_controller_test.go
@@ -366,6 +366,21 @@ func TestCreateDefaultSubnetSet(t *testing.T) {
 		setupMocks              func(r *NamespaceReconciler) *gomonkey.Patches
 	}{
 		{
+			name:               "Skip case - not create SubnetSet for kube-system when VpcWcpEnhance is true",
+			namespace:          "kube-system",
+			defaultSubnetSize:  24,
+			existingResources:  []client.Object{},
+			expectedError:      false,
+			networkStack:       v1alpha1.FullStackVPC,
+			nameSpaceType:      ctlcommon.SystemNs,
+			expectedSubnetSets: 0,
+			setupMocks: func(r *NamespaceReconciler) *gomonkey.Patches {
+				tr := true
+				r.NSXConfig.NsxConfig.VpcWcpEnhance = &tr
+				return gomonkey.NewPatches()
+			},
+		},
+		{
 			name:              "Skip case - not create SubnetSet for NormalNs",
 			namespace:         "test-ns",
 			defaultSubnetSize: 24,

--- a/pkg/controllers/subnetport/subnetport_controller.go
+++ b/pkg/controllers/subnetport/subnetport_controller.go
@@ -949,6 +949,26 @@ func (r *SubnetPortReconciler) CheckAndGetSubnetPathForSubnetPort(ctx context.Co
 		existing = true
 		return
 	}
+	if reusePort, ok := subnetPort.Annotations[servicecommon.AnnotationReusePort]; ok {
+		if reusePort == "" {
+			err = fmt.Errorf("reused port cannot be empty")
+			return
+		}
+		parts := strings.Split(reusePort, "/")
+		if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+			existingPorts := r.SubnetPortService.ListSubnetPortByName(parts[0], parts[1])
+			if len(existingPorts) > 0 && existingPorts[0].ParentPath != nil && len(*existingPorts[0].ParentPath) > 0 {
+				subnetPath = *existingPorts[0].ParentPath
+				existing = true
+				log.Debug("NSX SubnetPort will be reused on the existing NSX Subnet", "subnetPort.UID", subnetPort.UID, "reusePort", reusePort, "subnetPath", subnetPath)
+				return
+			}
+			err = fmt.Errorf("reused port %s not found in runtime store", reusePort)
+			return
+		}
+		err = fmt.Errorf("invalid reuse-port annotation value %s, expected format <namespace>/<name>", reusePort)
+		return
+	}
 	if r.restoreMode {
 		// For restore case, SubnetPort will be created on the Subnet with matching CIDR
 		if subnetPort.Status.NetworkInterfaceConfig.IPAddresses[0].Gateway != "" {

--- a/pkg/controllers/subnetport/subnetport_controller_test.go
+++ b/pkg/controllers/subnetport/subnetport_controller_test.go
@@ -2152,6 +2152,83 @@ func TestSubnetPortReconciler_CheckAndGetSubnetPathForSubnetPort(t *testing.T) {
 			restoreMode: true,
 			expectedErr: "mocked getSubnetBySubnetPort error",
 		},
+		{
+			name: "ReusePortAnnotationSuccess",
+			prepareFunc: func(t *testing.T, spr *SubnetPortReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
+					func(s *subnetport.SubnetPortStore, uid types.UID) (*model.VpcSubnetPort, error) {
+						return nil, nil
+					})
+				patches.ApplyFunc((*subnetport.SubnetPortService).ListSubnetPortByName,
+					func(s *subnetport.SubnetPortService, ns string, name string) []*model.VpcSubnetPort {
+						if ns == "kube-system" && name == "old-vm" {
+							return []*model.VpcSubnetPort{
+								{
+									Id:         servicecommon.String("reused-port-id"),
+									ParentPath: servicecommon.String("subnet-path-reused"),
+								},
+							}
+						}
+						return nil
+					})
+				return patches
+			},
+			expectedSubnetPath: "subnet-path-reused",
+			expectedIsExisting: true,
+			subnetport: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "new-vm",
+					Namespace: "user-ns",
+					Annotations: map[string]string{
+						servicecommon.AnnotationReusePort: "kube-system/old-vm",
+					},
+				},
+			},
+		},
+		{
+			name: "ReusePortAnnotationEmpty",
+			prepareFunc: func(t *testing.T, spr *SubnetPortReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
+					func(s *subnetport.SubnetPortStore, uid types.UID) (*model.VpcSubnetPort, error) {
+						return nil, nil
+					})
+				return patches
+			},
+			expectedErr: "reused port cannot be empty",
+			subnetport: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-anno-vm",
+					Namespace: "user-ns",
+					Annotations: map[string]string{
+						servicecommon.AnnotationReusePort: "",
+					},
+				},
+			},
+		},
+		{
+			name: "ReusePortAnnotationNotFound",
+			prepareFunc: func(t *testing.T, spr *SubnetPortReconciler) *gomonkey.Patches {
+				patches := gomonkey.ApplyFunc((*subnetport.SubnetPortStore).GetVpcSubnetPortByUID,
+					func(s *subnetport.SubnetPortStore, uid types.UID) (*model.VpcSubnetPort, error) {
+						return nil, nil
+					})
+				patches.ApplyFunc((*subnetport.SubnetPortService).ListSubnetPortByName,
+					func(s *subnetport.SubnetPortService, ns string, name string) []*model.VpcSubnetPort {
+						return nil
+					})
+				return patches
+			},
+			expectedErr: "reused port kube-system/not-exist not found in runtime store",
+			subnetport: &v1alpha1.SubnetPort{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "notfound-anno-vm",
+					Namespace: "user-ns",
+					Annotations: map[string]string{
+						servicecommon.AnnotationReusePort: "kube-system/not-exist",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -98,6 +98,7 @@ const (
 	AnnotationDefaultNetworkConfig     string = "nsx.vmware.com/default"
 	AnnotationAttachmentRef            string = "nsx.vmware.com/attachment_ref"
 	AnnotationAssociatedResource       string = "nsx.vmware.com/associated-resource"
+	AnnotationReusePort                string = "nsx.vmware.com/reuse-port"
 	AnnotationReconfigureNic           string = "nsx/reconfigure-nic"
 	AnnotationPodMAC                   string = "nsx.vmware.com/mac"
 	AnnotationAttachment               string = "nsx.vmware.com/attachment"

--- a/pkg/nsx/services/subnetport/builder.go
+++ b/pkg/nsx/services/subnetport/builder.go
@@ -177,7 +177,10 @@ func (service *SubnetPortService) buildSubnetPort(obj interface{}, nsxSubnet *mo
 	}
 	namespaceUid := namespace.UID
 
-	nsxSubnetPortID, nsxSubnetPortName := service.BuildSubnetPortIdAndName(objMeta, namespaceUid, stsUID)
+	nsxSubnetPortID, nsxSubnetPortName, err := service.BuildSubnetPortIdAndName(objMeta, namespaceUid, stsUID)
+	if err != nil {
+		return nil, err
+	}
 	nsxSubnetPortPath := fmt.Sprintf("%s/ports/%s", *nsxSubnet.Path, nsxSubnetPortID)
 
 	tags := util.BuildBasicTags(getCluster(service), obj, namespaceUid)
@@ -270,21 +273,45 @@ func (service *SubnetPortService) GetExistingSubnetPortForStatefulSetPod(podName
 	return nil
 }
 
-func (service *SubnetPortService) BuildSubnetPortIdAndName(obj *metav1.ObjectMeta, namespaceUID types.UID, stsUID string) (string, string) {
+func (service *SubnetPortService) BuildSubnetPortIdAndName(obj *metav1.ObjectMeta, namespaceUID types.UID, stsUID string) (string, string, error) {
 	existingSubnetPort, err := service.SubnetPortStore.GetVpcSubnetPortByUID(obj.GetUID())
 	if err == nil && existingSubnetPort != nil {
-		return *existingSubnetPort.Id, *existingSubnetPort.DisplayName
+		return *existingSubnetPort.Id, *existingSubnetPort.DisplayName, nil
+	}
+
+	if reusePort, ok := obj.Annotations[common.AnnotationReusePort]; ok {
+		if reusePort == "" {
+			return "", "", fmt.Errorf("reused port cannot be empty")
+		}
+		parts := strings.Split(reusePort, "/")
+		if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+			oldNamespace := parts[0]
+			oldName := parts[1]
+			log.Info("Checking reuse-port annotation", "oldNamespace", oldNamespace, "oldName", oldName)
+			existingPorts := service.ListSubnetPortByName(oldNamespace, oldName)
+			if len(existingPorts) > 0 {
+				log.Info("Reusing existing SubnetPort based on annotation",
+					"oldNamespace", oldNamespace, "oldName", oldName, "newNamespace", obj.Namespace, "newName", obj.Name)
+				return *existingPorts[0].Id, *existingPorts[0].DisplayName, nil
+			}
+			return "", "", fmt.Errorf("reused port %s not found in runtime store", reusePort)
+		}
+		return "", "", fmt.Errorf("invalid reuse-port annotation value %s, expected format <namespace>/<name>", reusePort)
 	}
 
 	// For StatefulSet pods: check if a SubnetPort with the same StatefulSet UID and pod name exists
 	// Note: STS UID is globally unique, so we only need to check pod name
 	// Only reuse if StatefulSet pod SubnetPort feature is enabled
-	enableStsFeature := nsx.StatefulSetPodSubnetPortFeatureEnabled(service.NSXClient, service.NSXConfig)
-	if enableStsFeature {
-		if port := service.GetExistingSubnetPortForStatefulSetPod(obj.Name, stsUID); port != nil {
-			log.Info("Reusing existing SubnetPort for StatefulSet pod",
-				"podName", obj.Name, "stsUID", stsUID, "portID", *port.Id)
-			return *port.Id, *port.DisplayName
+	if stsUID != "" && nsx.StatefulSetPodSubnetPortFeatureEnabled(service.NSXClient, service.NSXConfig) {
+		existingPorts := service.SubnetPortStore.GetByIndex(common.TagScopeStatefulSetUID, stsUID)
+		for _, port := range existingPorts {
+			log.Debug("BuildSubnetPortIdAndName", "port", port.Id, "path", port.Path)
+			portName := nsxutil.FindTag(port.Tags, common.TagScopePodName)
+			if portName == obj.Name {
+				log.Info("Reusing existing SubnetPort for StatefulSet pod",
+					"podName", obj.Name, "stsUID", stsUID)
+				return *port.Id, *port.DisplayName, nil
+			}
 		}
 	}
 
@@ -295,7 +322,7 @@ func (service *SubnetPortService) BuildSubnetPortIdAndName(obj *metav1.ObjectMet
 	}
 	return common.BuildUniqueIDWithRandomUUID(objWithNamespaceUID, util.GenerateIDByObject, func(id string) bool {
 		return service.SubnetPortStore.GetByKey(id) != nil
-	}), service.BuildSubnetPortName(obj)
+	}), service.BuildSubnetPortName(obj), nil
 }
 
 func (service *SubnetPortService) BuildSubnetPortName(obj *metav1.ObjectMeta) string {

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -1385,7 +1385,8 @@ func TestBuildSubnetPortIdAndName_existingPortByUID(t *testing.T) {
 	defer patchesStsFeat.Reset()
 
 	objMeta := &metav1.ObjectMeta{Name: "test-pod", UID: "pod-uid-123"}
-	id, name := service.BuildSubnetPortIdAndName(objMeta, types.UID("ns-uid-456"), "")
+	id, name, err := service.BuildSubnetPortIdAndName(objMeta, types.UID("ns-uid-456"), "")
+	assert.NoError(t, err)
 	assert.Equal(t, "existing-port-id", id)
 	assert.Equal(t, "existing-port-name", name)
 }
@@ -1433,7 +1434,8 @@ func TestBuildSubnetPortIdAndName_reuseSTSPortByUIDAndPodName(t *testing.T) {
 	defer patchesStsFeat.Reset()
 
 	objMeta := &metav1.ObjectMeta{Name: "test-pod", UID: "pod-uid-123"}
-	id, name := service.BuildSubnetPortIdAndName(objMeta, types.UID("ns-uid-456"), "sts-uid-123")
+	id, name, err := service.BuildSubnetPortIdAndName(objMeta, types.UID("ns-uid-456"), "sts-uid-123")
+	assert.NoError(t, err)
 	assert.Equal(t, "sts-port-id", id)
 	assert.Equal(t, "test-pod", name)
 }
@@ -1806,4 +1808,106 @@ func TestGetExistingSubnetPortForStatefulSetPod(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildSubnetPortIdAndName_reusePortAnnotation(t *testing.T) {
+	nsxClient := &nsx.Client{}
+	store := setupStore()
+	service := &SubnetPortService{
+		Service: common.Service{
+			NSXClient: nsxClient,
+		},
+		SubnetPortStore: store,
+	}
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(store), "GetVpcSubnetPortByUID",
+		func(s *SubnetPortStore, uid types.UID) (*model.VpcSubnetPort, error) {
+			return nil, nil
+		})
+	defer patches.Reset()
+
+	patches.ApplyMethod(reflect.TypeOf(service), "ListSubnetPortByName",
+		func(s *SubnetPortService, ns, name string) []*model.VpcSubnetPort {
+			if ns == "kube-system" && name == "vm-44" {
+				portID := "reused-port-id"
+				portName := "reused-port-name"
+				return []*model.VpcSubnetPort{
+					{
+						Id:          &portID,
+						DisplayName: &portName,
+					},
+				}
+			}
+			return nil
+		})
+
+	// Test successful reuse
+	objMeta := &metav1.ObjectMeta{
+		Name:      "new-vm-44",
+		Namespace: "user-ns",
+		UID:       "new-uid-123",
+		Annotations: map[string]string{
+			common.AnnotationReusePort: "kube-system/vm-44",
+		},
+	}
+
+	id, name, err := service.BuildSubnetPortIdAndName(objMeta, types.UID("ns-uid-456"), "")
+	assert.NoError(t, err)
+	assert.Equal(t, "reused-port-id", id)
+	assert.Equal(t, "reused-port-name", name)
+
+	// Test reuse port not found
+	objMetaNotFound := &metav1.ObjectMeta{
+		Name:      "new-vm-45",
+		Namespace: "user-ns",
+		UID:       "new-uid-124",
+		Annotations: map[string]string{
+			common.AnnotationReusePort: "kube-system/vm-45",
+		},
+	}
+	id, name, err = service.BuildSubnetPortIdAndName(objMetaNotFound, types.UID("ns-uid-456"), "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "reused port kube-system/vm-45 not found in runtime store")
+	assert.Equal(t, "", id)
+	assert.Equal(t, "", name)
+
+	// Test CRD without reuse-port annotation (should fall back to standard ID generation and not error)
+	objMetaNoAnnotation := &metav1.ObjectMeta{
+		Name:      "normal-vm",
+		Namespace: "user-ns",
+		UID:       "normal-uid-125",
+	}
+	id, name, err = service.BuildSubnetPortIdAndName(objMetaNoAnnotation, types.UID("ns-uid-456"), "")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, id)
+	assert.Equal(t, "normal-vm", name)
+
+	// Test CRD with empty reuse-port annotation (should report error)
+	objMetaEmptyAnnotation := &metav1.ObjectMeta{
+		Name:      "empty-anno-vm",
+		Namespace: "user-ns",
+		UID:       "empty-uid-126",
+		Annotations: map[string]string{
+			common.AnnotationReusePort: "",
+		},
+	}
+	id, name, err = service.BuildSubnetPortIdAndName(objMetaEmptyAnnotation, types.UID("ns-uid-456"), "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "reused port cannot be empty")
+	assert.Equal(t, "", id)
+	assert.Equal(t, "", name)
+
+	// Test CRD with invalid reuse-port annotation format (should report error)
+	objMetaInvalidAnnotation := &metav1.ObjectMeta{
+		Name:      "invalid-anno-vm",
+		Namespace: "user-ns",
+		UID:       "invalid-uid-127",
+		Annotations: map[string]string{
+			common.AnnotationReusePort: "invalid-format",
+		},
+	}
+	id, name, err = service.BuildSubnetPortIdAndName(objMetaInvalidAnnotation, types.UID("ns-uid-456"), "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid reuse-port annotation value")
+	assert.Equal(t, "", id)
+	assert.Equal(t, "", name)
 }

--- a/pkg/nsx/services/subnetport/subnetport.go
+++ b/pkg/nsx/services/subnetport/subnetport.go
@@ -491,6 +491,11 @@ func (service *SubnetPortService) ListSubnetPortByName(ns string, name string) [
 		tagName := nsxutil.FindTag(subnetport.Tags, servicecommon.TagScopeSubnetPortCRName)
 		if tagName == name {
 			result = append(result, subnetport)
+			continue
+		}
+		tagPodName := nsxutil.FindTag(subnetport.Tags, servicecommon.TagScopePodName)
+		if tagPodName == name {
+			result = append(result, subnetport)
 		}
 	}
 	return result


### PR DESCRIPTION
…SubnetSet for kube-system in Supervisor 2.0

- Support reuse-port annotation for cpVM migration
- Skip vm-default SubnetSet creation for kube-system in Supervisor 2.0

## Testing Done
### 1. Test Environment
* **Cluster / Host**: `10.161.60.138`
* **Component**: `nsx-operator` (running in `nsx-ncp` pod, namespace `vmware-system-nsx`)
* **Feature Flags**: `[nsx_v3] vpc_wcp_enhance = True`
---
### 2. Live Cluster Test Matrix
| # | Test Scenario | Annotation / Input | Expected Result | Actual Live Result | Status |
|:--|:---|:---|:---|:---|:--:|
| **1** | **Valid `reuse-port` annotation** | `nsx.vmware.com/reuse-port: "kube-system/vm-44"` | Reuses existing NSX SubnetPort (`vm-44_5rucs`), updates tags/status | SubnetPort reused, tags updated, `Ready: True` | **PASS** |
| **2** | **Non-existent target port** | `nsx.vmware.com/reuse-port: "kube-system/non-existent-vm"` | Fails reconcile, logs error, sets `Ready: False` | `Ready: False`<br>`reused port kube-system/non-existent-vm not found in runtime store` | **PASS** |
| **3** | **Empty annotation value** | `nsx.vmware.com/reuse-port: ""` | Explicitly reports error (does NOT fallback), sets `Ready: False` | `Ready: False`<br>`reused port cannot be empty` | **PASS** |
| **4** | **Invalid format annotation** | `nsx.vmware.com/reuse-port: "invalid-format-without-slash"` | Fails format validation, sets `Ready: False` | `Ready: False`<br>`invalid reuse-port annotation value ..., expected format <namespace>/<name>` | **PASS** |
| **5** | **Baseline CR without annotation** | *None* | Standard allocation via SubnetSet; allocates new IP and ID | Created new port (`test-vm-standard_5rucs`), IP `172.26.0.4/29`, `Ready: True` | **PASS** |
| **6** | **Skip `vm-default` SubnetSet for `kube-system`** | Reconcile `kube-system` namespace | Skips `vm-default` SubnetSet creation in Supervisor 2.0 | Logged: `Skipping default SubnetSet creation for kube-system in Supervisor 2.0` | **PASS** |
---
### 3. Key Verification Highlights
* **Strict Empty Value Validation**: Verified that `nsx.vmware.com/reuse-port: ""` is rejected with `reused port cannot be empty` and does not silently fall back to standard ID generation.
* **Backward Compatibility**: Standard SubnetPort CRDs without annotations continue normal SubnetSet allocation without issues.
* **Supervisor 2.0 Namespace Handling**: Confirmed that `vm-default` SubnetSet creation for `kube-system` is skipped when `vpc_wcp_enhance` is active.
