### PR TITLE
Set timeout for leader election config

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -362,6 +363,13 @@ func main() {
 		log.Error(err, "Failed to get rest config for manager")
 		os.Exit(1)
 	}
+	// Create a dedicated REST config for leader election with a shorter timeout.
+	// By default, controller-runtime inherits the main client's timeout (which is DefaultK8sClientTimeout = 2 minutes).
+	// If the first renew API request hangs, a 120s timeout would block the entire renew loop and result the new leader
+	// get elected before the old leader knows it has lost the lease.
+	// By explicitly setting the client timeout to 5s (RenewDeadline / 2), a hung request will be terminated at 5s.
+	leaderElectionCfg := rest.CopyConfig(cfg)
+	leaderElectionCfg.Timeout = 5 * time.Second
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:                  scheme,
 		HealthProbeBindAddress:  config.ProbeAddr,
@@ -369,6 +377,7 @@ func main() {
 		LeaderElection:          cf.HAEnabled(),
 		LeaderElectionNamespace: nsxOperatorNamespace,
 		LeaderElectionID:        "nsx-operator",
+		LeaderElectionConfig:    leaderElectionCfg,
 		Controller: ctrlconfig.Controller{
 			CacheSyncTimeout: pkgutil.GetCacheSyncTimeout(),
 		},


### PR DESCRIPTION
Our main REST config uses `DefaultK8sClientTimeout` of **120 seconds** (2 minutes). When leader election is enabled, it inherits this 120s timeout by default.
- If an API Server request to renew the lease hangs, the client will block waiting for a response for up to 120 seconds.
- As the default lease duration is 15s, a new leader may acquire the lease before the old leader realizes it has lost the lease.
- This will result in an overlap (brain-split) between the old leader and the new leader, where both instances are actively reconciling resources concurrently.

This PR explicitly sets a timeout of 5s for leader election config

