### PR TITLE
test: wait for NSX subnet deletion before reusing CIDR in SubnetPortWithDHCP

### DIFF
--- a/test/e2e/nsx_subnet_test.go
+++ b/test/e2e/nsx_subnet_test.go
@@ -843,6 +843,7 @@ func SubnetPortWithDHCP(t *testing.T) {
 	// then delete and recreate the Subnet with the available CIDR as specified IPAddresses.
 	subnetCreated := createSubnetWithCheck(t, dhcpSubnet)
 	ipAddresses := subnetCreated.Status.NetworkAddresses[0]
+	dhcpSubnetUID := string(subnetCreated.UID)
 	require.NotEmpty(t, ipAddresses, "No IP address in Subnet")
 	_, subnetCIDR, err := net.ParseCIDR(ipAddresses)
 	require.NoError(t, err, "Failed to parse Subnet CIDR")
@@ -866,6 +867,12 @@ func SubnetPortWithDHCP(t *testing.T) {
 			return true, nil
 		}
 		return false, err
+	})
+	require.NoError(t, err)
+	// Wait for NSX to mark the backing subnet for deletion before reusing its CIDR.
+	err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 100*time.Second, false, func(ctx context.Context) (bool, error) {
+		nsxSubnets := testData.fetchSubnetBySubnetUID(t, dhcpSubnetUID)
+		return len(nsxSubnets) == 0 || *nsxSubnets[0].MarkedForDelete, nil
 	})
 	require.NoError(t, err)
 	subnetCreated = createSubnetWithCheck(t, dhcpSubnet)


### PR DESCRIPTION
In SubnetPortWithDHCP E2E test, after deleting the probe DHCP subnet, the test immediately recreated a subnet with the same CIDR once the K8s CR disappeared. However, NSX backend subnet deletion and IP block capacity release are asynchronous, which could cause transient 520100 (spare capacity) or 500045 (marked for deletion) errors. Add a polling wait for the backing NSX subnet to be marked for deletion or removed before recreating the subnet with the same CIDR, matching the pattern used in SubnetMixedMode.