### PR TITLE
Support ip address type for ipblockusage eas api

### DIFF
--- a/build/yaml/crd/eas/eas.nsx.vmware.com_ipblockusages.yaml
+++ b/build/yaml/crd/eas/eas.nsx.vmware.com_ipblockusages.yaml
@@ -21,6 +21,14 @@ spec:
           IPBlockUsage is the usage information of an IPBlock.
           It contains used IP ranges and available IP ranges statistics of an IPBlock.
         properties:
+          addressType:
+            description: |-
+              IP address type of the IPBlock.
+              Must be IPv4 or IPv6.
+            enum:
+            - IPv4
+            - IPv6
+            type: string
           apiVersion:
             description: |-
               APIVersion defines the versioned schema of this representation of an object.

--- a/pkg/apis/eas/v1alpha1/ipblockusage_types.go
+++ b/pkg/apis/eas/v1alpha1/ipblockusage_types.go
@@ -36,7 +36,18 @@ type IPBlockUsage struct {
 	// Must be External or Private.
 	// +kubebuilder:validation:Enum=External;Private
 	Visibility IPAddressVisibility `json:"visibility,omitempty"`
+	// IP address type of the IPBlock.
+	// Must be IPv4 or IPv6.
+	// +kubebuilder:validation:Enum=IPv4;IPv6
+	AddressType IPAddressType `json:"addressType,omitempty"`
 }
+
+type IPAddressType string
+
+const (
+	IPv4 IPAddressType = "IPv4"
+	IPv6 IPAddressType = "IPv6"
+)
 
 // Represents used and available IP statistics for CIDRs in an IPBlock.
 type CIDRUsage struct {

--- a/pkg/apis/eas/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/eas/v1alpha1/zz_generated.openapi.go
@@ -346,6 +346,13 @@ func schema_pkg_apis_eas_v1alpha1_IPBlockUsage(ref common.ReferenceCallback) com
 							Format:      "",
 						},
 					},
+					"addressType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AddressType of IPBlock. Must be IPv4 or IPv6.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/eas/storage/ipblockusage.go
+++ b/pkg/eas/storage/ipblockusage.go
@@ -20,6 +20,13 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
 )
 
