### PR TITLE
Updating static route CR with ipallocation cause nil pointer error

### DIFF
--- a/pkg/nsx/services/staticroute/compare.go
+++ b/pkg/nsx/services/staticroute/compare.go
@@ -1,28 +1,75 @@
 package staticroute
 
 import (
+	"sort"
+
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
 )
 
-// assume that staticroute doesn't have the same ipaddress, return true if equal
-func (service *StaticRouteService) compareStaticRoute(oldStaticRoute *model.StaticRoutes, newStaticRoute *model.StaticRoutes) bool {
-	if *oldStaticRoute.Network != *newStaticRoute.Network {
-		return false
+type (
+	StaticRoute model.StaticRoutes
+)
+
+type Comparable = common.Comparable
+
+func (sr *StaticRoute) Key() string {
+	if sr != nil && sr.Id != nil {
+		return *sr.Id
 	}
-	oldNextHops := oldStaticRoute.NextHops
-	newNextHops := newStaticRoute.NextHops
-	if len(oldNextHops) != len(newNextHops) {
-		return false
+	return ""
+}
+
+func (sr *StaticRoute) Value() data.DataValue {
+	if sr == nil {
+		return nil
 	}
-	oldHopsSet := sets.NewString()
-	for _, addr := range oldNextHops {
-		oldHopsSet.Insert(*addr.IpAddress)
-	}
-	for _, addr := range newNextHops {
-		if !oldHopsSet.Has(*addr.IpAddress) {
-			return false
+	var nextHops []model.RouterNexthop
+	if len(sr.NextHops) > 0 {
+		nextHops = make([]model.RouterNexthop, len(sr.NextHops))
+		for i, nh := range sr.NextHops {
+			nextHops[i] = model.RouterNexthop{
+				IpAddress: nh.IpAddress,
+			}
 		}
+		sort.Slice(nextHops, func(i, j int) bool {
+			if nextHops[i].IpAddress == nil {
+				return true
+			}
+			if nextHops[j].IpAddress == nil {
+				return false
+			}
+			return *nextHops[i].IpAddress < *nextHops[j].IpAddress
+		})
 	}
-	return true
+	s := &StaticRoute{
+		Network:                 sr.Network,
+		NetworkIpAllocationPath: sr.NetworkIpAllocationPath,
+		NextHops:                nextHops,
+	}
+	dataValue, _ := ComparableToStaticRoute(s).GetDataValue__()
+	return dataValue
+}
+
+func StaticRouteToComparable(sr *model.StaticRoutes) Comparable {
+	return (*StaticRoute)(sr)
+}
+
+func ComparableToStaticRoute(sr Comparable) *model.StaticRoutes {
+	if sr == nil {
+		return nil
+	}
+	return (*model.StaticRoutes)(sr.(*StaticRoute))
+}
+
+func (service *StaticRouteService) compareStaticRoute(oldStaticRoute *model.StaticRoutes, newStaticRoute *model.StaticRoutes) bool {
+	if oldStaticRoute == nil && newStaticRoute == nil {
+		return true
+	}
+	if oldStaticRoute == nil || newStaticRoute == nil {
+		return false
+	}
+	return !common.CompareResource(StaticRouteToComparable(oldStaticRoute), StaticRouteToComparable(newStaticRoute))
 }

--- a/pkg/nsx/services/staticroute/compare_test.go
+++ b/pkg/nsx/services/staticroute/compare_test.go
@@ -9,6 +9,68 @@ import (
 	"github.com/vmware-tanzu/nsx-operator/pkg/util"
 )
 
+func TestKey(t *testing.T) {
+	id := "test-sr-id"
+	sr := &StaticRoute{Id: &id}
+	assert.Equal(t, "test-sr-id", sr.Key())
+
+	srNilId := &StaticRoute{Id: nil}
+	assert.Equal(t, "", srNilId.Key())
+
+	var srNil *StaticRoute
+	assert.Equal(t, "", srNil.Key())
+}
+
+func TestValue(t *testing.T) {
+	id := "test-sr-id"
+	network := "192.168.1.0/24"
+	sr := &StaticRoute{
+		Id:      &id,
+		Network: &network,
+		NextHops: []model.RouterNexthop{
+			{IpAddress: util.Ptr("192.168.1.2")},
+			{IpAddress: util.Ptr("192.168.1.1")},
+		},
+	}
+
+	dataValue := sr.Value()
+	assert.NotNil(t, dataValue)
+
+	// Nil receiver should return nil
+	var nilSr *StaticRoute
+	assert.Nil(t, nilSr.Value())
+}
+
+func TestStaticRouteToComparable(t *testing.T) {
+	id := "test-sr-id"
+	network := "192.168.1.0/24"
+	nsxSR := &model.StaticRoutes{
+		Id:      &id,
+		Network: &network,
+	}
+
+	comparable := StaticRouteToComparable(nsxSR)
+	assert.NotNil(t, comparable)
+	assert.IsType(t, &StaticRoute{}, comparable)
+}
+
+func TestComparableToStaticRoute(t *testing.T) {
+	id := "test-sr-id"
+	network := "192.168.1.0/24"
+	sr := &StaticRoute{
+		Id:      &id,
+		Network: &network,
+	}
+
+	nsxSR := ComparableToStaticRoute(sr)
+	assert.NotNil(t, nsxSR)
+	assert.IsType(t, &model.StaticRoutes{}, nsxSR)
+	assert.Equal(t, id, *nsxSR.Id)
+	assert.Equal(t, network, *nsxSR.Network)
+
+	assert.Nil(t, ComparableToStaticRoute(nil))
+}
+
 func TestCompareStaticRoute(t *testing.T) {
 	service := &StaticRouteService{}
 
@@ -28,6 +90,14 @@ func TestCompareStaticRoute(t *testing.T) {
 		},
 	}
 
+	newStaticRouteReorderedHops := &model.StaticRoutes{
+		Network: util.Ptr("192.168.1.0/24"),
+		NextHops: []model.RouterNexthop{
+			{IpAddress: util.Ptr("192.168.1.2")},
+			{IpAddress: util.Ptr("192.168.1.1")},
+		},
+	}
+
 	newStaticRouteDifferent := &model.StaticRoutes{
 		Network: util.Ptr("192.168.1.0/24"),
 		NextHops: []model.RouterNexthop{
@@ -42,7 +112,47 @@ func TestCompareStaticRoute(t *testing.T) {
 			{IpAddress: util.Ptr("192.168.1.2")},
 		},
 	}
+
+	oldStaticRouteWithAllocation := &model.StaticRoutes{
+		NetworkIpAllocationPath: util.Ptr("/infra/ip-pools/pool1"),
+		NextHops: []model.RouterNexthop{
+			{IpAddress: util.Ptr("192.168.1.1")},
+		},
+	}
+
+	newStaticRouteWithAllocationSame := &model.StaticRoutes{
+		NetworkIpAllocationPath: util.Ptr("/infra/ip-pools/pool1"),
+		NextHops: []model.RouterNexthop{
+			{IpAddress: util.Ptr("192.168.1.1")},
+		},
+	}
+
+	newStaticRouteWithAllocationDifferent := &model.StaticRoutes{
+		NetworkIpAllocationPath: util.Ptr("/infra/ip-pools/pool2"),
+		NextHops: []model.RouterNexthop{
+			{IpAddress: util.Ptr("192.168.1.1")},
+		},
+	}
+
+	// Same static routes
 	assert.True(t, service.compareStaticRoute(oldStaticRoute, newStaticRouteSame))
+	// Reordered next hops should still be considered equal
+	assert.True(t, service.compareStaticRoute(oldStaticRoute, newStaticRouteReorderedHops))
+	// Different next hops
 	assert.False(t, service.compareStaticRoute(oldStaticRoute, newStaticRouteDifferent))
+	// Different network
 	assert.False(t, service.compareStaticRoute(oldStaticRoute, newStaticRouteDifferentNetwork))
+
+	// Test allocation path comparisons
+	assert.True(t, service.compareStaticRoute(oldStaticRouteWithAllocation, newStaticRouteWithAllocationSame))
+	assert.False(t, service.compareStaticRoute(oldStaticRouteWithAllocation, newStaticRouteWithAllocationDifferent))
+
+	// Test cross-type comparisons (Network vs NetworkIpAllocationPath)
+	assert.False(t, service.compareStaticRoute(oldStaticRoute, oldStaticRouteWithAllocation))
+	assert.False(t, service.compareStaticRoute(oldStaticRouteWithAllocation, oldStaticRoute))
+
+	// Nil comparisons
+	assert.True(t, service.compareStaticRoute(nil, nil))
+	assert.False(t, service.compareStaticRoute(oldStaticRoute, nil))
+	assert.False(t, service.compareStaticRoute(nil, newStaticRouteSame))
 }


### PR DESCRIPTION
During a StaticRoute CR update, if the old CR uses the network field and the new CR uses the ipallocation field, comparing these values via string pointers will cause a nil pointer dereference error. Add protection code to ensure that nil values are handled correctly.


| # | Test Case Description | Scenario / Action | Expected Behavior | Actual Result | Status |
|:---:|---|---|---|---|:---:|
| 1 | Create StaticRoute with static CIDR | `spec.network: 10.100.1.0/24`, `nextHops: [192.168.0.1]` | Route realized on NSX, CR condition `Ready=True` | NSX route created, `Ready=True` | PASS |
| 2 | Add next-hop & Reorder NextHops | Add `192.168.0.2`, then reorder to `[192.168.0.2, 192.168.0.1]` | Reordered hops recognized as equal (order-insensitive), no unnecessary update | Order-insensitive comparison succeeded, `Ready=True` | PASS |
| 3 | Core Fix 1: Switch `network` to `networkIpAllocationName` | Change `spec.network` to `spec.networkIpAllocationName: test-ipalloc-1` | Old has `Network`, new has `nil` `Network`. Safe comparison, no nil dereference panic | Handled `nil` safely, NSX patched with allocation path, `Ready=True` | PASS |
| 4 | Core Fix 2: Switch between `networkIpAllocationName` allocations | Change `networkIpAllocationName` from `test-ipalloc-1` to `test-ipalloc-2` | Both have `nil` `Network`. Safe comparison detects path change without panic | Handled `nil` safely, NSX updated to `test-ipalloc-2`, `Ready=True` | PASS |
| 5 | Core Fix 3: Switch `networkIpAllocationName` back to `network` | Change `networkIpAllocationName: test-ipalloc-2` back to `spec.network: 10.200.2.0/24` | Old has `nil` `Network`, new has `Network`. Safe comparison without panic | Handled `nil` safely, NSX updated to new CIDR, `Ready=True` | PASS |
| 6 | Greenfield StaticRoute with `networkIpAllocationName` | Create new route `test-sr-2` directly with `spec.networkIpAllocationName: test-ipalloc-1` | Path resolved from allocation CR, NSX route created, `Ready=True` | Successfully created, `Ready=True` | PASS |
| 7 | NextHop mutation on IP allocation route | Add hop & reorder hops on `test-sr-2` using `networkIpAllocationName` | Safe comparison with `Network=nil`, order-insensitive hops | Route updated and reordered cleanly, `Ready=True` | PASS |
| 8 | Clean resource deletion & operator stability | Delete all test `StaticRoute` and `IPAddressAllocation` CRs | Resources cleanly deleted from NSX and K8s, 0 operator crashes/restarts | CRs and NSX objects deleted, 0 restarts, 0 panics | PASS |