+const (
+	nsxIPAddressTypeIPv4 = "IPV4"
+	nsxIPAddressTypeIPv6 = "IPV6"
+	crIPAddressTypeIPv4  = easv1alpha1.IPv4
+	crIPAddressTypeIPv6  = easv1alpha1.IPv6
+)
+
 // IPBlockUsageStorage implements REST operations for IPBlockUsage.
 type IPBlockUsageStorage struct {
 	nsxClient  *nsx.Client
@@ -204,6 +211,9 @@ func ConvertIpAddressBlockUsage(nsxUsage *model.IpAddressBlockUsage, name, names
 	item.AvailableIPsCount = derefCount(nsxUsage.AvailableIpsCount)
 	item.OverallIPsCount = derefCount(nsxUsage.OverallIpsCount)
 	item.Visibility = toIPAddressVisibility(DerefString(nsxUsage.Visibility))
+	if nsxUsage.AddressType != nil {
+		item.AddressType = toIPAddressType(*nsxUsage.AddressType)
+	}
 	for _, c := range nsxUsage.CidrUsage {
 		item.CIDRUsages = append(item.CIDRUsages, easv1alpha1.CIDRUsage{
 			CIDR: DerefString(c.Cidr),
@@ -260,14 +270,18 @@ func derefCount(s *string) string {
 }
 
 // ipBlockUsageName derives a metadata.name from the NSX intent path.
-// It returns the last path segment (the block ID) regardless of whether the block
-// is project-scoped or infra-scoped. The project context is implicit from the
-// namespace / VPC and does not need to be encoded in the name.
+// It returns the last path segment (the block ID) for project-scoped blocks.
+// For infra-scoped blocks, it prepends a ":" to the block ID.
+// The project context is implicit from the namespace / VPC and does not need to be encoded in the name.
 func ipBlockUsageName(intentPath, projectID string, index int) string {
 	if intentPath != "" {
 		parts := splitPolicyPath(intentPath)
 		if len(parts) > 0 {
-			return parts[len(parts)-1]
+			name := parts[len(parts)-1]
+			if strings.HasPrefix(intentPath, "/infra/") {
+				return ":" + name
+			}
+			return name
 		}
 	}
 	return fmt.Sprintf("ipblock-%d", index)
@@ -279,4 +293,16 @@ func splitPolicyPath(p string) []string {
 		return nil
 	}
 	return strings.Split(p, "/")
+}
+
+// toIPAddressType converts NSX address type string to K8s IPAddressType.
+func toIPAddressType(t string) easv1alpha1.IPAddressType {
+	if strings.EqualFold(t, nsxIPAddressTypeIPv4) {
+		return crIPAddressTypeIPv4
+	}
+	if strings.EqualFold(t, nsxIPAddressTypeIPv6) {
+		return crIPAddressTypeIPv6
+	}
+	logger.Log.Warn("Unknown IP address type, defaulting to IPv4", "unknownType", t)
+	return crIPAddressTypeIPv4
 }

--- a/pkg/eas/storage/ipblockusage_test.go
+++ b/pkg/eas/storage/ipblockusage_test.go
@@ -47,7 +47,7 @@ func TestConvertIpAddressBlockUsageList_InfraScoped(t *testing.T) {
 	}
 	items := ConvertIpAddressBlockUsageList(nsx, "", "ns1")
 	require.Len(t, items, 1)
-	assert.Equal(t, "global-block", items[0].Name)
+	assert.Equal(t, ":global-block", items[0].Name)
 	assert.Equal(t, easv1alpha1.External, items[0].Visibility)
 }
 
@@ -78,12 +78,32 @@ func TestConvertIpAddressBlockUsage_Nil(t *testing.T) {
 	assert.Empty(t, item.RangeUsages)
 }
 
+func TestConvertIpAddressBlockUsage_UnknownType(t *testing.T) {
+	ipType := "UNKNOWN"
+	nsxUsage := &model.IpAddressBlockUsage{
+		AddressType: &ipType,
+	}
+	item := ConvertIpAddressBlockUsage(nsxUsage, "block-a", "ns1")
+	assert.Equal(t, crIPAddressTypeIPv4, item.AddressType)
+}
+
+func TestConvertIpAddressBlockUsage_IPv6(t *testing.T) {
+	ipType := nsxIPAddressTypeIPv6
+	nsxUsage := &model.IpAddressBlockUsage{
+		AddressType: &ipType,
+	}
+	item := ConvertIpAddressBlockUsage(nsxUsage, "block-b", "ns1")
+	assert.Equal(t, crIPAddressTypeIPv6, item.AddressType)
+}
+
 func TestConvertIpAddressBlockUsage_WithFullData(t *testing.T) {
 	cidr, blockID := "10.0.0.0/8", "block-a"
 	overallUsed := "10.0.0.1-10.0.0.5"
 	rangeVal := "10.1.0.0-10.1.0.255"
+	ipType := nsxIPAddressTypeIPv4
 	nsxUsage := &model.IpAddressBlockUsage{
 		Visibility:        strPtr("PRIVATE"),
+		AddressType:       &ipType,
 		UsedIpsCount:      strPtr("5"),
 		AvailableIpsCount: strPtr("100"),
 		OverallIpsCount:   strPtr("256"),
@@ -116,6 +136,7 @@ func TestConvertIpAddressBlockUsage_WithFullData(t *testing.T) {
 	item := ConvertIpAddressBlockUsage(nsxUsage, "block-a", "ns1")
 	assert.Equal(t, "block-a", item.Name)
 	assert.Equal(t, easv1alpha1.Private, item.Visibility)
+	assert.Equal(t, crIPAddressTypeIPv4, item.AddressType)
 	assert.Equal(t, "5", item.UsedIPsCount)
 	assert.Equal(t, "100", item.AvailableIPsCount)
 	assert.Equal(t, "256", item.OverallIPsCount)
@@ -162,7 +183,7 @@ func TestIpBlockUsageName(t *testing.T) {
 		index      int
 		want       string
 	}{
-		{"infra block", "/infra/ip-blocks/blk1", "", 0, "blk1"},
+		{"infra block", "/infra/ip-blocks/blk1", "", 0, ":blk1"},
 		{"project block with param", "/orgs/default/projects/proj1/infra/ip-blocks/blk1", "proj1", 0, "blk1"},
 		{"project block param override path project", "/orgs/default/projects/path-proj/infra/ip-blocks/blk1", "override-proj", 0, "blk1"},
 		{"fallback with project", "", "proj1", 2, "ipblock-2"},


### PR DESCRIPTION
Add AddressType in ipblockusage eas api, the value must be IPv4 or IPv6.

This patch also contains a bugfix, that for ipblockusage list api, if the ipblock is under /infra, the response body meta for ipblock name should be ":${ipblock name}"

Testing Done:
```
k get ipblockusage -n svc-velero-31x0n -o yaml
apiVersion: v1
items:
- addressType: IPv4
  apiVersion: eas.nsx.vmware.com/v1alpha1
  availableIPRanges:
  - 192.168.0.4-192.168.0.5
  - 192.168.0.9-192.168.255.255
  availableIPsCount: "65529"
  cidrUsages:
  - cidr: 192.168.0.0/16
    usageDetails:
      availableIPRanges:
      - 192.168.0.4-192.168.0.5
      - 192.168.0.9-192.168.255.255
      availableIPsCount: "65529"
      overallUsedIPRanges:
      - 192.168.0.0-192.168.0.0
      - 192.168.0.1-192.168.0.1
      - 192.168.0.2-192.168.0.2
      - 192.168.0.3-192.168.0.3
      - 192.168.0.6-192.168.0.6
      - 192.168.0.7-192.168.0.7
      - 192.168.0.8-192.168.0.8
      overallUsedIPsCount: "7"
      usedIPRanges:
      - 192.168.0.0-192.168.0.0
      - 192.168.0.1-192.168.0.1
      - 192.168.0.2-192.168.0.2
      - 192.168.0.3-192.168.0.3
      - 192.168.0.6-192.168.0.6
      - 192.168.0.7-192.168.0.7
      - 192.168.0.8-192.168.0.8
      usedIPsCount: "7"
  kind: IPBlockUsage
  metadata:
    name: :ipblock-192.168.0.0-netmask-16
    namespace: svc-velero-31x0n
  overallIPsCount: "65536"
  usedIPRanges:
  - 192.168.0.0-192.168.0.0
  - 192.168.0.1-192.168.0.1
  - 192.168.0.2-192.168.0.2
  - 192.168.0.3-192.168.0.3
  - 192.168.0.6-192.168.0.6
  - 192.168.0.7-192.168.0.7
  - 192.168.0.8-192.168.0.8
  usedIPsCount: "7"
  visibility: External
- addressType: IPv6
  apiVersion: eas.nsx.vmware.com/v1alpha1
  availableIPRanges:
  - 2026:f206:0:5::-2026:f206:ffff:ffff:ffff:ffff:ffff:ffff
  availableIPsCount: "79228162422030617224996192256"
  cidrUsages:
  - cidr: 2026:f206::/32
    usageDetails:
      availableIPRanges:
      - 2026:f206:0:5::-2026:f206:ffff:ffff:ffff:ffff:ffff:ffff
      availableIPsCount: "79228162422030617224996192256"
      overallUsedIPRanges:
      - 2026:f206::-2026:f206::ffff:ffff:ffff:ffff
      - 2026:f206:0:1::-2026:f206:0:1:ffff:ffff:ffff:ffff
      - 2026:f206:0:2::-2026:f206:0:2:ffff:ffff:ffff:ffff
      - 2026:f206:0:3::-2026:f206:0:3:ffff:ffff:ffff:ffff
      - 2026:f206:0:4::-2026:f206:0:4:ffff:ffff:ffff:ffff
      overallUsedIPsCount: "92233720368547758080"
      usedIPRanges:
      - 2026:f206::-2026:f206::ffff:ffff:ffff:ffff
      - 2026:f206:0:1::-2026:f206:0:1:ffff:ffff:ffff:ffff
      - 2026:f206:0:2::-2026:f206:0:2:ffff:ffff:ffff:ffff
      - 2026:f206:0:3::-2026:f206:0:3:ffff:ffff:ffff:ffff
      - 2026:f206:0:4::-2026:f206:0:4:ffff:ffff:ffff:ffff
      usedIPsCount: "92233720368547758080"
  kind: IPBlockUsage
  metadata:
    name: :ipblock-supervisor-ipv6-0
    namespace: svc-velero-31x0n
  overallIPsCount: "79228162514264337593543950336"
  usedIPRanges:
  - 2026:f206::-2026:f206::ffff:ffff:ffff:ffff
  - 2026:f206:0:1::-2026:f206:0:1:ffff:ffff:ffff:ffff
  - 2026:f206:0:2::-2026:f206:0:2:ffff:ffff:ffff:ffff
  - 2026:f206:0:3::-2026:f206:0:3:ffff:ffff:ffff:ffff
  - 2026:f206:0:4::-2026:f206:0:4:ffff:ffff:ffff:ffff
  usedIPsCount: "92233720368547758080"
  visibility: External
- addressType: IPv4
  apiVersion: eas.nsx.vmware.com/v1alpha1
  availableIPRanges:
  - 172.26.0.8-172.26.255.255
  availableIPsCount: "65528"
  cidrUsages:
  - cidr: 172.26.0.0/16
    usageDetails:
      availableIPRanges:
      - 172.26.0.8-172.26.255.255
      availableIPsCount: "65528"
      overallUsedIPRanges:
      - 172.26.0.0-172.26.0.7
      overallUsedIPsCount: "8"
      usedIPRanges:
      - 172.26.0.0-172.26.0.7
      usedIPsCount: "8"
  kind: IPBlockUsage
  metadata:
    name: kube-system_5qyvw-172_26_0_0_16
    namespace: svc-velero-31x0n
  overallIPsCount: "65536"
  usedIPRanges:
  - 172.26.0.0-172.26.0.7
  usedIPsCount: "8"
  visibility: Private
- addressType: IPv4
  apiVersion: eas.nsx.vmware.com/v1alpha1
  availableIPRanges:
  - 172.26.0.0-172.26.255.255
  availableIPsCount: "65536"
  cidrUsages:
  - cidr: 172.26.0.0/16
    usageDetails:
      availableIPRanges:
      - 172.26.0.0-172.26.255.255
      availableIPsCount: "65536"
      overallUsedIPsCount: "0"
      usedIPsCount: "0"
  kind: IPBlockUsage
  metadata:
    name: vmware-system-monitoring-public_cn7vg-172_26_0_0_16
    namespace: svc-velero-31x0n
  overallIPsCount: "65536"
  usedIPsCount: "0"
  visibility: Private
- addressType: IPv4
  apiVersion: eas.nsx.vmware.com/v1alpha1
  availableIPRanges:
  - 172.26.0.0-172.26.255.255
  availableIPsCount: "65536"
  cidrUsages:
  - cidr: 172.26.0.0/16
    usageDetails:
      availableIPRanges:
      - 172.26.0.0-172.26.255.255
      availableIPsCount: "65536"
      overallUsedIPsCount: "0"
      usedIPsCount: "0"
  kind: IPBlockUsage
  metadata:
    name: vmware-system-supervisor-services-vpc_el4m9-172_26_0_0_16
    namespace: svc-velero-31x0n
  overallIPsCount: "65536"
  usedIPsCount: "0"
  visibility: Private
- addressType: IPv4
  apiVersion: eas.nsx.vmware.com/v1alpha1
  availableIPRanges:
  - 10.246.0.0-10.246.255.255
  availableIPsCount: "65536"
  cidrUsages:
  - cidr: 10.246.0.0/16
    usageDetails:
      availableIPRanges:
      - 10.246.0.0-10.246.255.255
      availableIPsCount: "65536"
      overallUsedIPsCount: "0"
      usedIPsCount: "0"
  kind: IPBlockUsage
  metadata:
    name: project-quality-ipblock-10.246.0.0-netmask-16
    namespace: svc-velero-31x0n
  overallIPsCount: "65536"
  usedIPsCount: "0"
  visibility: Private
kind: List
metadata:
  resourceVersion: ""
```

for the bug fix , confirm for ipblocks under infra, the reponse for ipblock name contains ":"
```
 - addressType: IPv6
  apiVersion: eas.nsx.vmware.com/v1alpha1
  availableIPRanges:
  - 2026:f206:0:5::-2026:f206:ffff:ffff:ffff:ffff:ffff:ffff
  availableIPsCount: "79228162422030617224996192256"
  cidrUsages:
  - cidr: 2026:f206::/32
    usageDetails:
      availableIPRanges:
      - 2026:f206:0:5::-2026:f206:ffff:ffff:ffff:ffff:ffff:ffff
      availableIPsCount: "79228162422030617224996192256"
      overallUsedIPRanges:
      - 2026:f206::-2026:f206::ffff:ffff:ffff:ffff
      - 2026:f206:0:1::-2026:f206:0:1:ffff:ffff:ffff:ffff
      - 2026:f206:0:2::-2026:f206:0:2:ffff:ffff:ffff:ffff
      - 2026:f206:0:3::-2026:f206:0:3:ffff:ffff:ffff:ffff
      - 2026:f206:0:4::-2026:f206:0:4:ffff:ffff:ffff:ffff
      overallUsedIPsCount: "92233720368547758080"
      usedIPRanges:
      - 2026:f206::-2026:f206::ffff:ffff:ffff:ffff
      - 2026:f206:0:1::-2026:f206:0:1:ffff:ffff:ffff:ffff
      - 2026:f206:0:2::-2026:f206:0:2:ffff:ffff:ffff:ffff
      - 2026:f206:0:3::-2026:f206:0:3:ffff:ffff:ffff:ffff
      - 2026:f206:0:4::-2026:f206:0:4:ffff:ffff:ffff:ffff
      usedIPsCount: "92233720368547758080"
  kind: IPBlockUsage
  metadata:
    name: :ipblock-supervisor-ipv6-0
    namespace: svc-velero-31x0n
  overallIPsCount: "79228162514264337593543950336"
  usedIPRanges:
  - 2026:f206::-2026:f206::ffff:ffff:ffff:ffff
  - 2026:f206:0:1::-2026:f206:0:1:ffff:ffff:ffff:ffff
  - 2026:f206:0:2::-2026:f206:0:2:ffff:ffff:ffff:ffff
  - 2026:f206:0:3::-2026:f206:0:3:ffff:ffff:ffff:ffff
  - 2026:f206:0:4::-2026:f206:0:4:ffff:ffff:ffff:ffff
  usedIPsCount: "92233720368547758080"
  visibility: External
```